### PR TITLE
fix datastore indices

### DIFF
--- a/app/index.yaml
+++ b/app/index.yaml
@@ -9,10 +9,12 @@ indexes:
   - name: CreateTimestamp
     direction: desc
 - kind: Task
+  ancestor: yes
   properties:
   - name: StageName
     direction: desc
 - kind: Task
+  ancestor: yes
   properties:
   - name: Name
   - name: CreateTimestamp


### PR DESCRIPTION
We query tasks specifying the checklist as an ancestor, but the index didn't have ancestor set.

@devoncarew 
