### PR TITLE
redirect all http traffic to https automatically

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -9,11 +9,14 @@ handlers:
 - url: /
   static_files: build/web/index.html
   upload: build/web/index.html
+  secure: always
 - url: /(.*\.(html|css|js|ico|svg|png|jpg|map|dart))$
   static_files: build/web/\1
   upload: build/web/.*\.(html|css|js|ico|svg|png|jpg|map|dart)$
+  secure: always
 - url: /api/.*
   script: _go_app
+  secure: always
 skip_files:
 - (.+/)?(?<!build/web/)packages(?!/browser)/.*
 - .pub/.*


### PR DESCRIPTION
Currently non-secure (http://) requests simply crash. This change will cause us to not even attempt to process non-secure requests and cause an automatic redirect to https.

/cc @devoncarew 
