### PR TITLE
reserve only from checklists with successful primary stages

### DIFF
--- a/db/collection_utils.go
+++ b/db/collection_utils.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package db
+
+// Every is like Dart's Iterable.every.
+func Every(len int, getter func(i int) interface{}, predicate func(element interface{}) bool) bool {
+	for i := 0; i < len; i++ {
+		if !predicate(getter(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+// Any is like Dart's Iterable.any.
+func Any(len int, getter func(i int) interface{}, predicate func(element interface{}) bool) bool {
+	for i := 0; i < len; i++ {
+		if predicate(getter(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+// Where is like Dart's Iterable.where.
+func Where(len int, getter func(i int) interface{}, predicate func(element interface{}) bool) []interface{} {
+	var results []interface{}
+	for i := 0; i < len; i++ {
+		element := getter(i)
+		if predicate(element) {
+			results = append(results, element)
+		}
+	}
+	return results
+}

--- a/db/schema.go
+++ b/db/schema.go
@@ -39,8 +39,16 @@ type Checklist struct {
 // tasks into a pipeline, where tasks in some stages only run _after_ a previous
 // stage is successful.
 type Stage struct {
-	Name  string
-	Tasks []*TaskEntity
+	Name string
+	// Aggregated status of the stage, computed as follows:
+	//
+	// - TaskSucceeded if all tasks in this stage succeeded
+	// - TaskFailed if at least one task in this stage failed
+	// - TaskInProgress if at least one task is in progress and others are New
+	// - Same as Task.Status if all tasks have the same status
+	// - TaskFailed otherwise
+	Status TaskStatus
+	Tasks  []*TaskEntity
 }
 
 // TaskEntity contains storage data on a Task.
@@ -68,6 +76,11 @@ type Task struct {
 
 // TaskStatus indicates the status of a task.
 type TaskStatus string
+
+// TaskNoStatus is the zero value, meaning no status value. It is not a valid
+// status value and should only be used as a temporary variable value in
+// algorithms that need it.
+const TaskNoStatus = TaskStatus("")
 
 // TaskNew indicates that the task was created but not acted upon.
 const TaskNew = TaskStatus("New")


### PR DESCRIPTION
There are two categories of task stages: primary and secondary. Tasks in the secondary stages are only performed if _all_ tasks in the primary stages are successful.

Currently the primary stages are "travis" and "chromebot". Everything else it secondary.

/cc @devoncarew 
