### PR TITLE
whitelisted accounts; better sign in/out ergonomics

### DIFF
--- a/app/web/build.html
+++ b/app/web/build.html
@@ -29,6 +29,11 @@
     <status-table></status-table>
   </div>
 
+  <footer>
+    <button id="logout-button">Sign out of Google</button>
+    <button id="login-button">Sign in with Google</button>
+  </footer>
+
   <script defer src="main.dart" type="application/dart"></script>
   <script defer src="packages/browser/dart.js"></script>
 </body>

--- a/app/web/buildStyles.css
+++ b/app/web/buildStyles.css
@@ -86,9 +86,9 @@ footer {
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 2px 19px 10px 19px;
+  padding: 2px 19px;
   z-index: 2;
-  background: inherit;
+  background-color: #917FFF;
   display: flex;
 }
 

--- a/app/web/buildbot.js
+++ b/app/web/buildbot.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Globally visible list of current build statuses encoded as:
 //
 // {

--- a/app/web/firebase.js
+++ b/app/web/firebase.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ref = new Firebase("https://purple-butterfly-3000.firebaseio.com/");
 
 var whenFirebaseReady = new Promise(function(resolve, reject) {

--- a/app/web/github.js
+++ b/app/web/github.js
@@ -1,3 +1,5 @@
+"use strict";
+
 (function() {
 
   var ACCESS_TOKEN = '6a93c73f10808b9a92d4ec8a91b9e823c192d204';

--- a/app/web/main.dart
+++ b/app/web/main.dart
@@ -20,6 +20,9 @@ main() async {
   logger = new HtmlLogger();
   http.Client httpClient = await _getAuthenticatedClientOrRedirectToSignIn();
 
+  if (httpClient == null)
+    return;
+
   // Start the angular app
   ComponentRef ref = await bootstrap(StatusTable, [
     provide(http.Client, useValue: httpClient),
@@ -33,12 +36,22 @@ Future<http.Client> _getAuthenticatedClientOrRedirectToSignIn() async {
   http.Client client = new browser_http.BrowserClient();
   Map<String, dynamic> status = JSON.decode((await client.get('/api/get-authentication-status')).body);
 
+  document.querySelector('#logout-button').on['click'].listen((_) {
+    window.open(status['LogoutURL'], '_self');
+  });
+
+  document.querySelector('#login-button').on['click'].listen((_) {
+    window.open(status['LoginURL'], '_self');
+  });
+
   if (status['Status'] == 'OK') {
     return client;
-  } else {
-    window.open(status['LoginURL'], '_self');
-    return null;
   }
+
+  document.body.append(new DivElement()
+    ..text = 'You are not signed in, or signed in under an unauthorized account. '
+             'Use the buttons at the bottom of this page to sign in.');
+  return null;
 }
 
 class HtmlLogger implements Logger {

--- a/db/db.go
+++ b/db/db.go
@@ -433,6 +433,21 @@ func (c *Cocoon) RefreshAgentAuthToken(agentID string) (*Agent, string, error) {
 	return agent, authToken, nil
 }
 
+// IsWhitelisted verifies that the given email address is whitelisted for access.
+func (c *Cocoon) IsWhitelisted(email string) error {
+	query := datastore.NewQuery("WhitelistedAccount").
+		Filter("Email =", email).
+		Limit(20)
+	iter := query.Run(c.Ctx)
+	_, err := iter.Next(&WhitelistedAccount{})
+
+	if err == datastore.Done {
+		return fmt.Errorf("%v is not authorized to access the dashboard", email)
+	}
+
+	return nil
+}
+
 // allTaskStatuses contains all possible task statuses.
 var allTaskStatuses = [...]TaskStatus{
 	TaskNew,

--- a/db/schema.go
+++ b/db/schema.go
@@ -107,3 +107,17 @@ type Agent struct {
 	AuthTokenHash        []byte
 	Capabilities         []string
 }
+
+// WhitelistedAccount gives permission to access the dashboard to a specific
+// Google account.
+//
+// In production an account can be added by an administrator using the
+// Datastore web UI.
+//
+// The Datastore UI on the dev server is limited. To add an account make a
+// HTTP GET call to:
+//
+// http://localhost:8080/api/whitelist-account?email=ACCOUNT_EMAIL
+type WhitelistedAccount struct {
+	Email string
+}


### PR DESCRIPTION
- Create a table of whitelisted Google accounts that are allowed to
  access the dashboard (this is for wall-mounted TVs)
- Add “Sign in” and “Sign out” buttons instead of automatic redirects
  for better authentication experience (for example if signed in under a
  wrong Google account we enter an infinite redirect loop)

/cc @devoncarew @sethladd 
