### PR TITLE
simplify dangling process cleanup

### DIFF
--- a/agent/lib/src/adb.dart
+++ b/agent/lib/src/adb.dart
@@ -47,7 +47,7 @@ class Adb {
   static final RegExp _kDeviceRegex = new RegExp(r'^(\S+)\s+(\S+)(.*)');
 
   static Future<List<String>> get deviceIds async {
-    List<String> output = (await eval(config.adbPath, ['devices', '-l'], canFail: false, onKill: _adbTimeout()))
+    List<String> output = (await eval(config.adbPath, ['devices', '-l'], canFail: false))
         .trim().split('\n');
     List<String> results = <String>[];
     for (String line in output) {
@@ -122,13 +122,11 @@ class Adb {
 
   /// Executes [command] on `adb shell` and returns its exit code.
   Future<Null> shellExec(String command, List<String> arguments, {Map<String, String> env}) async {
-    await exec(config.adbPath, ['shell', command]..addAll(arguments), env: env, canFail: false, onKill: _adbTimeout());
+    await exec(config.adbPath, ['shell', command]..addAll(arguments), env: env, canFail: false);
   }
 
   /// Executes [command] on `adb shell` and returns its standard output as a [String].
   Future<String> shellEval(String command, List<String> arguments, {Map<String, String> env}) {
-    return eval(config.adbPath, ['shell', command]..addAll(arguments), env: env, canFail: false, onKill: _adbTimeout());
+    return eval(config.adbPath, ['shell', command]..addAll(arguments), env: env, canFail: false);
   }
-
-  static Future<Null> _adbTimeout() => new Future<Null>.delayed(const Duration(seconds: 5));
 }

--- a/agent/lib/src/analysis.dart
+++ b/agent/lib/src/analysis.dart
@@ -43,19 +43,19 @@ abstract class AnalyzerTask extends Task {
 
 class AnalyzerCliTask extends AnalyzerTask {
   AnalyzerCliTask(String sdk, String commit, DateTime timestamp) : super('analyzer_cli__analysis_time') {
-    this.benchmark = new FlutterAnalyzeBenchmark(onCancel, sdk, commit, timestamp);
+    this.benchmark = new FlutterAnalyzeBenchmark(sdk, commit, timestamp);
   }
 }
 
 class AnalyzerServerTask extends AnalyzerTask {
   AnalyzerServerTask(String sdk, String commit, DateTime timestamp) : super('analyzer_server__analysis_time') {
-    this.benchmark = new FlutterAnalyzeAppBenchmark(onCancel, sdk, commit, timestamp);
+    this.benchmark = new FlutterAnalyzeAppBenchmark(sdk, commit, timestamp);
   }
 }
 
 class FlutterAnalyzeBenchmark extends Benchmark {
-  FlutterAnalyzeBenchmark(Future<Null> onCancel, this.sdk, this.commit, this.timestamp)
-    : super('flutter analyze --flutter-repo', onCancel);
+  FlutterAnalyzeBenchmark(this.sdk, this.commit, this.timestamp)
+    : super('flutter analyze --flutter-repo');
 
   final String sdk;
   final String commit;
@@ -70,15 +70,15 @@ class FlutterAnalyzeBenchmark extends Benchmark {
   Future<num> run() async {
     rm(benchmarkFile);
     await inDirectory(config.flutterDirectory, () async {
-      await flutter('analyze', onCancel, options: ['--flutter-repo', '--benchmark']);
+      await flutter('analyze', options: ['--flutter-repo', '--benchmark']);
     });
     return addBuildInfo(benchmarkFile, timestamp: timestamp, expected: 25.0, sdk: sdk, commit: commit);
   }
 }
 
 class FlutterAnalyzeAppBenchmark extends Benchmark {
-  FlutterAnalyzeAppBenchmark(Future<Null> onCancel, this.sdk, this.commit, this.timestamp)
-    : super('analysis server mega_gallery', onCancel);
+  FlutterAnalyzeAppBenchmark(this.sdk, this.commit, this.timestamp)
+    : super('analysis server mega_gallery');
 
   final String sdk;
   final String commit;
@@ -92,7 +92,7 @@ class FlutterAnalyzeAppBenchmark extends Benchmark {
 
   Future<Null> init() {
     return inDirectory(config.flutterDirectory, () async {
-      await dart(['dev/tools/mega_gallery.dart'], onCancel);
+      await dart(['dev/tools/mega_gallery.dart']);
     });
   }
 
@@ -100,7 +100,7 @@ class FlutterAnalyzeAppBenchmark extends Benchmark {
   Future<num> run() async {
     rm(benchmarkFile);
     await inDirectory(megaDir, () async {
-      await flutter('analyze', onCancel, options: ['--watch', '--benchmark']);
+      await flutter('analyze', options: ['--watch', '--benchmark']);
     });
     return addBuildInfo(benchmarkFile, timestamp: timestamp, expected: 10.0, sdk: sdk, commit: commit);
   }

--- a/agent/lib/src/benchmarks.dart
+++ b/agent/lib/src/benchmarks.dart
@@ -7,10 +7,9 @@ import 'dart:async';
 import 'framework.dart';
 
 abstract class Benchmark {
-  Benchmark(this.name, this.onCancel);
+  Benchmark(this.name);
 
   final String name;
-  final Future<Null> onCancel;
 
   TaskResultData bestResult;
 

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -68,13 +68,15 @@ class RunCommand extends Command {
             await agent.updateTaskStatus(task.key, 'Failed');
           }
         }
-      });
+      }).timeout(taskTimeout);
     } catch(error, chain) {
       // TODO(yjbanov): upload logs
       print('Caught: $error\n${(chain as Chain).terse}');
       if (task.key != null)
         await agent.updateTaskStatus(task.key, 'Failed');
-      exit(1);
+      exitCode = 1;
+    } finally {
+      await forceQuitRunningProcesses();
     }
   }
 }

--- a/agent/lib/src/gallery.dart
+++ b/agent/lib/src/gallery.dart
@@ -21,8 +21,8 @@ class GalleryTransitionTest extends Task {
     device.unlock();
     Directory galleryDirectory = dir('${config.flutterDirectory.path}/examples/flutter_gallery');
     await inDirectory(galleryDirectory, () async {
-      await pub('get', onCancel);
-      await flutter('drive', onCancel, options: [
+      await pub('get');
+      await flutter('drive', options: [
         '--profile',
         '--trace-startup',
         '-t',

--- a/agent/lib/src/perf_tests.dart
+++ b/agent/lib/src/perf_tests.dart
@@ -45,8 +45,8 @@ class StartupTest extends Task {
     return await inDirectory(testDirectory, () async {
       Adb device = await adb();
       device.unlock();
-      await pub('get', onCancel);
-      await flutter('run', onCancel, options: [
+      await pub('get');
+      await flutter('run', options: [
         '--profile',
         '--trace-startup',
         '-d',
@@ -77,8 +77,8 @@ class PerfTest extends Task {
     return inDirectory(testDirectory, () async {
       Adb device = await adb();
       device.unlock();
-      await pub('get', onCancel);
-      await flutter('drive', onCancel, options: [
+      await pub('get');
+      await flutter('drive', options: [
         '--profile',
         '--trace-startup', // Enables "endless" timeline event buffering.
         '-t',
@@ -107,10 +107,10 @@ class BuildTest extends Task {
     return await inDirectory(testDirectory, () async {
       Adb device = await adb();
       device.unlock();
-      await pub('get', onCancel);
+      await pub('get');
 
       var watch = new Stopwatch()..start();
-      await flutter('build', onCancel, options: [
+      await flutter('build', options: [
         'aot',
         '--profile',
         '--no-pub',

--- a/agent/lib/src/refresh.dart
+++ b/agent/lib/src/refresh.dart
@@ -31,7 +31,7 @@ class EditRefreshTask extends Task {
   Future<TaskResultData> run() async {
     Adb device = await adb();
     device.unlock();
-    Benchmark benchmark = new EditRefreshBenchmark(commit, timestamp, onCancel);
+    Benchmark benchmark = new EditRefreshBenchmark(commit, timestamp);
     section(benchmark.name);
     await runBenchmark(benchmark, iterations: 3, warmUpBenchmark: true);
     return benchmark.bestResult;
@@ -39,8 +39,8 @@ class EditRefreshTask extends Task {
 }
 
 class EditRefreshBenchmark extends Benchmark {
-  EditRefreshBenchmark(this.commit, this.timestamp, Future<Null> onCancel)
-      : super('edit refresh', onCancel);
+  EditRefreshBenchmark(this.commit, this.timestamp)
+      : super('edit refresh');
 
   final String commit;
   final DateTime timestamp;
@@ -53,7 +53,7 @@ class EditRefreshBenchmark extends Benchmark {
 
   Future<Null> init() {
     return inDirectory(config.flutterDirectory, () async {
-      await dart(['dev/tools/mega_gallery.dart'], onCancel);
+      await dart(['dev/tools/mega_gallery.dart']);
     });
   }
 
@@ -63,7 +63,7 @@ class EditRefreshBenchmark extends Benchmark {
     rm(benchmarkFile);
     int exitCode = await inDirectory(megaDir, () async {
       return await flutter(
-        'run', onCancel, options: ['-d', device.deviceId, '--resident', '--benchmark'], canFail: true
+        'run', options: ['-d', device.deviceId, '--resident', '--benchmark'], canFail: true
       );
     });
     if (exitCode != 0)

--- a/agent/lib/src/size_tests.dart
+++ b/agent/lib/src/size_tests.dart
@@ -24,15 +24,15 @@ class BasicMaterialAppSizeTest extends Task {
     int apkSizeInBytes;
 
     await inDirectory(Directory.systemTemp, () async {
-      await flutter('create', onCancel, options: [sampleAppName]);
+      await flutter('create', options: [sampleAppName]);
 
       if (!(await sampleDir.exists()))
         throw 'Failed to create sample Flutter app in ${sampleDir.path}';
 
       await inDirectory(sampleDir, () async {
-        await pub('get', onCancel);
-        await flutter('build', onCancel, options: ['clean']);
-        await flutter('build', onCancel, options: ['apk', '--release']);
+        await pub('get');
+        await flutter('build', options: ['clean']);
+        await flutter('build', options: ['apk', '--release']);
         apkSizeInBytes = await file('${sampleDir.path}/build/app.apk').length();
       });
     });


### PR DESCRIPTION
Instead of passing `onKill`/`onCancel` futures around, store running
processes in a global list. When a task times out, force-quit all
processes still in the list.

Fixes #22 

/cc @cbracken 
