### PR TITLE
report & show agent health; color-code flaky successes

### DIFF
--- a/agent/bin/agent.dart
+++ b/agent/bin/agent.dart
@@ -59,7 +59,7 @@ Future<Null> main(List<String> rawArgs) async {
     exit(1);
   }
 
-  print('Agent configuration:');
+  section('Agent configuration:');
   print(config);
 
   await command.run(args.command);

--- a/agent/lib/src/adb.dart
+++ b/agent/lib/src/adb.dart
@@ -46,6 +46,22 @@ class Adb {
   // 015d172c98400a03       device usb:340787200X product:nakasi model:Nexus_7 device:grouper
   static final RegExp _kDeviceRegex = new RegExp(r'^(\S+)\s+(\S+)(.*)');
 
+  static Future<Map<String, HealthCheckResult>> checkDevices() async {
+    Map<String, HealthCheckResult> results = <String, HealthCheckResult>{};
+    for (String deviceId in await deviceIds) {
+      try {
+        Adb device = new Adb(deviceId: deviceId);
+        // Just a smoke test that we can read wakefulness state
+        // TODO(yjbanov): check battery level
+        await device._getWakefulness();
+        results['android-device-$deviceId'] = new HealthCheckResult.success();
+      } catch(e, s) {
+        results['android-device-$deviceId'] = new HealthCheckResult.error(e, s);
+      }
+    }
+    return results;
+  }
+
   static Future<List<String>> get deviceIds async {
     List<String> output = (await eval(config.adbPath, ['devices', '-l'], canFail: false))
         .trim().split('\n');

--- a/agent/lib/src/firebase.dart
+++ b/agent/lib/src/firebase.dart
@@ -16,9 +16,17 @@ Firebase _measurements() {
       auth: firebaseToken);
 }
 
-Future<Null> checkFirebaseConnection() async {
-  if (await _measurements().child('dashboard_bot_status').child('current').get() == null) {
-    throw 'Connection to Firebase is unhealthy. Failed to read the current dashboard_bot_status entity.';
+Future<HealthCheckResult> checkFirebaseConnection() async {
+  try {
+    if ((await _measurements().child('dashboard_bot_status').child('current').get()).val == null) {
+      return new HealthCheckResult.failure(
+        'Connection to Firebase is unhealthy. Failed to read the current dashboard_bot_status entity.'
+      );
+    } else {
+      return new HealthCheckResult.success();
+    }
+  } catch (e, s) {
+    return new HealthCheckResult.error(e, s);
   }
 }
 

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -38,6 +38,31 @@ class ProcessInfo {
   }
 }
 
+/// Result of a health check for a specific parameter.
+class HealthCheckResult {
+  HealthCheckResult.success([this.details]) : succeeded = true;
+  HealthCheckResult.failure(this.details) : succeeded = false;
+  HealthCheckResult.error(dynamic error, dynamic stackTrace)
+    : succeeded = false,
+      details = 'ERROR: $error\n${stackTrace ?? ''}';
+
+  final bool succeeded;
+  final String details;
+
+  @override
+  String toString() {
+    StringBuffer buf = new StringBuffer(succeeded ? 'succeeded' : 'failed');
+    if (details != null && details.trim().isNotEmpty) {
+      buf.writeln();
+      // Indent details by 4 spaces
+      for (String line in details.trim().split('\n')) {
+        buf.writeln('    $line');
+      }
+    }
+    return '$buf';
+  }
+}
+
 class BuildFailedError extends Error {
   BuildFailedError(this.message);
 

--- a/app/lib/entity.dart
+++ b/app/lib/entity.dart
@@ -30,6 +30,9 @@ abstract class JsonSerializer<T> {
 /// Serializes strings.
 StringSerializer string() => const StringSerializer();
 
+/// Serializes booleans.
+BoolSerializer boolean() => const BoolSerializer();
+
 /// Serializes ints and doubles.
 NumSerializer number() => const NumSerializer();
 
@@ -81,6 +84,15 @@ class StringSerializer implements JsonSerializer<String> {
     return jsonValue as String;
   }
   dynamic serialize(String value) => value;
+}
+
+class BoolSerializer implements JsonSerializer<bool> {
+  const BoolSerializer();
+
+  bool deserialize(dynamic jsonValue) {
+    return jsonValue as bool;
+  }
+  dynamic serialize(bool value) => value;
 }
 
 class NumSerializer implements JsonSerializer<num> {

--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -36,6 +36,7 @@ class GetStatusResult extends Entity {
     (Map<String, dynamic> props) => new GetStatusResult(props),
     <String, JsonSerializer>{
       'Statuses': listOf(BuildStatus._serializer),
+      'AgentStatuses': listOf(AgentStatus._serializer),
     }
   );
 
@@ -45,6 +46,7 @@ class GetStatusResult extends Entity {
   GetStatusResult([Map<String, dynamic> props]) : super(_serializer, props);
 
   List<BuildStatus> get statuses => this['Statuses'];
+  List<AgentStatus> get agentStatuses => this['AgentStatuses'];
 }
 
 class BuildStatus extends Entity {
@@ -60,6 +62,25 @@ class BuildStatus extends Entity {
 
   ChecklistEntity get checklist => this['Checklist'];
   List<Stage> get stages => this['Stages'];
+}
+
+class AgentStatus extends Entity {
+  static final _serializer = new EntitySerializer(
+    (Map<String, dynamic> props) => new AgentStatus(props),
+    <String, JsonSerializer>{
+    	'AgentID': string(),
+    	'IsHealthy': boolean(),
+    	'HealthCheckTimestamp': dateTime(),
+    	'HealthDetails': string(),
+    }
+  );
+
+  AgentStatus([Map<String, dynamic> props]) : super(_serializer, props);
+
+  String get agentId => this['AgentID'];
+  bool get isHealthy => this['IsHealthy'];
+  DateTime get healthCheckTimestamp => this['HealthCheckTimestamp'];
+  String get healthDetails => this['HealthDetails'];
 }
 
 class CommitInfo extends Entity {
@@ -164,6 +185,7 @@ class Task extends Entity {
       'Status': string(),
       'StartTimestamp': dateTime(),
       'EndTimestamp': dateTime(),
+      'Attempts': number(),
     }
   );
 
@@ -175,4 +197,5 @@ class Task extends Entity {
   String get status => this['Status'];
   DateTime get startTimestamp => this['StartTimestamp'];
   DateTime get endTimestamp => this['EndTimestamp'];
+  int get attempts => this['Attempts'];
 }

--- a/app/main.go
+++ b/app/main.go
@@ -33,6 +33,7 @@ func init() {
 	registerRPC("/api/refresh-travis-status", commands.RefreshTravisStatus)
 	registerRPC("/api/refresh-chromebot-status", commands.RefreshChromebotStatus)
 	registerRPC("/api/reserve-task", commands.ReserveTask)
+	registerRPC("/api/update-agent-health", commands.UpdateAgentHealth)
 	registerRPC("/api/update-task-status", commands.UpdateTaskStatus)
 	registerRPC("/api/vacuum-clean", commands.VacuumClean)
 

--- a/app/web/buildStyles.css
+++ b/app/web/buildStyles.css
@@ -298,12 +298,16 @@ td.stats-value {
   background-color: green;
   cursor: pointer;
 }
+.task-succeeded-but-flaky {
+  background-color: #cccc00;
+  cursor: pointer;
+}
 .task-failed {
   background-color: red;
   cursor: pointer;
 }
 .task-underperformed {
-  background-color: yellow;
+  background-color: orange;
   cursor: pointer;
 }
 .task-skipped {
@@ -321,4 +325,37 @@ td.stats-value {
   100% {
     transform: rotateZ(180deg);
   }
+}
+
+.agent-bar {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.agent-bar > * {
+  align-self: center;
+  padding: 7px;
+}
+
+.agent-chip {
+  border-radius: 2px;
+  margin-left: 10px;
+  color: white;
+  cursor: pointer;
+}
+
+.agent-healthy {
+  background-color: #33CC33;
+}
+
+.agent-unhealthy {
+  background-color: #CC3333;
+}
+
+.agent-health-details-card {
+  position: relative;
+  background-color: #DDD;
+  border-radius: 2px;
+  padding: 15px;
+  margin-bottom: 10px;
 }

--- a/commands/update_agent_health.go
+++ b/commands/update_agent_health.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"cocoon/db"
+	"encoding/json"
+	"fmt"
+)
+
+// UpdateAgentHealthCommand updates health status of an agent.
+type UpdateAgentHealthCommand struct {
+	AgentID       string
+	IsHealthy     bool   // overall health status
+	HealthDetails string // a human-readable printout health details
+}
+
+// UpdateAgentHealth updates health status of an agent.
+func UpdateAgentHealth(cocoon *db.Cocoon, inputJSON []byte) (interface{}, error) {
+	agent := cocoon.CurrentAgent()
+
+	if agent == nil {
+		return nil, fmt.Errorf("This command must be executed by an agent")
+	}
+
+	var command *UpdateAgentHealthCommand
+	err := json.Unmarshal(inputJSON, &command)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if agent.AgentID != command.AgentID {
+		messageFormat := "Currently signed in agent's ID (%v) does not match agent ID supplied in the request (%v)"
+		return nil, fmt.Errorf(messageFormat, agent.AgentID, command.AgentID)
+	}
+
+	agent.IsHealthy = command.IsHealthy
+	agent.HealthDetails = command.HealthDetails
+	agent.HealthCheckTimestamp = db.NowMillis()
+
+	if err := cocoon.UpdateAgent(agent); err != nil {
+		return nil, err
+	}
+
+	return "OK", nil
+}

--- a/db/schema.go
+++ b/db/schema.go
@@ -115,7 +115,17 @@ type Agent struct {
 	AgentID              string
 	IsHealthy            bool
 	HealthCheckTimestamp int64
+	HealthDetails        string // a human-readable printout of health details
 	AuthTokenHash        []byte
+	Capabilities         []string
+}
+
+// AgentStatus contains agent health status.
+type AgentStatus struct {
+	AgentID              string
+	IsHealthy            bool
+	HealthCheckTimestamp int64
+	HealthDetails        string
 	Capabilities         []string
 }
 


### PR DESCRIPTION
- Add more health checks:
  - can we talk to all connected devices via `adb`?
  - do we have at least one healthy Android device?
  - can we connect to Firebase?
  - can we connect to Cocoon backend? (relevant for pre-flight check only; if fails while running CI we won't be able to upload the health check to Cocoon)
- Upload health status to Cocoon before each task
- Show agent health status on the dashboard (and track health check age)
- Color code successful tasks that succeeded after >1 attempts (i.e. flaky)
- Fix Firebase health check (we never read the value and always succeeded)

Fixes https://github.com/flutter/cocoon/issues/15

/cc @cbracken 
