### PR TITLE
don't pass in the (removed) --resident cli arg

### DIFF
--- a/agent/lib/src/refresh.dart
+++ b/agent/lib/src/refresh.dart
@@ -63,7 +63,7 @@ class EditRefreshBenchmark extends Benchmark {
     rm(benchmarkFile);
     int exitCode = await inDirectory(megaDir, () async {
       return await flutter(
-        'run', options: ['-d', device.deviceId, '--resident', '--benchmark'], canFail: true
+        'run', options: ['-d', device.deviceId, '--benchmark'], canFail: true
       );
     });
     if (exitCode != 0)


### PR DESCRIPTION
Don't use the `--resident` flag, which doesn't exist anymore (fix https://github.com/flutter/flutter/issues/5285); @yjbanov.
