### PR TITLE
run tests on iOS

### DIFF
--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -82,11 +82,15 @@ class Agent {
 
     List<Task> allTasks = <Task>[
       createComplexLayoutScrollPerfTest(),
+      createComplexLayoutScrollPerfTest(ios: true),
       createFlutterGalleryStartupTest(),
+      createFlutterGalleryStartupTest(ios: true),
       createComplexLayoutStartupTest(),
+      createComplexLayoutStartupTest(ios: true),
       createFlutterGalleryBuildTest(),
       createComplexLayoutBuildTest(),
       createGalleryTransitionTest(),
+      createGalleryTransitionTest(ios: true),
       createBasicMaterialAppSizeTest(),
       createAnalyzerCliTest(sdk: dartSdkVersion, commit: task.revision, timestamp: revisionTimestamp),
       createAnalyzerServerTest(sdk: dartSdkVersion, commit: task.revision, timestamp: revisionTimestamp),

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -57,7 +57,7 @@ class RunCommand extends Command {
     try {
       await runAndCaptureAsyncStacks(() async {
         // Load-balance tests across attached devices
-        pickNextDevice();
+        await pickNextDevice();
 
         BuildResult result = await agent.performTask(task);
         if (task.key != null) {

--- a/agent/lib/src/gallery.dart
+++ b/agent/lib/src/gallery.dart
@@ -10,25 +10,32 @@ import 'adb.dart';
 import 'framework.dart';
 import 'utils.dart';
 
-Task createGalleryTransitionTest() => new GalleryTransitionTest();
+Task createGalleryTransitionTest({ bool ios: false }) => new GalleryTransitionTest(ios: ios);
 
 class GalleryTransitionTest extends Task {
-  GalleryTransitionTest() : super('flutter_gallery__transition_perf');
+  GalleryTransitionTest({ this.ios }) : super('flutter_gallery__transition_perf');
+
+  final bool ios;
 
   @override
   Future<TaskResultData> run() async {
-    Adb device = await adb();
-    device.unlock();
+    String deviceId = await getUnlockedDeviceId(ios: ios);
     Directory galleryDirectory = dir('${config.flutterDirectory.path}/examples/flutter_gallery');
     await inDirectory(galleryDirectory, () async {
       await pub('get');
+
+      if (ios) {
+        // This causes an Xcode project to be created.
+        await flutter('build', options: ['ios', '--profile']);
+      }
+
       await flutter('drive', options: [
         '--profile',
         '--trace-startup',
         '-t',
         'test_driver/transitions_perf.dart',
         '-d',
-        device.deviceId,
+        deviceId,
       ]);
     });
 


### PR DESCRIPTION
Enables the agents to run iOS tests.

Note: this does not yet add the tests to the CI builds. They are known to be broken. I'll do that in a separate PR.

/cc @devoncarew @chinmaygarde 
