### PR TITLE
display attempt counts; show more commits; run new tasks first

### DIFF
--- a/app/lib/components/status_table.dart
+++ b/app/lib/components/status_table.dart
@@ -67,6 +67,7 @@ import 'package:http/http.dart' as http;
     <td class="task-status-cell" *ngFor="let metaTask of headerRow.allMetaTasks">
       <div [ngClass]="getStatusStyle(status.checklist.checklist.commit.sha, metaTask.name)"
            (click)="openLog(status.checklist.checklist.commit.sha, metaTask.name)">
+        {{getAttempts(status.checklist.checklist.commit.sha, metaTask.name)}}
       </div>
     </td>
   </tr>
@@ -141,6 +142,8 @@ class StatusTable implements OnInit {
     String cssClass;
     if (taskStatus == 'Succeeded' && attempts > 1) {
       cssClass = 'task-succeeded-but-flaky';
+    } else if (taskStatus == 'New' && attempts > 1) {
+      cssClass = 'task-underperformed';
     } else {
       cssClass = statusMap[taskStatus] ?? 'task-unknown';
     }
@@ -164,6 +167,17 @@ class StatusTable implements OnInit {
       return taskStatusToCssStyle('Skipped', 0);
 
     return taskStatusToCssStyle(taskEntity.task.status, taskEntity.task.attempts);
+  }
+
+  String getAttempts(String sha, String taskName) {
+    TaskEntity taskEntity = _findTask(sha, taskName);
+
+    if (taskEntity == null)
+      return '';
+
+    int attempts = taskEntity.task.attempts;
+    bool succeededImmediately = attempts == 1 && taskEntity.task.status == 'Succeeded';
+    return attempts == 0 || succeededImmediately ? '' : '${attempts}';
   }
 
   List<String> getAgentStyle(AgentStatus status) {

--- a/app/web/buildStyles.css
+++ b/app/web/buildStyles.css
@@ -284,14 +284,16 @@ td.stats-value {
   border-radius: 10px;
   height: 20px;
   width: 20px;
+  text-align: center;
+  color: white;
 }
 
 .task-new {
   background-color: #CCCCFF;
 }
 .task-in-progress {
-  background: linear-gradient(0deg, blue 0%, blue 40%, white 41%, white 59%, blue 60%, blue 100%);;
-  animation: inProgressAnimation 2s infinite linear;
+  background-color: blue;
+  animation: inProgressAnimation 3s infinite linear;
   cursor: pointer;
 }
 .task-succeeded {
@@ -323,7 +325,7 @@ td.stats-value {
     transform: rotateZ(0deg);
   }
   100% {
-    transform: rotateZ(180deg);
+    transform: rotateZ(360deg);
   }
 }
 

--- a/commands/get_status.go
+++ b/commands/get_status.go
@@ -25,7 +25,9 @@ type BuildStatus struct {
 // GetStatus returns current build status.
 func GetStatus(c *db.Cocoon, inputJSON []byte) (interface{}, error) {
 	var err error
-	checklists, err := c.QueryLatestChecklists()
+
+	const maxStatusesToReturn = 50
+	checklists, err := c.QueryLatestChecklists(maxStatusesToReturn)
 
 	if err != nil {
 		return nil, err

--- a/db/db.go
+++ b/db/db.go
@@ -87,8 +87,8 @@ func (c *Cocoon) GetChecklist(key *datastore.Key) (*ChecklistEntity, error) {
 
 // QueryLatestChecklists queries the datastore for the latest checklists sorted
 // by CreateTimestamp in descending order. Returns up to 20 entities.
-func (c *Cocoon) QueryLatestChecklists() ([]*ChecklistEntity, error) {
-	query := datastore.NewQuery("Checklist").Order("-CreateTimestamp").Limit(20)
+func (c *Cocoon) QueryLatestChecklists(limit int) ([]*ChecklistEntity, error) {
+	query := datastore.NewQuery("Checklist").Order("-CreateTimestamp").Limit(limit)
 	var buffer []*ChecklistEntity
 	for iter := query.Run(c.Ctx); ; {
 		var checklist Checklist
@@ -193,7 +193,8 @@ func (c *Cocoon) QueryAllPendingTasks() ([]*FullTask, error) {
 //
 // See also IsFinal.
 func (c *Cocoon) QueryPendingTasks(taskName string) ([]*FullTask, error) {
-	checklists, err := c.QueryLatestChecklists()
+	const maxChecklistsToScan = 20
+	checklists, err := c.QueryLatestChecklists(maxChecklistsToScan)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When a task fails we retry it immediately. This is annoying when you
want to get the overall picture quickly as the agent can get stuck
retrying a task that keeps timing out. This change will cause the
agents to run through all tasks before retrying the failed ones.

Bonus: display and color-code attempt counts on the dashboard; show
more commits on the page

Fixes https://github.com/flutter/cocoon/issues/33

/cc @cbracken 
