### PR TITLE
time out startup tests sooner

### DIFF
--- a/agent/lib/src/perf_tests.dart
+++ b/agent/lib/src/perf_tests.dart
@@ -45,6 +45,7 @@ Task createComplexLayoutBuildTest() {
 
 /// Measure application startup performance.
 class StartupTest extends Task {
+  static const Duration _startupTimeout = const Duration(minutes: 10);
 
   StartupTest(String name, this.testDirectory, { this.ios }) : super(name);
 
@@ -66,7 +67,7 @@ class StartupTest extends Task {
         '--trace-startup',
         '-d',
         deviceId
-      ]);
+      ]).timeout(_startupTimeout);
       Map<String, dynamic> data = JSON.decode(file('$testDirectory/build/start_up_info.json').readAsStringSync());
       return new TaskResultData(data, benchmarkScoreKeys: <String>[
         'engineEnterTimestampMicros',


### PR DESCRIPTION
Due to https://github.com/flutter/flutter/issues/5477 flutter run
is unable to exit when an error occurs. Currently our tests get
stuck until the default timeout of 10 minutes expires. That's way
too long for a startup test. This PR customizes the timeout for
startup tests to 2 minutes.

/cc @cbracken 
