### PR TITLE
actually reduce the timeout of startup tests

### DIFF
--- a/agent/lib/src/perf_tests.dart
+++ b/agent/lib/src/perf_tests.dart
@@ -45,7 +45,7 @@ Task createComplexLayoutBuildTest() {
 
 /// Measure application startup performance.
 class StartupTest extends Task {
-  static const Duration _startupTimeout = const Duration(minutes: 10);
+  static const Duration _startupTimeout = const Duration(minutes: 2);
 
   StartupTest(String name, this.testDirectory, { this.ios }) : super(name);
 


### PR DESCRIPTION
Oops! Accidentally configured it to the same 10-minute timeout instead of 2.

TBR: @cbracken 
