### PR TITLE
scrape possible remote access IP and report with health checks

### DIFF
--- a/app/lib/components/status_table.dart
+++ b/app/lib/components/status_table.dart
@@ -41,7 +41,7 @@ import 'package:http/http.dart' as http;
     {{agentHealthCheckAge(displayedAgentStatus.healthCheckTimestamp)}}
   </div>
   <div>Details:</div>
-  <div>{{displayedAgentStatus.healthDetails}}</div>
+  <pre>{{displayedAgentStatus.healthDetails}}</pre>
 </div>
 
 <table class="status-table"


### PR DESCRIPTION
This will simplify remote access as the IP will be displayed on
the dashboard with the rest of the health checks.

Bonus: use `<pre>` to ascii-format health check info on the dashboard

Fixes https://github.com/flutter/cocoon/issues/36

/cc @cbracken 
