### PR TITLE
kill obsolete logic for preserving local modifications

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -361,24 +361,10 @@ String jsonEncode(dynamic data) {
   return new JsonEncoder.withIndent('  ').convert(data) + '\n';
 }
 
-Future<bool> getFlutter(String revision) async {
+Future<Null> getFlutter(String revision) async {
   section('Get Flutter!');
 
-  if (exists(dir('${config.flutterDirectory.path}/.git'))) {
-    bool hasLocalChanges = await inDirectory(config.flutterDirectory, () async {
-      String unstagedChanges = await eval('git', ['diff', '--numstat']);
-      String stagedChanges = await eval('git', ['diff', '--numstat', '--cached']);
-      return unstagedChanges.trim().isNotEmpty || stagedChanges.trim().isNotEmpty;
-    });
-
-    if (hasLocalChanges) {
-      section('WARNING');
-      print(
-        'Pending changes detected in the local Flutter repo. Will skip syncing '
-        'Flutter repo. The build will continue but it will marked as failed.'
-      );
-      return false;
-    }
+  if (exists(config.flutterDirectory)) {
     rrm(config.flutterDirectory);
   }
 
@@ -397,7 +383,6 @@ Future<bool> getFlutter(String revision) async {
 
   section('flutter update-packages');
   await flutter('update-packages');
-  return true;
 }
 
 void checkNotNull(Object o1, [Object o2 = 1, Object o3 = 1, Object o4 = 1,


### PR DESCRIPTION
In the past we didn't have a way to run individual tasks at current revision of Flutter. Now we do: `dart agent.dart run [options]`. The logic is dangerous as it may cause us to run tests against the wrong flutter revision, as it did today.

TBR: @devoncarew 
