### PR TITLE
self-destruct when a task goes bad

### DIFF
--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -77,6 +77,14 @@ class RunCommand extends Command {
     } finally {
       await forceQuitRunningProcesses();
     }
+
+    if (exitCode != 0) {
+      // Force-quitting child processes sometimes causes the Dart VM to fail to
+      // exit. So we give a 2-second grace period for any pending cleanups, then
+      // self-destruct.
+      await new Future<Null>.delayed(const Duration(seconds: 2));
+      exit(exitCode);
+    }
   }
 }
 


### PR DESCRIPTION
The Dart VM sometimes retains phantom "ports" and is unable to exit
when child processes are force-quit.

/cc @cbracken 
