### PR TITLE
reduce task retry count 3 -> 2; do not start adb when restarting

### DIFF
--- a/agent/lib/src/adb.dart
+++ b/agent/lib/src/adb.dart
@@ -84,20 +84,13 @@ class Adb {
     return results;
   }
 
-  /// Kills and restarts the `adb` server.
+  /// Kills the `adb` server causing it to start a new instance upon next
+  /// command.
   ///
   /// Restarting `adb` helps with keeping device connections alive. When `adb`
   /// runs non-stop for too long it loses connections to devices.
   static Future restart() async {
-    int exitCode = await exec(config.adbPath, ['kill-server'], canFail: false);
-
-    if (exitCode != 0)
-      throw 'Failed to kill ADB server';
-
-    exitCode = await exec(config.adbPath, ['start-server'], canFail: false);
-
-    if (exitCode != 0)
-      throw 'Failed to start ADB server';
+    await exec(config.adbPath, ['kill-server'], canFail: false);
   }
 
   static Future<List<String>> get deviceIds async {

--- a/db/schema.go
+++ b/db/schema.go
@@ -83,7 +83,7 @@ type Task struct {
 
 // MaxAttempts is the maximum number of times a single task will be attempted
 // before giving up on it.
-const MaxAttempts = 3
+const MaxAttempts = 2
 
 // TaskStatus indicates the status of a task.
 type TaskStatus string


### PR DESCRIPTION
Rationale:

Failing tasks tend to hand due to
https://github.com/flutter/flutter/issues/5477. This is a quick fix to
unblock the dashboard when there are many failing tasks.

For some reason `adb start-server` sometimes fails to exit. This change
removes this command. It should be safe to only kill the server because
any `adb` command causes it to start automatically anyway.

/cc @cbracken 
