### PR TITLE
read tasks from manifest; misc. fixes

### DIFF
--- a/app/bin/build_and_test.sh
+++ b/app/bin/build_and_test.sh
@@ -10,7 +10,7 @@ if [ ! -f "pubspec.yaml" -a ! -f "app.yaml" ]; then
 fi
 
 rm -rf build
-pub get
+pub get --no-packages-dir
 pub run test
 pub build
 cp web/*.dart build/web/

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/cocoon
 environment:
   sdk: '>=1.13.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.17
+  angular2: 2.0.0-beta.21
   args: ^0.13.4
   browser: ^0.10.0
   charted: ^0.4.0

--- a/commands/get_status.go
+++ b/commands/get_status.go
@@ -35,11 +35,11 @@ func GetStatus(c *db.Cocoon, inputJSON []byte) (interface{}, error) {
 
 	var statuses []*BuildStatus
 	for _, checklist := range checklists {
-		// Need to define another error variable to not "shadow" the other one, Go figure!
-		stages, errr := c.QueryTasksGroupedByStage(checklist.Key)
+		var stages []*db.Stage
+		stages, err = c.QueryTasksGroupedByStage(checklist.Key)
 
-		if errr != nil {
-			return nil, errr
+		if err != nil {
+			return nil, err
 		}
 
 		statuses = append(statuses, &BuildStatus{

--- a/commands/refresh_chromebot_status.go
+++ b/commands/refresh_chromebot_status.go
@@ -8,9 +8,6 @@ import (
 	"cocoon/db"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-
-	"google.golang.org/appengine/urlfetch"
 )
 
 // RefreshChromebotStatusResult contains chromebot status results.
@@ -113,15 +110,8 @@ func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderName string) ([]*Chro
 }
 
 func fetchJSON(cocoon *db.Cocoon, url string) (interface{}, error) {
-	httpClient := urlfetch.Client(cocoon.Ctx)
-	response, err := httpClient.Get(url)
-	if err != nil {
-		return nil, err
-	}
+	body, err := cocoon.FetchURL(url)
 
-	defer response.Body.Close()
-
-	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/refresh_travis_status.go
+++ b/commands/refresh_travis_status.go
@@ -7,9 +7,6 @@ package commands
 import (
 	"cocoon/db"
 	"encoding/json"
-	"io/ioutil"
-
-	"google.golang.org/appengine/urlfetch"
 )
 
 // RefreshTravisStatusResult pulls down the latest Travis builds and updates
@@ -40,15 +37,7 @@ func RefreshTravisStatus(cocoon *db.Cocoon, inputJSON []byte) (interface{}, erro
 	}
 
 	// Fetch data from Travis
-	httpClient := urlfetch.Client(cocoon.Ctx)
-	travisResp, err := httpClient.Get("https://api.travis-ci.org/repos/flutter/flutter/builds")
-	if err != nil {
-		return nil, err
-	}
-
-	defer travisResp.Body.Close()
-
-	buildData, err := ioutil.ReadAll(travisResp.Body)
+	buildData, err := cocoon.FetchURL("https://api.travis-ci.org/repos/flutter/flutter/builds")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is phase 1 of moving all our CI tests into the flutter/flutter repo. Phase 2 will be to run from the [sources](https://github.com/flutter/flutter/tree/master/dev/devicelab/bin/tasks) in the flutter/flutter repo.
- read tasks from manifest instead of hard-coding
- create a reusable FetchURL method
- switch away from the packages directory
- remove the `errr` hack
