### PR TITLE
Split Android/iOS impl behind a unified interface

### DIFF
--- a/agent/config.sample.yaml
+++ b/agent/config.sample.yaml
@@ -33,8 +33,5 @@ auth_token: blahblahblah
 # get a Firebase token.
 firebase_flutter_dashboard_token: blahblahblah
 
-# Whether the device tests on Android (true by default)
-tests_android: true
-
-# Whether the device tests on iOS (false by default)
-tests_ios: false
+# The device operating system. Possible values: android, ios.
+device_os: android

--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -62,7 +62,7 @@ class Agent {
 
   Future<Null> _screenOff() async {
     try {
-      await (await adb()).sendToSleep();
+      await devices.workingDevice.sendToSleep();
     } catch(error, stackTrace) {
       print('Failed to turn off screen: $error\n$stackTrace');
     }

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -57,7 +57,7 @@ class RunCommand extends Command {
     try {
       await runAndCaptureAsyncStacks(() async {
         // Load-balance tests across attached devices
-        await pickNextDevice();
+        await devices.chooseWorkingDevice();
 
         BuildResult result = await agent.performTask(task);
         if (task.key != null) {

--- a/agent/lib/src/gallery.dart
+++ b/agent/lib/src/gallery.dart
@@ -21,7 +21,7 @@ class GalleryTransitionTest extends Task {
 
   @override
   Future<TaskResultData> run() async {
-    String deviceId = await getUnlockedDeviceId(ios: ios);
+    String deviceId = devices.workingDevice.deviceId;
     Directory galleryDirectory = dir('${config.flutterDirectory.path}/examples/flutter_gallery');
     await inDirectory(galleryDirectory, () async {
       await flutter('packages', options: ['get']);

--- a/agent/lib/src/hot_dev_cycle.dart
+++ b/agent/lib/src/hot_dev_cycle.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import 'adb.dart';
-import 'benchmarks.dart';
 import 'framework.dart';
 import 'utils.dart';
 
@@ -41,7 +40,7 @@ class HotDevCycleTask extends Task {
 
   @override
   Future<TaskResultData> run() async {
-    Adb device = await adb();
+    Device device = devices.workingDevice;
     device.unlock();
     rm(benchmarkFile);
     await inDirectory(appDir, () async {

--- a/agent/lib/src/perf_tests.dart
+++ b/agent/lib/src/perf_tests.dart
@@ -54,7 +54,7 @@ class StartupTest extends Task {
 
   Future<TaskResultData> run() async {
     return await inDirectory(testDirectory, () async {
-      String deviceId = await getUnlockedDeviceId(ios: ios);
+      String deviceId = devices.workingDevice.deviceId;
       await flutter('packages', options: ['get']);
 
       if (ios) {
@@ -92,7 +92,7 @@ class PerfTest extends Task {
   @override
   Future<TaskResultData> run() {
     return inDirectory(testDirectory, () async {
-      String deviceId = await getUnlockedDeviceId(ios: ios);
+      String deviceId = devices.workingDevice.deviceId;
       await flutter('packages', options: ['get']);
 
       if (ios) {
@@ -127,7 +127,7 @@ class BuildTest extends Task {
 
   Future<TaskResultData> run() async {
     return await inDirectory(testDirectory, () async {
-      Adb device = await adb();
+      Device device = devices.workingDevice;
       device.unlock();
       await flutter('packages', options: ['get']);
 

--- a/agent/lib/src/refresh.dart
+++ b/agent/lib/src/refresh.dart
@@ -29,7 +29,7 @@ class EditRefreshTask extends Task {
 
   @override
   Future<TaskResultData> run() async {
-    Adb device = await adb();
+    Device device = devices.workingDevice;
     device.unlock();
     Benchmark benchmark = new EditRefreshBenchmark(commit, timestamp);
     section(benchmark.name);
@@ -59,7 +59,7 @@ class EditRefreshBenchmark extends Benchmark {
 
   @override
   Future<num> run() async {
-    Adb device = await adb();
+    Device device = devices.workingDevice;
     rm(benchmarkFile);
     int exitCode = await inDirectory(megaDir, () async {
       return await flutter(

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -12,6 +12,8 @@ import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 import 'package:yaml/yaml.dart';
 
+import 'adb.dart';
+
 /// Virtual current working directory, which affect functions, such as [exec].
 String cwd = Directory.current.path;
 
@@ -268,8 +270,7 @@ class Config {
     @required this.authToken,
     @required this.flutterDirectory,
     @required this.runTaskFile,
-    @required this.testsAndroid,
-    @required this.testsIos,
+    @required this.deviceOperatingSystem,
   });
 
   static void initialize(ArgResults args) {
@@ -293,6 +294,18 @@ class Config {
     Directory flutterDirectory = dir('${Platform.environment['HOME']}/.cocoon/flutter');
     mkdirs(flutterDirectory);
 
+    DeviceOperatingSystem deviceOperatingSystem;
+    switch(agentConfig['device_os']) {
+      case 'android':
+        deviceOperatingSystem = DeviceOperatingSystem.android;
+        break;
+      case 'ios':
+        deviceOperatingSystem = DeviceOperatingSystem.ios;
+        break;
+      default:
+        throw new BuildFailedError('Unrecognized device_os value: ${agentConfig['device_os']}');
+    }
+
     _config = new Config(
       baseCocoonUrl: baseCocoonUrl,
       agentId: agentId,
@@ -300,8 +313,7 @@ class Config {
       authToken: authToken,
       flutterDirectory: flutterDirectory,
       runTaskFile: runTaskFile,
-      testsAndroid: agentConfig['tests_android'] ?? true,
-      testsIos: agentConfig['tests_ios'] ?? false,
+      deviceOperatingSystem: deviceOperatingSystem,
     );
   }
 
@@ -311,8 +323,7 @@ class Config {
   final String authToken;
   final Directory flutterDirectory;
   final File runTaskFile;
-  final bool testsAndroid;
-  final bool testsIos;
+  final DeviceOperatingSystem deviceOperatingSystem;
 
   String get adbPath {
     String androidHome = Platform.environment['ANDROID_HOME'];
@@ -336,9 +347,8 @@ baseCocoonUrl: $baseCocoonUrl
 agentId: $agentId
 flutterDirectory: $flutterDirectory
 runTaskFile: $runTaskFile
-adbPath: $adbPath
-testsAndroid: $testsAndroid
-testsIos: $testsIos
+adbPath: ${deviceOperatingSystem == DeviceOperatingSystem.android ? adbPath : 'N/A'}
+deviceOperatingSystem: $deviceOperatingSystem
 '''.trim();
 }
 

--- a/agent/test/src/adb_test.dart
+++ b/agent/test/src/adb_test.dart
@@ -9,29 +9,28 @@ import 'package:collection/collection.dart';
 
 import 'package:cocoon_agent/src/adb.dart';
 
-main() {
-  group('adb', () {
-    Adb device;
+void main() {
+  group('device', () {
+    Device device;
 
     setUp(() {
-      FakeAdb.resetLog();
-      adb = null;
-      device = new FakeAdb();
+      FakeDevice.resetLog();
+      device = null;
+      device = new FakeDevice();
     });
 
     tearDown(() {
-      adb = realAdbGetter;
     });
 
     group('isAwake/isAsleep', () {
       test('reads Awake', () async {
-        FakeAdb.pretendAwake();
+        FakeDevice.pretendAwake();
         expect(await device.isAwake(), isTrue);
         expect(await device.isAsleep(), isFalse);
       });
 
       test('reads Asleep', () async {
-        FakeAdb.pretendAsleep();
+        FakeDevice.pretendAsleep();
         expect(await device.isAwake(), isFalse);
         expect(await device.isAsleep(), isTrue);
       });
@@ -48,7 +47,7 @@ main() {
 
     group('wakeUp', () {
       test('when awake', () async {
-        FakeAdb.pretendAwake();
+        FakeDevice.pretendAwake();
         await device.wakeUp();
         expectLog([
           cmd(command: 'dumpsys', arguments: ['power']),
@@ -56,7 +55,7 @@ main() {
       });
 
       test('when asleep', () async {
-        FakeAdb.pretendAsleep();
+        FakeDevice.pretendAsleep();
         await device.wakeUp();
         expectLog([
           cmd(command: 'dumpsys', arguments: ['power']),
@@ -67,7 +66,7 @@ main() {
 
     group('sendToSleep', () {
       test('when asleep', () async {
-        FakeAdb.pretendAsleep();
+        FakeDevice.pretendAsleep();
         await device.sendToSleep();
         expectLog([
           cmd(command: 'dumpsys', arguments: ['power']),
@@ -75,7 +74,7 @@ main() {
       });
 
       test('when awake', () async {
-        FakeAdb.pretendAwake();
+        FakeDevice.pretendAwake();
         await device.sendToSleep();
         expectLog([
           cmd(command: 'dumpsys', arguments: ['power']),
@@ -86,7 +85,7 @@ main() {
 
     group('unlock', () {
       test('sends unlock event', () async {
-        FakeAdb.pretendAwake();
+        FakeDevice.pretendAwake();
         await device.unlock();
         expectLog([
           cmd(command: 'dumpsys', arguments: ['power']),
@@ -98,7 +97,7 @@ main() {
 }
 
 void expectLog(List<CommandArgs> log) {
-  expect(FakeAdb.commandLog, log);
+  expect(FakeDevice.commandLog, log);
 }
 
 CommandArgs cmd({String command, List<String> arguments, Map<String, String> env}) => new CommandArgs(
@@ -142,8 +141,8 @@ class CommandArgs {
     : null.hashCode;
 }
 
-class FakeAdb extends Adb {
-  FakeAdb({String deviceId: null}) : super(deviceId: deviceId);
+class FakeDevice extends AndroidDevice {
+  FakeDevice({String deviceId: null}) : super(deviceId: deviceId);
 
   static String output = '';
   static ExitErrorFactory exitErrorFactory = () => null;

--- a/commands/refresh_github_commits.go
+++ b/commands/refresh_github_commits.go
@@ -169,5 +169,5 @@ type ManifestTask struct {
 	Name                      string
 	Description               string
 	Stage                     string
-	RequiredAgentCapabilities []string
+	RequiredAgentCapabilities []string `yaml:"required_agent_capabilities"`
 }


### PR DESCRIPTION
- Split Android/iOS impl behind a unified interface; most changes are
  in `adb.dart` (keeping the name for now), everything else just
  cascading refactoring.
- Bonus: fix deserialization of `required_agent_capabilities` manifest
  field
