### PR TITLE
Switch from pub get to flutter packages get

### DIFF
--- a/agent/lib/src/gallery.dart
+++ b/agent/lib/src/gallery.dart
@@ -24,7 +24,7 @@ class GalleryTransitionTest extends Task {
     String deviceId = await getUnlockedDeviceId(ios: ios);
     Directory galleryDirectory = dir('${config.flutterDirectory.path}/examples/flutter_gallery');
     await inDirectory(galleryDirectory, () async {
-      await pub('get');
+      await flutter('packages', options: ['get']);
 
       if (ios) {
         // This causes an Xcode project to be created.

--- a/agent/lib/src/perf_tests.dart
+++ b/agent/lib/src/perf_tests.dart
@@ -55,7 +55,7 @@ class StartupTest extends Task {
   Future<TaskResultData> run() async {
     return await inDirectory(testDirectory, () async {
       String deviceId = await getUnlockedDeviceId(ios: ios);
-      await pub('get');
+      await flutter('packages', options: ['get']);
 
       if (ios) {
         // This causes an Xcode project to be created.
@@ -93,7 +93,7 @@ class PerfTest extends Task {
   Future<TaskResultData> run() {
     return inDirectory(testDirectory, () async {
       String deviceId = await getUnlockedDeviceId(ios: ios);
-      await pub('get');
+      await flutter('packages', options: ['get']);
 
       if (ios) {
         // This causes an Xcode project to be created.
@@ -129,7 +129,7 @@ class BuildTest extends Task {
     return await inDirectory(testDirectory, () async {
       Adb device = await adb();
       device.unlock();
-      await pub('get');
+      await flutter('packages', options: ['get']);
 
       var watch = new Stopwatch()..start();
       await flutter('build', options: [

--- a/agent/lib/src/size_tests.dart
+++ b/agent/lib/src/size_tests.dart
@@ -30,7 +30,7 @@ class BasicMaterialAppSizeTest extends Task {
         throw 'Failed to create sample Flutter app in ${sampleDir.path}';
 
       await inDirectory(sampleDir, () async {
-        await pub('get');
+        await flutter('packages', options: ['get']);
         await flutter('build', options: ['clean']);
         await flutter('build', options: ['apk', '--release']);
         apkSizeInBytes = await file('${sampleDir.path}/build/app.apk').length();

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -234,13 +234,6 @@ String get dartBin => path.join(config.flutterDirectory.path, 'bin/cache/dart-sd
 
 Future<int> dart(List<String> args) => exec(dartBin, args);
 
-Future<int> pub(String command) {
-  return exec(
-    path.join(config.flutterDirectory.path, 'bin/cache/dart-sdk/bin/pub'),
-    [command]
-  );
-}
-
 Future<dynamic> inDirectory(dynamic directory, Future<dynamic> action()) async {
   String previousCwd = cwd;
   try {


### PR DESCRIPTION
We need to use `flutter packages get` so that we can find the Flutter
SDK when searching for packages.
