### PR TITLE
set and display goals for each performance metric

### DIFF
--- a/app/bin/build_and_test.sh
+++ b/app/bin/build_and_test.sh
@@ -15,8 +15,6 @@ dartanalyzer --strong bin/*.dart web/*.dart test/*.dart
 pub run test -p vm
 pub run test -p dartium
 pub build
-cp web/*.dart build/web/
-cp -RL packages build/web/
 
 echo
 echo "Build succeeded! To deploy to App Engine run the following command after replacing {VERSION}:"

--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -256,6 +256,7 @@ class Timeseries extends Entity {
       'TaskName': string(),
       'Label': string(),
       'Unit': string(),
+      'Goal': number(),
     }
   );
 
@@ -265,6 +266,7 @@ class Timeseries extends Entity {
   String get taskName => this['TaskName'];
   String get label => this['Label'];
   String get unit => this['Unit'];
+  double get goal => this['Goal'];
 }
 
 class TimeseriesValue extends Entity {

--- a/app/test/benchmark_grid_test.dart
+++ b/app/test/benchmark_grid_test.dart
@@ -61,6 +61,7 @@ final _testData = {
         'ID': 'series$i',
         'Label': 'Series $i',
         'Unit': 'ms',
+        'Goal': i.toDouble(),
       },
     },
     'Values': new List.generate(_rnd.nextInt(5), (int v) => {

--- a/app/web/benchmarks.css
+++ b/app/web/benchmarks.css
@@ -47,6 +47,21 @@ benchmark-card {
   pointer-events: none;
 }
 
+.metric-chart-container {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: flex-end;
+}
+
+.metric-goal {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-top: 1px dashed #81C784;
+  pointer-events: none;
+}
+
 .metric-value {
   font-size: 42px;
   font-weight: bold;
@@ -56,6 +71,10 @@ benchmark-card {
   width: 5px;
   background-color: #AAFFAA;
   display: inline-block;
+}
+
+.metric-value-bar-underperformed {
+  background-color: #FFAAAA;
 }
 
 .metric-value-tooltip {

--- a/db/schema.go
+++ b/db/schema.go
@@ -91,6 +91,9 @@ type Timeseries struct {
 	Label string
 	// The unit used for the values, e.g. "ms", "kg", "pumpkins".
 	Unit string
+	// The current goal we want to reach for this metric. As of today, all our metrics are smaller
+	// is better.
+	Goal float64
 }
 
 // TimeseriesEntity contains storage data on a Timeseries.


### PR DESCRIPTION
Add a database field and UI for setting and viewing our performance goals.

This is what it looks like (uses fake data):

![charts-with-goals](https://cloud.githubusercontent.com/assets/211513/19664424/1d46778a-99f5-11e6-8c88-28a738ba9695.png)

Fixes #72 

/cc @cbracken 
