### PR TITLE
add a baseline to each metric

### DIFF
--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -257,6 +257,7 @@ class Timeseries extends Entity {
       'Label': string(),
       'Unit': string(),
       'Goal': number(),
+      'Baseline': number(),
       'Archived': boolean(),
     }
   );
@@ -268,6 +269,7 @@ class Timeseries extends Entity {
   String get label => this['Label'];
   String get unit => this['Unit'];
   double get goal => this['Goal'];
+  double get baseline => this['Baseline'];
   bool get isArchived => this['Archived'];
 }
 

--- a/app/web/benchmarks.css
+++ b/app/web/benchmarks.css
@@ -62,6 +62,15 @@ benchmark-card {
   pointer-events: none;
 }
 
+.metric-baseline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-top: 1px dashed #FFAAAA;
+  pointer-events: none;
+}
+
 .metric-value {
   font-size: 42px;
   font-weight: bold;
@@ -75,6 +84,10 @@ benchmark-card {
 
 .metric-value-bar-underperformed {
   background-color: #FFAAAA;
+}
+
+.metric-value-bar-needs-work {
+  background-color: #AAAAFF;
 }
 
 .metric-value-tooltip {

--- a/db/schema.go
+++ b/db/schema.go
@@ -94,6 +94,9 @@ type Timeseries struct {
 	// The current goal we want to reach for this metric. As of today, all our metrics are smaller
 	// is better.
 	Goal float64
+	// The value higher than which (in the smaller-is-better sense) we consider the result as a
+	// regression that must be fixed as soon as possible.
+	Baseline float64
 	// Indicates that this series contains old data that's no longer interesting (e.g. it will be
 	// hidden from the UI).
 	Archived bool


### PR DESCRIPTION
Add a new field to the "Timeline" entity - "Baseline". We will consider the benchmark as failing if we're not meeting the baseline. This is in addition to "Goal", which is the number we would like to reach eventually. "Baseline" is basically protection from regressions.

The color coding in the charts is as follows:

- red: we're not meeting the baseline, likely regressed and should fix asap
- blue: we're meeting the baseline but not yet reaching our next goal, needs more work
- green: woohoo! Time to move the baseline and set new goals.

![baseline](https://cloud.githubusercontent.com/assets/211513/20156417/0f351fd8-a685-11e6-9715-ab3f10db8e6f.png)


/cc @cbracken 
