### PR TITLE
add baseline to popup; reverse chart direction

### DIFF
--- a/app/lib/components/benchmark_grid.dart
+++ b/app/lib/components/benchmark_grid.dart
@@ -168,7 +168,8 @@ class BenchmarkCard implements AfterViewInit, OnDestroy {
           ..text = '${value.value}$unit\n'
             'Flutter revision: ${value.revision}\n'
             'Recorded on: ${new DateTime.fromMillisecondsSinceEpoch(value.createTimestamp)}\n'
-            'Goal: $goal$unit'
+            'Goal: $goal$unit\n'
+            'Baseline: $baseline$unit'
           ..classes.add('metric-value-tooltip')
           ..style.top = '${bar.getBoundingClientRect().top}px'
           ..style.left = '${bar.getBoundingClientRect().right + 5}px';

--- a/app/web/benchmarks.css
+++ b/app/web/benchmarks.css
@@ -49,7 +49,7 @@ benchmark-card {
 
 .metric-chart-container {
   display: flex;
-  flex-direction: row-reverse;
+  flex-direction: row;
   align-items: flex-end;
 }
 


### PR DESCRIPTION
In charts put the latest values on the right.
Add the baseline field to the mouse-over chart popup.

/cc @cbracken 