### PR TITLE
redesign landing page; update logo

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -13,64 +13,69 @@
   <title>Flutter Dashboard</title>
 
   <style>
-    .visible-frame {
-      animation: appear 1s;
-      opacity: 1;
-    }
-    @keyframes appear {
-      from {
-        opacity: 0;
-      }
-      to {
-        opacity: 1;
-      }
+    @import url(https://fonts.googleapis.com/css?family=Roboto:300);
+
+    body {
+      background: #eee;
+      font: 16px Roboto, sans-serif;
+      font-weight: 300;
+      color: #333;
+      padding: 0;
+      margin: 0;
     }
 
-    .invisible-frame {
-      animation: disappear 1s;
-      opacity: 0;
+    .link-container {
+      display: flex;
+      justify-content: center;
+      flex-direction: row;
+      height: 200px;
     }
-    @keyframes disappear {
-      from {
-        opacity: 1;
-      }
-      to {
-        opacity: 0;
-      }
+
+    .page-link {
+      position: relative;
+      width: 30%;
+      min-width: 200px;
+      margin: 10px;
+    }
+
+    .page-link > a {
+      position: absolute;
+      top: 0; right: 0; bottom: 0; left: 0;
+      background-color: #5E97F6;
+      border-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+      text-decoration: none;
+
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      color: black;
+      font-size: 24px;
+    }
+
+    .page-link > a:hover {
+      background-color: #71A3F7;
     }
   </style>
-
-  <script>
-    var showBuild = true;
-    setInterval(function() {
-      var buildFrame = document.querySelector('#buildFrame');
-      var statusFrame = document.querySelector('#statusFrame');
-      if (showBuild) {
-        buildFrame.classList.add('visible-frame');
-        buildFrame.classList.remove('invisible-frame');
-        statusFrame.classList.add('invisible-frame');
-        statusFrame.classList.remove('visible-frame');
-      } else {
-        buildFrame.classList.add('invisible-frame');
-        buildFrame.classList.remove('visible-frame');
-        statusFrame.classList.add('visible-frame');
-        statusFrame.classList.remove('invisible-frame');
-      }
-      showBuild = !showBuild;
-    }, 20000);
-  </script>
 </head>
 <body style="padding: 0; margin: 0; width: 100%; height: 100%; position: relative">
-  <div id="buildFrame" style="position: absolute; top: 0; right: 0; bottom: 0; left: 0">
-    <iframe src="/build.html"
-            style="width: 100%; height: 100%; border: none">
-    </iframe>
-  </div>
+  <h1 style="text-align: center">
+    <img src="logo.svg" width="30px">
+    Flutter Dashboard
+  </h1>
 
-  <div id="statusFrame" style="position: absolute; top: 0; right: 0; bottom: 0; left: 0">
-    <iframe src="/status.html"
-            style="width: 100%; height: 100%; border: none">
-    </iframe>
+  <div class="link-container">
+    <div class="page-link">
+      <a href="build.html">Build</a>
+    </div>
+
+    <div class="page-link">
+      <a href="benchmarks.html">Benchmarks</a>
+    </div>
+
+    <div class="page-link">
+      <a href="status.html">Status (experimental)</a>
+    </div>
   </div>
 </body>
 </html>

--- a/app/web/logo.svg
+++ b/app/web/logo.svg
@@ -1,18 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="138" height="88" viewBox="0, 0, 138, 88">
-  <path style="fill:#917FFF;stroke:#FFFFFF"
-      d="M76.4457337257,68.7452964326 C101.752495779,57.3530559496 135.725273541,36.7508699436 137.277276695,27.9537925266 C139.020387832,18.0734752246 107.915173462,3.92339415459 97.4530579447,14.4850425266 C95.1465857817,16.8134576466 93.4051234527,19.9608116636 90.2871451447,25.7303597706
-      C83.4782275207,38.3296705796 80.6965459177,43.5220231536 72.4379212257,60.0055503386"/>
-  <path style="fill:#917FFF;stroke:#FFFFFF"
-      d="M70.1859681007,71.5577964326 C53.6924782047,79.3410536876 21.3511379877,87.9323432556 10.8895813827,87.2345542446 C-0.569589177341,86.4702240796 0.167012582659,71.1381905366 0.808526694659,64.1232261206
-      C1.488675985659,56.6857855696 11.6428135557,52.8666953906 16.2610736157,54.1728108736 C31.4302764167,58.4628964016 39.3239571067,60.1654189286 63.2787415377,65.2824058076"/>
-  <path style="fill:#C17FFF;stroke:#FFFFFF"
-      d="M62.9970032567,65.2179526826 C35.7624401197,59.7527053476 31.5365086327,58.4229596446 16.4313860597,54.0262146736 C5.501511163659,50.8447858396 4.485308601659,38.4254490056 7.263604819659,34.3751792456
-      C16.5292274657,20.8675226556 38.8852752047,26.7885268026 41.1854798197,24.9391440886 C44.1062927437,22.5907873836 48.4834815267,11.2805581096 66.4120423197,2.08758158859 C79.2369795017,-4.48848147341 98.1220582767,10.5374053906 90.1752619167,25.6336385076
-      C83.3176166697,38.6608518136 80.5025840477,43.9089156316 72.3554016947,60.0524253386"/>
-  <path style="fill:none;stroke:#917FFF"
-      d="M76.3044902367,70.9561037246 C78.3960485157,71.1152751536 80.8837389927,72.0497411666 82.5466777357,73.1357912246"/>
-  <path style="fill:none;stroke:#917FFF"
-      d="M74.1747421897,78.9875197396 C73.5907633597,77.2543737016 73.1612175077,74.8484721426 73.3666367197,72.8654494276"/>
-  <path style="fill:#7F9DFF;stroke:#FFFFFF"
-      d="M75.3978821637,72.3585776826 C67.6445429637,78.2751666966 36.8970328207,27.9635637636 41.1740052107,24.9553794406 C45.5338006747,22.0644831736 82.2169468337,67.6594945666 75.3978821637,72.3585776826 z"/>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 166 202" style="enable-background:new 0 0 166 202;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#54C5F8;}
+	.st1{fill:#01579B;}
+	.st2{fill:#29B6F6;}
+	.st3{opacity:0.75;fill:url(#SVGID_1_);}
+	.st4{opacity:0.5;fill:url(#SVGID_2_);}
+</style>
+<g>
+	<polygon class="st0" points="37.7,128.9 9.8,101 100.4,10.4 156.2,10.4 	"/>
+	<polygon class="st1" points="79.5,170.7 100.4,191.6 156.2,191.6 156.2,191.6 107.4,142.8 	"/>
+	<polygon class="st0" points="156.2,94 156.2,94 156.2,94 100.4,94 79.5,114.9 107.4,142.8 	"/>
+	
+		<rect x="59.8" y="123.1" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -77.697 98.057)" class="st2" width="39.4" height="39.4"/>
+	
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="87.2623" y1="28.8384" x2="42.9205" y2="35.0952" gradientTransform="matrix(1 0 0 1 37.9092 123.4389)">
+		<stop  offset="0.269" style="stop-color:#FFFFFF"/>
+		<stop  offset="0.4093" style="stop-color:#FCFCFC"/>
+		<stop  offset="0.4972" style="stop-color:#F4F4F4"/>
+		<stop  offset="0.5708" style="stop-color:#E5E5E5"/>
+		<stop  offset="0.6364" style="stop-color:#D1D1D1"/>
+		<stop  offset="0.6968" style="stop-color:#B6B6B6"/>
+		<stop  offset="0.7533" style="stop-color:#959595"/>
+		<stop  offset="0.8058" style="stop-color:#6E6E6E"/>
+		<stop  offset="0.8219" style="stop-color:#616161"/>
+	</linearGradient>
+	<polygon class="st3" points="79.5,170.7 120.9,156.4 107.4,142.8 	"/>
+	
+		<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="62.3643" y1="40.135" x2="54.0376" y2="31.8083" gradientTransform="matrix(1 0 0 1 37.9092 123.4389)">
+		<stop  offset="0.4588" style="stop-color:#FFFFFF"/>
+		<stop  offset="0.5509" style="stop-color:#FCFCFC"/>
+		<stop  offset="0.6087" style="stop-color:#F4F4F4"/>
+		<stop  offset="0.657" style="stop-color:#E5E5E5"/>
+		<stop  offset="0.7001" style="stop-color:#D1D1D1"/>
+		<stop  offset="0.7397" style="stop-color:#B6B6B6"/>
+		<stop  offset="0.7768" style="stop-color:#959595"/>
+		<stop  offset="0.8113" style="stop-color:#6E6E6E"/>
+		<stop  offset="0.8219" style="stop-color:#616161"/>
+	</linearGradient>
+	<polygon class="st4" points="107.4,142.8 79.5,170.7 86.1,177.3 114,149.4 	"/>
+</g>
 </svg>


### PR DESCRIPTION
- The landing page now simply lists the available dashboards
- The status page was demoted to "experimental" - this is because this page requires manual upkeep and I don't have cycles to maintain it; so a bunch of stuff there is out-of-date

Here's the new look:

![flutter-dashboard-landing-page](https://cloud.githubusercontent.com/assets/211513/20231002/bcc288a4-a813-11e6-8b3d-1457d6ee8dee.png)
