### PR TITLE
improve printout of health-check failures

### DIFF
--- a/agent/analysis_options.yaml
+++ b/agent/analysis_options.yaml
@@ -12,8 +12,6 @@ analyzer:
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore
-  exclude:
-    - 'bin/**'
 
 linter:
   rules:

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 import '../adb.dart';
 import '../agent.dart';
@@ -121,21 +122,23 @@ class ContinuousIntegrationCommand extends Command {
 
   Future<AgentHealth> _performHealthChecks() async {
     AgentHealth results = new AgentHealth();
-    try {
-      results['firebase-connection'] = await checkFirebaseConnection();
+
+    results['able-to-perform-health-check'] = await _captureErrors(() async {
+      results['ssh-connectivity'] = await _captureErrors(_scrapeRemoteAccessInfo);
+      results['firebase-connection'] = await _captureErrors(checkFirebaseConnection);
 
       Map<String, HealthCheckResult> deviceChecks = await devices.checkDevices();
       results.addAll(deviceChecks);
 
       bool hasHealthyDevices = deviceChecks.values
-        .where((HealthCheckResult r) => r.succeeded)
-        .isNotEmpty;
+          .where((HealthCheckResult r) => r.succeeded)
+          .isNotEmpty;
 
       results['has-healthy-devices'] = hasHealthyDevices
-        ? new HealthCheckResult.success('Found ${deviceChecks.length} healthy devices')
-        : new HealthCheckResult.failure('No attached devices were found.');
+          ? new HealthCheckResult.success('Found ${deviceChecks.length} healthy devices')
+          : new HealthCheckResult.failure('No attached devices were found.');
 
-      try {
+      results['cocoon-connection'] = await _captureErrors(() async {
         String authStatus = await agent.getAuthenticationStatus();
         results['cocoon-connection'] = new HealthCheckResult.success();
 
@@ -144,16 +147,10 @@ class ContinuousIntegrationCommand extends Command {
         } else {
           results['cocoon-authentication'] = new HealthCheckResult.success();
         }
-      } catch(e, s) {
-        results['cocoon-connection'] = new HealthCheckResult.error(e, s);
-      }
+      });
 
       results['able-to-perform-health-check'] = new HealthCheckResult.success();
-    } catch(e, s) {
-      results['able-to-perform-health-check'] = new HealthCheckResult.error(e, s);
-    }
-
-    results['ssh-connectivity'] = await _scrapeRemoteAccessInfo();
+    });
 
     return results;
   }
@@ -183,6 +180,20 @@ class ContinuousIntegrationCommand extends Command {
   }
 }
 
+/// Catches all exceptions and turns them into [HealthCheckResult] error.
+///
+/// Null callback results are turned into [HealthCheckResult] success.
+Future<HealthCheckResult> _captureErrors(Future<dynamic> healthCheckCallback()) async {
+  return await Chain.capture(() async {
+    try {
+      dynamic result = await healthCheckCallback();
+      return result is HealthCheckResult ? result : new HealthCheckResult.success();
+    } catch(error, stackTrace) {
+      return new HealthCheckResult.error(error, stackTrace is Chain ? stackTrace.terse : stackTrace);
+    }
+  });
+}
+
 Future<Null> getFlutterAt(String revision) async {
   String currentRevision = await getCurrentFlutterRepoCommit();
 
@@ -201,7 +212,7 @@ Future<Null> getFlutterAt(String revision) async {
 ///
 /// Uses `ipconfig getifaddr en0`.
 ///
-/// Always returns [new HealthCheckResult.success] regardless of whether an IP
+/// Always returns [HealthCheckResult] success regardless of whether an IP
 /// is available or not. Having remote access to an agent is not a prerequisite
 /// for being able to perform Cocoon tasks. It's only there to make maintenance
 /// convenient. The goal is only to report available IPs as part of the health

--- a/agent/lib/src/firebase.dart
+++ b/agent/lib/src/firebase.dart
@@ -17,16 +17,12 @@ Firebase _measurements() {
 }
 
 Future<HealthCheckResult> checkFirebaseConnection() async {
-  try {
-    if ((await _measurements().child('dashboard_bot_status').child('current').get()).val == null) {
-      return new HealthCheckResult.failure(
-        'Connection to Firebase is unhealthy. Failed to read the current dashboard_bot_status entity.'
-      );
-    } else {
-      return new HealthCheckResult.success();
-    }
-  } catch (e, s) {
-    return new HealthCheckResult.error(e, s);
+  if ((await _measurements().child('dashboard_bot_status').child('current').get()).val == null) {
+    return new HealthCheckResult.failure(
+      'Connection to Firebase is unhealthy. Failed to read the current dashboard_bot_status entity.'
+    );
+  } else {
+    return new HealthCheckResult.success();
   }
 }
 

--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -12,8 +12,6 @@ analyzer:
     strong_mode_down_cast_composite: ignore
     # allow having TODOs in the code
     todo: ignore
-  exclude:
-    - 'bin/**'
 
 linter:
   rules:


### PR DESCRIPTION
Capture async stacks from health checks and print them into the `HealthCheckResult`.

Bonus:

- move SSH check to the top so that if something fails in the middle we have the SSH info to debug remotely
- remove `bin/**` from analyzer exclusions

/cc @cbracken 