### PR TITLE
use Chain API moar correctly; dedupe checks; log command

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -204,7 +204,7 @@ Future<int> exec(String executable, List<String> arguments,
   int exitCode = await proc.exitCode;
 
   if (exitCode != 0 && !canFail)
-    fail('Executable failed with exit code ${exitCode}.');
+    fail('Executable $executable failed with exit code $exitCode.');
 
   return exitCode;
 }
@@ -222,7 +222,7 @@ Future<String> eval(String executable, List<String> arguments,
   int exitCode = await proc.exitCode;
 
   if (exitCode != 0 && !canFail)
-    fail('Executable failed with exit code ${exitCode}.');
+    fail('Executable $executable failed with exit code $exitCode.');
 
   return output.trimRight();
 }


### PR DESCRIPTION
- Turns out `try/catch` doesn't always work; must use the formal `Chain` API
- Remove duplicate health check names
- Include executable name in the error message when it returns non-zero status

TBR: @cbracken (would like to deploy and make sure it works before I head home)