### PR TITLE
relax devicelab requirements; stop crashing on linux

### DIFF
--- a/agent/config.sample.yaml
+++ b/agent/config.sample.yaml
@@ -30,8 +30,9 @@ agent_id: agent-with-ios-devices-#5
 auth_token: blahblahblah
 
 # Contact sethladd@google.com, yjbanov@google.com or devoncarew@google.com to
-# get a Firebase token.
-firebase_flutter_dashboard_token: blahblahblah
+# get a Firebase token. Token "test" will cause the agent to skip uploading
+# results to Firebase.
+firebase_flutter_dashboard_token: test
 
 # The device operating system. Possible values: android, ios.
 device_os: android

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -125,7 +125,9 @@ class ContinuousIntegrationCommand extends Command {
 
     results['able-to-perform-health-check'] = await _captureErrors(() async {
       results['ssh-connectivity'] = await _captureErrors(_scrapeRemoteAccessInfo);
-      results['firebase-connection'] = await _captureErrors(checkFirebaseConnection);
+
+      if (config.firebaseFlutterDashboardToken != 'test')
+        results['firebase-connection'] = await _captureErrors(checkFirebaseConnection);
 
       Map<String, HealthCheckResult> deviceChecks = await devices.checkDevices();
       results.addAll(deviceChecks);
@@ -222,6 +224,10 @@ Future<Null> getFlutterAt(String revision) async {
 /// convenient. The goal is only to report available IPs as part of the health
 /// check.
 Future<HealthCheckResult> _scrapeRemoteAccessInfo() async {
+  if (!Platform.isMacOS) {
+    return new HealthCheckResult.success('${Platform.operatingSystem} not yet supported.');
+  }
+
   String ip = (await eval('ipconfig', ['getifaddr', 'en0'], canFail: true)).trim();
 
   return new HealthCheckResult.success(ip.isEmpty


### PR DESCRIPTION
- Proceed to testing on devicelab if Travis is green (ok for chromebots to fail); chromebots are too flaky causing us to miss a lot of data
- Bonus: make it possible to run agent code on Linux and without Firebase
- Bonus: fix Go linter warnings (`errors.New` instead of `fmt.Errorf`; `len` overload; apply `gofmt`)

/cc @cbracken 