### PR TITLE
do not go straight to red the first time agent reports bad health

### DIFF
--- a/app/web/buildStyles.css
+++ b/app/web/buildStyles.css
@@ -346,14 +346,6 @@ td.stats-value {
   cursor: pointer;
 }
 
-.agent-healthy {
-  background-color: #33CC33;
-}
-
-.agent-unhealthy {
-  background-color: #CC3333;
-}
-
 .agent-health-details-card {
   position: relative;
   background-color: #DDD;


### PR DESCRIPTION
Today we paint an agent extreme red as soon as it reports an unhealthy status. However, in most cases an agent is able to recover within minutes (adb can be flaky). This change uses a softer color scheme, interpolating between extreme healthy color and extreme unhealthy color. The longer it takes an agent to recover, the closer is the color to the extreme red. An agent that does not recover within 20 minutes is colored extremely unhealthy.

Here's an example range of agents along the health spectrum:

![agent_health_color_spectrum](https://cloud.githubusercontent.com/assets/211513/22130847/ba5fdf2c-de63-11e6-8654-ba79ab7496e9.png)

/cc @cbracken 
