### PR TITLE
card filtering & long term charts

### DIFF
--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -33,6 +33,35 @@ class _KeySerializer implements JsonSerializer<Key> {
   }
 }
 
+/// Datastore cursor.
+class Cursor {
+  static const _serializer = const _CursorSerializer();
+
+  const Cursor(this.value);
+
+  final String value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Cursor other) => other != null && other.value == value;
+}
+
+class _CursorSerializer implements JsonSerializer<Cursor> {
+  const _CursorSerializer();
+
+  @override
+  Cursor deserialize(dynamic jsonValue) {
+    return new Cursor(jsonValue);
+  }
+
+  @override
+  dynamic serialize(Cursor cursor) {
+    return cursor.value;
+  }
+}
+
 class GetStatusResult extends Entity {
   static final _serializer = new EntitySerializer(
     (Map<String, dynamic> props) => new GetStatusResult(props),
@@ -231,6 +260,24 @@ class BenchmarkData extends Entity {
 
   TimeseriesEntity get timeseries => this['Timeseries'];
   List<TimeseriesValue> get values => this['Values'];
+}
+
+class GetTimeseriesHistoryResult extends Entity {
+  static final _serializer = new EntitySerializer(
+          (Map<String, dynamic> props) => new GetTimeseriesHistoryResult(props),
+      <String, JsonSerializer>{
+        'BenchmarkData': BenchmarkData._serializer,
+        'LastPosition': Cursor._serializer,
+      }
+  );
+
+  GetTimeseriesHistoryResult([Map<String, dynamic> props]) : super(_serializer, props);
+
+  static GetTimeseriesHistoryResult fromJson(dynamic json) =>
+      _serializer.deserialize(json);
+
+  BenchmarkData get benchmarkData => this['BenchmarkData'];
+  Cursor get lastPosition => this['LastPosition'];
 }
 
 class TimeseriesEntity extends Entity {

--- a/app/main.go
+++ b/app/main.go
@@ -29,6 +29,7 @@ func init() {
 	registerRPC("/api/create-agent", commands.CreateAgent)
 	registerRPC("/api/authorize-agent", commands.AuthorizeAgent)
 	registerRPC("/api/get-benchmarks", commands.GetBenchmarks)
+	registerRPC("/api/get-timeseries-history", commands.GetTimeseriesHistory)
 	registerRPC("/api/get-status", commands.GetStatus)
 	registerRPC("/api/refresh-github-commits", commands.RefreshGithubCommits)
 	registerRPC("/api/refresh-travis-status", commands.RefreshTravisStatus)

--- a/app/test/benchmark_grid_test.dart
+++ b/app/test/benchmark_grid_test.dart
@@ -31,7 +31,7 @@ void main() {
     test('should show a grid', () async {
       List<String> httpCalls = <String>[];
 
-      var component = await bootstrap(BenchmarkGrid, [
+      var componentRef = await bootstrap(BenchmarkGrid, [
         provide(http.Client, useValue: new MockClient((http.Request request) async {
           httpCalls.add(request.url.path);
           return new http.Response(
@@ -47,14 +47,18 @@ void main() {
       expect(httpCalls, <String>['/api/get-benchmarks']);
       expect(document.querySelectorAll('benchmark-card'), hasLength(5));
 
-      expect(component.instance.isShowArchived, isFalse);
+      BenchmarkGrid component = componentRef.instance;
+      expect(component.isShowArchived, isFalse);
       document.body.querySelector('#toggleArchived').click();
-      expect(component.instance.isShowArchived, isTrue);
+      expect(component.isShowArchived, isTrue);
 
       await new Future.delayed(Duration.ZERO);
 
-      expect(component.instance.benchmarks, hasLength(10));
+      expect(component.visibleBenchmarks, hasLength(10));
       expect(document.querySelectorAll('benchmark-card'), hasLength(10));
+
+      component.applyTextFilter('series 1');
+      expect(component.visibleBenchmarks.single.timeseries.timeseries.label, 'Series 1');
     });
   });
 }

--- a/app/web/benchmarks.css
+++ b/app/web/benchmarks.css
@@ -24,7 +24,6 @@ body {
 benchmark-card {
   display: inline-block;
   position: relative;
-  width: 250px;
   height: 100px;
   padding: 0;
   margin: 5px;
@@ -38,6 +37,16 @@ benchmark-card {
   display: flex;
   flex-direction: row-reverse;
   overflow: hidden;
+}
+
+.short-benchmark-card {
+  width: 250px;
+}
+
+.benchmark-history-container {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #ccc;
 }
 
 .metric {
@@ -82,6 +91,10 @@ benchmark-card {
   display: inline-block;
 }
 
+.metric-value-bar-narrow {
+  width: 2px;
+}
+
 .metric-value-bar-underperformed {
   background-color: #FFAAAA;
 }
@@ -116,6 +129,22 @@ benchmark-card {
   bottom: 5px;
   left: 5px;
   pointer-events: none;
+}
+
+.zoom-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: #f7f7f7;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  padding: 3px;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.zoom-button:hover {
+  opacity: 1.0;
 }
 
 footer {

--- a/commands/get_benchmarks.go
+++ b/commands/get_benchmarks.go
@@ -22,7 +22,7 @@ type BenchmarkData struct {
 }
 
 // GetBenchmarks returns recent benchmark results.
-func GetBenchmarks(c *db.Cocoon, inputJSON []byte) (interface{}, error) {
+func GetBenchmarks(c *db.Cocoon, _ []byte) (interface{}, error) {
 	seriesList, err := c.QueryTimeseries()
 
 	if err != nil {
@@ -31,7 +31,7 @@ func GetBenchmarks(c *db.Cocoon, inputJSON []byte) (interface{}, error) {
 
 	var benchmarks []*BenchmarkData
 	for _, series := range seriesList {
-		values, err := c.QueryLatestTimeseriesValues(series)
+		values, _, err := c.QueryLatestTimeseriesValues(series, nil, 50)
 
 		if err != nil {
 			return nil, err

--- a/commands/get_timeseries_history.go
+++ b/commands/get_timeseries_history.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"cocoon/db"
+	"google.golang.org/appengine/datastore"
+	"encoding/json"
+)
+
+// GetTimeseriesHistoryCommand returns recent benchmark results.
+type GetTimeseriesHistoryCommand struct {
+	TimeSeriesKey *datastore.Key
+	StartFrom *datastore.Cursor
+}
+
+// GetTimeseriesHistoryResult contains recent benchmark results.
+type GetTimeseriesHistoryResult struct {
+	BenchmarkData *BenchmarkData
+	LastPosition *datastore.Cursor
+}
+
+// GetTimeseriesHistory returns recent benchmark results.
+func GetTimeseriesHistory(c *db.Cocoon, inputJSON []byte) (interface{}, error) {
+	var command *GetTimeseriesHistoryCommand
+
+	err := json.Unmarshal(inputJSON, &command)
+
+	if err != nil {
+		return nil, err
+	}
+
+	series, err := c.GetTimeseries(command.TimeSeriesKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	values, cursor, err := c.QueryLatestTimeseriesValues(series, command.StartFrom, 1500)
+
+	return &GetTimeseriesHistoryResult{
+		BenchmarkData: &BenchmarkData{
+			Timeseries: series,
+			Values: values,
+		},
+		LastPosition: cursor,
+	}, nil
+}


### PR DESCRIPTION
Fixes #68

[Live preview](https://v37-test-dot-flutter-dashboard.appspot.com/benchmarks.html)

Add a textbox to the top toolbar. Entering text in it will filter benchmarks cards by entered text.

On the screenshot below notice the magnifying glass button in the corner of the 3rd card on the first row. It appears when you hover the mouse pointer in that corner. Clicking on it, will add a wide benchmark card at the top with a more dense timeline going multiple months back in history.

![screenshot from 2017-03-21 18 42 03](https://cloud.githubusercontent.com/assets/211513/24178451/6b7d0ca8-0e66-11e7-8464-a8668cab7e65.png)

/cc @Hixie