### PR TITLE
stop using package:stack_trace

### DIFF
--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -32,10 +32,6 @@ class ContinuousIntegrationCommand extends Command {
 
   @override
   Future<Null> run(ArgResults args) async {
-    return runAndCaptureAsyncStacks(() => _runContinuously(args));
-  }
-
-  Future<Null> _runContinuously(ArgResults args) async {
     // Perform one pre-flight round of checks and quit immediately if something
     // is wrong.
     AgentHealth health = await performHealthChecks(agent);
@@ -98,15 +94,13 @@ class ContinuousIntegrationCommand extends Command {
   }
 
   Future<Null> _runTask(CocoonTask task) async {
-    await runAndCaptureAsyncStacks(() async {
-      TaskResult result = await runTask(agent, task);
-      if (result.succeeded) {
-        await agent.reportSuccess(task.key, result.data, result.benchmarkScoreKeys);
-        await _uploadDataToFirebase(task, result);
-      } else {
-        await agent.reportFailure(task.key, result.reason);
-      }
-    });
+    TaskResult result = await runTask(agent, task);
+    if (result.succeeded) {
+      await agent.reportSuccess(task.key, result.data, result.benchmarkScoreKeys);
+      await _uploadDataToFirebase(task, result);
+    } else {
+      await agent.reportFailure(task.key, result.reason);
+    }
   }
 
   Future<Null> _screensOff() async {

--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:stack_trace/stack_trace.dart';
-
 import 'adb.dart';
 import 'agent.dart';
 import 'firebase.dart';
@@ -58,12 +56,12 @@ Future<HealthCheckResult> _captureErrors(Future<dynamic> healthCheckCallback()) 
   // One way to think about this is that "we _successfully_ discovered health
   // check error, and will report it to the Cocoon back-end".
   // ignore: unawaited_futures
-  Chain.capture(() async {
+  try {
     dynamic result = await healthCheckCallback();
     completer.complete(result is HealthCheckResult ? result : new HealthCheckResult.success());
-  }, onError: (error, Chain chain) {
-    completer.complete(new HealthCheckResult.error(error, chain.terse));
-  });
+  } catch (error, stackTrace) {
+    completer.complete(new HealthCheckResult.error(error, stackTrace));
+  }
   return completer.future;
 }
 

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -10,7 +10,6 @@ import 'package:args/args.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:path/path.dart' as path;
-import 'package:stack_trace/stack_trace.dart';
 import 'package:yaml/yaml.dart';
 
 import 'adb.dart';
@@ -478,29 +477,6 @@ Iterable<String> grep(Pattern pattern, {@required String from}) {
   return from.split('\n').where((String line) {
     return line.contains(pattern);
   });
-}
-
-/// Captures asynchronous stack traces thrown by [callback].
-///
-/// This is a convenience wrapper around [Chain] optimized for use with
-/// `async`/`await`.
-///
-/// Example:
-///
-///     try {
-///       await captureAsyncStacks(() { /* async things */ });
-///     } catch (error, chain) {
-///
-///     }
-Future<Null> runAndCaptureAsyncStacks(Future<Null> callback()) {
-  Completer<Null> completer = new Completer<Null>();
-  Chain.capture(() async {
-    await callback();
-    completer.complete();
-  }, onError: (error, Chain chain) async {
-    completer.completeError(error, chain);
-  });
-  return completer.future;
 }
 
 bool canRun(String path) => _processManager.canRun(path);

--- a/agent/pubspec.yaml
+++ b/agent/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   meta: ^1.0.4
   path: ^1.3.0
   process: ^2.0.1
-  stack_trace: ^1.6.5
   vm_service_client: ^0.2.0
   yaml: ^2.1.10
 

--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -16,7 +16,7 @@ class Key {
   int get hashCode => value.hashCode;
 
   @override
-  bool operator ==(Key other) => other != null && other.value == value;
+  bool operator==(Object other) => other is Key && other.value == value;
 }
 
 class _KeySerializer implements JsonSerializer<Key> {


### PR DESCRIPTION
For mysterious reasons `package:stack_trace` goes into an infinite loop requiring me to lift my butt, walk over to the lab and force restart the agent. This happens relatively rarely, but we're adding 4 new agents, which will make it a more noticeable hassle.
