### PR TITLE
implement "flaky" status; graduate iOS tests to stable

### DIFF
--- a/commands/get_public_build_status.go
+++ b/commands/get_public_build_status.go
@@ -43,11 +43,6 @@ func computeTrend(statuses []*db.BuildStatus) db.BuildResult {
 	for _, status := range statuses {
 		for _, stage := range status.Stages {
 			for _, task := range stage.Tasks {
-				if stage.Name == "devicelab_ios" {
-					// TODO: the iOS build is still too unstable; ignore it.
-					continue
-				}
-
 				if isLatestBuild {
 					// We only care about tasks defined in the latest build. If a task is removed from CI, we
 					// no longer care about its status.
@@ -56,7 +51,7 @@ func computeTrend(statuses []*db.BuildStatus) db.BuildResult {
 
 				if statusSeen, isRelevant := relevantTasks[task.Task.Name]; isRelevant && !statusSeen.IsFinal() && task.Task.Status.IsFinal() {
 					relevantTasks[task.Task.Name] = task.Task.Status
-					if task.Task.Status == db.TaskFailed || task.Task.Status == db.TaskSkipped {
+					if !task.Task.Flaky && (task.Task.Status == db.TaskFailed || task.Task.Status == db.TaskSkipped) {
 						return db.BuildWillFail
 					}
 				}

--- a/commands/get_public_build_status_test.go
+++ b/commands/get_public_build_status_test.go
@@ -81,6 +81,117 @@ func TestGetPublicBuildStatusSucceededThenFailed(t *testing.T) {
 	}
 }
 
+// Test that flakes are considered successful:
+// foo
+// failed (flaky)
+func TestGetPublicBuildStatusFlaky(t *testing.T) {
+	result := computeTrend([]*db.BuildStatus{
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+								Flaky: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if result != db.BuildSucceeded {
+		t.Errorf("Expected %v but was %v", db.BuildSucceeded, result)
+		t.Fail()
+	}
+}
+
+// Test that marking a test as flaky shuts of warnings:
+// foo
+// failed (flaky)
+// failed
+func TestGetPublicBuildStatusFailedThenFlaky(t *testing.T) {
+	result := computeTrend([]*db.BuildStatus{
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+								Flaky: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if result != db.BuildSucceeded {
+		t.Errorf("Expected %v but was %v", db.BuildSucceeded, result)
+		t.Fail()
+	}
+}
+
+// Test that unmarking a test as flaky resumes warnings:
+// foo
+// failed
+// failed (flaky)
+func TestGetPublicBuildStatusFlakyThenFailed(t *testing.T) {
+	result := computeTrend([]*db.BuildStatus{
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+								Flaky: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if result != db.BuildWillFail {
+		t.Errorf("Expected %v but was %v", db.BuildWillFail, result)
+		t.Fail()
+	}
+}
+
 // Test:
 // foo
 // succeeded

--- a/commands/refresh_github_commits_test.go
+++ b/commands/refresh_github_commits_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func TestParseManifestSuccess(t *testing.T) {
+func TestParseManifestMinimal(t *testing.T) {
 	yaml := "tasks:\n" +
 			"  test_task:\n" +
 			"    description: test_description\n" +
@@ -32,6 +32,56 @@ func TestParseManifestSuccess(t *testing.T) {
 		}
 		if len(task.RequiredAgentCapabilities) != 2 || task.RequiredAgentCapabilities[0] != "a" ||  task.RequiredAgentCapabilities[1] != "b" {
 			t.Errorf("Wrong required_agent_capabilities %v", task.RequiredAgentCapabilities)
+			t.Fail()
+		}
+		if task.Flaky {
+			t.Errorf("Wrong task flaky flag %v", task.Flaky)
+			t.Fail()
+		}
+		if task.TimeoutInMinutes != 0 {
+			t.Errorf("Wrong TimeoutInMinutes %v", task.TimeoutInMinutes)
+			t.Fail()
+		}
+	}
+}
+
+func TestParseManifestFull(t *testing.T) {
+	yaml := "tasks:\n" +
+			"  test_task:\n" +
+			"    description: test_description\n" +
+			"    stage: test_stage\n" +
+			"    required_agent_capabilities: [\"a\", \"b\"]\n" +
+	    "    flaky: true\n" +
+	    "    timeout_in_minutes: 24"
+	manifest, err := ParseManifest([]byte(yaml))
+
+	if err != nil {
+		t.Errorf("Did not expect error but got %v", err)
+		t.Fail()
+	} else {
+		if len(manifest.Tasks) != 1 {
+			t.Errorf("Expected exactly one task but got %v", len(manifest.Tasks))
+			t.Fail()
+		}
+		task := manifest.Tasks["test_task"]
+		if task.Description != "test_description" {
+			t.Errorf("Wrong task description %v", task.Description)
+			t.Fail()
+		}
+		if task.Stage != "test_stage" {
+			t.Errorf("Wrong task stage %v", task.Stage)
+			t.Fail()
+		}
+		if len(task.RequiredAgentCapabilities) != 2 || task.RequiredAgentCapabilities[0] != "a" ||  task.RequiredAgentCapabilities[1] != "b" {
+			t.Errorf("Wrong required_agent_capabilities %v", task.RequiredAgentCapabilities)
+			t.Fail()
+		}
+		if !task.Flaky {
+			t.Errorf("Wrong task flaky flag %v", task.Flaky)
+			t.Fail()
+		}
+		if task.TimeoutInMinutes != 24 {
+			t.Errorf("Wrong task TimeoutInMinutes %v", task.TimeoutInMinutes)
 			t.Fail()
 		}
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -432,12 +432,14 @@ func computeBuildResult(checklist *Checklist, stages []*Stage) BuildResult {
 	failedCount := 0
 
 	for _, stage := range stages {
-		if stage.Name == "devicelab_ios" {
-			// TODO: the iOS build is still too unstable; ignore it.
-			continue
-		}
 		for _, task := range stage.Tasks {
 			taskCount++
+
+			if !task.Task.Flaky {
+				// Do not count flakes towards failures.
+				continue
+			}
+
 			switch task.Task.Status {
 			case TaskFailed, TaskSkipped:
 				failedCount++

--- a/db/schema.go
+++ b/db/schema.go
@@ -79,6 +79,10 @@ type Task struct {
 	CreateTimestamp    int64
 	StartTimestamp     int64
 	EndTimestamp       int64
+	Flaky              bool
+
+	// Optional custom timeout for this task. The default value of 0 means "use default timeout".
+	TimeoutInMinutes int64
 }
 
 // BuildStatus contains build status information about a particular checklist.


### PR DESCRIPTION
* parse and store the "flaky" and "timeout_in_minutes" manifest attributes
* remove flaky tasks from consideration when computing overall build status
* failing iOS tasks will now trigger red build status and email notifications

This PR is limited to backend code only. It **does not** implement the custom timeout logic in the agent code. That will be done in a follow-up PR.

fyi @Hixie 