### PR TITLE
pass the custom timeout to devicelab test runner

### DIFF
--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -14,11 +14,17 @@ import 'package:cocoon_agent/src/utils.dart';
 
 /// Contains information about a Cocoon task.
 class CocoonTask {
-  CocoonTask({this.name, this.key, this.revision});
+  CocoonTask({
+    @required this.name,
+    @required this.key,
+    @required this.revision,
+    @required this.timeoutInMinutes,
+  });
 
   final String name;
   final String key;
   final String revision;
+  final int timeoutInMinutes;
 }
 
 /// Client to the Coocon backend.
@@ -64,7 +70,8 @@ class Agent {
       return new CocoonTask(
         name: reservation['TaskEntity']['Task']['Name'],
         key: reservation['TaskEntity']['Key'],
-        revision: reservation['ChecklistEntity']['Checklist']['Commit']['Sha']
+        revision: reservation['ChecklistEntity']['Checklist']['Commit']['Sha'],
+        timeoutInMinutes: reservation['TaskEntity']['Task']['TimeoutInMinutes'],
       );
     }
 

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -68,9 +68,12 @@ class ContinuousIntegrationCommand extends Command {
         try {
           if (task != null) {
             section('Task info:');
-            print('  name     : ${task.name}');
-            print('  key      : ${task.key ?? ""}');
-            print('  revision : ${task.revision}');
+            print('  name           : ${task.name}');
+            print('  key            : ${task.key ?? ""}');
+            print('  revision       : ${task.revision}');
+            if (task.timeoutInMinutes != 0) {
+              print('  custom timeout : ${task.timeoutInMinutes}');
+            }
 
             // Sync flutter outside of the task so it does not contribute to
             // the task timeout.


### PR DESCRIPTION
The devicelab test runner will ignore the passed value until I send a follow-up PR over in flutter/flutter to actually use it.