### PR TITLE
do not wait for final status on flaky tasks

### DIFF
--- a/commands/get_public_build_status_test.go
+++ b/commands/get_public_build_status_test.go
@@ -192,6 +192,48 @@ func TestGetPublicBuildStatusFlakyThenFailed(t *testing.T) {
 	}
 }
 
+// Test that marking a test as flaky shuts off warnings immediately:
+// foo
+// new (flaky)
+// failed
+func TestGetPublicBuildStatusEagerlyFlaky(t *testing.T) {
+	result := computeTrend([]*db.BuildStatus{
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskNew,
+								Flaky: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Stages: []*db.Stage {
+				{
+					Tasks: []*db.TaskEntity{
+						{
+							Task: &db.Task{
+								Name: "foo",
+								Status: db.TaskFailed,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if result != db.BuildSucceeded {
+		t.Errorf("Expected %v but was %v", db.BuildSucceeded, result)
+		t.Fail()
+	}
+}
+
 // Test:
 // foo
 // succeeded


### PR DESCRIPTION
Previously we would wait for a flaky task to succeed or fail before we removed it from consideration in the overall build status. With this change a flaky task status will be considered immediately.

/cc @Hixie 