### PR TITLE
fix CocoonConfig pointer; increase Github ping frequency

### DIFF
--- a/app/cron.yaml
+++ b/app/cron.yaml
@@ -1,7 +1,7 @@
 cron:
 - description: refresh commits from GitHub
   url: /api/refresh-github-commits
-  schedule: every 5 minutes
+  schedule: every 1 minutes
 - description: refresh travis build status
   url: /api/refresh-travis-status
   schedule: every 3 minutes

--- a/db/db.go
+++ b/db/db.go
@@ -873,7 +873,7 @@ func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
 // GetConfigValue returns the value of the CocoonConfig parameter with key parameterName. This
 // function is intended to always succeed and therefore it panics when things go wrong.
 func (c *Cocoon) GetConfigValue(parameterName string) string {
-	var value *CocoonConfig
+	value := new(CocoonConfig)
 	err := datastore.Get(c.Ctx, datastore.NewKey(c.Ctx, "CocoonConfig", parameterName, 0, nil), value)
 
 	if err != nil {


### PR DESCRIPTION
- ping Github more frequently to check for new master commits to reduce test latency (now that we have an auth token we're not rate-limited)
- fix pointer we're feeding to datastore API for reading `CocoonConfig` table; it cannot be `nil` (iow Go is not C++)