### PR TITLE
add more info to the build status when broken

### DIFF
--- a/commands/push_build_status_to_github.go
+++ b/commands/push_build_status_to_github.go
@@ -109,6 +109,8 @@ func pushToGithub(c *db.Cocoon, sha string, status db.BuildResult) (error) {
 		data["state"] = "success"
 	} else {
 		data["state"] = "failure"
+		data["target_url"] = "https://flutter-dashboard.appspot.com/build.html"
+		data["description"] = "Flutter build is currently broken. Be careful when merging this PR."
 	}
 	data["context"] = "flutter-build"
 


### PR DESCRIPTION
Add URL to the dashboard (which is now publicly visible) and a description of what's going on when we're going red due to a build.

/cc @sethladd 