### PR TITLE
add a legend to the build page

### DIFF
--- a/app/lib/components/status_table.dart
+++ b/app/lib/components/status_table.dart
@@ -17,6 +17,8 @@ import 'package:http/http.dart' as http;
   Loading...
 </div>
 
+<legend></legend>
+
 <div class="agent-bar">
   <div>Agents</div>
   <div *ngFor="let agentStatus of agentStatuses"
@@ -92,7 +94,7 @@ import 'package:http/http.dart' as http;
   </tr>
 </table>
 ''',
-  directives: const [NgIf, NgFor, NgClass, NgStyle]
+  directives: const [Legend, NgIf, NgFor, NgClass, NgStyle],
 )
 class StatusTable implements OnInit {
   static const Duration maxHealthCheckAge = const Duration(minutes: 10);
@@ -367,4 +369,45 @@ class Color {
       (from.g + (to.g - from.g) * c).toInt(),
       (from.b + (to.b - from.b) * c).toInt(),
   );
+}
+
+@Component(
+  selector: 'legend',
+  template: '''
+  <div class="legend-icon" (click)="toggleVisibility()">?</div>
+  <div *ngIf="legendVisible" class="legend">
+    <div class="row">
+      <div class="task-status-circle task-new"></div><span class="description">- new task</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-in-progress"></div><span class="description">- task is running</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-succeeded"></div><span class="description">- task succeeded</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-succeeded-but-flaky"></div><span class="description">- task is flaky</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-failed"></div><span class="description">- task failed</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-underperformed"></div><span class="description">- task underperformed</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-skipped"></div><span class="description">- task was skipped</span>
+    </div>
+    <div class="row">
+      <div class="task-status-circle task-unknown"></div><span class="description">- task status unknown</span>
+    </div>
+  </div>
+  ''',
+  directives: const [NgIf, NgFor, NgClass, NgStyle],
+)
+class Legend {
+  bool legendVisible = false;
+
+  void toggleVisibility() {
+    legendVisible = !legendVisible;
+  }
 }

--- a/app/web/buildStyles.css
+++ b/app/web/buildStyles.css
@@ -370,3 +370,35 @@ td.stats-value {
   padding: 15px;
   margin-bottom: 10px;
 }
+
+legend .legend-icon {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  height: 20px;
+  width: 20px;
+  border: 1px solid black;
+  border-radius: 10px;
+  background-color: white;
+  cursor: pointer;
+  text-align: center;
+}
+
+legend .legend {
+  position: fixed;
+  top: 40px;
+  right: 10px;
+  border: 1px solid black;
+  background-color: white;
+  padding: 15px;
+}
+
+legend .row {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 10px;
+}
+
+legend .description {
+  margin-left: 10px;
+}


### PR DESCRIPTION
Clicking on the question mark at the top-right corner reveals a legend:

![legend](https://cloud.githubusercontent.com/assets/211513/26321775/1316771e-3edd-11e7-9a7d-5dc136106812.png)

Fixes https://github.com/flutter/cocoon/issues/135