### PR TITLE
custom AuthenticatedClientError exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ packages
 app/build
 pubspec.lock
 config.yaml
+
+# IntelliJ
+.idea
+*.iml

--- a/agent/bin/agent.dart
+++ b/agent/bin/agent.dart
@@ -60,6 +60,14 @@ Future<Null> main(List<String> rawArgs) async {
   await command.run(args.command);
 }
 
+/// An error thrown by [AuthenticatedClient].
+class AuthenticatedClientError extends Error {
+  AuthenticatedClientError(this.message);
+
+  /// Error message.
+  final String message;
+}
+
 class AuthenticatedClient extends BaseClient {
   AuthenticatedClient(this._agentId, this._authToken);
 
@@ -71,10 +79,12 @@ class AuthenticatedClient extends BaseClient {
   Future<StreamedResponse> send(Request request) async {
     request.headers['Agent-ID'] = _agentId;
     request.headers['Agent-Auth-Token'] = _authToken;
-    StreamedResponse resp = await _delegate.send(request);
+    final StreamedResponse resp = await _delegate.send(request);
 
-    if (resp.statusCode != 200)
-      throw 'HTTP error ${resp.statusCode}:\n${(await Response.fromStream(resp)).body}';
+    if (resp.statusCode != 200) {
+      final String message = 'HTTP error ${resp.statusCode}:\n${(await Response.fromStream(resp)).body}';
+      throw new AuthenticatedClientError(message);
+    }
 
     return resp;
   }

--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -16,16 +16,26 @@ import 'package:cocoon_agent/src/utils.dart';
 class CocoonTask {
   CocoonTask({
     @required this.name,
-    @required this.key,
     @required this.revision,
     @required this.timeoutInMinutes,
-    @required this.cloudAuthToken,
+    this.key,
+    this.cloudAuthToken,
   });
 
+  /// Task name as it appears on dashboards and in logs.
   final String name;
+
+  /// Identifies the task in the database, where the tasks status is stored.
   final String key;
+
+  /// The Flutter revision (git SHA) this task is expected to run with.
   final String revision;
+
+  /// Task timeout.
   final int timeoutInMinutes;
+
+  /// Authentication token that gives the task write access to Google Cloud
+  /// Storage buckets to upload artifacts, such as screenshots.
   final String cloudAuthToken;
 }
 

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -39,7 +39,7 @@ class RunCommand extends Command {
       exit(1);
     }
 
-    CocoonTask task = new CocoonTask(name: taskName, revision: revision);
+    CocoonTask task = new CocoonTask(name: taskName, revision: revision, timeoutInMinutes: 30);
     TaskResult result;
     try {
       if (task.revision != null) {


### PR DESCRIPTION
Throw a custom error in `AuthenticatedClient` rather than `String` in hopes that we are able to catch it in the `while` loop (currently the `String` flies right out of the loop killing the VM)

Bonus: some dartdocs and minor clean-ups