### PR TITLE
reduce lsof noise in the log output

### DIFF
--- a/agent/lib/src/list_processes.dart
+++ b/agent/lib/src/list_processes.dart
@@ -16,7 +16,7 @@ Future<List<int>> listFlutterProcessIds(Directory flutterDirectory) {
     return _listFlutterProcessesPosix(flutterDirectory);
   if (Platform.isWindows)
     return _listFlutterProcessesWindows(flutterDirectory);
-  throw "Unsupported platform: ${Platform.operatingSystem}";
+  throw 'Unsupported platform: ${Platform.operatingSystem}';
 }
 
 // POSIX implementation
@@ -46,7 +46,7 @@ Future<List<ProcessListResult>> _listProcessesPosix() async {
   String ps = await eval('ps', ['-ef', '-u', Platform.environment['USER']]);
   for (String psLine in ps.split('\n').skip(1)) {
     int processId = int.parse(psLine.trim().split(_emptySpace)[1].trim());
-    String lsof = await eval('lsof', ['-p', '$processId'], canFail: true);
+    String lsof = await eval('lsof', ['-p', '$processId'], canFail: true, silent: true);
     Iterable<String> cwdGrep = grep('cwd', from: lsof);
     if (cwdGrep.isEmpty) {
       // Not all processes report cwd; skip those, unlikely to be interesting.

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -263,8 +263,8 @@ Future<int> exec(String executable, List<String> arguments,
 ///
 /// Standard error is redirected to the current process' standard error stream.
 Future<String> eval(String executable, List<String> arguments,
-    {Map<String, String> env, bool canFail: false}) async {
-  Process proc = await startProcess(executable, arguments, env: env);
+    {Map<String, String> env, bool canFail: false, bool silent: false}) async {
+  Process proc = await startProcess(executable, arguments, env: env, silent: silent);
   proc.stderr.listen((List<int> data) {
     stderr.add(data);
   });


### PR DESCRIPTION
`lsof` produces way too much log noise even when the agent does no work at all, because we run `lsof` for every live process.