### PR TITLE
Use isolates for improved clean-up and recovery

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -322,6 +322,11 @@ class Config {
     @required this.deviceOperatingSystem,
   });
 
+  /// Uses a pre-existing configuration object as the global [config].
+  static void adopt(Config existingConfig) {
+    _config = existingConfig;
+  }
+
   static void initialize(ArgResults args) {
     File agentConfigFile = file(args['config-file']);
 


### PR DESCRIPTION
The current CI loop proved to be not very reliable. This PR attempts an isolate-based approach. The outer "main isolate" has minimal logic in it. It is responsible for spawning a "command isolate" (which has lots of complicated logic), then waiting for it to finish or time out or error out. In CI mode, the outer isolate respawns the command isolate continuously.

So the outer CI loop is rewritten from (roughly):

```dart
// command logic
runZoned(() {
  while(true) {
    try {
      dothings();
    } catch(error) {
      report(error);
    } finally {
      cleanUp();
    }
  }
}, onError: (error) { report(error); });
```

To an infinite async recursion (roughly):

```dart
// main isolate
main() {
  runInIsolate(command);
}

runInIsolate(command) {
  var isolate = spawnIsolate(command);
  waitUtilFinished(isolate);
  if (command.runContinuously) {
    // Recurse
    runInIsolate(command);
  }
}

// command logic
try {
  dothings();
} catch(error) {
  report(error);
} finally {
  cleanUp();
}
```

Rollout plan:

- [ ] run on the agent on my desk for a few days
- [ ] if the previous step is successful, deploy to all agents
