### PR TITLE
invert Chromebot and AppVeyor status scan direction

### DIFF
--- a/commands/refresh_appveyor_status.go
+++ b/commands/refresh_appveyor_status.go
@@ -62,7 +62,10 @@ func RefreshAppVeyorStatus(cocoon *db.Cocoon, _ []byte) (interface{}, error) {
 	for _, fullTask := range appveyorTasks {
 		task := fullTask.TaskEntity.Task
 		checklistEntity := fullTask.ChecklistEntity
-		for _, appveyorResult := range appveyorResults {
+		// Scan results in reverse, as AppVeyor sorts the results with the latest
+		// towards the tail of the list.
+		for i := len(appveyorResults) - 1; i >= 0; i-- {
+			appveyorResult := appveyorResults[i]
 			if appveyorResult.CommitId == checklistEntity.Checklist.Commit.Sha {
 				if appveyorResult.Status == "success" {
 					task.Status = db.TaskSucceeded

--- a/commands/refresh_chromebot_status.go
+++ b/commands/refresh_chromebot_status.go
@@ -74,8 +74,7 @@ func refreshChromebot(cocoon *db.Cocoon, taskName string, builderName string) ([
 	}
 
 	for _, fullTask := range tasks {
-		// Scan build statuses in reverse so the newer result take precedence over old results.
-		for i := len(buildStatuses) - 1; i >= 0; i-- {
+		for i := 0; i < len(buildStatuses); i++ {
 			status := buildStatuses[i]
 			if status.Commit == fullTask.ChecklistEntity.Checklist.Commit.Sha {
 				task := fullTask.TaskEntity.Task


### PR DESCRIPTION
After this change the dashboard will show the latest build status for a given commit rather than the first.