### PR TITLE
Add .dart_tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dart_tool
 .DS_Store
 *~
 *.pyc


### PR DESCRIPTION
Dart 2 uses .dart_tool subdirectories for temporary caches for pub and
other SDK tooling.