### PR TITLE
Update android_sdk_packages

### DIFF
--- a/disk_images/android_sdk_packages
+++ b/disk_images/android_sdk_packages
@@ -1,4 +1,4 @@
 tools
 platform-tools
-build-tools;26.0.2
+build-tools;27.0.3
 platforms;android-27


### PR DESCRIPTION
We need build tools 27.0.3 installed to work with the newest Android Studio project templates, cf. https://github.com/flutter/flutter/pull/17942