### PR TITLE
Use a new HTTP client for each CI loop

### DIFF
--- a/agent/bin/agent.dart
+++ b/agent/bin/agent.dart
@@ -6,13 +6,11 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:http/http.dart';
 
 import 'package:cocoon_agent/src/agent.dart';
 import 'package:cocoon_agent/src/commands/ci.dart';
 import 'package:cocoon_agent/src/commands/run.dart';
 import 'package:cocoon_agent/src/utils.dart';
-import 'package:meta/meta.dart';
 
 Future<Null> main(List<String> rawArgs) async {
   ArgParser argParser = new ArgParser()
@@ -31,7 +29,7 @@ Future<Null> main(List<String> rawArgs) async {
   Agent agent = new Agent(
     baseCocoonUrl: config.baseCocoonUrl,
     agentId: config.agentId,
-    httpClient: new AuthenticatedClient(config.agentId, config.authToken)
+    authToken: config.authToken,
   );
 
   Map<String, Command> allCommands = <String, Command>{};
@@ -59,49 +57,4 @@ Future<Null> main(List<String> rawArgs) async {
   print(config);
 
   await command.run(args.command);
-}
-
-/// An error thrown by [AuthenticatedClient].
-class AuthenticatedClientError extends Error {
-  AuthenticatedClientError({
-    @required this.uri,
-    @required this.statusCode,
-    @required this.body,
-  });
-
-  final Uri uri;
-  final int statusCode;
-  final String body;
-
-  @override
-  String toString() => '$AuthenticatedClientError:\n'
-      '  URI: $uri\n'
-      '  HTTP status: $statusCode\n'
-      '  Response body:\n'
-      '$body';
-}
-
-class AuthenticatedClient extends BaseClient {
-  AuthenticatedClient(this._agentId, this._authToken);
-
-  final String _agentId;
-  final String _authToken;
-  final Client _delegate = new Client();
-
-  @override
-  Future<StreamedResponse> send(Request request) async {
-    request.headers['Agent-ID'] = _agentId;
-    request.headers['Agent-Auth-Token'] = _authToken;
-    final StreamedResponse resp = await _delegate.send(request);
-
-    if (resp.statusCode != 200) {
-      throw new AuthenticatedClientError(
-        uri: request.url,
-        statusCode: resp.statusCode,
-        body: (await Response.fromStream(resp)).body,
-      );
-    }
-
-    return resp;
-  }
 }

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -54,6 +54,8 @@ class ContinuousIntegrationCommand extends Command {
     _listenToShutdownSignals();
     await runZoned(() async {
       while(!_exiting) {
+        agent.resetHttpClient();
+
         // This try/catch captures errors that we cannot send to the server,
         // because we have not yet reserved a task. It will simply log to the
         // console.


### PR DESCRIPTION
This also updates send() to throw ClientException as required by
package:http, rather than an Error subclass.