### PR TITLE
Bundle build-tools 26.0.2 and 27.0.3 in images

### DIFF
--- a/disk_images/android_sdk_packages
+++ b/disk_images/android_sdk_packages
@@ -1,4 +1,5 @@
 tools
 platform-tools
+build-tools;26.0.2
 build-tools;27.0.3
 platforms;android-27


### PR DESCRIPTION
For the moment, it appears that we still rely on 26.0.2. Once we've
eliminated the dependency, we can remove the old version.