### PR TITLE
Increase timeout for VM launch

### DIFF
--- a/agent/lib/src/runner.dart
+++ b/agent/lib/src/runner.dart
@@ -192,7 +192,7 @@ Future<VMIsolate> _connectToRunnerIsolate(int vmServicePort) async {
         throw 'not ready yet';
       return isolate;
     } catch (error) {
-      const Duration connectionTimeout = const Duration(seconds: 2);
+      const Duration connectionTimeout = const Duration(seconds: 10);
       if (new DateTime.now().difference(started) > connectionTimeout) {
         throw new TimeoutException(
           'Failed to connect to the task runner process',


### PR DESCRIPTION
This fixes Windows bot failures post dart2 migration.