### PR TITLE
Close agent after comment terminates

### DIFF
--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -176,6 +176,13 @@ class Agent {
     }
     httpClient = new AuthenticatedClient(agentId, authToken);
   }
+
+  void close() {
+    if (httpClient != null) {
+      httpClient.close();
+    }
+    httpClient = null;
+  }
 }
 
 abstract class Command {


### PR DESCRIPTION
Ensures that we call HttpClient.close() to avoid leaving any dangling
sockets/subscriptions that would prevent termination.