### PR TITLE
Reverse order of considered checklists

### DIFF
--- a/commands/reserve_task.go
+++ b/commands/reserve_task.go
@@ -143,7 +143,7 @@ func findNextTaskToRun(cocoon *db.Cocoon, agent *db.Agent) (*db.TaskEntity, *db.
 		return nil, nil, err
 	}
 
-	for ci := len(checklists) - 1; ci >= 0; ci-- {
+	for ci := 0; ci < len(checklists); ci++ {
 		checklist := checklists[ci]
 		stages, err := cocoon.QueryTasksGroupedByStage(checklist.Key)
 


### PR DESCRIPTION
In order to run the newest tasks first. While there might be an overall more intelligent process, this gets us 80% there and should somewhat ameliorate the current situation.

Work for https://github.com/flutter/cocoon/issues/126