### PR TITLE
Fix LUCI statuses

### DIFF
--- a/commands/chromebot.go
+++ b/commands/chromebot.go
@@ -167,6 +167,12 @@ func getStatus(buildJSON map[string]interface{}) db.TaskStatus {
 	if buildJSON["finished"] != true {
 		return db.TaskInProgress
 	}
+	// Can happen if there was an "Infra Failure".
+	// Doesn't appear to be reported in any other way.
+	if buildJSON["text"] == nil {
+		return db.TaskFailed
+	}
+
 	text := buildJSON["text"].([]interface{})
 	if text[0].(string) == "Build successful" || text[1].(string) == "successful" {
 		return db.TaskSucceeded


### PR DESCRIPTION
Only the last commit is actually part of this change.

The "text" field can be `null` if there was an infra failure.  Our parsing logic was throwing an exception in that case and failing to update.

This is already staged (as v208) and migrated/running - to verify I had to make sure no competing instances were poluting the data.  If it's causing problems it can be rolled back.