### PR TITLE
add doc to cron.yaml

### DIFF
--- a/app/cron.yaml
+++ b/app/cron.yaml
@@ -1,3 +1,5 @@
+# Updates to this file must be pushed with:
+#   gcloud app deploy --project flutter-dashboard cron.yaml
 cron:
 - description: refresh commits from GitHub
   url: /api/refresh-github-commits


### PR DESCRIPTION
Changes to cron.yaml don't get pushed via the normal push instructions.

This is why I was seeing not all engine PRs get updated - the only ones that got updated were from my manual testing.