### PR TITLE
Fix luci check

### DIFF
--- a/commands/chromebot.go
+++ b/commands/chromebot.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"cocoon/db"
 	"context"
-	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -20,11 +20,22 @@ type ChromebotResult struct {
 	State  db.TaskStatus
 }
 
-// Fetches Flutter chromebot build statuses for the given builder in chronological order.
-func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderName string) ([]*ChromebotResult, error) {
-	const miloURL = "https://ci.chromium.org/prpc/milo.Buildbot/GetBuildbotBuildsJSON"
-	requestData := fmt.Sprintf("{\"master\": \"client.flutter\", \"builder\": \"%v\"}", builderName)
-	request, err := http.NewRequest("POST", miloURL, bytes.NewReader([]byte(requestData)))
+func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderNames []string) (map[string][]*ChromebotResult, error) {
+	const buildbucketV2URL = "https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds/Batch"
+	const maxResults = 40
+	statuses := make(map[string][]*ChromebotResult)
+
+	var requestData bytes.Buffer
+	requestData.WriteString("{\"requests\": [")
+	for i, builderName := range builderNames {
+		statuses[builderName] = make([]*ChromebotResult, 0, maxResults)
+		requestData.WriteString(fmt.Sprintf("{\"searchBuilds\":{\"predicate\":{\"builder\":{\"project\":\"flutter\",\"bucket\":\"prod\",\"builder\":\"%v\"}},\"pageSize\": %d}}", builderName, maxResults))
+		if i != len(builderNames)-1 {
+			requestData.WriteString(",")
+		}
+	}
+	requestData.WriteString("]}")
+	request, err := http.NewRequest("POST", buildbucketV2URL, bytes.NewReader(requestData.Bytes()))
 
 	if err != nil {
 		return nil, err
@@ -43,7 +54,7 @@ func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderName string) ([]*Chro
 	}
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("%v responded with HTTP status %v", miloURL, response.StatusCode)
+		return nil, fmt.Errorf("%v responded with HTTP status %v", buildbucketV2URL, response.StatusCode)
 	}
 
 	defer response.Body.Close()
@@ -60,7 +71,7 @@ func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderName string) ([]*Chro
 	openBraceIndex := bytes.Index(responseData, []byte("{"))
 
 	if openBraceIndex == -1 {
-		return nil, fmt.Errorf("%v returned JSON that's missing open brace", miloURL)
+		return nil, fmt.Errorf("%v returned JSON that's missing open brace", buildbucketV2URL)
 	}
 
 	responseData = responseData[openBraceIndex:]
@@ -71,115 +82,44 @@ func fetchChromebotBuildStatuses(cocoon *db.Cocoon, builderName string) ([]*Chro
 	if err != nil {
 		return nil, err
 	}
+	responses := responseJSON.(map[string]interface{})["responses"].([]interface{})
 
-	builds := responseJSON.(map[string]interface{})["builds"].([]interface{})
-
-	var results []*ChromebotResult
-
-	count := len(builds)
-	if count > 40 {
-		count = 40
+	if len(responses) != len(builderNames) {
+		return nil, errors.New("failed to get all builders")
 	}
 
-	for i := count - 1; i >= 0; i-- {
-		rawBuildJSON := builds[i].(map[string]interface{})
-		buildBase64String := rawBuildJSON["data"].(string)
-		buildBase64Bytes, err := base64.StdEncoding.DecodeString(buildBase64String)
+	for _, response := range responses {
+		searchBuilds := response.(map[string]interface{})["searchBuilds"].(map[string]interface{})
+		builds := searchBuilds["builds"].([]interface{})
+		for _, rawBuild := range builds {
+			build := rawBuild.(map[string]interface{})
+			builder := build["builder"].(map[string]interface{})
+			builderName := builder["builder"].(string)
+			commit := build["input"].(map[string]interface{})["gitilesCommit"].(map[string]interface{})["id"].(string)
 
-		if err != nil {
-			return nil, err
-		}
-
-		var buildJSON map[string]interface{}
-		err = json.Unmarshal(buildBase64Bytes, &buildJSON)
-
-		if err != nil {
-			return nil, err
-		}
-
-		results = append(results, &ChromebotResult{
-			Commit: getBuildProperty(buildJSON, "got_revision"),
-			State:  getStatus(buildJSON),
-		})
-	}
-
-	return results, nil
-}
-
-// Properties are encoded as:
-//
-//     {
-//       "properties": [
-//         [
-//           "name1",
-//           value1,
-//           ... things we don't care about ...
-//         ],
-//         [
-//           "name2",
-//           value2,
-//           ... things we don't care about ...
-//         ]
-//       ]
-//     }
-func getBuildProperty(buildJSON map[string]interface{}, propertyName string) string {
-	properties := buildJSON["properties"].([]interface{})
-	for _, property := range properties {
-		if property.([]interface{})[0] == propertyName {
-			return property.([]interface{})[1].(string)
+			switch status := build["status"].(string); status {
+			case "STATUS_UNSPECIFIED", "SCHEDULED", "STARTED":
+				statuses[builderName] = append(statuses[builderName], &ChromebotResult{
+					Commit: commit,
+					State:  db.TaskInProgress,
+				})
+			case "CANCELED":
+				statuses[builderName] = append(statuses[builderName], &ChromebotResult{
+					Commit: commit,
+					State:  db.TaskSkipped,
+				})
+			case "SUCCESS":
+				statuses[builderName] = append(statuses[builderName], &ChromebotResult{
+					Commit: commit,
+					State:  db.TaskSucceeded,
+				})
+			case "FAILURE", "INFRA_FAILURE":
+				statuses[builderName] = append(statuses[builderName], &ChromebotResult{
+					Commit: commit,
+					State:  db.TaskFailed,
+				})
+			}
 		}
 	}
-	return ""
-}
-
-// Parses out whether the build was successful.
-//
-// Successes are encoded like this:
-//
-//     "text": [
-//       "build",
-//       "successful"
-//     ]
-// or:
-//     "text": [
-//       "Build successful"
-//     ]
-//
-// Exceptions are encoded like this:
-//
-//     "text": [
-//       "exception",
-//       "steps",
-//       "exception",
-//       "flutter build apk material_gallery"
-//     ]
-//
-// Errors are encoded like this:
-//
-//     "text": [
-//       "failed",
-//       "steps",
-//       "failed",
-//       "flutter build ios simulator stocks"
-//     ]
-//
-// In-progress builds are encoded like this:
-//
-//    "finished": true
-//
-func getStatus(buildJSON map[string]interface{}) db.TaskStatus {
-	if buildJSON["finished"] != true {
-		return db.TaskInProgress
-	}
-	// Can happen if there was an "Infra Failure".
-	// Doesn't appear to be reported in any other way.
-	if buildJSON["text"] == nil {
-		return db.TaskFailed
-	}
-
-	text := buildJSON["text"].([]interface{})
-	if text[0].(string) == "Build successful" || (len(text) > 1 && text[1].(string) == "successful") {
-		return db.TaskSucceeded
-	}
-	return db.TaskFailed
+	return statuses, nil
 }

--- a/commands/github.go
+++ b/commands/github.go
@@ -44,7 +44,7 @@ func pushToGitHub(c *db.Cocoon, info GitHubBuildStatusInfo) error {
 		data["state"] = "success"
 	} else {
 		data["state"] = "failure"
-		data["target_url"] = "https://flutter-dashboard.appspot.com/build.html"
+		data["target_url"] = info.link
 		data["description"] = fmt.Sprintf("%v is currently broken. Please do not merge this PR unless it contains a fix to the broken build.", info.buildName)
 	}
 	data["context"] = info.buildContext

--- a/commands/refresh_chromebot_status.go
+++ b/commands/refresh_chromebot_status.go
@@ -54,7 +54,7 @@ func refreshChromebot(cocoon *db.Cocoon, taskName string, builderName string) ([
 		return make([]*ChromebotResult, 0), nil
 	}
 
-	buildStatuses, err := fetchChromebotBuildStatuses(cocoon, builderName)
+	buildStatuses, err := fetchChromebotBuildStatuses(cocoon, []string{builderName})
 
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func refreshChromebot(cocoon *db.Cocoon, taskName string, builderName string) ([
 
 	for _, fullTask := range tasks {
 		for i := 0; i < len(buildStatuses); i++ {
-			status := buildStatuses[i]
+			status := buildStatuses[builderName][i]
 			if status.Commit == fullTask.ChecklistEntity.Checklist.Commit.Sha {
 				task := fullTask.TaskEntity.Task
 				task.Status = status.State
@@ -71,5 +71,5 @@ func refreshChromebot(cocoon *db.Cocoon, taskName string, builderName string) ([
 		}
 	}
 
-	return buildStatuses, nil
+	return buildStatuses[builderName], nil
 }


### PR DESCRIPTION
Now that the engine builders are sharded, we need to update this.

The milo API is too slow to handle this many builders (it was already struggling anyway).  It's also about to be turned off, so I've moved the call over to the newer faster buildbucket.V2 api.

I've also fixed the link that gets posted to github.  We'll only get one status line for LUCI, but the link now goes to the engine console.