### PR TITLE
Fix status logic

### DIFF
--- a/commands/push_engine_build_status_to_github.go
+++ b/commands/push_engine_build_status_to_github.go
@@ -71,7 +71,7 @@ func pushLatestEngineBuildStatusToGithub(c *db.Cocoon, builderNames []string) er
 				}
 			}
 
-			cacheLastEngineBuildStatusSubmittedToGithub(c.Ctx, "LUCI Engine Build", pr.Head.Sha, latestStatus)
+			cacheLastEngineBuildStatusSubmittedToGithub(c.Ctx, "luci-engine", pr.Head.Sha, latestStatus)
 		}
 	}
 


### PR DESCRIPTION
Adds some logging.  Turns out I was using different strings to check before and after, which has resulted in us being rate limited.

Due to the fact that this was causing issues I've already moved us to the new version (v212) containing this logic.