### PR TITLE
Make build history page aware of flaky tests

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -78,8 +78,7 @@ class MetapodBottomNavigationBar extends StatelessWidget {
           backgroundColor: theme.primaryColor,
         ),
         BottomNavigationBarItem(
-          icon: const Icon(Icons.people_outline),
-          activeIcon: const Icon(Icons.people),
+          icon: const Icon(Icons.desktop_windows),
           title: const Text('Agents'),
           backgroundColor: theme.primaryColor,
         ),


### PR DESCRIPTION
1. If all tests pass except flaky tests, show results as flaky instead of completely failing.
2. Change letters in build result boxes as icons.
3. Change agents icon from people to computer, since that's what they are.
4. Make pending build status boxes pulse instead of spin.