### PR TITLE
When widget is removed from the tree ensure outstanding timer callbacks do not operate on null contexts

### DIFF
--- a/app/lib/repository/models/providers.dart
+++ b/app/lib/repository/models/providers.dart
@@ -33,12 +33,21 @@ class ModelBinding<T> extends StatefulWidget {
   static Type _typeOf<T>() => T;  // https://github.com/dart-lang/sdk/issues/33297
 
   static T of<T>(BuildContext context) {
+    if (context == null) {
+      // The widget is not in the tree.
+      return null;
+    }
+
     final Type scopeType = _typeOf<_ModelBindingScope<T>>();
     final _ModelBindingScope<T> scope = context.inheritFromWidgetOfExactType(scopeType);
     return scope.modelBindingState.currentModel;
   }
 
   static void update<T>(BuildContext context, T newModel) {
+    if (context == null) {
+      // The widget is not in the tree.
+      return;
+    }
     final Type scopeType = _typeOf<_ModelBindingScope<T>>();
     final _ModelBindingScope<dynamic> scope = context.inheritFromWidgetOfExactType(scopeType);
     scope.modelBindingState.updateModel(newModel);

--- a/app/lib/repository/models/repository_status.dart
+++ b/app/lib/repository/models/repository_status.dart
@@ -183,21 +183,24 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
   }
 
   Future<void> _fetchRepositoryDetails() async {
+    if (!mounted) {
+      return;
+    }
     final T refreshedRepositoryStatus = ModelBinding.of<T>(context).copy();
 
     // Update with the fast, cheap, possibly cached repository details to show UI ASAP.
     try {
       await fetchRepositoryDetails(refreshedRepositoryStatus);
       ModelBinding.update<T>(context, refreshedRepositoryStatus);
-
-      // Then fetch update with the more expensive issues query value.
-      ModelBinding.of<T>(context).copy();
     } catch (error) {
       print('Error refreshing "${refreshedRepositoryStatus.name}" repository details: $error');
     }
   }
 
   Future<void> _fetchRepositoryIssues() async {
+    if (!mounted) {
+      return;
+    }
     final T refreshedRepositoryStatus = ModelBinding.of<T>(context).copy();
     try {
       await fetchRepositoryIssues(refreshedRepositoryStatus);
@@ -211,6 +214,9 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
   }
 
   Future<void> _fetchToDoCount() async {
+    if (!mounted) {
+      return;
+    }
     final T refreshedRepositoryStatus = ModelBinding.of<T>(context).copy();
 
     try {

--- a/app/lib/repository/models/roll_history.dart
+++ b/app/lib/repository/models/roll_history.dart
@@ -77,17 +77,22 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
 
   Future<void> _refresh(Timer timer) async {
     final RollHistory rollHistory = ModelBinding.of<RollHistory>(context).copy();
-    await _updateLastSkiaAutoRoll(rollHistory);
-    await _updateLastEngineAutoRoll(rollHistory);
-    await _updateLastDevBranchRoll(rollHistory);
-    await _updateLastBetaBranchRoll(rollHistory);
-    await _updateLastStableBranchRoll(rollHistory);
-    await _updateLastFlutterWebRoll(rollHistory);
+    await Future.wait([
+      _updateLastSkiaAutoRoll(rollHistory),
+      _updateLastEngineAutoRoll(rollHistory),
+      _updateLastDevBranchRoll(rollHistory),
+      _updateLastBetaBranchRoll(rollHistory),
+      _updateLastStableBranchRoll(rollHistory),
+      _updateLastFlutterWebRoll(rollHistory)
+    ]);
 
     ModelBinding.update<RollHistory>(context, rollHistory);
   }
 
   Future<void> _updateLastSkiaAutoRoll(RollHistory history) async {
+    if (!mounted) {
+      return;
+    }
     try {
       DateTime fetchedDate = await lastCommitFromAuthor('engine', 'skia-flutter-autoroll');
       if (fetchedDate != null) {
@@ -99,6 +104,9 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
   }
 
   Future<void> _updateLastEngineAutoRoll(RollHistory history) async {
+    if (!mounted) {
+      return;
+    }
     try {
       DateTime fetchedDate = await lastCommitFromAuthor('flutter', 'engine-flutter-autoroll');
       if (fetchedDate != null) {
@@ -110,6 +118,9 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
   }
 
   Future<void> _updateLastDevBranchRoll(RollHistory history) async {
+    if (!mounted) {
+      return;
+    }
     try {
       DateTime fetchedDate = await fetchBranchLastCommitDate('flutter', 'dev');
       if (fetchedDate != null) {
@@ -121,6 +132,9 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
   }
 
   Future<void> _updateLastBetaBranchRoll(RollHistory history) async {
+    if (!mounted) {
+      return;
+    }
     try {
       DateTime fetchedDate = await fetchBranchLastCommitDate('flutter', 'beta');
       if (fetchedDate != null) {
@@ -132,6 +146,9 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
   }
 
   Future<void> _updateLastStableBranchRoll(RollHistory history) async {
+    if (!mounted) {
+      return;
+    }
     try {
       DateTime fetchedDate = await fetchBranchLastCommitDate('flutter', 'stable');
       if (fetchedDate != null) {


### PR DESCRIPTION
Avoid "Cannot read property 'inheritFromWidgetOfExactType' of null" errors when the context is null during a Timer callback due to the widget being unmounted.