### PR TITLE
Reset issue counters on refresh

### DIFF
--- a/app/lib/repository/services/github_service.dart
+++ b/app/lib/repository/services/github_service.dart
@@ -45,6 +45,16 @@ Future<void> fetchRepositoryIssues(RepositoryStatus repositoryStatus) async {
 
   Map<String, int> pullRequestCountByTopicAggregator = {};
   Map<String, int> issueCountByLabelAggregator = {};
+
+  // Reset counters to be aggregated in _fetchRepositoryIssuesByPage.
+  repositoryStatus.issueCount = 0;
+  repositoryStatus.missingMilestoneIssuesCount = 0;
+  repositoryStatus.staleIssueCount = 0;
+  repositoryStatus.totalAgeOfAllIssues = 0;
+  repositoryStatus.pullRequestCount = 0;
+  repositoryStatus.stalePullRequestCount = 0;
+  repositoryStatus.totalAgeOfAllPullRequests = 0;
+
   await _fetchRepositoryIssuesByPage(url, repositoryStatus, issueCountByLabelAggregator, pullRequestCountByTopicAggregator);
 
   // SplayTreeMap doesn't allow sorting by value (count) on insert. Sort at the end once all search page fetches are complete.


### PR DESCRIPTION
Counters were not reset on refresh, so they were continuously aggregating.
After a weekend there were 10,000+ PRs.