### PR TITLE
Add keep alives to widgets that kick off networking

### DIFF
--- a/app/lib/repository/models/build_status.dart
+++ b/app/lib/repository/models/build_status.dart
@@ -44,7 +44,7 @@ class RefreshBuildStatus extends StatefulWidget {
   }
 }
 
-class _RefreshRefreshBuildStatusState extends State<RefreshBuildStatus> {
+class _RefreshRefreshBuildStatusState extends State<RefreshBuildStatus> with AutomaticKeepAliveClientMixin<RefreshBuildStatus> {
   Timer _refreshTimer;
 
   @override
@@ -60,6 +60,9 @@ class _RefreshRefreshBuildStatusState extends State<RefreshBuildStatus> {
     super.dispose();
   }
 
+  @override
+  bool get wantKeepAlive => true;
+
   Future<void> _refresh(Timer timer) async {
     try {
       BuildStatus status = await fetchBuildStatus();
@@ -73,6 +76,7 @@ class _RefreshRefreshBuildStatusState extends State<RefreshBuildStatus> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return widget.child;
   }
 }

--- a/app/lib/repository/models/github_status.dart
+++ b/app/lib/repository/models/github_status.dart
@@ -44,7 +44,7 @@ class RefreshGithubStatus extends StatefulWidget {
   }
 }
 
-class _RefreshGithubStatusState extends State<RefreshGithubStatus> {
+class _RefreshGithubStatusState extends State<RefreshGithubStatus> with AutomaticKeepAliveClientMixin<RefreshGithubStatus> {
   Timer _refreshTimer;
 
   @override
@@ -60,6 +60,9 @@ class _RefreshGithubStatusState extends State<RefreshGithubStatus> {
     super.dispose();
   }
 
+  @override
+  bool get wantKeepAlive => true;
+
   Future<void> _refresh(Timer timer) async {
     try {
       final GithubStatus status = await fetchGithubStatus();
@@ -73,6 +76,7 @@ class _RefreshGithubStatusState extends State<RefreshGithubStatus> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return widget.child;
   }
 }

--- a/app/lib/repository/models/repository_status.dart
+++ b/app/lib/repository/models/repository_status.dart
@@ -155,7 +155,7 @@ class RefreshRepository<T extends RepositoryStatus> extends StatefulWidget {
   }
 }
 
-class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshRepository<T>> {
+class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshRepository<T>> with AutomaticKeepAliveClientMixin<RefreshRepository<T>> {
   Timer _refreshTimer;
   bool _isLoaded = false;
 
@@ -171,6 +171,9 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
     _refreshTimer?.cancel();
     super.dispose();
   }
+
+  @override
+  bool get wantKeepAlive => true;
 
   Future<void> _refresh(Timer timer) async {
     // Update with the fast, cheap, possibly cached repository details to show UI ASAP.
@@ -257,6 +260,7 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return _isLoaded ? widget.child : const Center(child: CircularProgressIndicator());
   }
 }

--- a/app/lib/repository/models/roll_history.dart
+++ b/app/lib/repository/models/roll_history.dart
@@ -59,7 +59,7 @@ class RefreshRollHistory extends StatefulWidget {
   }
 }
 
-class _RefreshRollHistoryState extends State<RefreshRollHistory> {
+class _RefreshRollHistoryState extends State<RefreshRollHistory> with AutomaticKeepAliveClientMixin<RefreshRollHistory> {
   Timer _refreshTimer;
 
   @override
@@ -74,6 +74,9 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
     _refreshTimer?.cancel();
     super.dispose();
   }
+
+  @override
+  bool get wantKeepAlive => true;
 
   Future<void> _refresh(Timer timer) async {
     final RollHistory rollHistory = ModelBinding.of<RollHistory>(context).copy();
@@ -176,6 +179,7 @@ class _RefreshRollHistoryState extends State<RefreshRollHistory> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return widget.child;
   }
 }

--- a/app/lib/repository/repository.dart
+++ b/app/lib/repository/repository.dart
@@ -85,6 +85,7 @@ class _RepositoryDashboardWidget extends StatelessWidget {
               const InfrastructureDetails(),
               const RollDetails()
             ],
+            addAutomaticKeepAlives: true,
           )
         ),
       ),


### PR DESCRIPTION
Confirmed networking no longer kicks off when cards scroll in.