### PR TITLE
Show more triage labels in repo widgets

### DIFF
--- a/app/lib/repository/details/repository.dart
+++ b/app/lib/repository/details/repository.dart
@@ -10,13 +10,10 @@ import 'package:flutter_web/material.dart';
 import '../models/providers.dart';
 import '../models/repository_status.dart';
 
-typedef LabelEvaluator = bool Function(String labelName);
-
 class RepositoryDetails<T extends RepositoryStatus> extends StatelessWidget {
-  const RepositoryDetails({@required this.icon, this.labelEvaluation});
+  const RepositoryDetails({@required this.icon});
 
   final Widget icon;
-  final LabelEvaluator labelEvaluation;
 
   @override
   Widget build(BuildContext context) {
@@ -30,8 +27,8 @@ class RepositoryDetails<T extends RepositoryStatus> extends StatelessWidget {
           _IssueWidget<T>(),
           // The Flutter repository contains labels relevant to some other repos like plugins, engine, etc. Avoiding displaying twice in the Flutter repository widget.
           if (repositoryStatus.runtimeType != flutterStatus.runtimeType)
-            _TopicListWidget(title: 'Flutter Pull Request Labels', countByTopic: flutterStatus.pullRequestCountByLabelName, labelEvaluation: labelEvaluation),
-          _TopicListWidget(title: 'Pull Request Labels', countByTopic: repositoryStatus.pullRequestCountByLabelName, labelEvaluation: labelEvaluation),
+            _TopicListWidget(title: 'Flutter Pull Request Labels', countByTopic: flutterStatus.pullRequestCountByLabelName, labelEvaluation: repositoryStatus.labelEvaluation),
+          _TopicListWidget(title: 'Pull Request Labels', countByTopic: repositoryStatus.pullRequestCountByLabelName, labelEvaluation: repositoryStatus.labelEvaluation),
           _TopicListWidget(title: 'Pull Requests by Topic', countByTopic: repositoryStatus.pullRequestCountByTitleTopic)
         ]
       )

--- a/app/lib/repository/repository.dart
+++ b/app/lib/repository/repository.dart
@@ -64,38 +64,19 @@ class _RepositoryDashboardWidget extends StatelessWidget {
             maxCrossAxisExtent: 450.0,
             childAspectRatio: .55,
             children: <Widget>[
-              RepositoryDetails<FlutterRepositoryStatus>(
-                icon: const FlutterLogo(),
-                labelEvaluation: (String labelName) => <String>[
-                  'waiting for tree to go green',
-                  '⚠ TODAY',
-                  'severe: customer blocker',
-                  'severe: customer critical',
-                  'framework',
-                  'f: cupertino',
-                  'f: material design',
-                  'tool',
-                  'will need additional triage',
-                  'customer: crowd',
-                ].contains(labelName)
+              const RepositoryDetails<FlutterRepositoryStatus>(
+                icon: FlutterLogo(),
               ),
               ModelBinding<FlutterEngineRepositoryStatus>(
                 initialModel: FlutterEngineRepositoryStatus(),
                 child: RepositoryDetails<FlutterEngineRepositoryStatus>(
                   icon: Icon(Icons.layers),
-                  labelEvaluation: (String labelName) => labelName == 'engine'
-                    || labelName == 'needs love'
-                    || labelName.startsWith('e:')
-                    || labelName.startsWith('affects:')
                 ),
               ),
               ModelBinding<FlutterPluginsRepositoryStatus>(
                 initialModel: FlutterPluginsRepositoryStatus(),
                 child: RepositoryDetails<FlutterPluginsRepositoryStatus>(
                   icon: Icon(Icons.extension),
-                  labelEvaluation: (String labelName) => labelName.startsWith('p:')
-                    || labelName == 'flutterfire'
-                    || labelName == 'needs love'
                 ),
               ),
               const InfrastructureDetails(),

--- a/app/lib/repository/services/github_service.dart
+++ b/app/lib/repository/services/github_service.dart
@@ -44,7 +44,7 @@ Future<int> fetchIssueCount(String repositoryName) async {
 }
 
 Future<int> fetchStaleIssueCount(String repositoryName) async {
-  final DateTime staleDate = DateTime.now().subtract(Duration(days: RepositoryStatus.staleIssueThresholdInDays));
+  final DateTime staleDate = DateTime.now().subtract(const Duration(days: RepositoryStatus.staleIssueThresholdInDays));
   final String stateDateQuery = DateFormat('yyyy-MM-dd').format(staleDate);
   return _searchIssuesTotalCount(repositoryName, additionalQuery: 'updated:<=$stateDateQuery');
 }


### PR DESCRIPTION
1. Add more labels to show in widgets, including the triage classification labels.
2. Separate out flutter labels from the engine and plugin labels.
3. issueCountByLabelName renamed to pullRequestCountByLabelName to be accurate.