### PR TITLE
Make benchmarks page refresh every 2 minutes instead of 20

### DIFF
--- a/app/web/benchmarks.html
+++ b/app/web/benchmarks.html
@@ -8,7 +8,7 @@
 
 <html>
 <head>
-  <meta http-equiv="refresh" content="1200">
+  <meta http-equiv="refresh" content="120">
 
   <title>Flutter Benchmarks</title>
   <link href="benchmarks.css" rel="stylesheet">


### PR DESCRIPTION
... to keep the dashboard TV from going to sleep.