### PR TITLE
Show "no labels" instead of "no milestone" to represent untriaged issues

### DIFF
--- a/app/lib/repository/details/repository.dart
+++ b/app/lib/repository/details/repository.dart
@@ -67,7 +67,7 @@ class _IssueWidget<T extends RepositoryStatus> extends StatelessWidget {
         const Divider(),
         const _DetailTitle(title: 'Issues'),
         _DetailItem(title: 'Open', value: numberFormat.format(issueCount)),
-        _DetailItem(title: 'No Milestone', value: '${numberFormat.format(repositoryStatus.missingMilestoneIssuesCount)} (${percentFormat.format(repositoryStatus.missingMilestoneIssuesCount / issueCount)})'),
+        _DetailItem(title: 'No Labels', value: '${numberFormat.format(repositoryStatus.missingLabelsIssuesCount)} (${percentFormat.format(repositoryStatus.missingLabelsIssuesCount / issueCount)})'),
         _DetailItem(title: 'Unmodified in month', value: '${numberFormat.format(repositoryStatus.staleIssueCount)} (${percentFormat.format(repositoryStatus.staleIssueCount / issueCount)})'),
       ];
     }

--- a/app/lib/repository/models/repository_status.dart
+++ b/app/lib/repository/models/repository_status.dart
@@ -35,7 +35,7 @@ abstract class RepositoryStatus {
   int todoCount = 0;
 
   int issueCount = 0;
-  int missingMilestoneIssuesCount = 0;
+  int missingLabelsIssuesCount = 0;
   /// Number of issues that have been unmodified in [staleIssueThresholdInDays] days.
   int staleIssueCount = 0;
 
@@ -69,7 +69,7 @@ abstract class RepositoryStatus {
       ..todoCount = todoCount
       ..issueCount = issueCount
       ..pullRequestCount = pullRequestCount
-      ..missingMilestoneIssuesCount = missingMilestoneIssuesCount
+      ..missingLabelsIssuesCount = missingLabelsIssuesCount
       ..staleIssueCount = staleIssueCount
       ..stalePullRequestCount = stalePullRequestCount
       ..totalAgeOfAllPullRequests = totalAgeOfAllPullRequests
@@ -98,7 +98,7 @@ abstract class RepositoryStatus {
       && (typedOther.issuesEnabled == issuesEnabled)
       && (typedOther.todoCount == todoCount)
       && (typedOther.issueCount == issueCount)
-      && (typedOther.missingMilestoneIssuesCount == missingMilestoneIssuesCount)
+      && (typedOther.missingLabelsIssuesCount == missingLabelsIssuesCount)
       && (typedOther.staleIssueCount == staleIssueCount)
       && (typedOther.pullRequestCount == pullRequestCount)
       && (typedOther.stalePullRequestCount == stalePullRequestCount)
@@ -118,7 +118,7 @@ abstract class RepositoryStatus {
     issuesEnabled,
     todoCount,
     issueCount,
-    missingMilestoneIssuesCount,
+    missingLabelsIssuesCount,
     staleIssueCount,
     pullRequestCount,
     stalePullRequestCount,
@@ -218,7 +218,7 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
         futuresToFetch.addAll(<Future<void>>[
           _updateIssueCount(repositoryStatus),
           _updateStaleIssueCount(repositoryStatus),
-          _updateIssuesWithoutMilestone(repositoryStatus)]);
+          _updateIssuesWithoutLabels(repositoryStatus)]);
       }
       await Future.wait(futuresToFetch, eagerError: true);
     } catch (error) {
@@ -257,13 +257,13 @@ class _RefreshRepositoryState<T extends RepositoryStatus> extends State<RefreshR
     }
   }
 
-  Future<void> _updateIssuesWithoutMilestone(T repositoryStatus) async {
+  Future<void> _updateIssuesWithoutLabels(T repositoryStatus) async {
     if (!mounted) {
       return;
     }
-    final int missingMilestoneIssuesCount = await fetchIssuesWithoutMilestone(repositoryStatus.name);
-    if (missingMilestoneIssuesCount != null) {
-      repositoryStatus.missingMilestoneIssuesCount = missingMilestoneIssuesCount;
+    final int missingLabelsIssuesCount = await fetchIssuesWithoutLabels(repositoryStatus.name);
+    if (missingLabelsIssuesCount != null) {
+      repositoryStatus.missingLabelsIssuesCount = missingLabelsIssuesCount;
     }
   }
 

--- a/app/lib/repository/services/github_service.dart
+++ b/app/lib/repository/services/github_service.dart
@@ -49,8 +49,8 @@ Future<int> fetchStaleIssueCount(String repositoryName) async {
   return _searchIssuesTotalCount(repositoryName, additionalQuery: 'updated:<=$stateDateQuery');
 }
 
-Future<int> fetchIssuesWithoutMilestone(String repositoryName) async {
-  return _searchIssuesTotalCount(repositoryName, additionalQuery: 'no:milestone');
+Future<int> fetchIssuesWithoutLabels(String repositoryName) async {
+  return _searchIssuesTotalCount(repositoryName, additionalQuery: 'no:label');
 }
 
 Future<int>_searchIssuesTotalCount(String repositoryName, {String additionalQuery = ''}) async {


### PR DESCRIPTION
The "no milestones" issue count was intended to track the number of issues that needed to be triaged.  However "no labels" seems to be a more accurate metric.