### PR TITLE
Remove Cirrus status indicators that never refresh

### DIFF
--- a/app/lib/repository/details/infrastructure.dart
+++ b/app/lib/repository/details/infrastructure.dart
@@ -13,10 +13,6 @@ class InfrastructureDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final CircleAvatar cirrusLogo = CircleAvatar(
-      child: Image.network('https://avatars2.githubusercontent.com/ml/953?s=28'),
-      backgroundColor: const Color(0xFF212121),
-    );
     return Card(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20.0),
@@ -29,21 +25,6 @@ class InfrastructureDetails extends StatelessWidget {
             const ModelBinding<BuildStatus>(
               initialModel: BuildStatus(),
               child: _BuildStatusWidget()
-            ),
-            ListTile(
-              leading: cirrusLogo,
-              title: const Text('packages'),
-              trailing: Image.network('https://api.cirrus-ci.com/github/flutter/packages.svg?branch=master', semanticLabel: 'Packages Cirrus CI Status'),
-            ),
-            ListTile(
-              leading: cirrusLogo,
-              title: const Text('website'),
-              trailing: Image.network('https://api.cirrus-ci.com/github/flutter/website.svg?branch=master', semanticLabel: 'Website Cirrus CI Status'),
-            ),
-            ListTile(
-              leading: cirrusLogo,
-              title: const Text('flutter_markdown'),
-              trailing: Image.network('https://api.cirrus-ci.com/github/flutter/flutter_markdown.svg?branch=master', semanticLabel: 'Flutter Markdown Cirrus CI Status'),
             ),
             ModelBinding<GithubStatus>(
               initialModel: const GithubStatus(),

--- a/app/lib/repository/details/repository.dart
+++ b/app/lib/repository/details/repository.dart
@@ -42,7 +42,6 @@ class RepositoryDetails<T extends RepositoryStatus> extends StatelessWidget {
               leading: IconTheme(data: Theme.of(context).iconTheme.copyWith(size: 36.0), child: icon),
               title: Text(toBeginningOfSentenceCase(repositoryStatus.name)),
               subtitle: Text('Watchers: ${numberFormat.format(repositoryStatus.watchersCount)}\nSubscribers: ${numberFormat.format(repositoryStatus.subscribersCount)}\nTODOs: ${numberFormat.format(repositoryStatus.todoCount)}'),
-              trailing: Image.network('https://api.cirrus-ci.com/github/flutter/${repositoryStatus.name}.svg?branch=master', semanticLabel: 'Cirrus CI status'), // TODO: Refresh CI image periodically.
               isThreeLine: true,
             ),
             refreshWidget


### PR DESCRIPTION
The Cirrus status icons never refresh. Remove them instead of showing incorrect data.