### PR TITLE
Limit to last 50 commits for refresh commits

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -33,7 +33,8 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
   Future<Body> get() async {
     final GitHub github = await config.createGitHubClient();
     final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-    final List<RepositoryCommit> commits = await github.repositories.listCommits(slug).toList();
+    final List<RepositoryCommit> commits =
+        await github.repositories.listCommits(slug).take(50).toList();
     log.debug('Downloaded ${commits.length} commits from GitHub');
 
     final int now = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
The go version of this API is just getting the "first page" of commits.  The Dart version is trying to get all of them.

Limiting it to 50 for now to prevent us from processing way more data than we need to.  Longer term, this should probably be incorporated into the webhook or into some more robust method.

