### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -23,9 +23,9 @@ class Task extends Model {
     this.attempts,
     this.isFlaky,
     this.timeoutInMinutes,
-    this.reason,
+    this.reason = '',
     this.requiredCapabilities,
-    this.reservedForAgentId,
+    this.reservedForAgentId = '',
     this.stageName,
     String status,
   }) : _status = status {

--- a/app_dart/lib/src/model/luci/buildbucket.dart
+++ b/app_dart/lib/src/model/luci/buildbucket.dart
@@ -22,7 +22,7 @@ part 'buildbucket.g.dart';
 ///
 /// This message can be used to find, get, schedule, or cancel multiple builds.
 @JsonSerializable(includeIfNull: false)
-class BatchRequest implements Body {
+class BatchRequest extends JsonBody {
   /// Creates a request for the Batch RPC.
   const BatchRequest({
     this.requests,
@@ -42,7 +42,7 @@ class BatchRequest implements Body {
 ///
 /// A single request must contain only one object.
 @JsonSerializable(includeIfNull: false)
-class Request implements Body {
+class Request extends JsonBody {
   /// Creates a request for the Batch RPC.
   ///
   /// One and only one argument should be set.
@@ -91,7 +91,7 @@ class Request implements Body {
 
 /// A response from the Batch RPC.
 @JsonSerializable(includeIfNull: false)
-class BatchResponse implements Body {
+class BatchResponse extends JsonBody {
   /// Creates a response for the Batch RPC.
   const BatchResponse({
     this.responses,
@@ -109,7 +109,7 @@ class BatchResponse implements Body {
 
 /// An individual response from a batch request.
 @JsonSerializable(includeIfNull: false)
-class Response implements Body {
+class Response extends JsonBody {
   /// Creates a response for the response from the Batch RPC.
   ///
   /// One and only one of these should be set.
@@ -156,7 +156,7 @@ class Response implements Body {
 
 /// A request for the GetBuild RPC.
 @JsonSerializable(includeIfNull: false)
-class GetBuildRequest implements Body {
+class GetBuildRequest extends JsonBody {
   /// Creates a request for the GetBuild RPC.
   const GetBuildRequest({
     this.id,
@@ -191,7 +191,7 @@ class GetBuildRequest implements Body {
 
 /// A request for the CancelBuild RPC.
 @JsonSerializable(includeIfNull: false)
-class CancelBuildRequest implements Body {
+class CancelBuildRequest extends JsonBody {
   /// Creates a request object for the CancelBuild RPC.
   ///
   /// Both [id] and [summaryMarkdown] are required.
@@ -220,7 +220,7 @@ class CancelBuildRequest implements Body {
 
 /// A request object for the SearchBuilds RPC.
 @JsonSerializable(includeIfNull: false)
-class SearchBuildsRequest implements Body {
+class SearchBuildsRequest extends JsonBody {
   /// Creates a request object for the SearchBuilds RPC.
   ///
   /// The [predicate] is required.
@@ -260,7 +260,7 @@ class SearchBuildsRequest implements Body {
 
 /// A predicate to apply when searching for builds in the SearchBuilds RPC.
 @JsonSerializable(includeIfNull: false)
-class BuildPredicate implements Body {
+class BuildPredicate extends JsonBody {
   /// Creates a predicate to apply when searching for builds in the SearchBuilds
   /// RPC.
   ///
@@ -301,7 +301,7 @@ class BuildPredicate implements Body {
 
 /// The response object from a SearchBuilds RPC.
 @JsonSerializable(includeIfNull: false)
-class SearchBuildsResponse implements Body {
+class SearchBuildsResponse extends JsonBody {
   /// Creates a new response object from the SearchBuilds RPC.
   ///
   /// The [nextPageToken] can be used to coninue searching if there are more
@@ -331,7 +331,7 @@ class SearchBuildsResponse implements Body {
 
 /// A request object for the ScheduleBuild RPC.
 @JsonSerializable(includeIfNull: false)
-class ScheduleBuildRequest implements Body {
+class ScheduleBuildRequest extends JsonBody {
   /// Creates a new request object for the ScheduleBuild RPC.
   ///
   /// The [requestId] is "strongly recommended", and is used by the back end to
@@ -419,7 +419,7 @@ class ScheduleBuildRequest implements Body {
 ///   * [BuilderId]
 ///   * [GetBuildRequest]
 @JsonSerializable(includeIfNull: false)
-class Build implements Body {
+class Build extends JsonBody {
   /// Creates a build object.
   ///
   /// The [id] and [builderId] parameter is required.
@@ -503,7 +503,7 @@ class Build implements Body {
 
 /// A unique handle to a builder on BuildBucket.
 @JsonSerializable(includeIfNull: false)
-class BuilderId implements Body {
+class BuilderId extends JsonBody {
   /// Creates a unique handle to a builder on BuildBucket.
   ///
   /// The bucket and builder control what ACLs for the infra, as specified in
@@ -536,7 +536,7 @@ class BuilderId implements Body {
 /// Specifies a Cloud PubSub topic to send notification updates to from a
 /// [ScheduleBuildRequest].
 @JsonSerializable(includeIfNull: false)
-class NotificationConfig extends Body {
+class NotificationConfig extends JsonBody {
   const NotificationConfig({this.pubsubTopic, this.userData});
 
   static NotificationConfig fromJson(Map<String, dynamic> json) => _$NotificationConfigFromJson(json);
@@ -557,7 +557,7 @@ class NotificationConfig extends Body {
 
 /// The build inputs for a build.
 @JsonSerializable(includeIfNull: false)
-class Input implements Body {
+class Input extends JsonBody {
   /// Creates a set of build inputs for a build.
   const Input({
     this.properties,
@@ -584,7 +584,7 @@ class Input implements Body {
 
 /// A landed Git commit hosted on Gitiles.
 @JsonSerializable(includeIfNull: false)
-class GitilesCommit implements Body {
+class GitilesCommit extends JsonBody {
   /// Creates a object corresponding to a landed Git commit hosted on Gitiles.
   const GitilesCommit({
     this.host,

--- a/app_dart/lib/src/model/luci/push_message.dart
+++ b/app_dart/lib/src/model/luci/push_message.dart
@@ -29,7 +29,7 @@ part 'push_message.g.dart';
 ///
 /// See https://cloud.google.com/pubsub/docs/push#receiving_push_messages
 @JsonSerializable(includeIfNull: false)
-class PushMessageEnvelope implements Body {
+class PushMessageEnvelope extends JsonBody {
   const PushMessageEnvelope({
     this.message,
     this.subscription,
@@ -50,7 +50,7 @@ class PushMessageEnvelope implements Body {
 
 /// A PubSub push message payload.
 @JsonSerializable(includeIfNull: false)
-class PushMessage implements Body {
+class PushMessage extends JsonBody {
   const PushMessage({
     this.attributes,
     this.data,
@@ -75,7 +75,7 @@ class PushMessage implements Body {
 
 /// The LUCI build data from a PubSub push message payload.
 @JsonSerializable(includeIfNull: false)
-class BuildPushMessage implements Body {
+class BuildPushMessage extends JsonBody {
   const BuildPushMessage({
     this.build,
     this.hostname,
@@ -100,7 +100,7 @@ class BuildPushMessage implements Body {
 
 /// See https://github.com/luci/luci-go/blob/master/common/api/buildbucket/buildbucket/v1/buildbucket-gen.go#L332ƒ
 @JsonSerializable(includeIfNull: false)
-class Build implements Body {
+class Build extends JsonBody {
   const Build({
     this.bucket,
     this.canary,

--- a/app_dart/lib/src/request_handlers/debug/get_task.dart
+++ b/app_dart/lib/src/request_handlers/debug/get_task.dart
@@ -50,7 +50,7 @@ class DebugGetTaskById extends ApiRequestHandler<Body> {
 }
 
 @immutable
-class GetTaskByIdResponse extends Body {
+class GetTaskByIdResponse extends JsonBody {
   const GetTaskByIdResponse(this.task, this.commit, this.keyHelper)
       : assert(task != null),
         assert(commit != null),

--- a/app_dart/lib/src/request_handlers/debug/reset_pending_tasks.dart
+++ b/app_dart/lib/src/request_handlers/debug/reset_pending_tasks.dart
@@ -58,7 +58,7 @@ class DebugResetPendingTasks extends ApiRequestHandler<ResetPendingTasksResponse
 }
 
 @immutable
-class ResetPendingTasksResponse extends Body {
+class ResetPendingTasksResponse extends JsonBody {
   const ResetPendingTasksResponse(this.count) : assert(count != null);
 
   final int count;

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -140,7 +140,7 @@ class GithubWebhook extends RequestHandler<Body> {
           createdBy: serviceAccount.email,
           tags: <String, List<String>>{
             'buildset': <String>['pr/git/$number'],
-            'user_agent': <String>['flutter-cocoon'],
+            'user_agent': const <String>['flutter-cocoon'],
           },
           includeExperimental: true,
         ),
@@ -199,7 +199,7 @@ class GithubWebhook extends RequestHandler<Body> {
             experimental: Trinary.yes,
             tags: <String, List<String>>{
               'buildset': <String>['pr/git/$number', 'sha/git/$sha'],
-              'user_agent': <String>['flutter-cocoon'],
+              'user_agent': const <String>['flutter-cocoon'],
               'github_link': <String>['https://github.com/flutter/$repositoryName/pulls/$number'],
             },
             properties: <String, String>{

--- a/app_dart/lib/src/request_handlers/reserve_task.dart
+++ b/app_dart/lib/src/request_handlers/reserve_task.dart
@@ -86,7 +86,7 @@ class ReserveTask extends ApiRequestHandler<ReserveTaskResponse> {
 }
 
 @immutable
-class ReserveTaskResponse extends Body {
+class ReserveTaskResponse extends JsonBody {
   const ReserveTaskResponse(this.task, this.commit, this.accessToken, this.keyHelper)
       : assert(task != null),
         assert(commit != null),

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -135,7 +135,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 }
 
 @immutable
-class UpdateTaskStatusResponse extends Body {
+class UpdateTaskStatusResponse extends JsonBody {
   const UpdateTaskStatusResponse(this.task) : assert(task != null);
 
   final Task task;

--- a/app_dart/lib/src/request_handling/body.dart
+++ b/app_dart/lib/src/request_handling/body.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:meta/meta.dart';
 
 /// Class that represents an HTTP response body before it has been serialized.
@@ -10,8 +13,26 @@ abstract class Body {
   /// Creates a new [Body].
   const Body();
 
+  /// Creates a [Body] that serializes the specified String [content].
+  factory Body.forString(String content) => _StringBody(content);
+
+  /// Creates a [Body] that passes through the already-serialized [stream].
+  factory Body.forStream(Stream<Uint8List> stream) => _StreamBody(stream);
+
   /// Value indicating that the HTTP response body should be empty.
   static const Body empty = _EmptyBody();
+
+  /// Serializes this response body to bytes.
+  Stream<Uint8List> serialize();
+}
+
+abstract class JsonBody extends Body {
+  const JsonBody();
+
+  @override
+  Stream<Uint8List> serialize() {
+    return utf8.encoder.bind(json.encoder.bind(Stream<Object>.fromIterable(<Object>[toJson()])));
+  }
 
   /// Serializes this response body to a JSON-primitive map.
   Map<String, dynamic> toJson();
@@ -21,5 +42,25 @@ class _EmptyBody extends Body {
   const _EmptyBody();
 
   @override
-  Map<String, dynamic> toJson() => throw StateError('Unreachable');
+  Stream<Uint8List> serialize() => const Stream<Uint8List>.empty();
+}
+
+class _StringBody extends Body {
+  const _StringBody(this.content);
+
+  final String content;
+
+  @override
+  Stream<Uint8List> serialize() {
+    return utf8.encoder.bind(Stream<String>.fromIterable(<String>[content]));
+  }
+}
+
+class _StreamBody extends Body {
+  const _StreamBody(this.stream);
+
+  final Stream<Uint8List> stream;
+
+  @override
+  Stream<Uint8List> serialize() => stream;
 }

--- a/app_dart/lib/src/request_handling/request_handler.dart
+++ b/app_dart/lib/src/request_handling/request_handler.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
@@ -53,7 +52,7 @@ abstract class RequestHandler<T extends Body> {
               throw MethodNotAllowed(request.method);
           }
           assert(body != null);
-          await respond(body: body == Body.empty ? null : json.encode(body.toJson()));
+          await _respond(body: body);
           httpClient?.close();
           return;
         } on HttpStatusException {
@@ -82,13 +81,11 @@ abstract class RequestHandler<T extends Body> {
   /// [body].
   ///
   /// Returns a future that completes when [response] has been closed.
-  @protected
-  Future<void> respond({int status = HttpStatus.ok, String body}) async {
+  Future<void> _respond({int status = HttpStatus.ok, Body body = Body.empty}) async {
     assert(status != null);
+    assert(body != null);
     response.statusCode = status;
-    if (body != null) {
-      response.write(body);
-    }
+    await response.addStream(body.serialize());
     await response.flush();
     await response.close();
   }

--- a/app_dart/lib/src/service/buildbucket.dart
+++ b/app_dart/lib/src/service/buildbucket.dart
@@ -52,7 +52,7 @@ class BuildBucketClient {
   /// Defaults to `HttpClient()`.
   final HttpClient httpClient;
 
-  Future<T> _postRequest<S extends Body, T>(
+  Future<T> _postRequest<S extends JsonBody, T>(
     String path,
     S request,
     T responseFromJson(Map<String, dynamic> rawResponse),

--- a/app_dart/test/request_handling/request_handler_test.dart
+++ b/app_dart/test/request_handling/request_handler_test.dart
@@ -127,7 +127,7 @@ void main() {
   });
 }
 
-class TestBody extends Body {
+class TestBody extends JsonBody {
   const TestBody();
 
   @override

--- a/app_dart/test/service/buildbucket_test.dart
+++ b/app_dart/test/service/buildbucket_test.dart
@@ -33,7 +33,7 @@ void main() {
       mockAccessTokenProvider = MockAccessTokenProvider();
     });
 
-    Future<T> _httpTest<R extends Body, T>(
+    Future<T> _httpTest<R extends JsonBody, T>(
       R request,
       String response,
       String expectedPath,


### PR DESCRIPTION
1) Make `Body` be used formore than just JSON responses.
   It can now be used to serialize generic responses, with
   a subclass specialized forJSON.
2) Remove attempts to `rollback()` database transactions
   that fail to commit.  They always fail with "the transaction
   has already been committed." It seems in general that `rollback()`
   is used when you decide to not commit a transaction and are not
   needed in case of error.
3) Default some `Task` properties to the empty string.