### PR TITLE
Fix bug in push-build-status-to-github

### DIFF
--- a/app_dart/lib/src/model/appengine/github_build_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_build_status_update.dart
@@ -12,6 +12,7 @@ class GithubBuildStatusUpdate extends Model {
     Key key,
     this.repository,
     this.pr,
+    this.head,
     this.status,
     this.updates,
   }) {
@@ -29,6 +30,9 @@ class GithubBuildStatusUpdate extends Model {
   @IntProperty(propertyName: 'PR', required: true)
   int pr;
 
+  @StringProperty(propertyName: 'Head')
+  String head;
+
   @StringProperty(propertyName: 'Status', required: true)
   String status;
 
@@ -44,6 +48,7 @@ class GithubBuildStatusUpdate extends Model {
       ..write(', key: ${parentKey == null ? null : key.id}')
       ..write(', repository: $repository')
       ..write(', pr: $pr')
+      ..write(', head: $head')
       ..write(', lastStatus: $status')
       ..write(', updates: $updates')
       ..write(')');

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -116,13 +116,15 @@ class DatastoreService {
   ) async {
     final Query<GithubBuildStatusUpdate> query = db.query<GithubBuildStatusUpdate>()
       ..filter('repository =', slug.fullName)
-      ..filter('pr =', pr.number);
+      ..filter('pr =', pr.number)
+      ..filter('head =', pr.head.sha);
     final List<GithubBuildStatusUpdate> previousStatusUpdates = await query.run().toList();
 
     if (previousStatusUpdates.isEmpty) {
       return GithubBuildStatusUpdate(
         repository: slug.fullName,
         pr: pr.number,
+        head: pr.head.sha,
         status: null,
         updates: 0,
       );


### PR DESCRIPTION
It was recording the last status pushed, but it wasn't factoring
in the fact that different heads each need their own status
pushed to them.  The result was that we were not sending status
to newly pushed heads in PRs, causing them to be able to merge
on red.