### PR TITLE
Kill all dart.exe(except current one) when starting new run on Windows.

### DIFF
--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -102,6 +102,12 @@ class ContinuousIntegrationCommand extends Command {
                 logger.info('  custom timeout : ${task.timeoutInMinutes}');
               }
 
+              if (Platform.isWindows) {
+                // Kill all dart.exe that are potentially holding flutter bin/cache,
+                // preventing it from being deleted.
+                await killAllRunningProcessesOnWindows('dart');
+              }
+
               // Sync flutter outside of the task so it does not contribute to
               // the task timeout.
               await getFlutterAt(task.revision).timeout(_kInstallationTimeout);

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -45,7 +45,7 @@ class RunCommand extends Command {
     if (Platform.isWindows) {
       // Kill all dart.exe that are potentially holding flutter bin/cache,
       // preventing it from being deleted.
-      killAllRunningProcessesOnWindows('dart');
+      await killAllRunningProcessesOnWindows('dart');
     }
 
     CocoonTask task = CocoonTask(


### PR DESCRIPTION
There are seem to be frequent occurrences of dart.exe left running that keep lock on flutter bin/cache folder, causing test run failures