### PR TITLE
Fit commit widget into status grid

### DIFF
--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -21,17 +21,13 @@ class CommitBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        Image.network(
-          avatarUrl,
-          height: 40,
-        ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Text(message),
-        ),
-      ],
+    // TODO(chillers): add overlay to view more information
+    return Container(
+      margin: const EdgeInsets.all(1.0),
+      child: Image.network(
+        avatarUrl,
+        height: 40,
+      ),
     );
   }
 }

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -32,11 +32,6 @@ class BuildDashboardPage extends StatelessWidget {
       body: Column(
         children: [
           StatusGrid(),
-          // To demo CommitBox
-          CommitBox(
-            message: 'my first commit',
-            avatarUrl: 'https://avatars2.githubusercontent.com/u/42042535?v=4',
-          ),
         ],
       ),
     );

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/material.dart';
 
-import 'commit_box.dart';
 import 'status_grid.dart';
 
 void main() => runApp(MyApp());

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import 'commit_box.dart';
 import 'result_box.dart';
 
 /// Display results from flutter/flutter repository's continuous integration.
@@ -26,10 +27,18 @@ class StatusGrid extends StatelessWidget {
         width: taskCount * 50.0,
         height: 500.0,
         child: GridView.count(
-          // TODO(chillers)L implement custom scroll physics to match horizontal scroll
+          // TODO(chillers): implement custom scroll physics to match horizontal scroll
           crossAxisCount: taskCount,
           // TODO(chillers): Use result data
           children: List.generate(taskCount * commitCount, (index) {
+            if (index % taskCount == 0) {
+              return CommitBox(
+                message: 'commit #$index',
+                avatarUrl:
+                    'https://avatars2.githubusercontent.com/u/2148558?v=4',
+              );
+            }
+
             return ResultBox(message: 'Succeeded');
           }),
         ),

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -22,7 +22,6 @@ void main() {
         textDirection: TextDirection.ltr,
       ));
 
-      expect(find.text(message), findsOneWidget);
       expect(find.byType(Image), findsOneWidget);
 
       // Image.Network throws a 400 exception in tests

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -9,11 +9,15 @@ import 'package:app_flutter/status_grid.dart';
 
 void main() {
   // TODO(chillers): smoke screen test, remove when actual tests added
-  testWidgets('StatusGrid smoke test',
-      (WidgetTester tester) async {
-        // SingleChildScrollView needs an ancestor that has directionality
-        await tester.pumpWidget(MaterialApp(home: StatusGrid(),));
+  testWidgets('StatusGrid smoke test', (WidgetTester tester) async {
+    // SingleChildScrollView needs an ancestor that has directionality
+    await tester.pumpWidget(MaterialApp(
+      home: StatusGrid(),
+    ));
 
-        expect(find.text('404'), findsNothing);
+    expect(find.text('404'), findsNothing);
+
+    // CommitBox is expected to throw an exception when loading images
+    tester.takeException();
   });
 }


### PR DESCRIPTION
Removed displaying the message. This allows commit box to fit easily into the grid with no extra changes.

Added a TODO for work on the overlay that will show more information for a commit.

![commit box inlined](https://user-images.githubusercontent.com/2148558/65088199-4ee7fd80-d96d-11e9-9a12-01325ed4fcb5.png)
