### PR TITLE
Commit overlay

### DIFF
--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -51,12 +51,12 @@ class _CommitBoxState extends State<CommitBox> {
 
   void _handleTap() {
     _commitOverlay = OverlayEntry(
-        builder: (nullContext) => CommitOverlayContents(
+        builder: (overlayContext) => CommitOverlayContents(
             parentContext: context,
             widget: widget,
             closeCallback: closeOverlay));
 
-    Overlay.of(context).insert(this._commitOverlay);
+    Overlay.of(context).insert(_commitOverlay);
   }
 
   void closeOverlay() => _commitOverlay.remove();

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -29,15 +29,11 @@ class CommitBox extends StatefulWidget {
 
 class _CommitBoxState extends State<CommitBox> {
   OverlayEntry _commitOverlay;
-  final LayerLink _layerLink = LayerLink();
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        this._commitOverlay = this._createCommitOverlay(widget);
-        Overlay.of(context).insert(this._commitOverlay);
-      },
+      onTap: _handleTap,
       child: Container(
         margin: const EdgeInsets.all(1.0),
         child: Image.network(
@@ -48,6 +44,11 @@ class _CommitBoxState extends State<CommitBox> {
     );
   }
 
+  void _handleTap() {
+    _commitOverlay = this._createCommitOverlay(widget);
+    Overlay.of(context).insert(this._commitOverlay);
+  }
+
   OverlayEntry _createCommitOverlay(CommitBox widget) {
     RenderBox renderBox = context.findRenderObject();
 
@@ -56,9 +57,7 @@ class _CommitBoxState extends State<CommitBox> {
               children: <Widget>[
                 // This is the area a user can click (the rest of the screen) to close the overlay.
                 GestureDetector(
-                  onTap: () {
-                    _commitOverlay.remove();
-                  },
+                  onTap: _commitOverlay.remove,
                   child: Container(
                     width: MediaQuery.of(context).size.width,
                     height: MediaQuery.of(context).size.height,

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -32,14 +32,84 @@ class CommitBox extends StatefulWidget {
 }
 
 class _CommitBoxState extends State<CommitBox> {
+  OverlayEntry _commitOverlay;
+  final LayerLink _layerLink = LayerLink();
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.all(1.0),
-      child: Image.network(
-        widget.avatarUrl,
-        height: 40,
+    return GestureDetector(
+      onTap: () {
+        this._commitOverlay = this._createCommitOverlay(widget);
+        Overlay.of(context).insert(this._commitOverlay);
+      },
+      child: Container(
+        margin: const EdgeInsets.all(1.0),
+        child: Image.network(
+          widget.avatarUrl,
+          height: 40,
+        ),
       ),
     );
+  }
+
+  OverlayEntry _createCommitOverlay(CommitBox widget) {
+    RenderBox renderBox = context.findRenderObject();
+
+    return OverlayEntry(
+        builder: (context) => Stack(
+              children: <Widget>[
+                // This is the area a user can click (the rest of the screen) to close the overlay.
+                GestureDetector(
+                  onTap: () {
+                    _commitOverlay.remove();
+                  },
+                  child: Container(
+                    width: MediaQuery.of(context).size.width,
+                    height: MediaQuery.of(context).size.height,
+                    color: Colors.blueGrey.withOpacity(0.01),
+                  ),
+                ),
+                Positioned(
+                  width: 300,
+                  child: CompositedTransformFollower(
+                    link: this._layerLink,
+                    showWhenUnlinked: false,
+                    offset: Offset(25.0, renderBox.size.height),
+                    child: Card(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        children: <Widget>[
+                          ListTile(
+                            leading: CircleAvatar(
+                              radius: 25.0,
+                              backgroundImage: NetworkImage(widget.avatarUrl),
+                              backgroundColor: Colors.transparent,
+                            ),
+                            title: Text(widget.message),
+                            subtitle: Text(widget.author),
+                          ),
+                          ButtonBar(
+                            children: <Widget>[
+                              IconButton(
+                                icon: const Icon(Icons.repeat),
+                                onPressed: () {
+                                  // TODO(chillers): rerun all tests for this commit
+                                },
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.open_in_new),
+                                onPressed: () {
+                                  // TODO(chillers): open new tab with the commit on Github
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ));
   }
 }

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -45,70 +45,89 @@ class _CommitBoxState extends State<CommitBox> {
   }
 
   void _handleTap() {
-    _commitOverlay = CommitOverlay(widget, context);
+    CommitOverlayContents _content =
+        CommitOverlayContents(parentContext: context, widget: widget);
+    _commitOverlay = OverlayEntry(builder: (context) => _content);
+    _content.setOverlayEntry(_commitOverlay);
+
     Overlay.of(context).insert(this._commitOverlay);
   }
 }
 
-class CommitOverlay extends OverlayEntry {
-  CommitOverlay(CommitBox widget, BuildContext parentContext)
-      : super(builder: (context) {
-          RenderBox renderBox = parentContext.findRenderObject();
+class CommitOverlayContents extends StatelessWidget {
+  CommitOverlayContents({
+    Key key,
+    @required this.parentContext,
+    @required this.widget,
+  }) : super(key: key);
 
-          return Stack(
-            children: <Widget>[
-              // This is the area a user can click (the rest of the screen) to close the overlay.
-              GestureDetector(
-                onTap:
-                    remove, // error: Only static members can be accessed in initializers.
-                child: Container(
-                  width: MediaQuery.of(parentContext).size.width,
-                  height: MediaQuery.of(parentContext).size.height,
-                  // Color must be defined otherwise the container can't be clicked on
-                  color: Colors.transparent,
-                ),
-              ),
-              Positioned(
-                width: 300,
-                // Move this overlay to be where the parent is
-                top: renderBox.localToGlobal(Offset.zero).dy +
-                    (renderBox.size.height / 2),
-                left: renderBox.localToGlobal(Offset.zero).dx +
-                    (renderBox.size.width / 2),
-                child: Card(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    children: <Widget>[
-                      ListTile(
-                        leading: CircleAvatar(
-                          radius: 25.0,
-                          backgroundImage: NetworkImage(widget.avatarUrl),
-                          backgroundColor: Colors.transparent,
-                        ),
-                        title: Text(widget.message),
-                        subtitle: Text(widget.author),
-                      ),
-                      ButtonBar(
-                        children: <Widget>[
-                          IconButton(
-                            icon: const Icon(Icons.repeat),
-                            onPressed: () {
-                              // TODO(chillers): rerun all tests for this commit
-                            },
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.open_in_new),
-                            onPressed: () {
-                              // TODO(chillers): open new tab with the commit on Github
-                            },
-                          ),
-                        ],
-                      ),
-                    ],
+  /// The parent context that has the size of the whole screen
+  final BuildContext parentContext;
+
+  /// The parent widget that contains state variables
+  final CommitBox widget;
+
+  OverlayEntry _overlayEntry;
+
+  @override
+  Widget build(BuildContext context) {
+    RenderBox renderBox = parentContext.findRenderObject();
+
+    return Stack(
+      children: <Widget>[
+        // This is the area a user can click (the rest of the screen) to close the overlay.
+        GestureDetector(
+          onTap: _overlayEntry.remove,
+          child: Container(
+            width: MediaQuery.of(parentContext).size.width,
+            height: MediaQuery.of(parentContext).size.height,
+            // Color must be defined otherwise the container can't be clicked on
+            color: Colors.transparent,
+          ),
+        ),
+        Positioned(
+          width: 300,
+          // Move this overlay to be where the parent is
+          top: renderBox.localToGlobal(Offset.zero).dy +
+              (renderBox.size.height / 2),
+          left: renderBox.localToGlobal(Offset.zero).dx +
+              (renderBox.size.width / 2),
+          child: Card(
+            child: Column(
+              mainAxisSize: MainAxisSize.max,
+              children: <Widget>[
+                ListTile(
+                  leading: CircleAvatar(
+                    radius: 25.0,
+                    backgroundImage: NetworkImage(widget.avatarUrl),
+                    backgroundColor: Colors.transparent,
                   ),
+                  title: Text(widget.message),
+                  subtitle: Text(widget.author),
                 ),
-              ),
-            ],
-          );
-        });
+                ButtonBar(
+                  children: <Widget>[
+                    IconButton(
+                      icon: const Icon(Icons.repeat),
+                      onPressed: () {
+                        // TODO(chillers): rerun all tests for this commit
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.open_in_new),
+                      onPressed: () {
+                        // TODO(chillers): open new tab with the commit on Github
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void setOverlayEntry(OverlayEntry entry) => _overlayEntry = entry;
 }

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -5,6 +5,11 @@
 import 'package:flutter/material.dart';
 
 /// Displays Git commit information.
+/// 
+/// On click, it will open an [OverlayEntry] with [CommitOverlayContents]
+/// to show the information provided. Otherwise, it just shows the avatar
+/// for the author of this commit. Clicking outside of the [OverlayEntry]
+/// will close it.
 class CommitBox extends StatefulWidget {
   // TODO(chillers): convert to use commit model
   const CommitBox(

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -72,8 +72,10 @@ class _CommitBoxState extends State<CommitBox> {
                 ),
                 Positioned(
                   width: 300,
-                  top: renderBox.localToGlobal(Offset.zero).dy + (renderBox.size.height / 2),
-                  left: renderBox.localToGlobal(Offset.zero).dx + (renderBox.size.width / 2),
+                  top: renderBox.localToGlobal(Offset.zero).dy +
+                      (renderBox.size.height / 2),
+                  left: renderBox.localToGlobal(Offset.zero).dx +
+                      (renderBox.size.width / 2),
                   child: CompositedTransformFollower(
                     link: this._layerLink,
                     child: Card(

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -66,14 +66,14 @@ class _CommitBoxState extends State<CommitBox> {
                   child: Container(
                     width: MediaQuery.of(context).size.width,
                     height: MediaQuery.of(context).size.height,
-                    color: Colors.blueGrey.withOpacity(0.01),
+                    // Color must be defined otherwise the container can't be clicked on
+                    color: Colors.transparent,
                   ),
                 ),
                 Positioned(
-                  width: 300,
+                  width: 1000,
                   child: CompositedTransformFollower(
                     link: this._layerLink,
-                    showWhenUnlinked: false,
                     offset: Offset(25.0, renderBox.size.height),
                     child: Card(
                       child: Column(

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -11,8 +11,7 @@ class CommitBox extends StatefulWidget {
       {Key key,
       @required this.message,
       @required this.avatarUrl,
-      @required this.author,
-      @required this.sha})
+      @required this.author})
       : super(key: key);
 
   /// Commit message that summarizes the change made.
@@ -23,9 +22,6 @@ class CommitBox extends StatefulWidget {
 
   /// The person that authored this commit.
   final String author;
-
-  /// The unique identifier for the commit in this repository
-  final String sha;
 
   @override
   _CommitBoxState createState() => _CommitBoxState();
@@ -72,43 +68,41 @@ class _CommitBoxState extends State<CommitBox> {
                 ),
                 Positioned(
                   width: 300,
+                  // Move this overlay to be where the parent is
                   top: renderBox.localToGlobal(Offset.zero).dy +
                       (renderBox.size.height / 2),
                   left: renderBox.localToGlobal(Offset.zero).dx +
                       (renderBox.size.width / 2),
-                  child: CompositedTransformFollower(
-                    link: this._layerLink,
-                    child: Card(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.max,
-                        children: <Widget>[
-                          ListTile(
-                            leading: CircleAvatar(
-                              radius: 25.0,
-                              backgroundImage: NetworkImage(widget.avatarUrl),
-                              backgroundColor: Colors.transparent,
+                  child: Card(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.max,
+                      children: <Widget>[
+                        ListTile(
+                          leading: CircleAvatar(
+                            radius: 25.0,
+                            backgroundImage: NetworkImage(widget.avatarUrl),
+                            backgroundColor: Colors.transparent,
+                          ),
+                          title: Text(widget.message),
+                          subtitle: Text(widget.author),
+                        ),
+                        ButtonBar(
+                          children: <Widget>[
+                            IconButton(
+                              icon: const Icon(Icons.repeat),
+                              onPressed: () {
+                                // TODO(chillers): rerun all tests for this commit
+                              },
                             ),
-                            title: Text(widget.message),
-                            subtitle: Text(widget.author),
-                          ),
-                          ButtonBar(
-                            children: <Widget>[
-                              IconButton(
-                                icon: const Icon(Icons.repeat),
-                                onPressed: () {
-                                  // TODO(chillers): rerun all tests for this commit
-                                },
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.open_in_new),
-                                onPressed: () {
-                                  // TODO(chillers): open new tab with the commit on Github
-                                },
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
+                            IconButton(
+                              icon: const Icon(Icons.open_in_new),
+                              onPressed: () {
+                                // TODO(chillers): open new tab with the commit on Github
+                              },
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -45,13 +45,16 @@ class _CommitBoxState extends State<CommitBox> {
   }
 
   void _handleTap() {
-    CommitOverlayContents _content =
-        CommitOverlayContents(parentContext: context, widget: widget);
-    _commitOverlay = OverlayEntry(builder: (context) => _content);
-    _content.setOverlayEntry(_commitOverlay);
+    _commitOverlay = OverlayEntry(
+        builder: (nullContext) => CommitOverlayContents(
+            parentContext: context,
+            widget: widget,
+            closeCallback: closeOverlay));
 
     Overlay.of(context).insert(this._commitOverlay);
   }
+
+  void closeOverlay() => _commitOverlay.remove();
 }
 
 class CommitOverlayContents extends StatelessWidget {
@@ -59,6 +62,7 @@ class CommitOverlayContents extends StatelessWidget {
     Key key,
     @required this.parentContext,
     @required this.widget,
+    @required this.closeCallback,
   }) : super(key: key);
 
   /// The parent context that has the size of the whole screen
@@ -67,7 +71,7 @@ class CommitOverlayContents extends StatelessWidget {
   /// The parent widget that contains state variables
   final CommitBox widget;
 
-  OverlayEntry _overlayEntry;
+  final void Function() closeCallback;
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +81,7 @@ class CommitOverlayContents extends StatelessWidget {
       children: <Widget>[
         // This is the area a user can click (the rest of the screen) to close the overlay.
         GestureDetector(
-          onTap: _overlayEntry.remove,
+          onTap: closeCallback,
           child: Container(
             width: MediaQuery.of(parentContext).size.width,
             height: MediaQuery.of(parentContext).size.height,
@@ -128,6 +132,4 @@ class CommitOverlayContents extends StatelessWidget {
       ],
     );
   }
-
-  void setOverlayEntry(OverlayEntry entry) => _overlayEntry = entry;
 }

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -61,7 +61,6 @@ class _CommitBoxState extends State<CommitBox> {
                 // This is the area a user can click (the rest of the screen) to close the overlay.
                 GestureDetector(
                   onTap: () {
-                    print(renderBox.localToGlobal(Offset.zero).dx);
                     _commitOverlay.remove();
                   },
                   child: Container(

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -45,67 +45,70 @@ class _CommitBoxState extends State<CommitBox> {
   }
 
   void _handleTap() {
-    _commitOverlay = this._createCommitOverlay(widget);
+    _commitOverlay = CommitOverlay(widget, context);
     Overlay.of(context).insert(this._commitOverlay);
   }
+}
 
-  OverlayEntry _createCommitOverlay(CommitBox widget) {
-    RenderBox renderBox = context.findRenderObject();
+class CommitOverlay extends OverlayEntry {
+  CommitOverlay(CommitBox widget, BuildContext parentContext)
+      : super(builder: (context) {
+          RenderBox renderBox = parentContext.findRenderObject();
 
-    return OverlayEntry(
-        builder: (context) => Stack(
-              children: <Widget>[
-                // This is the area a user can click (the rest of the screen) to close the overlay.
-                GestureDetector(
-                  onTap: _commitOverlay.remove,
-                  child: Container(
-                    width: MediaQuery.of(context).size.width,
-                    height: MediaQuery.of(context).size.height,
-                    // Color must be defined otherwise the container can't be clicked on
-                    color: Colors.transparent,
-                  ),
+          return Stack(
+            children: <Widget>[
+              // This is the area a user can click (the rest of the screen) to close the overlay.
+              GestureDetector(
+                onTap:
+                    remove, // error: Only static members can be accessed in initializers.
+                child: Container(
+                  width: MediaQuery.of(parentContext).size.width,
+                  height: MediaQuery.of(parentContext).size.height,
+                  // Color must be defined otherwise the container can't be clicked on
+                  color: Colors.transparent,
                 ),
-                Positioned(
-                  width: 300,
-                  // Move this overlay to be where the parent is
-                  top: renderBox.localToGlobal(Offset.zero).dy +
-                      (renderBox.size.height / 2),
-                  left: renderBox.localToGlobal(Offset.zero).dx +
-                      (renderBox.size.width / 2),
-                  child: Card(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.max,
-                      children: <Widget>[
-                        ListTile(
-                          leading: CircleAvatar(
-                            radius: 25.0,
-                            backgroundImage: NetworkImage(widget.avatarUrl),
-                            backgroundColor: Colors.transparent,
+              ),
+              Positioned(
+                width: 300,
+                // Move this overlay to be where the parent is
+                top: renderBox.localToGlobal(Offset.zero).dy +
+                    (renderBox.size.height / 2),
+                left: renderBox.localToGlobal(Offset.zero).dx +
+                    (renderBox.size.width / 2),
+                child: Card(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    children: <Widget>[
+                      ListTile(
+                        leading: CircleAvatar(
+                          radius: 25.0,
+                          backgroundImage: NetworkImage(widget.avatarUrl),
+                          backgroundColor: Colors.transparent,
+                        ),
+                        title: Text(widget.message),
+                        subtitle: Text(widget.author),
+                      ),
+                      ButtonBar(
+                        children: <Widget>[
+                          IconButton(
+                            icon: const Icon(Icons.repeat),
+                            onPressed: () {
+                              // TODO(chillers): rerun all tests for this commit
+                            },
                           ),
-                          title: Text(widget.message),
-                          subtitle: Text(widget.author),
-                        ),
-                        ButtonBar(
-                          children: <Widget>[
-                            IconButton(
-                              icon: const Icon(Icons.repeat),
-                              onPressed: () {
-                                // TODO(chillers): rerun all tests for this commit
-                              },
-                            ),
-                            IconButton(
-                              icon: const Icon(Icons.open_in_new),
-                              onPressed: () {
-                                // TODO(chillers): open new tab with the commit on Github
-                              },
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                          IconButton(
+                            icon: const Icon(Icons.open_in_new),
+                            onPressed: () {
+                              // TODO(chillers): open new tab with the commit on Github
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
-              ],
-            ));
-  }
+              ),
+            ],
+          );
+        });
 }

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -54,14 +54,18 @@ class _CommitBoxState extends State<CommitBox> {
         builder: (overlayContext) => CommitOverlayContents(
             parentContext: context,
             widget: widget,
-            closeCallback: closeOverlay));
+            closeCallback: _closeOverlay));
 
     Overlay.of(context).insert(_commitOverlay);
   }
 
-  void closeOverlay() => _commitOverlay.remove();
+  void _closeOverlay() => _commitOverlay.remove();
 }
 
+/// Displays the information from a Git commit.
+///
+/// This is intended to be inserted in an [OverlayEntry] as it requires
+/// [closeCallback] that will remove the widget from the tree.
 class CommitOverlayContents extends StatelessWidget {
   CommitOverlayContents({
     Key key,

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -61,6 +61,7 @@ class _CommitBoxState extends State<CommitBox> {
                 // This is the area a user can click (the rest of the screen) to close the overlay.
                 GestureDetector(
                   onTap: () {
+                    print(renderBox.localToGlobal(Offset.zero).dx);
                     _commitOverlay.remove();
                   },
                   child: Container(
@@ -71,10 +72,11 @@ class _CommitBoxState extends State<CommitBox> {
                   ),
                 ),
                 Positioned(
-                  width: 1000,
+                  width: 300,
+                  top: renderBox.localToGlobal(Offset.zero).dy + (renderBox.size.height / 2),
+                  left: renderBox.localToGlobal(Offset.zero).dx + (renderBox.size.width / 2),
                   child: CompositedTransformFollower(
                     link: this._layerLink,
-                    offset: Offset(25.0, renderBox.size.height),
                     child: Card(
                       child: Column(
                         mainAxisSize: MainAxisSize.max,

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -5,13 +5,15 @@
 import 'package:flutter/material.dart';
 
 /// Displays Git commit information.
-class CommitBox extends StatelessWidget {
+class CommitBox extends StatefulWidget {
   // TODO(chillers): convert to use commit model
-  const CommitBox({
-    Key key,
-    @required this.message,
-    @required this.avatarUrl,
-  }) : super(key: key);
+  const CommitBox(
+      {Key key,
+      @required this.message,
+      @required this.avatarUrl,
+      @required this.author,
+      @required this.sha})
+      : super(key: key);
 
   /// Commit message that summarizes the change made.
   final String message;
@@ -19,13 +21,23 @@ class CommitBox extends StatelessWidget {
   /// Image URL to the avatar of the author of this commit.
   final String avatarUrl;
 
+  /// The person that authored this commit.
+  final String author;
+
+  /// The unique identifier for the commit in this repository
+  final String sha;
+
+  @override
+  _CommitBoxState createState() => _CommitBoxState();
+}
+
+class _CommitBoxState extends State<CommitBox> {
   @override
   Widget build(BuildContext context) {
-    // TODO(chillers): add overlay to view more information
     return Container(
       margin: const EdgeInsets.all(1.0),
       child: Image.network(
-        avatarUrl,
+        widget.avatarUrl,
         height: 40,
       ),
     );

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 
 /// Displays Git commit information.
-/// 
+///
 /// On click, it will open an [OverlayEntry] with [CommitOverlayContents]
 /// to show the information provided. Otherwise, it just shows the avatar
 /// for the author of this commit. Clicking outside of the [OverlayEntry]
@@ -76,11 +76,16 @@ class CommitOverlayContents extends StatelessWidget {
   /// The parent widget that contains state variables
   final CommitBox widget;
 
+  /// This callback removes the parent overlay from the widget tree.
+  ///
+  /// On a click that is outside the area of the overlay (the rest of the screen),
+  /// this callback is called closing the overlay.
   final void Function() closeCallback;
 
   @override
   Widget build(BuildContext context) {
-    RenderBox renderBox = parentContext.findRenderObject();
+    final RenderBox renderBox = parentContext.findRenderObject();
+    final Offset offsetLeft = renderBox.localToGlobal(Offset.zero);
 
     return Stack(
       children: <Widget>[
@@ -97,10 +102,8 @@ class CommitOverlayContents extends StatelessWidget {
         Positioned(
           width: 300,
           // Move this overlay to be where the parent is
-          top: renderBox.localToGlobal(Offset.zero).dy +
-              (renderBox.size.height / 2),
-          left: renderBox.localToGlobal(Offset.zero).dx +
-              (renderBox.size.width / 2),
+          top: offsetLeft.dy + (renderBox.size.height / 2),
+          left: offsetLeft.dx + (renderBox.size.width / 2),
           child: Card(
             child: Column(
               mainAxisSize: MainAxisSize.max,

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -34,8 +34,10 @@ class StatusGrid extends StatelessWidget {
             if (index % taskCount == 0) {
               return CommitBox(
                 message: 'commit #$index',
+                author: 'author #$index',
                 avatarUrl:
                     'https://avatars2.githubusercontent.com/u/2148558?v=4',
+                sha: 'sha shank hash',
               );
             }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -37,7 +37,6 @@ class StatusGrid extends StatelessWidget {
                 author: 'author #$index',
                 avatarUrl:
                     'https://avatars2.githubusercontent.com/u/2148558?v=4',
-                sha: 'sha shank hash',
               );
             }
 

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -9,20 +9,44 @@ import 'package:app_flutter/commit_box.dart';
 
 void main() {
   group('CommitBox', () {
-    testWidgets('shows information correctly', (WidgetTester tester) async {
-      const String message = 'message message';
-      const String avatarUrl =
-          'https://avatars2.githubusercontent.com/u/2148558?v=4';
+    const String message = 'message message';
+    const String avatarUrl =
+        'https://avatars2.githubusercontent.com/u/2148558?v=4';
+    const String author = 'contributor';
 
+    testWidgets('shows information correctly', (WidgetTester tester) async {
       await tester.pumpWidget(Directionality(
         child: CommitBox(
           message: message,
           avatarUrl: avatarUrl,
+          author: author,
         ),
         textDirection: TextDirection.ltr,
       ));
 
       expect(find.byType(Image), findsOneWidget);
+
+      // Image.Network throws a 400 exception in tests
+      tester.takeException();
+    });
+
+    testWidgets('shows overlay on click', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: CommitBox(
+          message: message,
+          avatarUrl: avatarUrl,
+          author: author,
+        ),
+      ));
+
+      expect(find.text(message), findsNothing);
+      expect(find.text(author), findsNothing);
+
+      await tester.tap(find.byType(CommitBox));
+      await tester.pump();
+
+      expect(find.text(message), findsOneWidget);
+      expect(find.text(author), findsOneWidget);
 
       // Image.Network throws a 400 exception in tests
       tester.takeException();

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -51,5 +51,29 @@ void main() {
       // Image.Network throws a 400 exception in tests
       tester.takeException();
     });
+
+    testWidgets('closes overlay on click out', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: CommitBox(
+          message: message,
+          avatarUrl: avatarUrl,
+          author: author,
+        ),
+      ));
+
+      // Open the overlay
+      await tester.tap(find.byType(CommitBox));
+      await tester.pump();
+
+      // Since the overlay positions itself in the middle of the widget,
+      // it is safe to click the widget to close it again
+      await tester.tap(find.byType(CommitBox));
+      await tester.pump();
+
+      expect(find.text(message), findsNothing);
+
+      // Image.Network throws a 400 exception in tests
+      tester.takeException();
+    });
   });
 }


### PR DESCRIPTION
This is meant to be a way of showing the information regarding a commit. On click, the overlay is shown. On click out, the overlay is closed.

Currently shows basic information, but when the widget is switched to use the commit model it will show more information.

![commit overlay](https://user-images.githubusercontent.com/2148558/65178342-637bd280-da0d-11e9-9c59-f85626544e24.png)
