### PR TITLE
Populate Task endTimestamp

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -64,7 +64,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       if (task.attempts >= maxRetries) {
         task.status = Task.statusFailed;
         task.reason = 'Task failed on agent';
-        task.endTimestamp = DateTime.now().millisecondsSinceEpoch;;
+        task.endTimestamp = DateTime.now().millisecondsSinceEpoch;
       } else {
         // This will cause this task to be picked up by an agent again.
         task.status = Task.statusNew;
@@ -72,7 +72,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       }
     } else {
       task.status = newStatus;
-      task.endTimestamp = DateTime.now().millisecondsSinceEpoch;;
+      task.endTimestamp = DateTime.now().millisecondsSinceEpoch;
     }
 
     await config.db.withTransaction<void>((Transaction transaction) async {

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -36,13 +36,10 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     checkRequiredParameters(<String>[taskKeyParam, newStatusParam]);
 
     final ClientContext clientContext = authContext.clientContext;
-    final KeyHelper keyHelper =
-        KeyHelper(applicationContext: clientContext.applicationContext);
+    final KeyHelper keyHelper = KeyHelper(applicationContext: clientContext.applicationContext);
     final String newStatus = requestData[newStatusParam];
-    final Map<String, dynamic> resultData =
-        requestData[resultsParam] ?? const <String, dynamic>{};
-    final List<String> scoreKeys =
-        requestData[scoreKeysParam]?.cast<String>() ?? const <String>[];
+    final Map<String, dynamic> resultData = requestData[resultsParam] ?? const <String, dynamic>{};
+    final List<String> scoreKeys = requestData[scoreKeysParam]?.cast<String>() ?? const <String>[];
 
     Key taskKey;
     try {
@@ -52,8 +49,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     }
 
     if (newStatus != Task.statusSucceeded && newStatus != Task.statusFailed) {
-      throw const BadRequestException(
-          'NewStatus can be one of "Succeeded", "Failed"');
+      throw const BadRequestException('NewStatus can be one of "Succeeded", "Failed"');
     }
 
     final Task task = await config.db.lookupValue<Task>(taskKey, orElse: () {
@@ -90,8 +86,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     if (newStatus == Task.statusSucceeded && scoreKeys.isNotEmpty) {
       for (String scoreKey in scoreKeys) {
         await config.db.withTransaction<void>((Transaction transaction) async {
-          final TimeSeries series =
-              await _getOrCreateTimeSeries(transaction, task, scoreKey);
+          final TimeSeries series = await _getOrCreateTimeSeries(transaction, task, scoreKey);
           final num value = resultData[scoreKey];
 
           final TimeSeriesValue seriesValue = TimeSeriesValue(
@@ -117,10 +112,8 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     String scoreKey,
   ) async {
     final String id = '${task.name}.$scoreKey';
-    final Key timeSeriesKey =
-        Key.emptyKey(Partition(null)).append(TimeSeries, id: id);
-    TimeSeries series =
-        (await transaction.lookup<TimeSeries>(<Key>[timeSeriesKey])).single;
+    final Key timeSeriesKey = Key.emptyKey(Partition(null)).append(TimeSeries, id: id);
+    TimeSeries series = (await transaction.lookup<TimeSeries>(<Key>[timeSeriesKey])).single;
 
     if (series == null) {
       series = TimeSeries(

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -58,14 +58,13 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
     final Commit commit = await config.db.lookupValue<Commit>(task.commitKey);
 
-    final int endTimestamp = DateTime.now().millisecondsSinceEpoch;
     if (newStatus == Task.statusFailed) {
       // Attempt to de-flake the test.
       final int maxRetries = await config.maxTaskRetries;
       if (task.attempts >= maxRetries) {
         task.status = Task.statusFailed;
         task.reason = 'Task failed on agent';
-        task.endTimestamp = endTimestamp;
+        task.endTimestamp = DateTime.now().millisecondsSinceEpoch;;
       } else {
         // This will cause this task to be picked up by an agent again.
         task.status = Task.statusNew;
@@ -73,7 +72,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       }
     } else {
       task.status = newStatus;
-      task.endTimestamp = endTimestamp;
+      task.endTimestamp = DateTime.now().millisecondsSinceEpoch;;
     }
 
     await config.db.withTransaction<void>((Transaction transaction) async {


### PR DESCRIPTION
Existing cocoon fails to populate task endTimestamp accordingly, resulting 0 value for all tasks. Now we are trying to calculate task execution time, and here is the fix.