### PR TITLE
Flutter Cocoon Service

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:cocoon_service/protos.dart' show CommitStatus;
 import 'package:http/http.dart' as http;
 
@@ -23,9 +25,14 @@ class AppEngineCocoonService implements CocoonService {
   @override
   Future<List<CommitStatus>> getStats() async {
     /// This endpoint returns a JSON [List<Agent>, List<CommitStatus>]
-    var response = await client.get('$baseApiUrl/public/get-status');
+    http.Response response = await client.get('$baseApiUrl/public/get-status');
 
-    return _jsonDecodeCommitStatuses(jsonDecode(response.body)[1]);
+    if (response.statusCode != 200) {
+      throw new HttpException(
+          '$baseApiUrl/public/get-status returned ${response.statusCode}');
+    }
+
+    return _jsonDecodeCommitStatuses(jsonDecode(response.body));
   }
 
   List<CommitStatus> _jsonDecodeCommitStatuses(List<String> pieces) {

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -30,7 +30,7 @@ class AppEngineCocoonService implements CocoonService {
     http.Response response = await client.get('$baseApiUrl/public/get-status');
 
     if (response.statusCode != 200) {
-      throw new HttpException(
+      throw HttpException(
           '$baseApiUrl/public/get-status returned ${response.statusCode}');
     }
 

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -22,12 +22,18 @@ class AppEngineCocoonService implements CocoonService {
   /// This is the base for all API requests to cocoon
   static const _baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
-  http.Client client = http.Client();
+  http.Client _client;
+
+  /// Creates a new [AppEngineCocoonService].
+  ///
+  /// If a [client] is not specified, a new [http.Client] instance is created.
+  AppEngineCocoonService({http.Client client}) :
+    _client = client ?? http.Client();
 
   @override
   Future<List<CommitStatus>> fetchCommitStatuses() async {
     /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
-    http.Response response = await client.get('$_baseApiUrl/public/get-status');
+    http.Response response = await _client.get('$_baseApiUrl/public/get-status');
 
     if (response.statusCode != HttpStatus.ok) {
       throw HttpException(

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -9,18 +9,27 @@ import 'dart:convert';
 
 import 'cocoon.dart';
 
+/// CocoonService for interacting with flutter/flutter production build data.
+///
+/// This queries API endpoints that are hosted on AppEngine.
 class AppEngineCocoonService implements CocoonService {
   /// The Cocoon API endpoint to query
+  ///
+  /// This is the base for all API requests to cocoon
   static const baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
   @override
   Future<List<CommitStatus>> getStats() async {
+    /// This endpoint returns a JSON [List<Agent>, List<CommitStatus>]
     var response = await http.get('$baseApiUrl/public/get-status');
 
+    return _jsonDecodeCommitStatuses(jsonDecode(response.body)[1]);
+  }
+
+  List<CommitStatus> _jsonDecodeCommitStatuses(List<String> pieces) {
     List<CommitStatus> statuses = List();
 
-    List<dynamic> responsePiece = jsonDecode(response.body);
-    responsePiece.map((piece) => statuses.add(CommitStatus.fromJson(piece)));
+    pieces.map((piece) => statuses.add(CommitStatus.fromJson(piece)));
 
     return statuses;
   }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -18,10 +18,12 @@ class AppEngineCocoonService implements CocoonService {
   /// This is the base for all API requests to cocoon
   static const baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
+  http.Client client = http.Client();
+
   @override
   Future<List<CommitStatus>> getStats() async {
     /// This endpoint returns a JSON [List<Agent>, List<CommitStatus>]
-    var response = await http.get('$baseApiUrl/public/get-status');
+    var response = await client.get('$baseApiUrl/public/get-status');
 
     return _jsonDecodeCommitStatuses(jsonDecode(response.body)[1]);
   }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -1,0 +1,27 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/protos.dart' show CommitStatus;
+import 'package:http/http.dart' as http;
+
+import 'dart:convert';
+
+import 'cocoon.dart';
+
+class AppEngineCocoonService implements CocoonService {
+  /// The Cocoon API endpoint to query
+  static const baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
+
+  @override
+  Future<List<CommitStatus>> getStats() async {
+    var response = await http.get('$baseApiUrl/public/get-status');
+
+    List<CommitStatus> statuses = List();
+
+    List<dynamic> responsePiece = jsonDecode(response.body);
+    responsePiece.map((piece) => statuses.add(CommitStatus.fromJson(piece)));
+
+    return statuses;
+  }
+}

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -34,48 +34,51 @@ class AppEngineCocoonService implements CocoonService {
           '$baseApiUrl/public/get-status returned ${response.statusCode}');
     }
 
-    Map<String, dynamic> jsonResponse = jsonDecode(response.body);
-    assert(jsonResponse != null);
+    Map<String, Object> jsonResponse = jsonDecode(response.body);
 
     return _commitStatusesFromJson(jsonResponse['Statuses']);
   }
 
-  List<CommitStatus> _commitStatusesFromJson(List<dynamic> jsonCommitStatuses) {
+  List<CommitStatus> _commitStatusesFromJson(List<Object> jsonCommitStatuses) {
     assert(jsonCommitStatuses != null);
     // TODO(chillers): Remove adapter code to just use proto fromJson method. https://github.com/flutter/cocoon/issues/441
 
-    List<CommitStatus> statuses = List();
+    List<CommitStatus> statuses = <CommitStatus>[];
 
-    jsonCommitStatuses.forEach((jsonCommitStatus) {
+    for (Map<String, Object> jsonCommitStatus in jsonCommitStatuses) {
+      Map<String, Object> commit = jsonCommitStatus['Checklist'];
       statuses.add(CommitStatus()
-        ..commit = _commitFromJson(jsonCommitStatus['Checklist']['Checklist'])
+        ..commit = _commitFromJson(commit['Checklist'])
         ..stages.addAll(_stagesFromJson(jsonCommitStatus['Stages'])));
-    });
+    }
 
     return statuses;
   }
 
-  Commit _commitFromJson(Map<String, dynamic> jsonCommit) {
+  Commit _commitFromJson(Map<String, Object> jsonCommit) {
     assert(jsonCommit != null);
+
+    Map<String, Object> commit = jsonCommit['Commit'];
+    Map<String, Object> author = commit['Author'];
 
     return Commit()
       ..timestamp = Int64() + jsonCommit['CreateTimestamp']
-      ..sha = jsonCommit['Commit']['Sha']
-      ..author = jsonCommit['Commit']['Author']['Login']
-      ..authorAvatarUrl = jsonCommit['Commit']['Author']['avatar_url']
+      ..sha = commit['Sha']
+      ..author = author['Login']
+      ..authorAvatarUrl = author['avatar_url']
       ..repository = jsonCommit['FlutterRepositoryPath'];
   }
 
-  List<Stage> _stagesFromJson(List<dynamic> json) {
+  List<Stage> _stagesFromJson(List<Object> json) {
     assert(json != null);
-    List<Stage> stages = List();
+    List<Stage> stages = <Stage>[];
 
     json.forEach((jsonStage) => stages.add(_stageFromJson(jsonStage)));
 
     return stages;
   }
 
-  Stage _stageFromJson(Map<String, dynamic> json) {
+  Stage _stageFromJson(Map<String, Object> json) {
     assert(json != null);
 
     return Stage()
@@ -84,22 +87,24 @@ class AppEngineCocoonService implements CocoonService {
       ..taskStatus = json['Status'];
   }
 
-  List<Task> _tasksFromJson(List<dynamic> json) {
+  List<Task> _tasksFromJson(List<Object> json) {
     assert(json != null);
-    List<Task> tasks = List();
+    List<Task> tasks = <Task>[];
 
-    json.forEach((jsonTask) => tasks.add(_taskFromJson(jsonTask['Task'])));
+    for (Map<String, Object> jsonTask in json) {
+      tasks.add(_taskFromJson(jsonTask['Task']));
+    }
 
     return tasks;
   }
 
-  Task _taskFromJson(Map<String, dynamic> json) {
+  Task _taskFromJson(Map<String, Object> json) {
     assert(json != null);
 
-    List<String> requiredCapabilities = List();
-    List<dynamic> dynamicRequiredCapabilities = json['RequiredCapabilities'];
-    dynamicRequiredCapabilities.forEach((dynamicCapability) =>
-        requiredCapabilities.add(dynamicRequiredCapabilities.toString()));
+    List<String> requiredCapabilities = <String>[];
+    List<Object> objectRequiredCapabilities = json['RequiredCapabilities'];
+    objectRequiredCapabilities.forEach((objectCapability) =>
+        requiredCapabilities.add(objectRequiredCapabilities.toString()));
 
     return Task()
       ..createTimestamp = Int64(json['CreateTimestamp'])

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -25,7 +25,7 @@ class AppEngineCocoonService implements CocoonService {
   http.Client client = http.Client();
 
   @override
-  Future<List<CommitStatus>> getStats() async {
+  Future<List<CommitStatus>> fetchCommitStatuses() async {
     /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
     http.Response response = await client.get('$baseApiUrl/public/get-status');
 

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -29,7 +29,7 @@ class AppEngineCocoonService implements CocoonService {
     /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
     http.Response response = await client.get('$baseApiUrl/public/get-status');
 
-    if (response.statusCode != 200) {
+    if (response.statusCode != HttpStatus.ok) {
       throw HttpException(
           '$baseApiUrl/public/get-status returned ${response.statusCode}');
     }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -22,7 +22,7 @@ class AppEngineCocoonService implements CocoonService {
   /// This is the base for all API requests to cocoon
   static const _baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
-  http.Client _client;
+  final http.Client _client;
 
   /// Creates a new [AppEngineCocoonService].
   ///

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -26,7 +26,7 @@ class AppEngineCocoonService implements CocoonService {
 
   @override
   Future<List<CommitStatus>> getStats() async {
-    /// This endpoint returns a JSON [List<Agent>, List<CommitStatus>]
+    /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
     http.Response response = await client.get('$baseApiUrl/public/get-status');
 
     if (response.statusCode != 200) {
@@ -67,6 +67,7 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   List<Stage> _stagesFromJson(List<dynamic> json) {
+    assert(json != null);
     List<Stage> stages = List();
 
     json.forEach((jsonStage) => stages.add(_stageFromJson(jsonStage)));
@@ -84,6 +85,7 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   List<Task> _tasksFromJson(List<dynamic> json) {
+    assert(json != null);
     List<Task> tasks = List();
 
     json.forEach((jsonTask) => tasks.add(_taskFromJson(jsonTask['Task'])));

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -20,18 +20,18 @@ class AppEngineCocoonService implements CocoonService {
   /// The Cocoon API endpoint to query
   ///
   /// This is the base for all API requests to cocoon
-  static const baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
+  static const _baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
 
   http.Client client = http.Client();
 
   @override
   Future<List<CommitStatus>> fetchCommitStatuses() async {
     /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
-    http.Response response = await client.get('$baseApiUrl/public/get-status');
+    http.Response response = await client.get('$_baseApiUrl/public/get-status');
 
     if (response.statusCode != HttpStatus.ok) {
       throw HttpException(
-          '$baseApiUrl/public/get-status returned ${response.statusCode}');
+          '$_baseApiUrl/public/get-status returned ${response.statusCode}');
     }
 
     Map<String, Object> jsonResponse = jsonDecode(response.body);

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:convert';
 
-import 'package:cocoon_service/protos.dart' show CommitStatus;
 import 'package:http/http.dart' as http;
 
-import 'dart:convert';
+import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import 'cocoon.dart';
 
@@ -32,13 +32,21 @@ class AppEngineCocoonService implements CocoonService {
           '$baseApiUrl/public/get-status returned ${response.statusCode}');
     }
 
-    return _jsonDecodeCommitStatuses(jsonDecode(response.body));
+    Map<String, dynamic> jsonResponse = jsonDecode(response.body);
+    assert(jsonResponse != null);
+
+    return _jsonDecodeCommitStatuses(jsonResponse['Statuses']);
   }
 
-  List<CommitStatus> _jsonDecodeCommitStatuses(List<String> pieces) {
+  List<CommitStatus> _jsonDecodeCommitStatuses(
+      List<dynamic> jsonCommitStatuses) {
+    assert(jsonCommitStatuses != null);
+
     List<CommitStatus> statuses = List();
 
-    pieces.map((piece) => statuses.add(CommitStatus.fromJson(piece)));
+    jsonCommitStatuses.map((jsonCommitStatus) {
+      statuses.add(CommitStatus.fromJson(jsonCommitStatus));
+    });
 
     return statuses;
   }

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -2,14 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ffi';
-
-import 'package:cocoon_service/protos.dart'
-    show Commit, CommitStatus, Stage, Task;
-import 'package:fixnum/fixnum.dart';
-import 'package:http/src/mock_client.dart';
+import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import 'appengine_cocoon.dart';
+import 'mock_cocoon.dart';
 
 /// Service class for interacting with flutter/flutter build data.
 ///
@@ -25,6 +21,8 @@ abstract class CocoonService {
       return AppEngineCocoonService();
     }
 
+    // TODO(chillers): LocalCocoonService. https://github.com/flutter/cocoon/issues/442
+
     return MockCocoonService();
   }
 
@@ -32,55 +30,4 @@ abstract class CocoonService {
   ///
   /// TODO(chillers): Make configurable to get range of commits
   Future<List<CommitStatus>> getStats();
-}
-
-class MockCocoonService implements CocoonService {
-  @override
-  Future<List<CommitStatus>> getStats() {
-    return Future.delayed(Duration(seconds: 1), () => _getFakeStats());
-  }
-
-  List<CommitStatus> _getFakeStats() {
-    List<CommitStatus> stats = List();
-
-    final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
-
-    for (int i = 0; i < 100; i++) {
-      Commit commit = _getFakeCommit(i, baseTimestamp);
-
-      CommitStatus status = CommitStatus()
-        ..commit = commit
-        ..stages.addAll(_getFakeStages(i, commit));
-
-      stats.add(status);
-    }
-
-    return stats;
-  }
-
-  Commit _getFakeCommit(int index, int baseTimestamp) {
-    return Commit()
-      ..author = 'Author McAuthory $index'
-      ..authorAvatarUrl = 'https://avatars2.githubusercontent.com/u/2148558?v=4'
-      ..repository = 'flutter/cocoon'
-      ..sha = 'Sha Shank Hash $index'
-      ..timestamp = (baseTimestamp - (index * 100)) as Int64;
-  }
-
-  List<Stage> _getFakeStages(int index, Commit commit) {
-    List<Stage> stages = List();
-
-    stages.add(Stage()
-      ..commit = commit
-      ..name = 'chromebot'
-      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
-
-    // TODO(chillers): Generate multiple stages to mimick production.
-
-    return stages;
-  }
-
-  Task _getFakeTask(int index) {
-    return Task();
-  }
 }

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -1,0 +1,85 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ffi';
+
+import 'package:cocoon_service/protos.dart'
+    show Commit, CommitStatus, Stage, Task;
+import 'package:fixnum/fixnum.dart';
+
+import 'appengine_cocoon.dart';
+
+/// Service class for interacting with flutter/flutter build data.
+///
+/// This service exists as a common interface for getting build data from a data source.
+abstract class CocoonService {
+  /// Creates a new [CocoonService] based on if the Flutter app is in production.
+  ///
+  /// Production uses the Cocoon backend running on AppEngine.
+  /// Otherwise, it uses fake data populated from a mock service.
+  factory CocoonService() {
+    const bool isProduction = bool.fromEnvironment('dart.vm.product');
+    if (isProduction) {
+      return AppEngineCocoonService();
+    }
+
+    return MockCocoonService();
+  }
+
+  /// Gets build information from the last 200 commits.
+  ///
+  /// TODO(chillers): Make configurable to get range of commits
+  Future<List<CommitStatus>> getStats();
+}
+
+class MockCocoonService implements CocoonService {
+  @override
+  Future<List<CommitStatus>> getStats() {
+    return Future.delayed(Duration(seconds: 1), () => _getFakeStats());
+  }
+
+  List<CommitStatus> _getFakeStats() {
+    List<CommitStatus> stats = List();
+
+    final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
+
+    for (int i = 0; i < 100; i++) {
+      Commit commit = _getFakeCommit(i, baseTimestamp);
+
+      CommitStatus status = CommitStatus()
+        ..commit = commit
+        ..stages.addAll(_getFakeStages(i, commit));
+
+      stats.add(status);
+    }
+
+    return stats;
+  }
+
+  Commit _getFakeCommit(int index, int baseTimestamp) {
+    return Commit()
+      ..author = 'Author McAuthory $index'
+      ..authorAvatarUrl = 'https://avatars2.githubusercontent.com/u/2148558?v=4'
+      ..repository = 'flutter/cocoon'
+      ..sha = 'Sha Shank Hash $index'
+      ..timestamp = (baseTimestamp - (index * 100)) as Int64;
+  }
+
+  List<Stage> _getFakeStages(int index, Commit commit) {
+    List<Stage> stages = List();
+
+    stages.add(Stage()
+      ..commit = commit
+      ..name = 'chromebot'
+      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
+
+    // TODO(chillers): Generate multiple stages to mimick production.
+
+    return stages;
+  }
+
+  Task _getFakeTask(int index) {
+    return Task();
+  }
+}

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart' show kReleaseMode;
+
 import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import 'appengine_cocoon.dart';
-import 'mock_cocoon.dart';
+import 'fake_cocoon.dart';
 
 /// Service class for interacting with flutter/flutter build data.
 ///
@@ -14,16 +16,15 @@ abstract class CocoonService {
   /// Creates a new [CocoonService] based on if the Flutter app is in production.
   ///
   /// Production uses the Cocoon backend running on AppEngine.
-  /// Otherwise, it uses fake data populated from a mock service.
+  /// Otherwise, it uses fake data populated from a fake service.
   factory CocoonService() {
-    const bool isProduction = bool.fromEnvironment('dart.vm.product');
-    if (isProduction) {
+    if (kReleaseMode) {
       return AppEngineCocoonService();
     }
 
     // TODO(chillers): LocalCocoonService. https://github.com/flutter/cocoon/issues/442
 
-    return MockCocoonService();
+    return FakeCocoonService();
   }
 
   /// Gets build information from the last 200 commits.

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -30,5 +30,5 @@ abstract class CocoonService {
   /// Gets build information from the last 200 commits.
   ///
   /// TODO(chillers): Make configurable to get range of commits
-  Future<List<CommitStatus>> getStats();
+  Future<List<CommitStatus>> fetchCommitStatuses();
 }

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -7,6 +7,7 @@ import 'dart:ffi';
 import 'package:cocoon_service/protos.dart'
     show Commit, CommitStatus, Stage, Task;
 import 'package:fixnum/fixnum.dart';
+import 'package:http/src/mock_client.dart';
 
 import 'appengine_cocoon.dart';
 

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -12,11 +12,11 @@ import 'cocoon.dart';
 class FakeCocoonService implements CocoonService {
   @override
   Future<List<CommitStatus>> getStats() {
-    return Future.delayed(Duration(seconds: 1), () => _getFakeStats());
+    return Future.value(_getFakeStats());
   }
 
   List<CommitStatus> _getFakeStats() {
-    List<CommitStatus> stats = List();
+    List<CommitStatus> stats = <CommitStatus>[];
 
     final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
 
@@ -43,7 +43,7 @@ class FakeCocoonService implements CocoonService {
   }
 
   List<Stage> _getFakeStages(int index, Commit commit) {
-    List<Stage> stages = List();
+    List<Stage> stages = <Stage>[];
 
     stages.add(Stage()
       ..commit = commit

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -9,23 +9,26 @@ import 'package:cocoon_service/protos.dart'
 
 import 'cocoon.dart';
 
+/// [CocoonService] for local development purposes.
+///
+/// This creates fake data that mimicks what production will send.
 class FakeCocoonService implements CocoonService {
   @override
   Future<List<CommitStatus>> getStats() {
-    return Future.value(_getFakeStats());
+    return Future.value(_createFakeCommitStatuses());
   }
 
-  List<CommitStatus> _getFakeStats() {
+  List<CommitStatus> _createFakeCommitStatuses() {
     List<CommitStatus> stats = <CommitStatus>[];
 
     final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
 
     for (int i = 0; i < 100; i++) {
-      Commit commit = _getFakeCommit(i, baseTimestamp);
+      Commit commit = _createFakeCommit(i, baseTimestamp);
 
       CommitStatus status = CommitStatus()
         ..commit = commit
-        ..stages.addAll(_getFakeStages(i, commit));
+        ..stages.addAll(_createFakeStages(i, commit));
 
       stats.add(status);
     }
@@ -33,7 +36,7 @@ class FakeCocoonService implements CocoonService {
     return stats;
   }
 
-  Commit _getFakeCommit(int index, int baseTimestamp) {
+  Commit _createFakeCommit(int index, int baseTimestamp) {
     return Commit()
       ..author = 'Author McAuthory $index'
       ..authorAvatarUrl = 'https://avatars2.githubusercontent.com/u/2148558?v=4'
@@ -42,23 +45,23 @@ class FakeCocoonService implements CocoonService {
       ..timestamp = Int64(baseTimestamp - (index * 100));
   }
 
-  List<Stage> _getFakeStages(int index, Commit commit) {
+  List<Stage> _createFakeStages(int index, Commit commit) {
     List<Stage> stages = <Stage>[];
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(List.generate(15, (i) => _getFakeTask(i))));
+      ..tasks.addAll(List.generate(15, (i) => _createFakeTask(i))));
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab_win'
-      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
+      ..tasks.addAll(List.generate(3, (i) => _createFakeTask(i))));
 
     return stages;
   }
 
-  Task _getFakeTask(int index) {
+  Task _createFakeTask(int index) {
     return Task()
       ..createTimestamp = Int64(index)
       ..startTimestamp = Int64(index + 1)

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -14,7 +14,7 @@ import 'cocoon.dart';
 /// This creates fake data that mimicks what production will send.
 class FakeCocoonService implements CocoonService {
   @override
-  Future<List<CommitStatus>> getStats() {
+  Future<List<CommitStatus>> fetchCommitStatuses() {
     return Future.value(_createFakeCommitStatuses());
   }
 

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -9,7 +9,7 @@ import 'package:cocoon_service/protos.dart'
 
 import 'cocoon.dart';
 
-class MockCocoonService implements CocoonService {
+class FakeCocoonService implements CocoonService {
   @override
   Future<List<CommitStatus>> getStats() {
     return Future.delayed(Duration(seconds: 1), () => _getFakeStats());

--- a/app_flutter/lib/service/mock_cocoon.dart
+++ b/app_flutter/lib/service/mock_cocoon.dart
@@ -44,9 +44,12 @@ class MockCocoonService implements CocoonService {
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
+      ..tasks.addAll(List.generate(15, (i) => _getFakeTask(i))));
 
-    // TODO(chillers): Generate multiple stages to mimick production.
+    stages.add(Stage()
+      ..commit = commit
+      ..name = 'devicelab_win'
+      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
 
     return stages;
   }

--- a/app_flutter/lib/service/mock_cocoon.dart
+++ b/app_flutter/lib/service/mock_cocoon.dart
@@ -1,3 +1,7 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:fixnum/fixnum.dart';
 
 import 'package:cocoon_service/protos.dart'

--- a/app_flutter/lib/service/mock_cocoon.dart
+++ b/app_flutter/lib/service/mock_cocoon.dart
@@ -1,0 +1,67 @@
+import 'package:fixnum/fixnum.dart';
+
+import 'package:cocoon_service/protos.dart'
+    show Commit, CommitStatus, Stage, Task;
+
+import 'cocoon.dart';
+
+class MockCocoonService implements CocoonService {
+  @override
+  Future<List<CommitStatus>> getStats() {
+    return Future.delayed(Duration(seconds: 1), () => _getFakeStats());
+  }
+
+  List<CommitStatus> _getFakeStats() {
+    List<CommitStatus> stats = List();
+
+    final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
+
+    for (int i = 0; i < 100; i++) {
+      Commit commit = _getFakeCommit(i, baseTimestamp);
+
+      CommitStatus status = CommitStatus()
+        ..commit = commit
+        ..stages.addAll(_getFakeStages(i, commit));
+
+      stats.add(status);
+    }
+
+    return stats;
+  }
+
+  Commit _getFakeCommit(int index, int baseTimestamp) {
+    return Commit()
+      ..author = 'Author McAuthory $index'
+      ..authorAvatarUrl = 'https://avatars2.githubusercontent.com/u/2148558?v=4'
+      ..repository = 'flutter/cocoon'
+      ..sha = 'Sha Shank Hash $index'
+      ..timestamp = Int64(baseTimestamp - (index * 100));
+  }
+
+  List<Stage> _getFakeStages(int index, Commit commit) {
+    List<Stage> stages = List();
+
+    stages.add(Stage()
+      ..commit = commit
+      ..name = 'devicelab'
+      ..tasks.addAll(List.generate(3, (i) => _getFakeTask(i))));
+
+    // TODO(chillers): Generate multiple stages to mimick production.
+
+    return stages;
+  }
+
+  Task _getFakeTask(int index) {
+    return Task()
+      ..createTimestamp = Int64(index)
+      ..startTimestamp = Int64(index + 1)
+      ..endTimestamp = Int64(index + 2)
+      ..name = 'task $index'
+      ..attempts = index % 3
+      ..isFlaky = false
+      ..requiredCapabilities.add('[linux/android]')
+      ..reservedForAgentId = 'linux1'
+      ..stageName = 'stage name'
+      ..status = 'Succeeded';
+  }
+}

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -35,6 +35,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  test: ^1.6.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  
+  test: ^1.6.0
 
 
 # For information on the generic Dart part of this file, see the

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -34,8 +34,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  
-  test: ^1.6.0
 
 
 # For information on the generic Dart part of this file, see the

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:app_flutter/service/appengine_cocoon.dart';
-import 'package:cocoon_service/protos.dart' show Commit, CommitStatus, Stage;
+import 'package:cocoon_service/protos.dart'
+    show Commit, CommitStatus, Stage, Task;
 import 'package:test/test.dart';
 
 import 'package:http/http.dart' show Response;
@@ -88,7 +89,22 @@ void main() {
           ..author = 'ShaSha'
           ..authorAvatarUrl = 'https://flutter.dev'
           ..repository = 'flutter/cocoon')
-        ..stages.add(Stage());
+        ..stages.add(Stage()
+          ..name = 'devicelab'
+          ..taskStatus = 'Succeeded'
+          ..tasks.add(Task()
+            ..createTimestamp = Int64(1569353940885)
+            ..startTimestamp = Int64(1569354594672)
+            ..endTimestamp = Int64(1569354700642)
+            ..name = 'complex_layout_semantics_perf'
+            ..attempts = 1
+            ..isFlaky = false
+            ..timeoutInMinutes = 0
+            ..reason = ''
+            ..requiredCapabilities.add('[linux/android]')
+            ..reservedForAgentId = 'linux2'
+            ..stageName = 'devicelab'
+            ..status = 'Succeeded'));
 
       expect(statuses.length, 1);
       expect(statuses.elementAt(0), expectedStatus);

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -3,10 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:fixnum/fixnum.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' show Response;
 import 'package:http/testing.dart';
+import 'package:test/test.dart';
 
 import 'package:app_flutter/service/appengine_cocoon.dart';
 import 'package:cocoon_service/protos.dart'

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -75,11 +75,12 @@ void main() {
     });
 
     test('should return List<CommitStatus>', () {
-      expect(service.getStats(), TypeMatcher<Future<List<CommitStatus>>>());
+      expect(service.fetchCommitStatuses(),
+          TypeMatcher<Future<List<CommitStatus>>>());
     });
 
     test('should return expected List<CommitStatus>', () async {
-      List<CommitStatus> statuses = await service.getStats();
+      List<CommitStatus> statuses = await service.fetchCommitStatuses();
 
       CommitStatus expectedStatus = CommitStatus()
         ..commit = (Commit()
@@ -112,13 +113,13 @@ void main() {
     test('should throw exception if given non-200 response', () {
       service.client = MockClient((request) async => Response('', 404));
 
-      expect(service.getStats(), throwsException);
+      expect(service.fetchCommitStatuses(), throwsException);
     });
 
     test('should throw exception if given bad response', () {
       service.client = MockClient((request) async => Response('bad', 200));
 
-      expect(service.getStats(), throwsException);
+      expect(service.fetchCommitStatuses(), throwsException);
     });
   });
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -12,8 +12,8 @@ import 'package:fixnum/fixnum.dart';
 
 void main() {
   // This is based off data the Cocoon backend sends out from v1.
-  // It doesn't map perfectly to the protos since the backend does
-  // not use the protos yet.
+  // It doesn't map directly to protos since the backend does
+  // not use protos yet.
   final String jsonGetStatsResponse = """
         {
           "Statuses": [
@@ -40,7 +40,18 @@ void main() {
                     {
                       "Key": "taskKey1",
                       "Task": {
-                        "Attempts": 1
+                        "Attempts": 1,
+                        "CreateTimestamp": 1569353940885,
+                        "EndTimestamp": 1569354700642,
+                        "Flaky": false,
+                        "Name": "complex_layout_semantics_perf",
+                        "Reason": "",
+                        "RequiredCapabilities": ["linux/android"],
+                        "ReservedForAgentID": "linux2",
+                        "StageName": "devicelab",
+                        "StartTimestamp": 1569354594672,
+                        "Status": "Succeeded",
+                        "TimeoutInMinutes": 0
                       }
                     }
                   ]

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -70,9 +70,8 @@ void main() {
 
     setUp(() async {
       service = AppEngineCocoonService();
-      service.client = MockClient((request) {
-        return Future<Response>.delayed(Duration(microseconds: 100),
-            () => Response(jsonGetStatsResponse, 200));
+      service.client = MockClient((request) async {
+        return Response(jsonGetStatsResponse, 200);
       });
     });
 
@@ -112,15 +111,13 @@ void main() {
     });
 
     test('should throw exception if given non-200 response', () {
-      service.client = MockClient((request) => Future<Response>.delayed(
-          Duration(microseconds: 100), () => Response('', 404)));
+      service.client = MockClient((request) async => Response('', 404));
 
       expect(service.getStats(), throwsException);
     });
 
     test('should throw exception if given bad response', () {
-      service.client = MockClient((request) => Future<Response>.delayed(
-          Duration(microseconds: 100), () => Response('bad', 200)));
+      service.client = MockClient((request) async => Response('bad', 200));
 
       expect(service.getStats(), throwsException);
     });

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -3,15 +3,26 @@
 // found in the LICENSE file.
 
 import 'package:app_flutter/service/appengine_cocoon.dart';
-import 'package:app_flutter/service/cocoon.dart';
+import 'package:cocoon_service/protos.dart';
 import 'package:test/test.dart';
+
+import 'package:http/http.dart' show Response;
+import 'package:http/testing.dart';
 
 void main() {
   group('AppEngine CocoonService', () {
     test('should make an http request', () {
-      final CocoonService service = AppEngineCocoonService();
+      final AppEngineCocoonService service = AppEngineCocoonService();
+      service.client = MockClient((request) {
+        const String jsonResponse = """
+        {"Statuses": ["Checklist": {"Key": "iamatestkey", "Checklist": {"FlutterRepositoryPath": "flutter/cocoon", "CreateTimestamp": 123456789, "Commit": {"Sha": "ShaShankHash", "Author": {"Login": "iamacontributor", "avatar_url": "https://google.com"}}}}, "Stages": []], "AgentStatuses": []}
+        """;
 
-      service.getStats();
+        return Future<Response>.delayed(
+            Duration(microseconds: 500), () => Response(jsonResponse, 200));
+      });
+
+      expect(service.getStats(), TypeMatcher<Future<CommitStatus>>());
     });
   });
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -84,7 +84,7 @@ void main() {
 
       CommitStatus expectedStatus = CommitStatus()
         ..commit = (Commit()
-          ..timestamp = Int64() + 123456789
+          ..timestamp = Int64(123456789)
           ..sha = 'ShaShankHash'
           ..author = 'ShaSha'
           ..authorAvatarUrl = 'https://flutter.dev'
@@ -107,7 +107,7 @@ void main() {
             ..status = 'Succeeded'));
 
       expect(statuses.length, 1);
-      expect(statuses.elementAt(0), expectedStatus);
+      expect(statuses.first, expectedStatus);
     });
 
     test('should throw exception if given non-200 response', () {

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -59,21 +59,24 @@ void main() {
       });
     });
 
-    test('should return List<CommitStatus>', () async {
+    test('should return List<CommitStatus>', () {
       expect(service.getStats(), TypeMatcher<Future<List<CommitStatus>>>());
     });
 
     test('should return expected List<CommitStatus>', () {});
 
-    test('should throw exception if given non-200 response', () async {
-      service.client = MockClient((request) {
-        return Future<Response>.delayed(
-            Duration(microseconds: 100), () => Response('', 404));
-      });
+    test('should throw exception if given non-200 response', () {
+      service.client = MockClient((request) => Future<Response>.delayed(
+          Duration(microseconds: 100), () => Response('', 404)));
 
       expect(service.getStats(), throwsException);
     });
 
-    test('should throw exception if given bad response', () async {});
+    test('should throw exception if given bad response', () {
+      service.client = MockClient((request) => Future<Response>.delayed(
+          Duration(microseconds: 100), () => Response('bad', 200)));
+
+      expect(service.getStats(), throwsException);
+    });
   });
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -68,10 +68,9 @@ void main() {
     AppEngineCocoonService service;
 
     setUp(() async {
-      service = AppEngineCocoonService();
-      service.client = MockClient((request) async {
+      service = AppEngineCocoonService(client: MockClient((request) async {
         return Response(jsonGetStatsResponse, 200);
-      });
+      }));
     });
 
     test('should return List<CommitStatus>', () {
@@ -111,13 +110,15 @@ void main() {
     });
 
     test('should throw exception if given non-200 response', () {
-      service.client = MockClient((request) async => Response('', 404));
+      service = AppEngineCocoonService(
+          client: MockClient((request) async => Response('', 404)));
 
       expect(service.fetchCommitStatuses(), throwsException);
     });
 
     test('should throw exception if given bad response', () {
-      service.client = MockClient((request) async => Response('bad', 200));
+      service = AppEngineCocoonService(
+          client: MockClient((request) async => Response('bad', 200)));
 
       expect(service.fetchCommitStatuses(), throwsException);
     });

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:app_flutter/service/appengine_cocoon.dart';
+import 'package:app_flutter/service/cocoon.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AppEngine CocoonService', () {
+    test('should make an http request', () {
+      final CocoonService service = AppEngineCocoonService();
+
+      service.getStats();
+    });
+  });
+}

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -12,7 +12,8 @@ import 'package:http/testing.dart';
 void main() {
   final String jsonGetStatsResponse = """
         {
-          "Statuses": {
+          "Statuses": [
+            {
             "Checklist": {
               "Key": "iamatestkey", 
               "Checklist": {
@@ -27,8 +28,22 @@ void main() {
                   }
                 }
               }, 
-              "Stages": []
-            }, 
+              "Stages": [
+                {
+                  "Name": "devicelab",
+                  "Status": "Succeeded",
+                  "Tasks": [
+                    {
+                      "Key": "taskKey1",
+                      "Task": {
+                        "Attempts": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ], 
           "AgentStatuses": []
         }
   """;
@@ -44,13 +59,13 @@ void main() {
       });
     });
 
-    test('should return List<CommitStatus>', () {
+    test('should return List<CommitStatus>', () async {
       expect(service.getStats(), TypeMatcher<Future<List<CommitStatus>>>());
     });
 
     test('should return expected List<CommitStatus>', () {});
 
-    test('should throw HttpException if given non-200 response', () {
+    test('should throw exception if given non-200 response', () async {
       service.client = MockClient((request) {
         return Future<Response>.delayed(
             Duration(microseconds: 100), () => Response('', 404));
@@ -58,5 +73,7 @@ void main() {
 
       expect(service.getStats(), throwsException);
     });
+
+    test('should throw exception if given bad response', () async {});
   });
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -2,14 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' show Response;
+import 'package:http/testing.dart';
+
 import 'package:app_flutter/service/appengine_cocoon.dart';
 import 'package:cocoon_service/protos.dart'
     show Commit, CommitStatus, Stage, Task;
-import 'package:test/test.dart';
-
-import 'package:http/http.dart' show Response;
-import 'package:http/testing.dart';
-import 'package:fixnum/fixnum.dart';
 
 void main() {
   // This is based off data the Cocoon backend sends out from v1.

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -12,59 +12,59 @@ import 'package:app_flutter/service/appengine_cocoon.dart';
 import 'package:cocoon_service/protos.dart'
     show Commit, CommitStatus, Stage, Task;
 
-void main() {
-  // This is based off data the Cocoon backend sends out from v1.
-  // It doesn't map directly to protos since the backend does
-  // not use protos yet.
-  final String jsonGetStatsResponse = """
-        {
-          "Statuses": [
-            {
+// This is based off data the Cocoon backend sends out from v1.
+// It doesn't map directly to protos since the backend does
+// not use protos yet.
+const String jsonGetStatsResponse = """
+      {
+        "Statuses": [
+          {
+          "Checklist": {
+            "Key": "iamatestkey", 
             "Checklist": {
-              "Key": "iamatestkey", 
-              "Checklist": {
-                "FlutterRepositoryPath": "flutter/cocoon", 
-                "CreateTimestamp": 123456789, 
-                "Commit": {
-                  "Sha": "ShaShankHash", 
-                  "Author": {
-                    "Login": "ShaSha", 
-                    "avatar_url": "https://flutter.dev"
-                    }
+              "FlutterRepositoryPath": "flutter/cocoon", 
+              "CreateTimestamp": 123456789, 
+              "Commit": {
+                "Sha": "ShaShankHash", 
+                "Author": {
+                  "Login": "ShaSha", 
+                  "avatar_url": "https://flutter.dev"
                   }
                 }
-              }, 
-              "Stages": [
-                {
-                  "Name": "devicelab",
-                  "Status": "Succeeded",
-                  "Tasks": [
-                    {
-                      "Key": "taskKey1",
-                      "Task": {
-                        "Attempts": 1,
-                        "CreateTimestamp": 1569353940885,
-                        "EndTimestamp": 1569354700642,
-                        "Flaky": false,
-                        "Name": "complex_layout_semantics_perf",
-                        "Reason": "",
-                        "RequiredCapabilities": ["linux/android"],
-                        "ReservedForAgentID": "linux2",
-                        "StageName": "devicelab",
-                        "StartTimestamp": 1569354594672,
-                        "Status": "Succeeded",
-                        "TimeoutInMinutes": 0
-                      }
+              }
+            }, 
+            "Stages": [
+              {
+                "Name": "devicelab",
+                "Status": "Succeeded",
+                "Tasks": [
+                  {
+                    "Key": "taskKey1",
+                    "Task": {
+                      "Attempts": 1,
+                      "CreateTimestamp": 1569353940885,
+                      "EndTimestamp": 1569354700642,
+                      "Flaky": false,
+                      "Name": "complex_layout_semantics_perf",
+                      "Reason": "",
+                      "RequiredCapabilities": ["linux/android"],
+                      "ReservedForAgentID": "linux2",
+                      "StageName": "devicelab",
+                      "StartTimestamp": 1569354594672,
+                      "Status": "Succeeded",
+                      "TimeoutInMinutes": 0
                     }
-                  ]
-                }
-              ]
-            }
-          ], 
-          "AgentStatuses": []
-        }
-  """;
+                  }
+                ]
+              }
+            ]
+          }
+        ], 
+        "AgentStatuses": []
+      }
+""";
 
+void main() {
   group('AppEngine CocoonService', () {
     AppEngineCocoonService service;
 

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -3,13 +3,17 @@
 // found in the LICENSE file.
 
 import 'package:app_flutter/service/appengine_cocoon.dart';
-import 'package:cocoon_service/protos.dart';
+import 'package:cocoon_service/protos.dart' show Commit, CommitStatus, Stage;
 import 'package:test/test.dart';
 
 import 'package:http/http.dart' show Response;
 import 'package:http/testing.dart';
+import 'package:fixnum/fixnum.dart';
 
 void main() {
+  // This is based off data the Cocoon backend sends out from v1.
+  // It doesn't map perfectly to the protos since the backend does
+  // not use the protos yet.
   final String jsonGetStatsResponse = """
         {
           "Statuses": [
@@ -22,8 +26,8 @@ void main() {
                 "Commit": {
                   "Sha": "ShaShankHash", 
                   "Author": {
-                    "Login": "iamacontributor", 
-                    "avatar_url": "https://google.com"
+                    "Login": "ShaSha", 
+                    "avatar_url": "https://flutter.dev"
                     }
                   }
                 }
@@ -63,7 +67,21 @@ void main() {
       expect(service.getStats(), TypeMatcher<Future<List<CommitStatus>>>());
     });
 
-    test('should return expected List<CommitStatus>', () {});
+    test('should return expected List<CommitStatus>', () async {
+      List<CommitStatus> statuses = await service.getStats();
+
+      CommitStatus expectedStatus = CommitStatus()
+        ..commit = (Commit()
+          ..timestamp = Int64() + 123456789
+          ..sha = 'ShaShankHash'
+          ..author = 'ShaSha'
+          ..authorAvatarUrl = 'https://flutter.dev'
+          ..repository = 'flutter/cocoon')
+        ..stages.add(Stage());
+
+      expect(statuses.length, 1);
+      expect(statuses.elementAt(0), expectedStatus);
+    });
 
     test('should throw exception if given non-200 response', () {
       service.client = MockClient((request) => Future<Response>.delayed(


### PR DESCRIPTION
This service allows the Flutter application to talk to the cocoon backend to get data.

It offers both a production service (talks to AppEngine via HTTP) and a mock service (generate dummy data) based on whether the application was built for production or not.

Most of the code in AppEngineCocoonService will be deleted once protos are being used in the backend.