### PR TITLE
StatusGrid refreshes to show the latest information

### DIFF
--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -48,7 +48,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
         children: [
           ChangeNotifierProvider(
             builder: (context) => buildState,
-            child: StatusGrid(),
+            child: StatusGridContainer(),
           ),
         ],
       ),

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -35,7 +35,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
   void initState() {
     super.initState();
 
-    buildState.startFetchingBuildStatusUpdates();
+    buildState.startFetchingBuildStateUpdates();
   }
 
   @override

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -10,9 +10,6 @@ import 'status_grid.dart';
 
 void main() => runApp(MyApp());
 
-/// How often to query the Cocoon backend for the current build state.
-final Duration dashboardRefreshRate = Duration(seconds: 10);
-
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -38,14 +35,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
   void initState() {
     super.initState();
 
-    _updateBuildState();
-  }
-
-  /// Recursive function that calls itself to maintain a constant cycle of updates.
-  void _updateBuildState() {
-    buildState.fetchBuildStatusUpdate();
-
-    Future.delayed(dashboardRefreshRate, () => _updateBuildState());
+    buildState.startFetchingBuildStatusUpdates();
   }
 
   @override

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -57,8 +57,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 
   @override
   void dispose() {
-    super.dispose();
-
     buildState.dispose();
+    super.dispose();
   }
 }

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -54,4 +54,11 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    buildState.dispose();
+  }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -18,17 +18,32 @@ class FlutterBuildState extends ChangeNotifier {
   /// How often to query the Cocoon backend for the current build state.
   final Duration _refreshRate = Duration(seconds: 10);
 
+  /// Timer that calls [_fetchBuildStatusUpdate] on a set interval.
+  Timer _refreshTimer;
+
   /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
   /// Start a fixed interval loop that fetches build state updates based on [_refreshRate].
   void startFetchingBuildStateUpdates() async {
-    Timer.periodic(_refreshRate, (t) => _fetchBuildStatusUpdate());
+    if (_refreshTimer != null) {
+      throw 'already fetching build state updates';
+    }
+
+    _refreshTimer =
+        Timer.periodic(_refreshRate, (t) => _fetchBuildStatusUpdate());
   }
 
   /// Request the latest [statuses] from [CocoonService].
   void _fetchBuildStatusUpdate() async {
     statuses = await _cocoonService.fetchCommitStatuses();
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    _refreshTimer?.cancel();
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -1,0 +1,18 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:app_flutter/service/cocoon.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:cocoon_service/protos.dart' show CommitStatus;
+
+class FlutterBuildState extends ChangeNotifier {
+  final CocoonService _cocoonService = CocoonService();
+
+  List<CommitStatus> statuses;
+
+  void fetchBuildStatusUpdate() async {
+    _cocoonService.fetchCommitStatuses();
+  }
+}

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -13,10 +13,11 @@ import '../service/cocoon.dart';
 /// State for the Flutter Build Dashboard
 class FlutterBuildState extends ChangeNotifier {
   /// Cocoon backend service that retrieves the data needed for this state.
-  final CocoonService _cocoonService = CocoonService();
+  final CocoonService _cocoonService;
 
   /// How often to query the Cocoon backend for the current build state.
-  final Duration _refreshRate = Duration(seconds: 10);
+  @visibleForTesting
+  final Duration refreshRate = Duration(seconds: 10);
 
   /// Timer that calls [_fetchBuildStatusUpdate] on a set interval.
   @visibleForTesting
@@ -25,7 +26,13 @@ class FlutterBuildState extends ChangeNotifier {
   /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
-  /// Start a fixed interval loop that fetches build state updates based on [_refreshRate].
+  /// Creates a new [FlutterBuildState].
+  ///
+  /// If [CocoonService] is not specified, a new [CocoonService] instance is created.
+  FlutterBuildState({CocoonService cocoonService})
+      : _cocoonService = cocoonService ?? CocoonService();
+
+  /// Start a fixed interval loop that fetches build state updates based on [refreshRate].
   void startFetchingBuildStateUpdates() async {
     if (refreshTimer != null) {
       // There's already an update loop, no need to make another.
@@ -33,7 +40,7 @@ class FlutterBuildState extends ChangeNotifier {
     }
 
     refreshTimer =
-        Timer.periodic(_refreshRate, (t) => _fetchBuildStatusUpdate());
+        Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
   }
 
   /// Request the latest [statuses] from [CocoonService].

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -2,17 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/service/cocoon.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 import 'package:cocoon_service/protos.dart' show CommitStatus;
+
+import '../service/cocoon.dart';
 
 class FlutterBuildState extends ChangeNotifier {
   final CocoonService _cocoonService = CocoonService();
 
-  List<CommitStatus> statuses;
+  List<CommitStatus> statuses = [];
 
   void fetchBuildStatusUpdate() async {
-    _cocoonService.fetchCommitStatuses();
+    statuses = await _cocoonService.fetchCommitStatuses();
+    notifyListeners();
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -19,18 +19,20 @@ class FlutterBuildState extends ChangeNotifier {
   final Duration _refreshRate = Duration(seconds: 10);
 
   /// Timer that calls [_fetchBuildStatusUpdate] on a set interval.
-  Timer _refreshTimer;
+  @visibleForTesting
+  Timer refreshTimer;
 
   /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
   /// Start a fixed interval loop that fetches build state updates based on [_refreshRate].
   void startFetchingBuildStateUpdates() async {
-    if (_refreshTimer != null) {
-      throw 'already fetching build state updates';
+    if (refreshTimer != null) {
+      // There's already an update loop, no need to make another.
+      return;
     }
 
-    _refreshTimer =
+    refreshTimer =
         Timer.periodic(_refreshRate, (t) => _fetchBuildStatusUpdate());
   }
 
@@ -44,6 +46,6 @@ class FlutterBuildState extends ChangeNotifier {
   void dispose() {
     super.dispose();
 
-    _refreshTimer?.cancel();
+    refreshTimer?.cancel();
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -44,8 +44,7 @@ class FlutterBuildState extends ChangeNotifier {
 
   @override
   void dispose() {
-    super.dispose();
-
     refreshTimer?.cancel();
+    super.dispose();
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -16,15 +16,17 @@ class FlutterBuildState extends ChangeNotifier {
   final CocoonService _cocoonService = CocoonService();
 
   /// How often to query the Cocoon backend for the current build state.
-  final Duration refreshRate = Duration(seconds: 10);
+  final Duration _refreshRate = Duration(seconds: 10);
 
   /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
-  void startFetchingBuildStatusUpdates() async {
-    Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
+  /// Start a fixed interval loop that fetches build state updates based on [_refreshRate].
+  void startFetchingBuildStateUpdates() async {
+    Timer.periodic(_refreshRate, (t) => _fetchBuildStatusUpdate());
   }
 
+  /// Request the latest [statuses] from [CocoonService].
   void _fetchBuildStatusUpdate() async {
     statuses = await _cocoonService.fetchCommitStatuses();
     notifyListeners();

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -10,26 +10,29 @@ import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import '../service/cocoon.dart';
 
-/// State for the build dashboard based on what is collected
+/// State for the Flutter Build Dashboard
 class FlutterBuildState extends ChangeNotifier {
-  /// Cocoon backend service that retrieves the data needed
+  /// Cocoon backend service that retrieves the data needed for this state.
   final CocoonService _cocoonService = CocoonService();
 
   /// How often to query the Cocoon backend for the current build state.
-  final Duration refreshRate = Duration(seconds: 1);
+  final Duration refreshRate = Duration(seconds: 10);
 
+  /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
-  Timer updateTimer;
+  Timer _updateTimer;
 
   void startFetchingBuildStatusUpdates() async {
-    print('start fetching!');
-    updateTimer = Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
+    _updateTimer =
+        Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
+  }
+
+  void stopFetchingBuildStatusUpdate() {
+    _updateTimer.cancel();
   }
 
   void _fetchBuildStatusUpdate() async {
-    print('updating!');
-
     statuses = await _cocoonService.fetchCommitStatuses();
     notifyListeners();
   }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -2,18 +2,34 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import '../service/cocoon.dart';
 
+/// State for the build dashboard based on what is collected
 class FlutterBuildState extends ChangeNotifier {
+  /// Cocoon backend service that retrieves the data needed
   final CocoonService _cocoonService = CocoonService();
+
+  /// How often to query the Cocoon backend for the current build state.
+  final Duration refreshRate = Duration(seconds: 1);
 
   List<CommitStatus> statuses = [];
 
-  void fetchBuildStatusUpdate() async {
+  Timer updateTimer;
+
+  void startFetchingBuildStatusUpdates() async {
+    print('start fetching!');
+    updateTimer = Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
+  }
+
+  void _fetchBuildStatusUpdate() async {
+    print('updating!');
+
     statuses = await _cocoonService.fetchCommitStatuses();
     notifyListeners();
   }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -21,15 +21,8 @@ class FlutterBuildState extends ChangeNotifier {
   /// The current status of the commits loaded.
   List<CommitStatus> statuses = [];
 
-  Timer _updateTimer;
-
   void startFetchingBuildStatusUpdates() async {
-    _updateTimer =
-        Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
-  }
-
-  void stopFetchingBuildStatusUpdate() {
-    _updateTimer.cancel();
+    Timer.periodic(refreshRate, (t) => _fetchBuildStatusUpdate());
   }
 
   void _fetchBuildStatusUpdate() async {

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -12,10 +12,9 @@ import 'state/flutter_build.dart';
 import 'commit_box.dart';
 import 'task_box.dart';
 
-/// Display results from flutter/flutter repository's continuous integration.
+/// Container that manages the layout and data handling for [StatusGrid].
 ///
-/// Results are displayed in a matrix format. Rows are commits and columns
-/// are the results from tasks.
+/// If there's no data for [StatusGrid], it shows [CircularProgressIndicator].
 class StatusGridContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -75,8 +75,7 @@ class StatusGrid extends StatelessWidget {
               }
 
               return TaskBox(
-                task: _mapGridIndexToTaskBruteForce(
-                    gridIndex, columnCount, statuses),
+                task: _mapGridIndexToTaskBruteForce(gridIndex, columnCount),
               );
             },
           ),
@@ -103,8 +102,7 @@ class StatusGrid extends StatelessWidget {
   }
 
   /// Maps a [gridIndex] to a specific [Task] in [List<CommitStatus>]
-  Task _mapGridIndexToTaskBruteForce(
-      int gridIndex, int columnCount, List<CommitStatus> statuses) {
+  Task _mapGridIndexToTaskBruteForce(int gridIndex, int columnCount) {
     int commitStatusIndex = gridIndex ~/ columnCount;
     CommitStatus status = statuses[commitStatusIndex];
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -67,7 +67,6 @@ class StatusGrid extends StatelessWidget {
           ),
         );
       },
-      child: Container(),
     );
   }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -16,6 +16,8 @@ import 'task_box.dart';
 ///
 /// If there's no data for [StatusGrid], it shows [CircularProgressIndicator].
 class StatusGridContainer extends StatelessWidget {
+  const StatusGridContainer({Key key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Consumer<FlutterBuildState>(

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -16,15 +16,12 @@ import 'task_box.dart';
 ///
 /// Results are displayed in a matrix format. Rows are commits and columns
 /// are the results from tasks.
-class StatusGrid extends StatelessWidget {
+class StatusGridContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    /// The build status data to display in the grid.
-    List<CommitStatus> statuses;
-
     return Consumer<FlutterBuildState>(
       builder: (context, buildState, child) {
-        statuses = buildState.statuses;
+        List<CommitStatus> statuses = buildState.statuses;
 
         // Assume if there is no data that it is loading.
         if (statuses.isEmpty) {
@@ -35,38 +32,56 @@ class StatusGrid extends StatelessWidget {
           );
         }
 
-        // The grid needs to know its dimensions, column is based off the stages and
-        // how many tasks they each run.
-        int columnCount = _getColumnCount(statuses.first);
-
-        return Expanded(
-          // The grid is wrapped with SingleChildScrollView to enable scrolling both
-          // horizontally and vertically
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Container(
-              width: columnCount * 50.0,
-              child: GridView.builder(
-                itemCount: columnCount * statuses.length,
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: columnCount),
-                itemBuilder: (BuildContext context, int gridIndex) {
-                  int statusIndex = gridIndex ~/ columnCount;
-
-                  if (gridIndex % columnCount == 0) {
-                    return CommitBox(commit: statuses[statusIndex].commit);
-                  }
-
-                  return TaskBox(
-                    task: _mapGridIndexToTaskBruteForce(
-                        gridIndex, columnCount, statuses),
-                  );
-                },
-              ),
-            ),
-          ),
+        return StatusGrid(
+          statuses: statuses,
         );
       },
+    );
+  }
+}
+
+/// Display results from flutter/flutter repository's continuous integration.
+///
+/// Results are displayed in a matrix format. Rows are commits and columns
+/// are the results from tasks.
+class StatusGrid extends StatelessWidget {
+  const StatusGrid({Key key, @required this.statuses}) : super(key: key);
+
+  /// The build status data to display in the grid.
+  final List<CommitStatus> statuses;
+
+  @override
+  Widget build(BuildContext context) {
+    // The grid needs to know its dimensions, column is based off the stages and
+    // how many tasks they each run.
+    int columnCount = _getColumnCount(statuses.first);
+
+    return Expanded(
+      // The grid is wrapped with SingleChildScrollView to enable scrolling both
+      // horizontally and vertically
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Container(
+          width: columnCount * 50.0,
+          child: GridView.builder(
+            itemCount: columnCount * statuses.length,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: columnCount),
+            itemBuilder: (BuildContext context, int gridIndex) {
+              int statusIndex = gridIndex ~/ columnCount;
+
+              if (gridIndex % columnCount == 0) {
+                return CommitBox(commit: statuses[statusIndex].commit);
+              }
+
+              return TaskBox(
+                task: _mapGridIndexToTaskBruteForce(
+                    gridIndex, columnCount, statuses),
+              );
+            },
+          ),
+        ),
+      ),
     );
   }
 

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 
   cocoon_service:
     path: ../app_dart
+  provider: ^3.0.0
   url_launcher: ^5.1.0
 
 dev_dependencies:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
     sdk: flutter
 
   test: ^1.6.0
+  mockito: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/app_flutter/test/service/mock_cocoon.dart
+++ b/app_flutter/test/service/mock_cocoon.dart
@@ -1,9 +1,0 @@
-// Copyright (c) 2019 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-import 'package:app_flutter/service/fake_cocoon.dart';
-import 'package:mockito/mockito.dart';
-
-/// CocoonService for checking interactions.
-class MockCocoonService extends Mock implements FakeCocoonService {}

--- a/app_flutter/test/service/mock_cocoon.dart
+++ b/app_flutter/test/service/mock_cocoon.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:app_flutter/service/fake_cocoon.dart';
+import 'package:mockito/mockito.dart';
+
+/// CocoonService for checking interactions.
+class MockCocoonService extends Mock implements FakeCocoonService {}

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:app_flutter/service/fake_cocoon.dart';
 import 'package:app_flutter/state/flutter_build.dart';
-import '../service/mock_cocoon.dart';
 
 void main() {
   group('FlutterBuildState', () {
@@ -47,3 +47,6 @@ void main() {
     });
   });
 }
+
+/// CocoonService for checking interactions.
+class MockCocoonService extends Mock implements FakeCocoonService {}

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -5,14 +5,38 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 import 'package:app_flutter/state/flutter_build.dart';
+import '../service/mock_cocoon.dart';
 
 void main() {
   group('FlutterBuildState', () {
-    test('multiple start updates should throw no exception', () {
-      FlutterBuildState buildState = FlutterBuildState();
+    FlutterBuildState buildState;
+    MockCocoonService mockService;
 
+    setUp(() {
+      mockService = MockCocoonService();
+      buildState = FlutterBuildState(cocoonService: mockService);
+    });
+
+    tearDown(() {
+      buildState.dispose();
+    });
+
+    testWidgets('timer should periodically fetch updates',
+        (WidgetTester tester) async {
+      verifyZeroInteractions(mockService);
+
+      buildState.startFetchingBuildStateUpdates();
+
+      // pump [refreshRate] so at least one fetch call is made
+      await tester.pump(buildState.refreshRate);
+
+      verify(mockService.fetchCommitStatuses()).called(greaterThan(0));
+    });
+
+    test('multiple start updates should not change the timer', () {
       buildState.startFetchingBuildStateUpdates();
       Timer refreshTimer = buildState.refreshTimer;
 

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:app_flutter/state/flutter_build.dart';
+
+void main() {
+  group('FlutterBuildState', () {
+    test('multiple start updates throws exception', () {
+      FlutterBuildState buildState = FlutterBuildState();
+
+      buildState.startFetchingBuildStateUpdates();
+
+      expect(() => buildState.startFetchingBuildStateUpdates(),
+          throwsA(equals('already fetching build state updates')));
+    });
+  });
+}

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -2,19 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:app_flutter/state/flutter_build.dart';
 
 void main() {
   group('FlutterBuildState', () {
-    test('multiple start updates throws exception', () {
+    test('multiple start updates should throw no exception', () {
       FlutterBuildState buildState = FlutterBuildState();
 
       buildState.startFetchingBuildStateUpdates();
+      Timer refreshTimer = buildState.refreshTimer;
 
-      expect(() => buildState.startFetchingBuildStateUpdates(),
-          throwsA(equals('already fetching build state updates')));
+      // This second run should not change the refresh timer
+      buildState.startFetchingBuildStateUpdates();
+
+      expect(refreshTimer, equals(buildState.refreshTimer));
     });
   });
 }

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/task_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,31 +11,21 @@ import 'package:cocoon_service/protos.dart' show CommitStatus;
 import 'package:app_flutter/service/fake_cocoon.dart';
 import 'package:app_flutter/commit_box.dart';
 import 'package:app_flutter/status_grid.dart';
-import 'package:provider/provider.dart';
 
 void main() {
   group('StatusGrid', () {
-    List<CommitStatus> expectedStatuses;
+    List<CommitStatus> statuses;
 
-    FlutterBuildState buildState;
-
-    setUp(() async {
-      buildState = FlutterBuildState();
-      buildState.startFetchingBuildStatusUpdates();
-
+    setUpAll(() async {
       final FakeCocoonService service = FakeCocoonService();
-      expectedStatuses = await service.fetchCommitStatuses();
-    });
-
-    tearDown(() async {
-      buildState.stopFetchingBuildStatusUpdate();
+      statuses = await service.fetchCommitStatuses();
     });
 
     testWidgets('shows loading indicator when statuses is empty',
         (WidgetTester tester) async {
       await tester.pumpWidget(Column(
         children: [
-          StatusGrid(),
+          StatusGridContainer(),
         ],
       ));
 
@@ -51,9 +40,8 @@ void main() {
         MaterialApp(
           home: Column(
             children: [
-              ChangeNotifierProvider(
-                builder: (_) => buildState,
-                child: StatusGrid(),
+              StatusGrid(
+                statuses: statuses,
               ),
             ],
           ),
@@ -77,9 +65,8 @@ void main() {
         MaterialApp(
           home: Column(
             children: [
-              ChangeNotifierProvider(
-                builder: (_) => buildState,
-                child: StatusGrid(),
+              StatusGrid(
+                statuses: statuses,
               ),
             ],
           ),
@@ -87,7 +74,7 @@ void main() {
       );
 
       TaskBox firstTask = find.byType(TaskBox).evaluate().first.widget;
-      expect(firstTask.task, expectedStatuses[0].stages[0].tasks[0]);
+      expect(firstTask.task, statuses[0].stages[0].tasks[0]);
 
       tester.takeException();
     });
@@ -98,9 +85,8 @@ void main() {
         MaterialApp(
           home: Column(
             children: [
-              ChangeNotifierProvider(
-                builder: (_) => buildState,
-                child: StatusGrid(),
+              StatusGrid(
+                statuses: statuses,
               ),
             ],
           ),
@@ -108,7 +94,7 @@ void main() {
       );
 
       TaskBox lastTask = find.byType(TaskBox).evaluate().last.widget;
-      expect(lastTask.task, expectedStatuses.last.stages.last.tasks.last);
+      expect(lastTask.task, statuses.last.stages.last.tasks.last);
 
       tester.takeException();
     });

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/task_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import 'package:app_flutter/service/fake_cocoon.dart';
+import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/commit_box.dart';
 import 'package:app_flutter/status_grid.dart';
+import 'package:app_flutter/task_box.dart';
 
 void main() {
   group('StatusGrid', () {
@@ -23,11 +25,18 @@ void main() {
 
     testWidgets('shows loading indicator when statuses is empty',
         (WidgetTester tester) async {
-      await tester.pumpWidget(Column(
-        children: [
-          StatusGridContainer(),
-        ],
-      ));
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: [
+              ChangeNotifierProvider(
+                builder: (_) => FlutterBuildState(),
+                child: StatusGridContainer(),
+              ),
+            ],
+          ),
+        ),
+      );
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byType(GridView), findsNothing);


### PR DESCRIPTION
Implemented the Provider package to handle the state management for the new build dashboard. Created a state class for the build dashboard. Once feature parity is reached with the current dashboard, it will contain more variables (e.g. tree build status, agent statuses).

Created a new wrapper widget for the StatusGrid that handles the state management section for now. If we find this creates performance issues, we can refactor it.

This fixes #422 since the feature parity is met. The dashboard loads production data in, and updates it with the latest information on a set interval.

## Tested
I did a manual test by building the app for release on my phone, and seeing if tasks that were running went to a different state.