### PR TITLE
In Progress Tasks show work is being done

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -17,24 +17,32 @@ class TaskBox extends StatelessWidget {
   /// [Task] to show information from.
   final Task task;
 
+  /// Status messages that map to TaskStatus enums.
+  /// TODO(chillers): Remove these and use TaskStatus enum when available. https://github.com/flutter/cocoon/issues/441
+  static const String statusFailed = 'Failed';
+  static const String statusNew = 'New';
+  static const String statusSkipped = 'Skipped';
+  static const String statusSucceeded = 'Succeeded';
+  static const String statusUnderperformed = 'Underperformed';
+  static const String statusInProgress = 'In Progress';
+
   /// A lookup table to define the background color for this TaskBox.
   ///
   /// The status messages are based on the messages the backend sends.
-  /// TODO(chillers): Update these to TaskStatus enum when backend switches to protos. https://github.com/flutter/cocoon/issues/441
   static const statusColor = <String, Color>{
-    'Failed': Colors.red,
-    'New': Colors.blue,
-    'Skipped': Colors.transparent,
-    'Succeeded': Colors.green,
-    'Underperformed': Colors.orange,
+    statusFailed: Colors.red,
+    statusNew: Colors.blue,
+    statusSkipped: Colors.transparent,
+    statusSucceeded: Colors.green,
+    statusUnderperformed: Colors.orange,
   };
 
   @override
   Widget build(BuildContext context) {
-    if (task.status == 'In Progress') {
+    if (task.status == statusInProgress) {
       return Container(
         margin: const EdgeInsets.all(1.0),
-        color: statusColor['New'],
+        color: statusColor[statusNew],
         child: const Padding(
           padding: EdgeInsets.all(25.0),
           child: const CircularProgressIndicator(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -32,6 +32,7 @@ class TaskBox extends StatelessWidget {
   static const statusColor = <String, Color>{
     statusFailed: Colors.red,
     statusNew: Colors.blue,
+    statusInProgress: Colors.blue,
     statusSkipped: Colors.transparent,
     statusSucceeded: Colors.green,
     statusUnderperformed: Colors.orange,
@@ -39,27 +40,20 @@ class TaskBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (task.status == statusInProgress) {
-      return Container(
-        margin: const EdgeInsets.all(1.0),
-        color: statusColor[statusNew],
-        child: const Padding(
-          padding: EdgeInsets.all(25.0),
-          child: const CircularProgressIndicator(
-            strokeWidth: 3.0,
-            backgroundColor: Colors.white70,
-          ),
-        ),
-        width: 20,
-        height: 20,
-      );
-    }
-
     return Container(
       margin: const EdgeInsets.all(1.0),
       color: statusColor.containsKey(task.status)
           ? statusColor[task.status]
           : Colors.black,
+      child: (task.status == statusInProgress)
+          ? const Padding(
+              padding: const EdgeInsets.all(15.0),
+              child: CircularProgressIndicator(
+                strokeWidth: 3.0,
+                backgroundColor: Colors.white70,
+              ),
+            )
+          : null,
       width: 20,
       height: 20,
     );

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -35,7 +35,8 @@ class TaskBox extends StatelessWidget {
         child: const Padding(
           padding: EdgeInsets.all(25.0),
           child: const CircularProgressIndicator(
-            backgroundColor: Colors.white60,
+            strokeWidth: 3.0,
+            backgroundColor: Colors.white70,
           ),
         ),
       );

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -20,6 +20,7 @@ class TaskBox extends StatelessWidget {
   /// A lookup table to define the background color for this TaskBox.
   ///
   /// The status messages are based on the messages the backend sends.
+  /// TODO(chillers): Update these to TaskStatus enum when backend switches to protos. https://github.com/flutter/cocoon/issues/441
   static const statusColor = <String, Color>{
     'Failed': Colors.red,
     'New': Colors.blue,

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -8,19 +8,20 @@ import 'package:cocoon_service/protos.dart' show Task;
 
 /// Displays information from a [Task].
 ///
-/// Shows a black box for unknown messages.
+/// If [Task.status] is "In Progress", it will show as a "New" task
+/// with a [CircularProgressIndicator] in the box.
+/// Shows a black box for unknown statuses.
 class TaskBox extends StatelessWidget {
   const TaskBox({Key key, @required this.task}) : super(key: key);
 
   /// [Task] to show information from.
   final Task task;
 
-  /// A lookup table to define the background color for this ResultBox.
+  /// A lookup table to define the background color for this TaskBox.
   ///
-  /// The result messages are based on the messages the backend sends.
-  static const resultColor = <String, Color>{
+  /// The status messages are based on the messages the backend sends.
+  static const statusColor = <String, Color>{
     'Failed': Colors.red,
-    'In Progress': Colors.purple, // v1 used the 'New' color while spinning
     'New': Colors.blue,
     'Skipped': Colors.transparent,
     'Succeeded': Colors.green,
@@ -31,7 +32,8 @@ class TaskBox extends StatelessWidget {
   Widget build(BuildContext context) {
     if (task.status == 'In Progress') {
       return Container(
-        color: resultColor['New'],
+        margin: const EdgeInsets.all(1.0),
+        color: statusColor['New'],
         child: const Padding(
           padding: EdgeInsets.all(25.0),
           child: const CircularProgressIndicator(
@@ -39,13 +41,15 @@ class TaskBox extends StatelessWidget {
             backgroundColor: Colors.white70,
           ),
         ),
+        width: 20,
+        height: 20,
       );
     }
 
     return Container(
       margin: const EdgeInsets.all(1.0),
-      color: resultColor.containsKey(task.status)
-          ? resultColor[task.status]
+      color: statusColor.containsKey(task.status)
+          ? statusColor[task.status]
           : Colors.black,
       width: 20,
       height: 20,

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -29,6 +29,18 @@ class TaskBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (task.status == 'In Progress') {
+      return Container(
+        color: resultColor['New'],
+        child: const Padding(
+          padding: EdgeInsets.all(25.0),
+          child: const CircularProgressIndicator(
+            backgroundColor: Colors.white60,
+          ),
+        ),
+      );
+    }
+
     return Container(
       margin: const EdgeInsets.all(1.0),
       color: resultColor.containsKey(task.status)

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -47,7 +47,7 @@ class TaskBox extends StatelessWidget {
           : Colors.black,
       child: (task.status == statusInProgress)
           ? const Padding(
-              padding: const EdgeInsets.all(15.0),
+              padding: EdgeInsets.all(15.0),
               child: CircularProgressIndicator(
                 strokeWidth: 3.0,
                 backgroundColor: Colors.white70,

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -21,7 +21,8 @@ void main() {
 
     testWidgets('shows loading indicator for In Progress task',
         (WidgetTester tester) async {
-      await tester.pumpWidget(TaskBox(task: Task()..status = 'In Progress'));
+      await tester
+          .pumpWidget(TaskBox(task: Task()..status = TaskBox.statusInProgress));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -10,25 +10,34 @@ import 'package:cocoon_service/protos.dart' show Task;
 import 'package:app_flutter/task_box.dart';
 
 void main() {
-  // Table Driven Approach to ensure every message does show the corresponding color
-  TaskBox.resultColor.forEach((String message, Color color) {
-    testWidgets('ResultBox is the color $color when given the message $message',
-        (WidgetTester tester) async {
-      expectResultBoxColorWithMessage(tester, message, color);
+  group('TaskBox', () {
+    // Table Driven Approach to ensure every message does show the corresponding color
+    TaskBox.statusColor.forEach((String message, Color color) {
+      testWidgets('is the color $color when given the message $message',
+          (WidgetTester tester) async {
+        expectTaskBoxColorWithMessage(tester, message, color);
+      });
     });
-  });
 
-  testWidgets('ResultBox is the color black when given an unknown message',
-      (WidgetTester tester) async {
-    expectResultBoxColorWithMessage(tester, '404', Colors.black);
+    testWidgets('shows loading indicator for In Progress task',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(TaskBox(task: Task()..status = 'In Progress'));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('is the color black when given an unknown message',
+        (WidgetTester tester) async {
+      expectTaskBoxColorWithMessage(tester, '404', Colors.black);
+    });
   });
 }
 
-void expectResultBoxColorWithMessage(
+void expectTaskBoxColorWithMessage(
     WidgetTester tester, String message, Color expectedColor) async {
   await tester.pumpWidget(TaskBox(task: Task()..status = message));
 
-  Container resultBoxWidget = find.byType(Container).evaluate().first.widget;
-  BoxDecoration decoration = resultBoxWidget.decoration;
+  Container taskBoxWidget = find.byType(Container).evaluate().first.widget;
+  BoxDecoration decoration = taskBoxWidget.decoration;
   expect(decoration.color, expectedColor);
 }


### PR DESCRIPTION
- Added a special case for In Progress tasks to show a loading indicator in the box
- Updated old references of ResultBox to TaskBox
- Added test for this new case

Here's a GIF (the performance issue comes from the GIF, not the app)
![task_running](https://user-images.githubusercontent.com/2148558/65984790-61fed100-e435-11e9-9397-f69bfe7b2f82.gif)
