### PR TITLE
Fix tree status updates not reflecting in UI

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -38,7 +38,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 }
 
 /// Shows information about the current build status of flutter/flutter.
-/// 
+///
 /// The tree's current build status is reflected in the color of [AppBar].
 /// The results from tasks run on individual commits is shown in [StatusGrid].
 class BuildDashboard extends StatelessWidget {

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -38,6 +38,9 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 }
 
 /// Shows information about the current build status of flutter/flutter.
+/// 
+/// The tree's current build status is reflected in the color of [AppBar].
+/// The results from tasks run on individual commits is shown in [StatusGrid].
 class BuildDashboard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'state/flutter_build.dart';
+import 'status_grid.dart';
+
+/// [BuildDashboard] parent widget that manages the state of the dashboard.
+class BuildDashboardPage extends StatefulWidget {
+  @override
+  _BuildDashboardPageState createState() => _BuildDashboardPageState();
+}
+
+class _BuildDashboardPageState extends State<BuildDashboardPage> {
+  final FlutterBuildState buildState = FlutterBuildState();
+
+  @override
+  void initState() {
+    super.initState();
+
+    buildState.startFetchingBuildStateUpdates();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+        builder: (context) => buildState, child: BuildDashboard());
+  }
+
+  @override
+  void dispose() {
+    buildState.dispose();
+    super.dispose();
+  }
+}
+
+/// Shows information about the current build status of flutter/flutter.
+class BuildDashboard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Consumer<FlutterBuildState>(
+      builder: (_, buildState, child) => Scaffold(
+        appBar: AppBar(
+          title: Text('Flutter Build Dashboard v2'),
+          backgroundColor:
+              buildState.isTreeBuilding ? theme.primaryColor : theme.errorColor,
+        ),
+        body: Column(
+          children: [
+            StatusGridContainer(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -48,7 +48,7 @@ class BuildDashboard extends StatelessWidget {
     return Consumer<FlutterBuildState>(
       builder: (_, buildState, child) => Scaffold(
         appBar: AppBar(
-          title: Text('Flutter Build Dashboard v2'),
+          title: const Text('Flutter Build Dashboard v2'),
           backgroundColor:
               buildState.isTreeBuilding ? theme.primaryColor : theme.errorColor,
         ),

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -3,10 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
-import 'state/flutter_build.dart';
-import 'status_grid.dart';
+import 'build_dashboard.dart';
 
 void main() => runApp(MyApp());
 
@@ -20,47 +18,5 @@ class MyApp extends StatelessWidget {
       ),
       home: BuildDashboardPage(),
     );
-  }
-}
-
-class BuildDashboardPage extends StatefulWidget {
-  @override
-  _BuildDashboardPageState createState() => _BuildDashboardPageState();
-}
-
-class _BuildDashboardPageState extends State<BuildDashboardPage> {
-  final FlutterBuildState buildState = FlutterBuildState();
-
-  @override
-  void initState() {
-    super.initState();
-
-    buildState.startFetchingBuildStateUpdates();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Flutter Build Dashboard v2'),
-        backgroundColor:
-            buildState.isTreeBuilding ? theme.primaryColor : theme.errorColor,
-      ),
-      body: Column(
-        children: [
-          ChangeNotifierProvider(
-            builder: (context) => buildState,
-            child: StatusGridContainer(),
-          ),
-        ],
-      ),
-    );
-  }
-
-  @override
-  void dispose() {
-    buildState.dispose();
-    super.dispose();
   }
 }

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:fixnum/fixnum.dart';
 
 import 'package:cocoon_service/protos.dart'
@@ -20,7 +22,7 @@ class FakeCocoonService implements CocoonService {
 
   @override
   Future<bool> fetchTreeBuildStatus() async {
-    return true;
+    return Random().nextBool();
   }
 
   List<CommitStatus> _createFakeCommitStatuses() {

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -15,6 +15,10 @@ import 'cocoon.dart';
 ///
 /// This creates fake data that mimicks what production will send.
 class FakeCocoonService implements CocoonService {
+  FakeCocoonService({Random rand}) : random = rand ?? Random();
+
+  final Random random;
+
   @override
   Future<List<CommitStatus>> fetchCommitStatuses() {
     return Future.value(_createFakeCommitStatuses());
@@ -22,7 +26,7 @@ class FakeCocoonService implements CocoonService {
 
   @override
   Future<bool> fetchTreeBuildStatus() async {
-    return Random().nextBool();
+    return random.nextBool();
   }
 
   List<CommitStatus> _createFakeCommitStatuses() {


### PR DESCRIPTION
Fixes #454 

Issue was there was no state for the AppBar. This creates a parent widget for the build dashboard that maintains the state, and wraps its children in a ChangeNotifierProvider.


# Tested
I updated the fake cocoon service to give a random value for the tree status, and verified that the AppBar switched colors randomly every 10 seconds.

I think a regression test for this bug would involve writing an integration test, and that is out of the scope of this project.