### PR TITLE
Update analysis_options to match flutter/flutter for app_flutter

### DIFF
--- a/app_flutter/analysis_options.yaml
+++ b/app_flutter/analysis_options.yaml
@@ -1,0 +1,192 @@
+# Specify analysis options.
+#
+# Until there are meta linter rules, each desired lint must be explicitly enabled.
+# See: https://github.com/dart-lang/linter/issues/288
+#
+# For a list of lints, see: http://dart-lang.github.io/linter/lints/
+# See the configuration guide for more
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+#
+# There are other similar analysis options files in the flutter repos,
+# which should be kept in sync with this file:
+#
+#   - analysis_options.yaml (this file)
+#   - packages/flutter/lib/analysis_options_user.yaml
+#   - https://github.com/flutter/plugins/blob/master/analysis_options.yaml
+#   - https://github.com/flutter/engine/blob/master/analysis_options.yaml
+#
+# This file contains the analysis options used by Flutter tools, such as IntelliJ,
+# Android Studio, and the `flutter analyze` command.
+
+analyzer:
+  strong-mode:
+    implicit-dynamic: false
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+    # allow having TODOs in the code
+    todo: ignore
+    # Ignore analyzer hints for updating pubspecs when using Future or
+    # Stream and not importing dart:async
+    # Please see https://github.com/flutter/flutter/pull/24528 for details.
+    sdk_version_async_exported_from_core: ignore
+  exclude:
+    - "bin/cache/**"
+    # the following two are relative to the stocks example and the flutter package respectively
+    # see https://github.com/dart-lang/sdk/issues/28463
+    - "lib/i18n/stock_messages_*.dart"
+    - "lib/src/http/**"
+
+linter:
+  rules:
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    - always_declare_return_types
+    - always_put_control_body_on_new_line
+    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_require_non_null_named_parameters
+    - always_specify_types
+    - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    - avoid_as
+    - avoid_bool_literals_in_conditional_expressions
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
+    - avoid_classes_with_only_static_members
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
+    - avoid_empty_else
+    - avoid_field_initializers_in_const_classes
+    - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # not yet tested
+    - avoid_init_to_null
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_null_for_future # not yet tested
+    - avoid_returning_null_for_void
+    # - avoid_returning_this # there are plenty of valid reasons to return this
+    # - avoid_setters_without_getters # not yet tested
+    # - avoid_shadowing_type_parameters # not yet tested
+    # - avoid_single_cascade_in_expression_statements # not yet tested
+    - avoid_slow_async_io
+    - avoid_types_as_parameter_names
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    # - cascade_invocations # not yet tested
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    - control_flow_in_finally
+    # - curly_braces_in_flow_control_structures # not yet tested
+    # - diagnostic_describe_all_properties # not yet tested
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    # - file_names # not yet tested
+    - flutter_style_todos
+    - hash_and_equals
+    - implementation_imports
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not yet tested
+    - library_names
+    - library_prefixes
+    # - lines_longer_than_80_chars # not yet tested
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    # - null_closures  # not yet tested
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    # - prefer_asserts_with_message # not yet tested
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # not yet tested
+    - prefer_contains
+    # - prefer_double_quotes # opposite of prefer_single_quotes
+    - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    - prefer_final_fields
+    # - prefer_final_in_for_each # not yet tested
+    - prefer_final_locals
+    # - prefer_for_elements_to_map_fromIterable # not yet tested
+    - prefer_foreach
+    # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    # - prefer_int_literals # not yet tested
+    # - prefer_interpolation_to_compose_strings # not yet tested
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_typing_uninitialized_variables
+    - prefer_void_to_null
+    # - provide_deprecation_message # not yet tested
+    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    - recursive_getters
+    - slash_for_doc_comments
+    # - sort_child_properties_last # not yet tested
+    - sort_constructors_first
+    - sort_pub_dependencies
+    - sort_unnamed_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    # - type_annotate_public_apis # subset of always_specify_types
+    - type_init_formals
+    # - unawaited_futures # too many false positives
+    # - unnecessary_await_in_return # not yet tested
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_getters_setters
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_overrides
+    - unnecessary_parenthesis
+    - unnecessary_statements
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    # - unsafe_html # not yet tested
+    - use_full_hex_values_for_flutter_colors
+    # - use_function_type_syntax_for_parameters # not yet tested
+    - use_rethrow_when_possible
+    # - use_setters_to_change_properties # not yet tested
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    # - void_checks # not yet tested

--- a/app_flutter/analysis_options.yaml
+++ b/app_flutter/analysis_options.yaml
@@ -1,22 +1,4 @@
-# Specify analysis options.
-#
-# Until there are meta linter rules, each desired lint must be explicitly enabled.
-# See: https://github.com/dart-lang/linter/issues/288
-#
-# For a list of lints, see: http://dart-lang.github.io/linter/lints/
-# See the configuration guide for more
-# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
-#
-# There are other similar analysis options files in the flutter repos,
-# which should be kept in sync with this file:
-#
-#   - analysis_options.yaml (this file)
-#   - packages/flutter/lib/analysis_options_user.yaml
-#   - https://github.com/flutter/plugins/blob/master/analysis_options.yaml
-#   - https://github.com/flutter/engine/blob/master/analysis_options.yaml
-#
-# This file contains the analysis options used by Flutter tools, such as IntelliJ,
-# Android Studio, and the `flutter analyze` command.
+# To be kept in sync with https://github.com/flutter/flutter/blob/master/analysis_options.yaml
 
 analyzer:
   strong-mode:

--- a/app_flutter/android/gradle.properties
+++ b/app_flutter/android/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 
+android.enableR8=true

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -26,8 +26,8 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-        builder: (context) => buildState, child: BuildDashboard());
+    return ChangeNotifierProvider<FlutterBuildState>(
+        builder: (_) => buildState, child: BuildDashboard());
   }
 
   @override
@@ -46,14 +46,14 @@ class BuildDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return Consumer<FlutterBuildState>(
-      builder: (_, buildState, child) => Scaffold(
+      builder: (_, FlutterBuildState buildState, Widget child) => Scaffold(
         appBar: AppBar(
           title: const Text('Flutter Build Dashboard v2'),
           backgroundColor:
               buildState.isTreeBuilding ? theme.primaryColor : theme.errorColor,
         ),
         body: Column(
-          children: [
+          children: const <Widget>[
             StatusGridContainer(),
           ],
         ),

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -44,7 +44,7 @@ class _CommitBoxState extends State<CommitBox> {
 
   void _handleTap() {
     _commitOverlay = OverlayEntry(
-      builder: (overlayContext) => CommitOverlayContents(
+      builder: (_) => CommitOverlayContents(
           parentContext: context,
           commit: widget.commit,
           closeCallback: _closeOverlay),
@@ -61,7 +61,7 @@ class _CommitBoxState extends State<CommitBox> {
 /// This is intended to be inserted in an [OverlayEntry] as it requires
 /// [closeCallback] that will remove the widget from the tree.
 class CommitOverlayContents extends StatelessWidget {
-  CommitOverlayContents({
+  const CommitOverlayContents({
     Key key,
     @required this.parentContext,
     @required this.commit,
@@ -130,7 +130,7 @@ class CommitOverlayContents extends StatelessWidget {
                     IconButton(
                       icon: const Icon(Icons.open_in_new),
                       onPressed: () async {
-                        String githubUrl =
+                        final String githubUrl =
                             'https://github.com/${commit.repository}/commit/${commit.sha}';
                         await launch(githubUrl);
                       },

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -29,7 +29,7 @@ abstract class CocoonService {
 
   /// Gets build information from the last 200 commits.
   ///
-  /// TODO(chillers): Make configurable to get range of commits
+  // TODO(chillers): Make configurable to get range of commits, https://github.com/flutter/cocoon/issues/458
   Future<List<CommitStatus>> fetchCommitStatuses();
 
   /// Gets the current build status of flutter/flutter.

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -20,8 +20,8 @@ class FakeCocoonService implements CocoonService {
   final Random random;
 
   @override
-  Future<List<CommitStatus>> fetchCommitStatuses() {
-    return Future.value(_createFakeCommitStatuses());
+  Future<List<CommitStatus>> fetchCommitStatuses() async {
+    return _createFakeCommitStatuses();
   }
 
   @override
@@ -30,14 +30,14 @@ class FakeCocoonService implements CocoonService {
   }
 
   List<CommitStatus> _createFakeCommitStatuses() {
-    List<CommitStatus> stats = <CommitStatus>[];
+    final List<CommitStatus> stats = <CommitStatus>[];
 
     final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
 
     for (int i = 0; i < 100; i++) {
-      Commit commit = _createFakeCommit(i, baseTimestamp);
+      final Commit commit = _createFakeCommit(i, baseTimestamp);
 
-      CommitStatus status = CommitStatus()
+      final CommitStatus status = CommitStatus()
         ..commit = commit
         ..stages.addAll(_createFakeStages(i, commit));
 
@@ -57,17 +57,17 @@ class FakeCocoonService implements CocoonService {
   }
 
   List<Stage> _createFakeStages(int index, Commit commit) {
-    List<Stage> stages = <Stage>[];
+    final List<Stage> stages = <Stage>[];
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(List.generate(15, (i) => _createFakeTask(i))));
+      ..tasks.addAll(List<Task>.generate(15, (int i) => _createFakeTask(i))));
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab_win'
-      ..tasks.addAll(List.generate(3, (i) => _createFakeTask(i))));
+      ..tasks.addAll(List<Task>.generate(3, (int i) => _createFakeTask(i))));
 
     return stages;
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -8,8 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:cocoon_service/protos.dart'
     show Commit, CommitStatus, Stage, Task;
 
-import 'state/flutter_build.dart';
 import 'commit_box.dart';
+import 'state/flutter_build.dart';
 import 'task_box.dart';
 
 /// Container that manages the layout and data handling for [StatusGrid].
@@ -21,12 +21,12 @@ class StatusGridContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer<FlutterBuildState>(
-      builder: (context, buildState, child) {
-        List<CommitStatus> statuses = buildState.statuses;
+      builder: (_, FlutterBuildState buildState, Widget child) {
+        final List<CommitStatus> statuses = buildState.statuses;
 
         // Assume if there is no data that it is loading.
         if (statuses.isEmpty) {
-          return Expanded(
+          return const Expanded(
             child: Center(
               child: CircularProgressIndicator(),
             ),
@@ -55,7 +55,7 @@ class StatusGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     // The grid needs to know its dimensions, column is based off the stages and
     // how many tasks they each run.
-    int columnCount = _getColumnCount(statuses.first);
+    final int columnCount = _getColumnCount(statuses.first);
 
     return Expanded(
       // The grid is wrapped with SingleChildScrollView to enable scrolling both
@@ -69,7 +69,7 @@ class StatusGrid extends StatelessWidget {
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: columnCount),
             itemBuilder: (BuildContext context, int gridIndex) {
-              int statusIndex = gridIndex ~/ columnCount;
+              final int statusIndex = gridIndex ~/ columnCount;
 
               if (gridIndex % columnCount == 0) {
                 return CommitBox(commit: statuses[statusIndex].commit);
@@ -104,14 +104,14 @@ class StatusGrid extends StatelessWidget {
 
   /// Maps a [gridIndex] to a specific [Task] in [List<CommitStatus>]
   Task _mapGridIndexToTaskBruteForce(int gridIndex, int columnCount) {
-    int commitStatusIndex = gridIndex ~/ columnCount;
-    CommitStatus status = statuses[commitStatusIndex];
+    final int commitStatusIndex = gridIndex ~/ columnCount;
+    final CommitStatus status = statuses[commitStatusIndex];
 
     int taskIndex = (gridIndex % columnCount) - 1;
 
     int currentStageIndex = 0;
     while (taskIndex >= 0 && currentStageIndex < status.stages.length) {
-      Stage currentStage = status.stages[currentStageIndex];
+      final Stage currentStage = status.stages[currentStageIndex];
       if (taskIndex >= currentStage.tasks.length) {
         taskIndex = taskIndex - currentStage.tasks.length;
         currentStageIndex++;

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -18,7 +18,7 @@ class TaskBox extends StatelessWidget {
   final Task task;
 
   /// Status messages that map to TaskStatus enums.
-  /// TODO(chillers): Remove these and use TaskStatus enum when available. https://github.com/flutter/cocoon/issues/441
+  // TODO(chillers): Remove these and use TaskStatus enum when available. https://github.com/flutter/cocoon/issues/441
   static const String statusFailed = 'Failed';
   static const String statusNew = 'New';
   static const String statusSkipped = 'Skipped';
@@ -32,7 +32,7 @@ class TaskBox extends StatelessWidget {
   /// A lookup table to define the background color for this TaskBox.
   ///
   /// The status messages are based on the messages the backend sends.
-  static const statusColor = <String, Color>{
+  static const Map<String, Color> statusColor = <String, Color>{
     statusFailed: Colors.red,
     statusNew: Colors.blue,
     statusInProgress: Colors.blue,

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -12,7 +12,7 @@ import 'package:app_flutter/commit_box.dart';
 
 void main() {
   group('CommitBox', () {
-    Commit expectedCommit = Commit()
+    final Commit expectedCommit = Commit()
       ..author = 'AuthoryMcAuthor Face'
       ..authorAvatarUrl = 'https://avatars2.githubusercontent.com/u/2148558?v=4'
       ..repository = 'flutter/cocoon'
@@ -30,7 +30,7 @@ void main() {
 
       // Image.Network throws a 400 exception in tests
       expect(tester.takeException(),
-          test.TypeMatcher<NetworkImageLoadException>());
+          const test.TypeMatcher<NetworkImageLoadException>());
     });
 
     testWidgets('shows overlay on click', (WidgetTester tester) async {

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:fixnum/fixnum.dart';
-import 'package:http/http.dart' show Response;
+import 'package:http/http.dart' show Request, Response;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
@@ -14,7 +14,7 @@ import 'package:cocoon_service/protos.dart'
 // This is based off data the Cocoon backend sends out from v1.
 // It doesn't map directly to protos since the backend does
 // not use protos yet.
-const String jsonGetStatsResponse = """
+const String jsonGetStatsResponse = '''
       {
         "Statuses": [
           {
@@ -61,39 +61,39 @@ const String jsonGetStatsResponse = """
         ], 
         "AgentStatuses": []
       }
-""";
+''';
 
-const String jsonBuildStatusTrueResponse = """
+const String jsonBuildStatusTrueResponse = '''
   {
     "AnticipatedBuildStatus": "Succeeded"
   }
-""";
+''';
 
-const String jsonBuildStatusFalseResponse = """
+const String jsonBuildStatusFalseResponse = '''
   {
     "AnticipatedBuildStatus": "Failed"
   }
-""";
+''';
 
 void main() {
   group('AppEngine CocoonService fetchCommitStatus ', () {
     AppEngineCocoonService service;
 
     setUp(() async {
-      service = AppEngineCocoonService(client: MockClient((request) async {
+      service = AppEngineCocoonService(client: MockClient((Request request) async {
         return Response(jsonGetStatsResponse, 200);
       }));
     });
 
     test('should return List<CommitStatus>', () {
       expect(service.fetchCommitStatuses(),
-          TypeMatcher<Future<List<CommitStatus>>>());
+          const TypeMatcher<Future<List<CommitStatus>>>());
     });
 
     test('should return expected List<CommitStatus>', () async {
-      List<CommitStatus> statuses = await service.fetchCommitStatuses();
+      final List<CommitStatus> statuses = await service.fetchCommitStatuses();
 
-      CommitStatus expectedStatus = CommitStatus()
+      final CommitStatus expectedStatus = CommitStatus()
         ..commit = (Commit()
           ..timestamp = Int64(123456789)
           ..sha = 'ShaShankHash'
@@ -123,14 +123,14 @@ void main() {
 
     test('should throw exception if given non-200 response', () {
       service = AppEngineCocoonService(
-          client: MockClient((request) async => Response('', 404)));
+          client: MockClient((Request request) async => Response('', 404)));
 
       expect(service.fetchCommitStatuses(), throwsException);
     });
 
     test('should throw exception if given bad response', () {
       service = AppEngineCocoonService(
-          client: MockClient((request) async => Response('bad', 200)));
+          client: MockClient((Request request) async => Response('bad', 200)));
 
       expect(service.fetchCommitStatuses(), throwsException);
     });
@@ -140,41 +140,41 @@ void main() {
     AppEngineCocoonService service;
 
     setUp(() async {
-      service = AppEngineCocoonService(client: MockClient((request) async {
+      service = AppEngineCocoonService(client: MockClient((Request request) async {
         return Response(jsonBuildStatusTrueResponse, 200);
       }));
     });
 
     test('should return bool', () {
-      expect(service.fetchTreeBuildStatus(), TypeMatcher<Future<bool>>());
+      expect(service.fetchTreeBuildStatus(), const TypeMatcher<Future<bool>>());
     });
 
     test('should return true when given Succeeded', () async {
-      bool treeBuildStatus = await service.fetchTreeBuildStatus();
+      final bool treeBuildStatus = await service.fetchTreeBuildStatus();
 
       expect(treeBuildStatus, true);
     });
 
     test('should return false when given Failed', () async {
-      service = AppEngineCocoonService(client: MockClient((request) async {
+      service = AppEngineCocoonService(client: MockClient((Request request) async {
         return Response(jsonBuildStatusFalseResponse, 200);
       }));
 
-      bool treeBuildStatus = await service.fetchTreeBuildStatus();
+      final bool treeBuildStatus = await service.fetchTreeBuildStatus();
 
       expect(treeBuildStatus, false);
     });
 
     test('should throw exception if given non-200 response', () {
       service = AppEngineCocoonService(
-          client: MockClient((request) async => Response('', 404)));
+          client: MockClient((Request request) async => Response('', 404)));
 
       expect(service.fetchTreeBuildStatus(), throwsException);
     });
 
     test('should throw exception if given bad response', () {
       service = AppEngineCocoonService(
-          client: MockClient((request) async => Response('bad', 200)));
+          client: MockClient((Request request) async => Response('bad', 200)));
 
       expect(service.fetchTreeBuildStatus(), throwsException);
     });

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:cocoon_service/protos.dart' show CommitStatus;
+
 import 'package:app_flutter/service/fake_cocoon.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 
@@ -20,9 +22,9 @@ void main() {
       buildState = FlutterBuildState(cocoonService: mockService);
 
       when(mockService.fetchCommitStatuses())
-          .thenAnswer((_) => Future.value([]));
+          .thenAnswer((_) => Future<List<CommitStatus>>.value(<CommitStatus>[]));
       when(mockService.fetchTreeBuildStatus())
-          .thenAnswer((_) => Future.value(true));
+          .thenAnswer((_) => Future<bool>.value(true));
     });
 
     testWidgets('timer should periodically fetch updates',
@@ -44,7 +46,7 @@ void main() {
     testWidgets('multiple start updates should not change the timer',
         (WidgetTester tester) async {
       buildState.startFetchingBuildStateUpdates();
-      Timer refreshTimer = buildState.refreshTimer;
+      final Timer refreshTimer = buildState.refreshTimer;
 
       // This second run should not change the refresh timer
       buildState.startFetchingBuildStateUpdates();

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -28,10 +28,10 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Column(
-            children: [
-              ChangeNotifierProvider(
+            children: <Widget>[
+              ChangeNotifierProvider<FlutterBuildState>(
                 builder: (_) => FlutterBuildState(),
-                child: StatusGridContainer(),
+                child: const StatusGridContainer(),
               ),
             ],
           ),
@@ -46,7 +46,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Column(
-            children: [
+            children: <Widget>[
               StatusGrid(
                 statuses: statuses,
               ),
@@ -55,9 +55,9 @@ void main() {
         ),
       );
 
-      List<Element> commits = find.byType(CommitBox).evaluate().toList();
+      final List<Element> commits = find.byType(CommitBox).evaluate().toList();
 
-      double xPosition = commits.first.size.topLeft(Offset.zero).dx;
+      final double xPosition = commits.first.size.topLeft(Offset.zero).dx;
 
       for (Element commit in commits) {
         // All the x positions should match the first instance if they're all in the same column
@@ -71,7 +71,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Column(
-            children: [
+            children: <Widget>[
               StatusGrid(
                 statuses: statuses,
               ),
@@ -80,7 +80,7 @@ void main() {
         ),
       );
 
-      TaskBox firstTask = find.byType(TaskBox).evaluate().first.widget;
+      final TaskBox firstTask = find.byType(TaskBox).evaluate().first.widget;
       expect(firstTask.task, statuses[0].stages[0].tasks[0]);
     });
 
@@ -89,7 +89,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Column(
-            children: [
+            children: <Widget>[
               StatusGrid(
                 statuses: statuses,
               ),
@@ -98,8 +98,8 @@ void main() {
         ),
       );
 
-      TaskBox lastTaskWidget = find.byType(TaskBox).evaluate().last.widget;
-      Task lastTask = statuses.last.stages.last.tasks.last;
+      final TaskBox lastTaskWidget = find.byType(TaskBox).evaluate().last.widget;
+      final Task lastTask = statuses.last.stages.last.tasks.last;
       
       expect(lastTaskWidget.task, lastTask);
     });

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -78,11 +78,11 @@ void main() {
   });
 }
 
-void expectTaskBoxColorWithMessage(
+Future<void> expectTaskBoxColorWithMessage(
     WidgetTester tester, String message, Color expectedColor) async {
   await tester.pumpWidget(TaskBox(task: Task()..status = message));
 
-  Container taskBoxWidget = find.byType(Container).evaluate().first.widget;
-  BoxDecoration decoration = taskBoxWidget.decoration;
+  final Container taskBoxWidget = find.byType(Container).evaluate().first.widget;
+  final BoxDecoration decoration = taskBoxWidget.decoration;
   expect(decoration.color, expectedColor);
 }


### PR DESCRIPTION
Mostly formatting stuff.

Removed unnecessary forEach for converting required capabilities json to the proto. Could just be done with a toString() in AppEngineCocoonService.

Fixes #455 