### PR TITLE
TaskBox reflects v1 task colors

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -23,7 +23,10 @@ class TaskBox extends StatelessWidget {
   static const String statusNew = 'New';
   static const String statusSkipped = 'Skipped';
   static const String statusSucceeded = 'Succeeded';
+  static const String statusSucceededButFlaky = 'Succeeded Flaky';
   static const String statusUnderperformed = 'Underperformed';
+  static const String statusUnderperformedInProgress =
+      'Underperfomed In Progress';
   static const String statusInProgress = 'In Progress';
 
   /// A lookup table to define the background color for this TaskBox.
@@ -35,17 +38,31 @@ class TaskBox extends StatelessWidget {
     statusInProgress: Colors.blue,
     statusSkipped: Colors.transparent,
     statusSucceeded: Colors.green,
+    statusSucceededButFlaky: Colors.yellow,
     statusUnderperformed: Colors.orange,
+    statusUnderperformedInProgress: Colors.orange,
   };
 
   @override
   Widget build(BuildContext context) {
+    final bool attempted = task.attempts > 1;
+    if (attempted) {
+      if (task.status == statusSucceeded) {
+        task.status = statusSucceededButFlaky;
+      } else if (task.status == statusNew) {
+        task.status = statusUnderperformed;
+      } else if (task.status == statusInProgress) {
+        task.status = statusUnderperformedInProgress;
+      }
+    }
+
     return Container(
       margin: const EdgeInsets.all(1.0),
       color: statusColor.containsKey(task.status)
           ? statusColor[task.status]
           : Colors.black,
-      child: (task.status == statusInProgress)
+      child: (task.status == statusInProgress ||
+              task.status == statusUnderperformedInProgress)
           ? const Padding(
               padding: EdgeInsets.all(15.0),
               child: CircularProgressIndicator(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -46,23 +46,23 @@ class TaskBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bool attempted = task.attempts > 1;
+    String status = task.status;
     if (attempted) {
-      if (task.status == statusSucceeded) {
-        task.status = statusSucceededButFlaky;
-      } else if (task.status == statusNew) {
-        task.status = statusUnderperformed;
-      } else if (task.status == statusInProgress) {
-        task.status = statusUnderperformedInProgress;
+      if (status == statusSucceeded) {
+        status = statusSucceededButFlaky;
+      } else if (status == statusNew) {
+        status = statusUnderperformed;
+      } else if (status == statusInProgress) {
+        status = statusUnderperformedInProgress;
       }
     }
 
     return Container(
       margin: const EdgeInsets.all(1.0),
-      color: statusColor.containsKey(task.status)
-          ? statusColor[task.status]
-          : Colors.black,
-      child: (task.status == statusInProgress ||
-              task.status == statusUnderperformedInProgress)
+      color:
+          statusColor.containsKey(status) ? statusColor[status] : Colors.black,
+      child: (status == statusInProgress ||
+              status == statusUnderperformedInProgress)
           ? const Padding(
               padding: EdgeInsets.all(15.0),
               child: CircularProgressIndicator(

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -99,9 +99,8 @@ void main() {
       );
 
       TaskBox lastTaskWidget = find.byType(TaskBox).evaluate().last.widget;
-      // TaskBox updates status
-      Task lastTask = statuses.last.stages.last.tasks.last
-        ..status = TaskBox.statusSucceededButFlaky;
+      Task lastTask = statuses.last.stages.last.tasks.last;
+      
       expect(lastTaskWidget.task, lastTask);
     });
   });

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
-import 'package:cocoon_service/protos.dart' show CommitStatus;
+import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
 
 import 'package:app_flutter/service/fake_cocoon.dart';
 import 'package:app_flutter/state/flutter_build.dart';
@@ -40,8 +40,6 @@ void main() {
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byType(GridView), findsNothing);
-
-      tester.takeException();
     });
 
     testWidgets('commits show in the same column', (WidgetTester tester) async {
@@ -84,8 +82,6 @@ void main() {
 
       TaskBox firstTask = find.byType(TaskBox).evaluate().first.widget;
       expect(firstTask.task, statuses[0].stages[0].tasks[0]);
-
-      tester.takeException();
     });
 
     testWidgets('last task in grid is the last task given',
@@ -102,10 +98,11 @@ void main() {
         ),
       );
 
-      TaskBox lastTask = find.byType(TaskBox).evaluate().last.widget;
-      expect(lastTask.task, statuses.last.stages.last.tasks.last);
-
-      tester.takeException();
+      TaskBox lastTaskWidget = find.byType(TaskBox).evaluate().last.widget;
+      // TaskBox updates status
+      Task lastTask = statuses.last.stages.last.tasks.last
+        ..status = TaskBox.statusSucceededButFlaky;
+      expect(lastTaskWidget.task, lastTask);
     });
   });
 }

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -27,6 +27,50 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
+    testWidgets('show orange when New but already attempted',
+        (WidgetTester tester) async {
+      final Task repeatTask = Task()
+        ..status = 'New'
+        ..attempts = 2;
+
+      await tester.pumpWidget(TaskBox(task: repeatTask));
+
+      final Container taskBoxWidget =
+          find.byType(Container).evaluate().first.widget;
+      final BoxDecoration decoration = taskBoxWidget.decoration;
+      expect(decoration.color, Colors.orange);
+    });
+
+    testWidgets(
+        'show loading indicator for In Progress task that is not on first attempt',
+        (WidgetTester tester) async {
+      final Task repeatTask = Task()
+        ..status = 'In Progress'
+        ..attempts = 2;
+
+      await tester.pumpWidget(TaskBox(task: repeatTask));
+
+      final Container taskBoxWidget =
+          find.byType(Container).evaluate().first.widget;
+      final BoxDecoration decoration = taskBoxWidget.decoration;
+      expect(decoration.color, Colors.orange);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('show yellow when Succeeded but ran multiple times',
+        (WidgetTester tester) async {
+      final Task repeatTask = Task()
+        ..status = 'Succeeded'
+        ..attempts = 2;
+
+      await tester.pumpWidget(TaskBox(task: repeatTask));
+
+      final Container taskBoxWidget =
+          find.byType(Container).evaluate().first.widget;
+      final BoxDecoration decoration = taskBoxWidget.decoration;
+      expect(decoration.color, Colors.yellow);
+    });
+
     testWidgets('is the color black when given an unknown message',
         (WidgetTester tester) async {
       expectTaskBoxColorWithMessage(tester, '404', Colors.black);


### PR DESCRIPTION
- If tasks have been attempted, update their status to the correct status (New->Underperformed, Succeeded->SucceededButFlaky, InProgress->UnderpformedInProgress)
- Removed unncessary tester.takeException()s in StatusGrid tests

Fixes #456 , a feature request that asked for tasks that are in progress but have run before to be differentiated from first time running tasks.

![image](https://user-images.githubusercontent.com/2148558/66086895-6eb12100-e52a-11e9-9a30-8025f21f499e.png)

![image](https://user-images.githubusercontent.com/2148558/66086903-7a9ce300-e52a-11e9-892a-92706eacd4f0.png)
