### PR TITLE
Task Overlay UI

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -149,8 +149,10 @@ class TaskOverlayContents extends StatelessWidget {
   static const Map<String, Icon> statusIcon = <String, Icon>{
     TaskBox.statusFailed: Icon(Icons.clear, color: Colors.red, size: 32),
     TaskBox.statusNew: Icon(Icons.new_releases, color: Colors.blue, size: 32),
-    TaskBox.statusInProgress: Icon(Icons.autorenew, color: Colors.blue, size: 32),
-    TaskBox.statusSucceeded: Icon(Icons.check_circle, color: Colors.green, size: 32),
+    TaskBox.statusInProgress:
+        Icon(Icons.autorenew, color: Colors.blue, size: 32),
+    TaskBox.statusSucceeded:
+        Icon(Icons.check_circle, color: Colors.green, size: 32),
     TaskBox.statusSucceededButFlaky: Icon(Icons.check_circle_outline, size: 32),
     TaskBox.statusUnderperformed:
         Icon(Icons.new_releases, color: Colors.orange, size: 32),
@@ -173,6 +175,18 @@ class TaskOverlayContents extends StatelessWidget {
             height: MediaQuery.of(parentContext).size.height,
             // Color must be defined otherwise the container can't be clicked on
             color: Colors.transparent,
+          ),
+        ),
+
+        /// This is a focus container to emphasize the [TaskBox] that this
+        /// [Overlay] is currently showing information from.
+        Positioned(
+          top: offsetLeft.dy,
+          left: offsetLeft.dx,
+          width: renderBox.size.width,
+          height: renderBox.size.height,
+          child: Container(
+            color: Colors.white70,
           ),
         ),
         Positioned(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -167,17 +167,6 @@ class TaskOverlayContents extends StatelessWidget {
 
     return Stack(
       children: <Widget>[
-        // This is the area a user can click (the rest of the screen) to close the overlay.
-        GestureDetector(
-          onTap: closeCallback,
-          child: Container(
-            width: MediaQuery.of(parentContext).size.width,
-            height: MediaQuery.of(parentContext).size.height,
-            // Color must be defined otherwise the container can't be clicked on
-            color: Colors.transparent,
-          ),
-        ),
-
         /// This is a focus container to emphasize the [TaskBox] that this
         /// [Overlay] is currently showing information from.
         Positioned(
@@ -187,6 +176,17 @@ class TaskOverlayContents extends StatelessWidget {
           height: renderBox.size.height,
           child: Container(
             color: Colors.white70,
+            key: const Key('task-overlay-key'),
+          ),
+        ),
+        // This is the area a user can click (the rest of the screen) to close the overlay.
+        GestureDetector(
+          onTap: closeCallback,
+          child: Container(
+            width: MediaQuery.of(parentContext).size.width,
+            height: MediaQuery.of(parentContext).size.height,
+            // Color must be defined otherwise the container can't be clicked on
+            color: Colors.transparent,
           ),
         ),
         Positioned(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -145,19 +145,17 @@ class TaskOverlayContents extends StatelessWidget {
   /// this callback is called closing the overlay.
   final void Function() closeCallback;
 
-  /// A lookup table to define the background color for this TaskBox.
-  ///
-  /// The status messages are based on the messages the backend sends.
+  /// A lookup table to define the [Icon] for this [Overlay].
   static const Map<String, Icon> statusIcon = <String, Icon>{
-    TaskBox.statusFailed: Icon(Icons.clear, color: Colors.red),
-    TaskBox.statusNew: Icon(Icons.new_releases, color: Colors.blue),
-    TaskBox.statusInProgress: Icon(Icons.autorenew, color: Colors.blue),
-    TaskBox.statusSucceeded: Icon(Icons.check_circle, color: Colors.green),
-    TaskBox.statusSucceededButFlaky: Icon(Icons.check_circle_outline),
+    TaskBox.statusFailed: Icon(Icons.clear, color: Colors.red, size: 32),
+    TaskBox.statusNew: Icon(Icons.new_releases, color: Colors.blue, size: 32),
+    TaskBox.statusInProgress: Icon(Icons.autorenew, color: Colors.blue, size: 32),
+    TaskBox.statusSucceeded: Icon(Icons.check_circle, color: Colors.green, size: 32),
+    TaskBox.statusSucceededButFlaky: Icon(Icons.check_circle_outline, size: 32),
     TaskBox.statusUnderperformed:
-        Icon(Icons.new_releases, color: Colors.orange),
+        Icon(Icons.new_releases, color: Colors.orange, size: 32),
     TaskBox.statusUnderperformedInProgress:
-        Icon(Icons.autorenew, color: Colors.orange),
+        Icon(Icons.autorenew, color: Colors.orange, size: 32),
   };
 
   @override

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -11,7 +11,7 @@ import 'package:cocoon_service/protos.dart' show Task;
 /// If [Task.status] is "In Progress", it will show as a "New" task
 /// with a [CircularProgressIndicator] in the box.
 /// Shows a black box for unknown statuses.
-class TaskBox extends StatelessWidget {
+class TaskBox extends StatefulWidget {
   const TaskBox({Key key, @required this.task}) : super(key: key);
 
   /// [Task] to show information from.
@@ -44,35 +44,139 @@ class TaskBox extends StatelessWidget {
   };
 
   @override
+  _TaskBoxState createState() => _TaskBoxState();
+}
+
+class _TaskBoxState extends State<TaskBox> {
+  OverlayEntry _taskOverlay;
+
+  @override
   Widget build(BuildContext context) {
-    final bool attempted = task.attempts > 1;
-    String status = task.status;
+    final bool attempted = widget.task.attempts > 1;
+    String status = widget.task.status;
     if (attempted) {
-      if (status == statusSucceeded) {
-        status = statusSucceededButFlaky;
-      } else if (status == statusNew) {
-        status = statusUnderperformed;
-      } else if (status == statusInProgress) {
-        status = statusUnderperformedInProgress;
+      if (status == TaskBox.statusSucceeded) {
+        status = TaskBox.statusSucceededButFlaky;
+      } else if (status == TaskBox.statusNew) {
+        status = TaskBox.statusUnderperformed;
+      } else if (status == TaskBox.statusInProgress) {
+        status = TaskBox.statusUnderperformedInProgress;
       }
     }
 
-    return Container(
-      margin: const EdgeInsets.all(1.0),
-      color:
-          statusColor.containsKey(status) ? statusColor[status] : Colors.black,
-      child: (status == statusInProgress ||
-              status == statusUnderperformedInProgress)
-          ? const Padding(
-              padding: EdgeInsets.all(15.0),
-              child: CircularProgressIndicator(
-                strokeWidth: 3.0,
-                backgroundColor: Colors.white70,
-              ),
-            )
-          : null,
-      width: 20,
-      height: 20,
+    return GestureDetector(
+      onTap: _handleTap,
+      child: Container(
+        margin: const EdgeInsets.all(1.0),
+        color: TaskBox.statusColor.containsKey(status)
+            ? TaskBox.statusColor[status]
+            : Colors.black,
+        child: (status == TaskBox.statusInProgress ||
+                status == TaskBox.statusUnderperformedInProgress)
+            ? const Padding(
+                padding: EdgeInsets.all(15.0),
+                child: CircularProgressIndicator(
+                  strokeWidth: 3.0,
+                  backgroundColor: Colors.white70,
+                ),
+              )
+            : null,
+        width: 20,
+        height: 20,
+      ),
+    );
+  }
+
+  void _handleTap() {
+    _taskOverlay = OverlayEntry(
+      builder: (_) => CommitOverlayContents(
+          parentContext: context,
+          task: widget.task,
+          closeCallback: _closeOverlay),
+    );
+
+    Overlay.of(context).insert(_taskOverlay);
+  }
+
+  void _closeOverlay() => _taskOverlay.remove();
+}
+
+/// Displays the information from [Task] and allows interacting with a [Task].
+///
+/// This is intended to be inserted in an [OverlayEntry] as it requires
+/// [closeCallback] that will remove the widget from the tree.
+class CommitOverlayContents extends StatelessWidget {
+  const CommitOverlayContents({
+    Key key,
+    @required this.parentContext,
+    @required this.task,
+    @required this.closeCallback,
+  })  : assert(parentContext != null),
+        assert(task != null),
+        assert(closeCallback != null),
+        super(key: key);
+
+  /// The parent context that has the size of the whole screen
+  final BuildContext parentContext;
+
+  /// The commit data to display in the overlay
+  final Task task;
+
+  /// This callback removes the parent overlay from the widget tree.
+  ///
+  /// On a click that is outside the area of the overlay (the rest of the screen),
+  /// this callback is called closing the overlay.
+  final void Function() closeCallback;
+
+  @override
+  Widget build(BuildContext context) {
+    final RenderBox renderBox = parentContext.findRenderObject();
+    final Offset offsetLeft = renderBox.localToGlobal(Offset.zero);
+
+    return Stack(
+      children: <Widget>[
+        // This is the area a user can click (the rest of the screen) to close the overlay.
+        GestureDetector(
+          onTap: closeCallback,
+          child: Container(
+            width: MediaQuery.of(parentContext).size.width,
+            height: MediaQuery.of(parentContext).size.height,
+            // Color must be defined otherwise the container can't be clicked on
+            color: Colors.transparent,
+          ),
+        ),
+        Positioned(
+          width: 300,
+          // Move this overlay to be where the parent is
+          top: offsetLeft.dy + (renderBox.size.height / 2),
+          left: offsetLeft.dx + (renderBox.size.width / 2),
+          child: Card(
+            child: Column(
+              mainAxisSize: MainAxisSize.max,
+              children: <Widget>[
+                ListTile(
+                  title: Text(task.name),
+                  subtitle: Text('Attempts: ${task.attempts}'),
+                ),
+                ButtonBar(
+                  children: <Widget>[
+                    IconButton(
+                      icon: const Icon(Icons.repeat),
+                      onPressed: () {
+                        // TODO(chillers): rerun all tests for this commit
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.open_in_new),
+                      onPressed: () async {},
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -172,7 +172,9 @@ class TaskOverlayContents extends StatelessWidget {
                     ),
                     IconButton(
                       icon: const Icon(Icons.open_in_new),
-                      onPressed: _openTaskLog,
+                      onPressed: () {
+                        // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
+                      },
                     ),
                   ],
                 ),
@@ -182,43 +184,5 @@ class TaskOverlayContents extends StatelessWidget {
         ),
       ],
     );
-  }
-
-  /// Open a new window with the log for this [Task].
-  Future<void> _openTaskLog() async {
-    final String logUrl = _getTaskLogUrl(task);
-
-    await launch(logUrl);
-  }
-
-  ///
-  String _getLuciLogUrl(String taskName) {
-    const String luciBaseUrl = 'https://ci.chromium.org/p';
-    switch (taskName) {
-      case 'mac_bot':
-        return '$luciBaseUrl/flutter/builders/luci.flutter.prod/Mac';
-      case 'linux_bot':
-        return '$luciBaseUrl/flutter/builders/luci.flutter.prod/Linux';
-      case 'windows_bot':
-        return '$luciBaseUrl/flutter/builders/luci.flutter.prod/Windows';
-      default:
-        return '$luciBaseUrl/flutter';
-    }
-  }
-
-  String _getTaskLogUrl(Task task) {
-    switch (task.stageName) {
-      case 'chromebot':
-        return _getLuciLogUrl(task.name);
-      case 'cirrus':
-        const String cirrusBaseUrl = 'https://cirrus-ci.com';
-        if (task.commitKey != null) {
-          return '$cirrusBaseUrl/build/flutter/flutter/${task.name}';
-        }
-
-        return '$cirrusBaseUrl/github/flutter/flutter/master';
-      default:
-        throw Exception('Could not get log url for ${task.stageName}');
-    }
   }
 }

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -178,7 +178,7 @@ class TaskOverlayContents extends StatelessWidget {
           ),
         ),
         Positioned(
-          width: 250,
+          width: 350,
           // Move this overlay to be where the parent is
           top: offsetLeft.dy + (renderBox.size.height / 2),
           left: offsetLeft.dx + (renderBox.size.width / 2),
@@ -190,20 +190,21 @@ class TaskOverlayContents extends StatelessWidget {
                   leading: Tooltip(
                       message: taskStatus, child: statusIcon[taskStatus]),
                   title: Text(task.name),
-                  subtitle: Text('Attempts: ${task.attempts}'),
+                  subtitle: Text(
+                      'Attempts: ${task.attempts}\nDuration: ${task.endTimestamp - task.startTimestamp} seconds\nAgent: ${task.reservedForAgentId}'),
                 ),
                 ButtonBar(
                   children: <Widget>[
                     IconButton(
-                      icon: const Icon(Icons.redo),
+                      icon: const Icon(Icons.receipt),
                       onPressed: () {
-                        // TODO(chillers): Rerun task. https://github.com/flutter/cocoon/issues/424
+                        // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
                       },
                     ),
                     IconButton(
-                      icon: const Icon(Icons.open_in_new),
+                      icon: const Icon(Icons.redo),
                       onPressed: () {
-                        // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
+                        // TODO(chillers): Rerun task. https://github.com/flutter/cocoon/issues/424
                       },
                     ),
                   ],

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -72,7 +72,7 @@ class _TaskBoxState extends State<TaskBox> {
       }
     }
 
-    return InkWell(
+    return GestureDetector(
       onTap: _handleTap,
       child: Container(
         margin: const EdgeInsets.all(1.0),

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -88,15 +88,22 @@ void main() {
         ),
       ));
 
-      final String expectTaskInfoString = 'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
+      final String expectTaskInfoString =
+          'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
       expect(find.text(expectedTask.name), findsNothing);
       expect(find.text(expectTaskInfoString), findsNothing);
+
+      // Ensure the task indicator isn't showing when overlay is not shown
+      expect(find.byKey(const Key('task-overlay-key')), findsNothing);
 
       await tester.tap(find.byType(TaskBox));
       await tester.pump();
 
       expect(find.text(expectedTask.name), findsOneWidget);
       expect(find.text(expectTaskInfoString), findsOneWidget);
+
+      // Since the overlay is on screen, the indicator should be showing
+      expect(find.byKey(const Key('task-overlay-key')), findsOneWidget);
     });
 
     testWidgets('closes overlay on click out', (WidgetTester tester) async {
@@ -116,6 +123,9 @@ void main() {
       await tester.pump();
 
       expect(find.text(expectedTask.name), findsNothing);
+
+      // The task indicator should not show after the overlay has been closed
+      expect(find.byKey(const Key('task-overlay-key')), findsNothing);
     });
   });
 }

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -11,6 +11,11 @@ import 'package:app_flutter/task_box.dart';
 
 void main() {
   group('TaskBox', () {
+    final Task expectedTask = Task()
+      ..attempts = 3
+      ..name = 'Tasky McTaskFace'
+      ..reason = 'Because I said so';
+
     // Table Driven Approach to ensure every message does show the corresponding color
     TaskBox.statusColor.forEach((String message, Color color) {
       testWidgets('is the color $color when given the message $message',
@@ -74,6 +79,42 @@ void main() {
     testWidgets('is the color black when given an unknown message',
         (WidgetTester tester) async {
       expectTaskBoxColorWithMessage(tester, '404', Colors.black);
+    });
+
+    testWidgets('shows overlay on click', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: TaskBox(
+          task: expectedTask,
+        ),
+      ));
+
+      expect(find.text(expectedTask.sha), findsNothing);
+      expect(find.text(expectedTask.author), findsNothing);
+
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      expect(find.text(expectedTask.sha), findsOneWidget);
+      expect(find.text(expectedTask.author), findsOneWidget);
+    });
+
+    testWidgets('closes overlay on click out', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: TaskBox(
+          task: expectedTask,
+        ),
+      ));
+
+      // Open the overlay
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      // Since the overlay positions itself in the middle of the widget,
+      // it is safe to click the widget to close it again
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      expect(find.text(expectedTask.sha), findsNothing);
     });
   });
 }

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -88,14 +88,15 @@ void main() {
         ),
       ));
 
+      final String expectTaskInfoString = 'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
       expect(find.text(expectedTask.name), findsNothing);
-      expect(find.text('Attempts: ${expectedTask.attempts}'), findsNothing);
+      expect(find.text(expectTaskInfoString), findsNothing);
 
       await tester.tap(find.byType(TaskBox));
       await tester.pump();
 
       expect(find.text(expectedTask.name), findsOneWidget);
-      expect(find.text('Attempts: ${expectedTask.attempts}'), findsOneWidget);
+      expect(find.text(expectTaskInfoString), findsOneWidget);
     });
 
     testWidgets('closes overlay on click out', (WidgetTester tester) async {

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -88,14 +88,14 @@ void main() {
         ),
       ));
 
-      expect(find.text(expectedTask.sha), findsNothing);
-      expect(find.text(expectedTask.author), findsNothing);
+      expect(find.text(expectedTask.name), findsNothing);
+      expect(find.text('Attempts: ${expectedTask.attempts}'), findsNothing);
 
       await tester.tap(find.byType(TaskBox));
       await tester.pump();
 
-      expect(find.text(expectedTask.sha), findsOneWidget);
-      expect(find.text(expectedTask.author), findsOneWidget);
+      expect(find.text(expectedTask.name), findsOneWidget);
+      expect(find.text('Attempts: ${expectedTask.attempts}'), findsOneWidget);
     });
 
     testWidgets('closes overlay on click out', (WidgetTester tester) async {
@@ -114,7 +114,7 @@ void main() {
       await tester.tap(find.byType(TaskBox));
       await tester.pump();
 
-      expect(find.text(expectedTask.sha), findsNothing);
+      expect(find.text(expectedTask.name), findsNothing);
     });
   });
 }

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -88,10 +88,10 @@ void main() {
         ),
       ));
 
-      final String expectTaskInfoString =
+      final String expectedTaskInfoString =
           'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
       expect(find.text(expectedTask.name), findsNothing);
-      expect(find.text(expectTaskInfoString), findsNothing);
+      expect(find.text(expectedTaskInfoString), findsNothing);
 
       // Ensure the task indicator isn't showing when overlay is not shown
       expect(find.byKey(const Key('task-overlay-key')), findsNothing);
@@ -100,7 +100,7 @@ void main() {
       await tester.pump();
 
       expect(find.text(expectedTask.name), findsOneWidget);
-      expect(find.text(expectTaskInfoString), findsOneWidget);
+      expect(find.text(expectedTaskInfoString), findsOneWidget);
 
       // Since the overlay is on screen, the indicator should be showing
       expect(find.byKey(const Key('task-overlay-key')), findsOneWidget);


### PR DESCRIPTION
This adds UI that allows users to view more information from a Task. New information shown is the duration of the task (how long it took to complete in seconds) and what agent it ran on. 

Currently, the backend is not  populating the end timestamp, so it defaults to 0. When the backend gets switched over to Dart, the duration will be correct.

*Images are from a phone running a release build. The overlay fits much better on desktop.*

![image](https://user-images.githubusercontent.com/2148558/66430123-50d23900-e9ce-11e9-8e18-7c1fe5a904e8.png)

![image](https://user-images.githubusercontent.com/2148558/66430154-5cbdfb00-e9ce-11e9-9a98-067a42af733b.png)

![image](https://user-images.githubusercontent.com/2148558/66430164-62b3dc00-e9ce-11e9-86f4-49afd44c4bb2.png)

