### PR TITLE
Task matrix

### DIFF
--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -63,17 +63,17 @@ class FakeCocoonService implements CocoonService {
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(List<Task>.generate(15, (int i) => _createFakeTask(i))));
+      ..tasks.addAll(List<Task>.generate(15, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab_win'
-      ..tasks.addAll(List<Task>.generate(3, (int i) => _createFakeTask(i))));
+      ..tasks.addAll(List<Task>.generate(3, (int i) => _createFakeTask(i, 'devicelab_win'))));
 
     return stages;
   }
 
-  Task _createFakeTask(int index) {
+  Task _createFakeTask(int index, String stageName) {
     return Task()
       ..createTimestamp = Int64(index)
       ..startTimestamp = Int64(index + 1)
@@ -83,7 +83,7 @@ class FakeCocoonService implements CocoonService {
       ..isFlaky = false
       ..requiredCapabilities.add('[linux/android]')
       ..reservedForAgentId = 'linux1'
-      ..stageName = 'stage name'
+      ..stageName = stageName
       ..status = 'Succeeded';
   }
 }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -51,6 +51,39 @@ class StatusGridContainer extends StatelessWidget {
       },
     );
   }
+
+  @visibleForTesting
+  Map<String, int> getTaskNameIndex(List<CommitStatus> statuses) {
+    final Map<String, int> taskNameIndex = <String, int>{};
+    int currentIndex = 0;
+
+    // O(N^2) scan to find all the task categories that were run in the history.
+    for (CommitStatus status in statuses) {
+      for (Stage stage in status.stages) {
+        for (Task task in stage.tasks) {
+          final String key = '${stage.name}:${task.name}';
+          if (taskNameIndex.containsKey(key)) {
+            continue;
+          }
+
+          taskNameIndex[key] = currentIndex++;
+        }
+      }
+    }
+
+    return taskNameIndex;
+  }
+
+  @visibleForTesting
+  List<List<Task>> taskMatrix(List<CommitStatus> statuses) {
+    /// Rows are commits, columns are same tasks
+    final List<List<Task>> tasks = List<List<Task>>();
+    final Map<String, int> taskNameIndex = getTaskNameIndex(statuses);
+    
+
+
+    return tasks;
+  }
 }
 
 /// Display results from flutter/flutter repository's continuous integration.
@@ -58,10 +91,12 @@ class StatusGridContainer extends StatelessWidget {
 /// Results are displayed in a matrix format. Rows are commits and columns
 /// are the results from tasks.
 class StatusGrid extends StatelessWidget {
-  const StatusGrid({Key key, @required this.statuses}) : super(key: key);
+  const StatusGrid({Key key, @required this.statuses, @required this.tasks}) : super(key: key);
 
   /// The build status data to display in the grid.
   final List<CommitStatus> statuses;
+
+  final List<List<Task>> tasks;
 
   @override
   Widget build(BuildContext context) {

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -132,9 +132,9 @@ class StatusGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // The grid needs to know its dimensions, column is based off the stages and
-    // how many tasks they each run.
-    final int columnCount = taskMatrix[0].length;
+    // The grid needs to know its dimensions, column is based off how many tasks are
+    // in a row and a commit
+    final int columnCount = taskMatrix[0].length + 1;
 
     return Expanded(
       // The grid is wrapped with SingleChildScrollView to enable scrolling both
@@ -171,7 +171,12 @@ class StatusGrid extends StatelessWidget {
                 return CommitBox(commit: statuses[statusIndex].commit);
               }
 
-              final int taskIndex = index % columnCount;
+              final int taskIndex = (index % columnCount) - 1;
+              if (taskMatrix[statusIndex][taskIndex] == null) {
+                /// [Task] was skipped so don't show anything.
+                return Container();
+              }
+
               return TaskBox(
                 task: taskMatrix[statusIndex][taskIndex],
               );

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -12,7 +12,9 @@ import 'package:cocoon_service/protos.dart' show Task;
 /// with a [CircularProgressIndicator] in the box.
 /// Shows a black box for unknown statuses.
 class TaskBox extends StatefulWidget {
-  const TaskBox({Key key, @required this.task}) : super(key: key);
+  const TaskBox({Key key, @required this.task})
+      : assert(task != null),
+        super(key: key);
 
   /// [Task] to show information from.
   final Task task;

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -26,6 +26,12 @@ void main() {
       statuses = response.data;
     });
 
+    test('task matrix builds', () {
+      List<List<Task>> tasks = StatusGridContainer.taskMatrix(statuses);
+
+      expect(tasks.length, statuses.length);
+    });
+
     testWidgets('shows loading indicator when statuses is empty',
         (WidgetTester tester) async {
       await tester.pumpWidget(

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -18,14 +18,20 @@ import 'package:app_flutter/task_box.dart';
 void main() {
   group('StatusGrid', () {
     List<CommitStatus> statuses;
-    List<List<Task>> tasks;
+    List<List<Task>> taskMatrix;
+    List<Task> taskIconRow;
 
     setUpAll(() async {
       final FakeCocoonService service = FakeCocoonService();
       final CocoonResponse<List<CommitStatus>> response =
           await service.fetchCommitStatuses();
       statuses = response.data;
-      tasks = StatusGridContainer.createTaskMatrix(statuses);
+      final Map<String, int> taskColumnKeyIndex =
+          StatusGridContainer.createTaskColumnKeyIndex(statuses);
+      taskMatrix =
+          StatusGridContainer.createTaskMatrix(statuses, taskColumnKeyIndex);
+      taskIconRow =
+          StatusGridContainer.createTaskIconRow(statuses, taskColumnKeyIndex);
     });
 
     testWidgets('shows loading indicator when statuses is empty',
@@ -54,7 +60,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: tasks,
+                taskMatrix: taskMatrix,
+                taskIconRow: taskIconRow,
               ),
             ],
           ),
@@ -80,7 +87,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: tasks,
+                taskMatrix: taskMatrix,
+                taskIconRow: taskIconRow,
               ),
             ],
           ),
@@ -99,7 +107,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: tasks,
+                taskMatrix: taskMatrix,
+                taskIconRow: taskIconRow,
               ),
             ],
           ),
@@ -109,7 +118,7 @@ void main() {
       final TaskBox lastTaskWidget =
           find.byType(TaskBox).evaluate().last.widget;
 
-      final Task lastTask = tasks.last.last;
+      final Task lastTask = taskMatrix.last.last;
 
       expect(lastTaskWidget.task, lastTask);
     });
@@ -128,8 +137,8 @@ void main() {
 
       final int totalTasksInCommitStatus =
           _totalTasksInCommitStatus(statuses[0]);
-      expect(tasks.length, statuses.length);
-      expect(tasks[0].length, totalTasksInCommitStatus);
+      expect(taskMatrix.length, statuses.length);
+      expect(taskMatrix[0].length, totalTasksInCommitStatus);
     });
 
     test('task matrix builds correctly when statuses have different tasks', () {
@@ -155,8 +164,8 @@ void main() {
 
       final List<CommitStatus> statusesAB = <CommitStatus>[statusA, statusB];
 
-      final List<List<Task>> tasks =
-          StatusGridContainer.createTaskMatrix(statusesAB);
+      final List<List<Task>> tasks = StatusGridContainer.createTaskMatrix(
+          statusesAB, StatusGridContainer.createTaskColumnKeyIndex(statusesAB));
 
       expect(tasks[0].length, 2);
     });

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -18,20 +18,15 @@ import 'package:app_flutter/task_box.dart';
 void main() {
   group('StatusGrid', () {
     List<CommitStatus> statuses;
-    List<List<Task>> taskMatrix;
-    List<Task> taskIconRow;
+
+    StatusGridHelper helper;
 
     setUpAll(() async {
       final FakeCocoonService service = FakeCocoonService();
       final CocoonResponse<List<CommitStatus>> response =
           await service.fetchCommitStatuses();
       statuses = response.data;
-      final Map<String, int> taskColumnKeyIndex =
-          StatusGridContainer.createTaskColumnKeyIndex(statuses);
-      taskMatrix =
-          StatusGridContainer.createTaskMatrix(statuses, taskColumnKeyIndex);
-      taskIconRow =
-          StatusGridContainer.createTaskIconRow(statuses, taskColumnKeyIndex);
+      helper = StatusGridHelper(statuses: statuses);
     });
 
     testWidgets('shows loading indicator when statuses is empty',
@@ -60,8 +55,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: taskMatrix,
-                taskIconRow: taskIconRow,
+                taskMatrix: helper.taskMatrix,
+                taskIconRow: helper.taskIconRow,
               ),
             ],
           ),
@@ -87,8 +82,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: taskMatrix,
-                taskIconRow: taskIconRow,
+                taskMatrix: helper.taskMatrix,
+                taskIconRow: helper.taskIconRow,
               ),
             ],
           ),
@@ -107,8 +102,8 @@ void main() {
             children: <Widget>[
               StatusGrid(
                 statuses: statuses,
-                taskMatrix: taskMatrix,
-                taskIconRow: taskIconRow,
+                taskMatrix: helper.taskMatrix,
+                taskIconRow: helper.taskIconRow,
               ),
             ],
           ),
@@ -118,7 +113,7 @@ void main() {
       final TaskBox lastTaskWidget =
           find.byType(TaskBox).evaluate().last.widget;
 
-      final Task lastTask = taskMatrix.last.last;
+      final Task lastTask = helper.taskMatrix.last.last;
 
       expect(lastTaskWidget.task, lastTask);
     });
@@ -137,8 +132,8 @@ void main() {
 
       final int totalTasksInCommitStatus =
           _totalTasksInCommitStatus(statuses[0]);
-      expect(taskMatrix.length, statuses.length);
-      expect(taskMatrix[0].length, totalTasksInCommitStatus);
+      expect(helper.taskMatrix.length, statuses.length);
+      expect(helper.taskMatrix[0].length, totalTasksInCommitStatus);
     });
 
     test('task matrix builds correctly when statuses have different tasks', () {
@@ -163,11 +158,9 @@ void main() {
                     ..name = 'special task'));
 
       final List<CommitStatus> statusesAB = <CommitStatus>[statusA, statusB];
+      final StatusGridHelper helper = StatusGridHelper(statuses: statusesAB);
 
-      final List<List<Task>> tasks = StatusGridContainer.createTaskMatrix(
-          statusesAB, StatusGridContainer.createTaskColumnKeyIndex(statusesAB));
-
-      expect(tasks[0].length, 2);
+      expect(helper.taskMatrix[0].length, 2);
     });
   });
 }


### PR DESCRIPTION
Fixes #461 

This helps with:
1. Easier ordering of the columns of the StatusGrid (for sorting purposes, like showing most recent failures first)
2. Faster prototyping experimental versions of the StatusGrid to improve the performance of it on Web

This fixes the issue where the StatusGrid was naively using the first CommitStatus as the base for constructing the StatusGrid. However, extra code had to be added to make the TaskIcon row at the top show the correct icons.