### PR TITLE
Improve performance of StatusGrid by not adding repaint boundaries

### DIFF
--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -198,6 +198,7 @@ class StatusGrid extends StatelessWidget {
         child: Container(
           width: columnCount * 50.0,
           child: GridView.builder(
+            addRepaintBoundaries: false,
             itemCount: columnCount * statuses.length,
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: columnCount),


### PR DESCRIPTION
Test: Scrolling through status grid to bottom with fake data, then swiping back up. Using [this stackoverflow on getting average fps from chrome](https://stackoverflow.com/questions/48079661/how-to-get-the-average-fps-in-chrome-devtools).

Current: ~26 average FPS
This fix: ~42 average FPS

Android showed better performance too.

## Future Work
- Experiment with using Skia for rendering on the web
- Experiment with removing use of expanded
- Experiment with List<Row> instead of GridView