### PR TITLE
Reland #479 url launching for web

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,9 @@ task:
   
 task:
   name: app_flutter
+  upgrade_script:
+  - flutter channel dev
+  - flutter upgrade
   pub_script: cd app_flutter && flutter packages get
   analyze_script: cd app_flutter && flutter analyze
   test_script: cd app_flutter && flutter test

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -32,7 +32,11 @@ dependencies:
     path: ../app_dart
   provider: ^3.0.0
   url_launcher: ^5.1.0
-
+  url_launcher_web:
+    git:
+      url: git://github.com/flutter/plugins.git
+      path: packages/url_launcher/url_launcher_web
+      
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -23,6 +23,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -36,7 +38,7 @@ dependencies:
     git:
       url: git://github.com/flutter/plugins.git
       path: packages/url_launcher/url_launcher_web
-      
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -23,8 +23,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_web_plugins:
-    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This should make it so any of the other Flutter for Web plugins can easily be included in the future. It makes Cirrus run on the Flutter dev channel when testing `app_flutter`.