### PR TITLE
deploy script clears old build files

### DIFF
--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:pedantic/pedantic.dart';
 
+const String flutterProjectDirectory = '../app_flutter';
+
 const String gcloudProjectIdFlag = 'project';
 const String gcloudProjectIdAbbrFlag = 'p';
 
@@ -40,9 +42,12 @@ bool _getArgs(ArgParser argParser, List<String> arguments) {
 
 /// Build app_flutter for web.
 Future<bool> _buildFlutterWebApp() async {
+  /// Clean up previous build files to ensure this codebase is deployed.
+  await Process.run('rm', <String>['-r', 'build/'], workingDirectory: flutterProjectDirectory);
+  
   final Process process = await Process.start(
       'flutter', <String>['build', 'web'],
-      workingDirectory: '../app_flutter');
+      workingDirectory: flutterProjectDirectory);
   await stdout.addStream(process.stdout);
 
   return await process.exitCode == 0;
@@ -50,8 +55,11 @@ Future<bool> _buildFlutterWebApp() async {
 
 /// Copy the built project from app_flutter to this app_dart project.
 Future<bool> _copyFlutterApp() async {
+  /// Clean up previous build files to ensure this codebase is deployed.
+  await Process.run('rm', <String>['-r', 'build/']);
+
   final ProcessResult result =
-      await Process.run('cp', <String>['-r', '../app_flutter/build', 'build']);
+      await Process.run('cp', <String>['-r', '$flutterProjectDirectory/build', 'build']);
 
   return result.exitCode == 0;
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/43508

When I have been deploying, I notice old versions of the app get deployed. 

It may sound like user error, but my process is always for deployment:
1. `git fetch upstream`
2. `git checkout upstream/master -b <new version>`
3. `dart dev/deploy.dart ...`

For example, I deployed `v307` for the redis caching. However, it cleared the previous commit's status ordering feature. I believe this is because while doing my own test deployments for caching, it had the project built without that latest change. I deployed `v308` with the same branch, but I cleared the `build` folders in `app_dart` and `app_flutter` and that deployment was successful.

```
$ git log v307

commit b5abdc601f98875a01a27ee4433d82244b0dc361 (HEAD -> v307)
Author: Casey Hillers <caseyhillers@gmail.com>
Date:   Thu Oct 24 15:41:23 2019 -0700

    CacheRequestHandler for /api/public/get-status (#484)

commit 139fdf7070dc76338584dddcaf87ff45e7c3d72f
Author: Casey Hillers <caseyhillers@gmail.com>
Date:   Thu Oct 24 06:59:31 2019 -0700

    Order StatusGrid by most recently failed (#482)
    
    * task column map
    
    * move out taskmatrix code
    
    * statusgrid use taskmatrix
....
```
Feel free to let me know if there is another issue at work here, but I think this should fix the issue I was running into.