### PR TITLE
Cache get-benchmarks

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -46,11 +46,7 @@ Future<void> main() async {
       '/api/debug/get-task-by-id': DebugGetTaskById(config, authProvider),
       '/api/debug/reset-pending-tasks': DebugResetPendingTasks(config, authProvider),
 
-      '/api/public/build-status': CacheRequestHandler<Body>(
-        cache: await cacheService.redisCache(),
-        config: config,
-        delegate: GetBuildStatus(config),
-      ),
+      '/api/public/build-status': GetBuildStatus(config),
       '/api/public/get-benchmarks': CacheRequestHandler<Body>(
         cache: await cacheService.redisCache(),
         config: config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -46,8 +46,17 @@ Future<void> main() async {
       '/api/debug/get-task-by-id': DebugGetTaskById(config, authProvider),
       '/api/debug/reset-pending-tasks': DebugResetPendingTasks(config, authProvider),
 
-      '/api/public/build-status': GetBuildStatus(config),
-      '/api/public/get-benchmarks': GetBenchmarks(config),
+      '/api/public/build-status': CacheRequestHandler<Body>(
+        cache: await cacheService.redisCache(),
+        config: config,
+        delegate: GetBuildStatus(config),
+      ),
+      '/api/public/get-benchmarks': CacheRequestHandler<Body>(
+        cache: await cacheService.redisCache(),
+        config: config,
+        delegate: GetBenchmarks(config),
+        ttl: const Duration(minutes: 15),
+      ),
       '/api/public/get-status': CacheRequestHandler<Body>(
         cache: await cacheService.redisCache(),
         config: config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:gcloud/db.dart';
+import 'package:neat_cache/neat_cache.dart';
 
 Future<void> main() async {
   await withAppEngineServices(() async {
@@ -21,6 +23,7 @@ Future<void> main() async {
     );
 
     final CacheService cacheService = CacheService(config);
+    final Cache<Uint8List> redisCache = await cacheService.redisCache();
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
       '/api/append-log': AppendLog(config, authProvider),
@@ -48,13 +51,13 @@ Future<void> main() async {
 
       '/api/public/build-status': GetBuildStatus(config),
       '/api/public/get-benchmarks': CacheRequestHandler<Body>(
-        cache: await cacheService.redisCache(),
+        cache: redisCache,
         config: config,
         delegate: GetBenchmarks(config),
         ttl: const Duration(minutes: 15),
       ),
       '/api/public/get-status': CacheRequestHandler<Body>(
-        cache: await cacheService.redisCache(),
+        cache: redisCache,
         config: config,
         delegate: GetStatus(config), 
       ),


### PR DESCRIPTION
Following #484, this caches the endpoint that returns all the time series history for the different benchmarks. Currently, it takes ~37 seconds to return, and this will bring it to under a second when returning from cache.

## Future Work
- Caching the `get-timeseries-history` endpoint, but we need to move the POST parameter to GET params. `CacheRequestHandler` stores responses by the URI and query parameters, and does not use the POST body.