### PR TITLE
[WIP] TaskHelper for opening source configuration from TaskIcon

### DIFF
--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/protos.dart' show Task;
+
+/// A helper class for common utilities done with a [Task].
+class TaskHelper {
+  /// Base URLs for various endpoints that can relate to a [Task].
+  static const String flutterGithubSourceUrl =
+      'https://github.com/flutter/flutter/blob/master';
+  static const String cirrusUrl =
+      'https://cirrus-ci.com/github/flutter/flutter';
+  static const String luciUrl = 'https://ci.chromium.org/p/flutter';
+
+  /// [Task.stageName] that maps to StageName enums.
+  // TODO(chillers): Remove these and use StageName enum when available. https://github.com/flutter/cocoon/issues/441
+  static const String stageCirrus = 'cirrus';
+  static const String stageLuci = 'chromebot';
+  static const String stageDevicelab = 'devicelab';
+  static const String stageDevicelabWin = 'devicelab_win';
+  static const String stageDevicelabIOs = 'devicelab_ios';
+
+  /// Get the URL for [Task] that shows its configuration.
+  ///
+  /// Devicelab tasks are stored in the flutter/flutter Github repository.
+  /// Luci tasks are stored on Luci.
+  /// Cirrus tasks are stored on Cirrus.
+  static String sourceConfigurationUrl(Task task) {
+    if (_isExternal(task)) {
+      return _externalSourceConfigurationUrl(task);
+    }
+
+    return '$flutterGithubSourceUrl/dev/devicelab/bin/tasks/${task.name}.dart';
+  }
+
+  static String _externalSourceConfigurationUrl(Task task) {
+    if (task.stageName == stageLuci) {
+      return _luciSourceConfigurationUrl(task);
+    } else if (task.stageName == stageCirrus) {
+      return '$cirrusUrl/master';
+    }
+
+    throw Exception(
+        'Failed to get source configuration url for ${task.stageName}');
+  }
+
+  static String _luciSourceConfigurationUrl(Task task) {
+    switch (task.name) {
+      case 'mac_bot':
+        return '$luciUrl/builders/luci.flutter.prod/Mac';
+      case 'linux_bot':
+        return '$luciUrl/builders/luci.flutter.prod/Linux';
+      case 'windows_bot':
+        return '$luciUrl/builders/luci.flutter.prod/Windows';
+    }
+
+    return luciUrl;
+  }
+
+  /// Whether the information from [Task] is available publically.
+  ///
+  /// Only devicelab tasks are not available publically.
+  static bool _isExternal(Task task) =>
+      task.stageName == stageLuci || task.stageName == stageCirrus;
+}

--- a/app_flutter/lib/task_icon.dart
+++ b/app_flutter/lib/task_icon.dart
@@ -3,8 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
+
+import 'task_helper.dart';
 
 /// Header icon for all [Task] that map to the same [task.stageName] and [task.name].
 ///
@@ -17,36 +20,31 @@ class TaskIcon extends StatelessWidget {
   /// [Task] to get information from.
   final Task task;
 
-  /// [stageName] that maps to StageName enums.
-  // TODO(chillers): Remove these and use StageName enum when available. https://github.com/flutter/cocoon/issues/441
-  static const String stageCirrus = 'cirrus';
-  static const String stageLuci = 'chromebot';
-  static const String stageDevicelab = 'devicelab';
-  static const String stageDevicelabWin = 'devicelab_win';
-  static const String stageDevicelabIOs = 'devicelab_ios';
-
   /// A lookup table for matching [stageName] to [Image].
   ///
   /// [stageName] is based on the backend.
   static final Map<String, Image> stageIcons = <String, Image>{
-    stageCirrus: Image.asset('assets/cirrus.png'),
-    stageLuci: Image.asset('assets/chromium.png'),
-    stageDevicelab: Image.asset('assets/android.png'),
-    stageDevicelabWin: Image.asset('assets/windows.png'),
-    stageDevicelabIOs: Image.asset('assets/apple.png'),
+    TaskHelper.stageCirrus: Image.asset('assets/cirrus.png'),
+    TaskHelper.stageLuci: Image.asset('assets/chromium.png'),
+    TaskHelper.stageDevicelab: Image.asset('assets/android.png'),
+    TaskHelper.stageDevicelabWin: Image.asset('assets/windows.png'),
+    TaskHelper.stageDevicelabIOs: Image.asset('assets/apple.png'),
   };
 
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: task.name,
-      child: Container(
-        margin: const EdgeInsets.all(7.5),
-        child: stageIcons.containsKey(task.stageName)
-            ? stageIcons[task.stageName]
-            : const Icon(Icons.help),
-        width: 100,
-        height: 100,
+    return GestureDetector(
+      onTap: () => launch(TaskHelper.sourceConfigurationUrl(task)),
+      child: Tooltip(
+        message: task.name,
+        child: Container(
+          margin: const EdgeInsets.all(7.5),
+          child: stageIcons.containsKey(task.stageName)
+              ? stageIcons[task.stageName]
+              : const Icon(Icons.help),
+          width: 100,
+          height: 100,
+        ),
       ),
     );
   }

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:cocoon_service/protos.dart' show Task;
+
+import 'package:app_flutter/task_helper.dart';
+
+void main() {
+  group('TaskHelper', () {
+    test('source configuration for devicelab', () {
+      final Task devicelabTask = Task()
+        ..stageName = 'devicelab'
+        ..name = 'test';
+
+      expect(TaskHelper.sourceConfigurationUrl(devicelabTask),
+          'https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/test.dart');
+    });
+
+    test('source configuration for luci', () {
+      final Task luciTask = Task()
+        ..stageName = 'chromebot'
+        ..name = 'mac_bot';
+
+      expect(TaskHelper.sourceConfigurationUrl(luciTask),
+          'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
+    });
+    test('source configuration for cirrus', () {
+      final Task cirrusTask = Task()..stageName = 'cirrus';
+
+      expect(TaskHelper.sourceConfigurationUrl(cirrusTask),
+          'https://cirrus-ci.com/github/flutter/flutter/master');
+    });
+  });
+}


### PR DESCRIPTION
This makes it so when you click `TaskIcon`, you are redirected to its configuration.

I used this PR as an opportunity to refactor some of the common `Task` logic into a `TaskHelper` class. Most of the logic created in this PR will want to be reused by `TaskBox` when we implement viewing logs.

Fixes https://github.com/flutter/flutter/issues/43094

## Future Work
- Add `logUrl` getter in `TaskHelper` to return the URL to open for viewing the log of a `Task`