### PR TITLE
TaskBox indicates flaky tasks

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -81,19 +81,43 @@ class _TaskBoxState extends State<TaskBox> {
         color: TaskBox.statusColor.containsKey(status)
             ? TaskBox.statusColor[status]
             : Colors.black,
-        child: (status == TaskBox.statusInProgress ||
-                status == TaskBox.statusUnderperformedInProgress)
-            ? const Padding(
-                padding: EdgeInsets.all(15.0),
-                child: CircularProgressIndicator(
-                  strokeWidth: 3.0,
-                  backgroundColor: Colors.white70,
-                ),
-              )
-            : null,
+        child: taskIndicators(widget.task, status),
         width: 20,
         height: 20,
       ),
+    );
+  }
+
+  /// Compiles a stack of indicators to show on a [TaskBox].
+  ///
+  /// If [Task.isFlaky], show a question mark.
+  /// If [status] is in progress, show an in progress indicator.
+  Stack taskIndicators(Task task, String status) {
+    final List<Widget> indicators = <Widget>[];
+
+    if (task.isFlaky) {
+      indicators.add(const Padding(
+          padding: EdgeInsets.all(12.0),
+          child: Icon(
+            Icons.help,
+            color: Colors.white60,
+            size: 25,
+          )));
+    }
+
+    if (status == TaskBox.statusInProgress ||
+        status == TaskBox.statusUnderperformedInProgress) {
+      indicators.add(const Padding(
+        padding: EdgeInsets.all(15.0),
+        child: CircularProgressIndicator(
+          strokeWidth: 3.0,
+          backgroundColor: Colors.white70,
+        ),
+      ));
+    }
+
+    return Stack(
+      children: indicators,
     );
   }
 

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -26,8 +26,8 @@ void main() {
 
     testWidgets('shows loading indicator for In Progress task',
         (WidgetTester tester) async {
-      await tester
-          .pumpWidget(TaskBox(task: Task()..status = TaskBox.statusInProgress));
+      await tester.pumpWidget(MaterialApp(
+          home: TaskBox(task: Task()..status = TaskBox.statusInProgress)));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
@@ -38,7 +38,7 @@ void main() {
         ..status = 'New'
         ..attempts = 2;
 
-      await tester.pumpWidget(TaskBox(task: repeatTask));
+      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -53,7 +53,7 @@ void main() {
         ..status = 'In Progress'
         ..attempts = 2;
 
-      await tester.pumpWidget(TaskBox(task: repeatTask));
+      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -68,7 +68,7 @@ void main() {
         ..status = 'Succeeded'
         ..attempts = 2;
 
-      await tester.pumpWidget(TaskBox(task: repeatTask));
+      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -132,7 +132,8 @@ void main() {
 
 Future<void> expectTaskBoxColorWithMessage(
     WidgetTester tester, String message, Color expectedColor) async {
-  await tester.pumpWidget(TaskBox(task: Task()..status = message));
+  await tester
+      .pumpWidget(MaterialApp(home: TaskBox(task: Task()..status = message)));
 
   final Container taskBoxWidget =
       find.byType(Container).evaluate().first.widget;

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -62,6 +62,30 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
+    testWidgets('shows question mark for task marked flaky',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+          home: TaskBox(
+              task: Task()
+                ..status = TaskBox.statusSucceeded
+                ..isFlaky = true)));
+
+      expect(find.byIcon(Icons.help), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows question mark and loading indicator for task marked flaky that is in progress',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+          home: TaskBox(
+              task: Task()
+                ..status = TaskBox.statusInProgress
+                ..isFlaky = true)));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.help), findsOneWidget);
+    });
+
     testWidgets('show yellow when Succeeded but ran multiple times',
         (WidgetTester tester) async {
       final Task repeatTask = Task()


### PR DESCRIPTION
This shows a question mark over the `TaskBox` when a `Task` is marked flaky. To do this, I had to add a stack of indicators since it also possible that a task marked flaky is also in progress.

![flaky_tasks](https://user-images.githubusercontent.com/2148558/67817346-4275bb00-fa6a-11e9-96c5-6f55429b5afc.png)