### PR TITLE
Cocoon authentication accepts access tokens as a method of authentication

### DIFF
--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -22,7 +22,7 @@ import 'exceptions.dart';
 
 /// Class capable of authenticating [HttpRequest]s.
 ///
-/// There are three types of authentication this class supports:
+/// There are four types of authentication this class supports:
 ///
 ///  1. If the request has the `'Agent-ID'` HTTP header set to the ID of the
 ///     Cocoon agent making the request and the `'Agent-Auth-Token'` HTTP
@@ -52,6 +52,9 @@ import 'exceptions.dart';
 ///
 ///     User accounts are only authorized if the user is either a "@google.com"
 ///     account or is a whitelisted account in the Cocoon backend.
+/// 
+///  4. If the request has the `'X-Flutter-IdToken'` HTTP header set to a valid
+///     JWT token, then this will follow the same logic as #3.
 ///
 /// If none of the above authentication methods yield an authenticated
 /// request, then the request is unauthenticated, and any call to
@@ -106,10 +109,12 @@ class AuthenticationProvider {
   Future<AuthenticatedContext> authenticate(HttpRequest request) async {
     final String agentId = request.headers.value('Agent-ID');
     final bool isCron = request.headers.value('X-Appengine-Cron') == 'true';
-    final String idToken = request.cookies
+    final String idToken = request.headers.value('X-Flutter-IdToken') ??
+      request.cookies
         .where((Cookie cookie) => cookie.name == 'X-Flutter-IdToken')
         .map<String>((Cookie cookie) => cookie.value)
         .followedBy(<String>[null]).first;
+        
     final ClientContext clientContext = _clientContextProvider();
     final Logging log = _loggingProvider();
 

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -210,7 +210,6 @@ class AuthenticationProvider {
           'access_token': accessToken,
         },
       );
-      log.info(googleOauthTokenInfoUri.toString());
       final HttpClientRequest verifyAccessTokenRequest = await client.getUrl(googleOauthTokenInfoUri);
       final HttpClientResponse verifyAccessTokenResponse = await verifyAccessTokenRequest.close();
 

--- a/app_dart/test/src/request_handling/fake_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_authentication.dart
@@ -24,6 +24,19 @@ class FakeAuthenticationProvider implements AuthenticationProvider {
 
   @override
   Future<AuthenticatedContext> authenticate(HttpRequest request) async {
+    if (request.headers.value('X-Flutter-AccessToken') != null) {
+      return authenticateAccessToken(accessToken: request.headers.value('X-Flutter-AccessToken'), clientContext: clientContext);
+    }
+    
+    if (authenticated) {
+      return FakeAuthenticatedContext(agent: agent, clientContext: clientContext);
+    } else {
+      throw const Unauthenticated('Not authenticated');
+    }
+  }
+
+  @override
+  Future<AuthenticatedContext> authenticateAccessToken({String accessToken, ClientContext clientContext, Logging log}) async {
     if (authenticated) {
       return FakeAuthenticatedContext(agent: agent, clientContext: clientContext);
     } else {


### PR DESCRIPTION
This allows authenticating in the Cocoon backend via a Google Auth access token sent through the `X-Flutter-AccessToken` header.

The `google_sign_in_all` plugin the Flutter app is using for handling Google Auth returns a null id token, but does return a valid access token. Debugging lead to a rabbit hole of where the issue could be occurring, so I decided to just add authenticating via access tokens. The process is very similar to authenticating for id tokens which the backend already does.

## Tested
- Added unit tests for the different authentication cases (based heavily off the id token's tests)
- Deployed to my test version on the AppEngine project and verified it worked with a working access token. Tested with an expired one too. (via curl)

## Future Work
- Use this authentication method for the Flutter App's actions to the backend that require authentication
- When Flutter's `google_sign_in` has web support, we can switch back to id token.