### PR TITLE
Rerun tasks

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -26,7 +26,8 @@ class AppEngineCocoonService implements CocoonService {
   /// The Cocoon API endpoint to query
   ///
   /// This is the base for all API requests to cocoon
-  static const String _baseApiUrl = 'https://flutter-dashboard.appspot.com/api';
+  static const String _cocoonHost = 'https://flutter-dashboard.appspot.com';
+  static const String _baseApiUrl = '$_cocoonHost/api';
 
   final http.Client _client;
 
@@ -85,10 +86,10 @@ class AppEngineCocoonService implements CocoonService {
   @override
   Future<bool> rerunTask(Task task, String accessToken) async {
     final http.Request request = http.Request(
-        'POST', Uri(host: '$_baseApiUrl', path: '/reset-devicelab-task'));
-    request.bodyFields = <String, String>{
-      'Key': task.key.toString(),
-    };
+        'POST', Uri(host: _cocoonHost, path: '/api/reset-devicelab-task'))
+      ..bodyFields = <String, String>{
+        'Key': task.key.toString(),
+      };
 
     // TODO(chillers): add auth token
 

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -84,9 +84,15 @@ class AppEngineCocoonService implements CocoonService {
 
   @override
   Future<bool> rerunTask(Task task, String accessToken) async {
+    final http.Request request = http.Request(
+        'POST', Uri(host: '$_baseApiUrl', path: '/reset-devicelab-task'));
+    request.bodyFields = <String, String>{
+      'Key': task.key.toString(),
+    };
+
     // TODO(chillers): add auth token
-    final http.Response response =
-        await _client.get('$_baseApiUrl/reset-devicelab-task');
+
+    final http.StreamedResponse response = await _client.send(request);
 
     return response.statusCode == 200;
   }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -26,8 +26,8 @@ class AppEngineCocoonService implements CocoonService {
   /// The Cocoon API endpoint to query
   ///
   /// This is the base for all API requests to cocoon
-  static const String _cocoonHost = 'https://flutter-dashboard.appspot.com';
-  static const String _baseApiUrl = '$_cocoonHost/api';
+  static const String _appengineAuthority = 'flutter-dashboard.appspot.com';
+  static const String _baseApiUrl = 'https://$_appengineAuthority/api';
 
   final http.Client _client;
 
@@ -85,8 +85,11 @@ class AppEngineCocoonService implements CocoonService {
 
   @override
   Future<bool> rerunTask(Task task, String accessToken) async {
+    assert(accessToken != null);
+
+    /// This endpoint only returns a status code.
     final http.Request request = http.Request(
-        'POST', Uri(host: _cocoonHost, path: '/api/reset-devicelab-task'))
+        'POST', Uri.https(_appengineAuthority, '/api/reset-devicelab-task'))
       ..bodyFields = <String, String>{
         'Key': task.key.toString(),
       }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -89,9 +89,10 @@ class AppEngineCocoonService implements CocoonService {
         'POST', Uri(host: _cocoonHost, path: '/api/reset-devicelab-task'))
       ..bodyFields = <String, String>{
         'Key': task.key.toString(),
-      };
-
-    // TODO(chillers): add auth token
+      }
+      ..headers.addAll(<String, String>{
+        'X-Flutter-AccessToken': accessToken,
+      });
 
     final http.StreamedResponse response = await _client.send(request);
 

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -82,6 +82,15 @@ class AppEngineCocoonService implements CocoonService {
       ..data = jsonResponse['AnticipatedBuildStatus'] == 'Succeeded';
   }
 
+  @override
+  Future<bool> rerunTask(Task task, String accessToken) async {
+    // TODO(chillers): add auth token
+    final http.Response response =
+        await _client.get('$_baseApiUrl/reset-devicelab-task');
+
+    return response.statusCode == 200;
+  }
+
   /// Check if [Map<String,Object>] follows the format for build-status.
   ///
   /// Template of the response it should receive:

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -99,7 +99,7 @@ class AppEngineCocoonService implements CocoonService {
 
     final http.StreamedResponse response = await _client.send(request);
 
-    return response.statusCode == 200;
+    return response.statusCode == HttpStatus.ok;
   }
 
   /// Check if [Map<String,Object>] follows the format for build-status.

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/foundation.dart' show kReleaseMode;
 
-import 'package:cocoon_service/protos.dart' show CommitStatus;
+import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
 
 import 'appengine_cocoon.dart';
 import 'fake_cocoon.dart';
@@ -34,6 +34,11 @@ abstract class CocoonService {
 
   /// Gets the current build status of flutter/flutter.
   Future<CocoonResponse<bool>> fetchTreeBuildStatus();
+
+  /// Send rerun [Task] command to devicelab.
+  ///
+  /// Will not rerun tasks that are outside of devicelab.
+  Future<bool> rerunTask(Task task, String accessToken);
 }
 
 /// Wrapper class for data this state serves.

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -30,6 +30,11 @@ class FakeCocoonService implements CocoonService {
     return CocoonResponse<bool>()..data = random.nextBool();
   }
 
+  @override
+  Future<bool> rerunTask(Task task, String accessToken) async {
+    return false;
+  }
+
   List<CommitStatus> _createFakeCommitStatuses() {
     final List<CommitStatus> stats = <CommitStatus>[];
 

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
-import 'package:cocoon_service/protos.dart' show CommitStatus;
+import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
 
 import '../service/cocoon.dart';
 import '../service/google_authentication.dart';
@@ -91,6 +91,10 @@ class FlutterBuildState extends ChangeNotifier {
   Future<void> signIn() async {
     await authService.signIn();
     notifyListeners();
+  }
+
+  Future<bool> rerunTask(Task task) {
+    return _cocoonService.rerunTask(task, authService.accessToken);
   }
 
   @override

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -50,6 +50,7 @@ class StatusGridContainer extends StatelessWidget {
         matrix.sort(compareRecentlyFailed);
 
         return StatusGrid(
+          buildState: buildState,
           statuses: statuses,
           taskMatrix: matrix,
         );
@@ -84,6 +85,7 @@ class StatusGridContainer extends StatelessWidget {
 class StatusGrid extends StatelessWidget {
   const StatusGrid({
     Key key,
+    @required this.buildState,
     @required this.statuses,
     @required this.taskMatrix,
   }) : super(key: key);
@@ -93,6 +95,9 @@ class StatusGrid extends StatelessWidget {
 
   /// Computed matrix of [Task] to make it easy to retrieve and sort tasks.
   final task_matrix.TaskMatrix taskMatrix;
+
+  /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
+  final FlutterBuildState buildState;
 
   @override
   Widget build(BuildContext context) {
@@ -144,7 +149,10 @@ class StatusGrid extends StatelessWidget {
                 return const SizedBox();
               }
 
-              return TaskBox(task: task);
+              return TaskBox(
+                task: task,
+                buildState: buildState,
+              );
             },
           ),
         ),

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/state/flutter_build.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_progress_button/flutter_progress_button.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
-import 'package:flutter_progress_button/flutter_progress_button.dart';
+
+import 'state/flutter_build.dart';
 
 /// Displays information from a [Task].
 ///

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -305,25 +305,25 @@ class TaskOverlayContents extends StatelessWidget {
                   progressWidget: const CircularProgressIndicator(),
                   width: 120,
                   height: 50,
-                  onPressed: () async {
-                    final bool success = await buildState.rerunTask(task);
-                    return () {
-                      final Text snackbarText = success
-                          ? const Text(rerunSuccessMessage)
-                          : const Text(rerunErrorMessage);
-                      Scaffold.of(parentContext).showSnackBar(
-                        SnackBar(
-                          content: snackbarText,
-                          duration: rerunSnackbarDuration,
-                        ),
-                      );
-                    };
-                  },
+                  onPressed: _rerunTask,
                   animate: false,
                 ),
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _rerunTask() async {
+    final bool success = await buildState.rerunTask(task);
+    final Text snackbarText = success
+        ? const Text(rerunSuccessMessage)
+        : const Text(rerunErrorMessage);
+    Scaffold.of(parentContext).showSnackBar(
+      SnackBar(
+        content: snackbarText,
+        duration: rerunSnackbarDuration,
       ),
     );
   }

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -17,6 +17,7 @@ class TaskBox extends StatefulWidget {
       : assert(task != null),
         super(key: key);
 
+  /// Reference to the build state to perform actions on this [Task], like rerunning or viewing the log.
   final FlutterBuildState buildState;
 
   /// [Task] to show information from.
@@ -122,10 +123,12 @@ class _TaskBoxState extends State<TaskBox> {
   void _handleTap() {
     _taskOverlay = OverlayEntry(
       builder: (_) => TaskOverlayContents(
-          parentContext: context,
-          task: widget.task,
-          taskStatus: status,
-          closeCallback: _closeOverlay),
+        buildState: widget.buildState,
+        parentContext: context,
+        task: widget.task,
+        taskStatus: status,
+        closeCallback: _closeOverlay,
+      ),
     );
 
     Overlay.of(context).insert(_taskOverlay);

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:app_flutter/task_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_progress_button/flutter_progress_button.dart';
 
@@ -177,6 +178,14 @@ class TaskOverlayContents extends StatelessWidget {
   /// this callback is called closing the overlay.
   final void Function() closeCallback;
 
+  @visibleForTesting
+  static const String rerunErrorMessage = 'Failed to rerun task.';
+  @visibleForTesting
+  static const String rerunSuccessMessage =
+      'Devicelab is rerunning the task. This can take a minute to propagate.';
+  @visibleForTesting
+  static const Duration rerunSnackbarDuration = Duration(seconds: 15);
+
   /// A lookup table to define the [Icon] for this [Overlay].
   static const Map<String, Icon> statusIcon = <String, Icon>{
     TaskBox.statusFailed: Icon(Icons.clear, color: Colors.red, size: 32),
@@ -247,28 +256,28 @@ class TaskOverlayContents extends StatelessWidget {
                         // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
                       },
                     ),
-                    ProgressButton(
-                      defaultWidget: const Text('Rerun task'),
-                      progressWidget: const CircularProgressIndicator(),
-                      width: 120,
-                      height: 50,
-                      onPressed: () async {
-                        final bool success = await buildState.rerunTask(task);
-                        return () {
-                          final Text snackbarText = success
-                              ? const Text(
-                                  'Rerunning task. This may take a minute to propagate.')
-                              : const Text('Failed to rerun task.');
-                          Scaffold.of(parentContext).showSnackBar(
-                            SnackBar(
-                              content: snackbarText,
-                              duration: const Duration(seconds: 12),
-                            ),
-                          );
-                        };
-                      },
-                      animate: false,
-                    ),
+                    if (isDevicelab(task))
+                      ProgressButton(
+                        defaultWidget: const Text('Rerun task'),
+                        progressWidget: const CircularProgressIndicator(),
+                        width: 120,
+                        height: 50,
+                        onPressed: () async {
+                          final bool success = await buildState.rerunTask(task);
+                          return () {
+                            final Text snackbarText = success
+                                ? const Text(rerunSuccessMessage)
+                                : const Text(rerunErrorMessage);
+                            Scaffold.of(parentContext).showSnackBar(
+                              SnackBar(
+                                content: snackbarText,
+                                duration: rerunSnackbarDuration,
+                              ),
+                            );
+                          };
+                        },
+                        animate: false,
+                      ),
                   ],
                 ),
               ],

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:app_flutter/state/flutter_build.dart';
 import 'package:flutter/material.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
@@ -12,9 +13,11 @@ import 'package:cocoon_service/protos.dart' show Task;
 /// with a [CircularProgressIndicator] in the box.
 /// Shows a black box for unknown statuses.
 class TaskBox extends StatefulWidget {
-  const TaskBox({Key key, @required this.task})
+  const TaskBox({Key key, @required this.buildState, @required this.task})
       : assert(task != null),
         super(key: key);
+
+  final FlutterBuildState buildState;
 
   /// [Task] to show information from.
   final Task task;
@@ -145,6 +148,7 @@ class TaskOverlayContents extends StatelessWidget {
     @required this.task,
     @required this.taskStatus,
     @required this.closeCallback,
+    @required this.buildState,
   })  : assert(parentContext != null),
         assert(task != null),
         assert(closeCallback != null),
@@ -152,6 +156,8 @@ class TaskOverlayContents extends StatelessWidget {
 
   /// The parent context that has the size of the whole screen
   final BuildContext parentContext;
+
+  final FlutterBuildState buildState;
 
   /// The [Task] to display in the overlay
   final Task task;
@@ -236,8 +242,10 @@ class TaskOverlayContents extends StatelessWidget {
                     ),
                     IconButton(
                       icon: const Icon(Icons.redo),
-                      onPressed: () {
-                        // TODO(chillers): Rerun task. https://github.com/flutter/cocoon/issues/424
+                      onPressed: () async {
+                        final bool successful =
+                            await buildState.rerunTask(task);
+                        // TODO(chillers): Do something if it was not successful.
                       },
                     ),
                   ],

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -213,7 +213,7 @@ class TaskOverlayEntry extends StatelessWidget {
           top: offsetLeft.dy + (renderBox.size.height / 2),
           left: offsetLeft.dx + (renderBox.size.width / 2),
           child: TaskOverlayContents(
-            snackbarCallback: Scaffold.of(parentContext).showSnackBar,
+            showSnackbarCallback: Scaffold.of(parentContext).showSnackBar,
             buildState: buildState,
             task: task,
             taskStatus: taskStatus,
@@ -233,11 +233,11 @@ class TaskOverlayEntry extends StatelessWidget {
 class TaskOverlayContents extends StatelessWidget {
   const TaskOverlayContents({
     Key key,
-    @required this.snackbarCallback,
+    @required this.showSnackbarCallback,
     @required this.buildState,
     @required this.task,
     @required this.taskStatus,
-  })  : assert(snackbarCallback != null),
+  })  : assert(showSnackbarCallback != null),
         assert(buildState != null),
         assert(task != null),
         super(key: key);

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -288,8 +288,9 @@ class TaskOverlayContents extends StatelessWidget {
             leading:
                 Tooltip(message: taskStatus, child: statusIcon[taskStatus]),
             title: Text(task.name),
-            subtitle: Text(
-                'Attempts: ${task.attempts}\nDuration: ${task.endTimestamp - task.startTimestamp} seconds\nAgent: ${task.reservedForAgentId}'),
+            subtitle: Text('Attempts: ${task.attempts}\n'
+                'Duration: ${task.endTimestamp - task.startTimestamp} seconds\n'
+                'Agent: ${task.reservedForAgentId}'),
           ),
           ButtonBar(
             children: <Widget>[

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -18,6 +18,7 @@ import 'state/flutter_build.dart';
 class TaskBox extends StatefulWidget {
   const TaskBox({Key key, @required this.buildState, @required this.task})
       : assert(task != null),
+        assert(buildState != null),
         super(key: key);
 
   /// Reference to the build state to perform actions on this [Task], like rerunning or viewing the log.
@@ -153,6 +154,7 @@ class TaskOverlayEntry extends StatelessWidget {
     @required this.closeCallback,
     @required this.buildState,
   })  : assert(parentContext != null),
+        assert(buildState != null),
         assert(task != null),
         assert(closeCallback != null),
         super(key: key);
@@ -236,6 +238,7 @@ class TaskOverlayContents extends StatelessWidget {
     @required this.task,
     @required this.taskStatus,
   })  : assert(parentContext != null),
+        assert(buildState != null),
         assert(task != null),
         super(key: key);
 

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -192,6 +192,8 @@ class TaskOverlayContents extends StatelessWidget {
         Icon(Icons.autorenew, color: Colors.orange, size: 32),
   };
 
+  static const Key scaffoldKey = Key('build-dashbord-scaffold');
+
   @override
   Widget build(BuildContext context) {
     final RenderBox renderBox = parentContext.findRenderObject();
@@ -251,12 +253,18 @@ class TaskOverlayContents extends StatelessWidget {
                       width: 120,
                       height: 50,
                       onPressed: () async {
-                        await Future<void>.delayed(const Duration(seconds: 5));
                         final bool success = await buildState.rerunTask(task);
                         return () {
-                          if (!success) {
-                            print('Failed to rerun Task ${task.key}');
-                          }
+                          final Text snackbarText = success
+                              ? const Text(
+                                  'Rerunning task. This may take a minute to propagate.')
+                              : const Text('Failed to rerun task.');
+                          Scaffold.of(parentContext).showSnackBar(
+                            SnackBar(
+                              content: snackbarText,
+                              duration: const Duration(seconds: 12),
+                            ),
+                          );
                         };
                       },
                       animate: false,

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -201,8 +201,6 @@ class TaskOverlayContents extends StatelessWidget {
         Icon(Icons.autorenew, color: Colors.orange, size: 32),
   };
 
-  static const Key scaffoldKey = Key('build-dashbord-scaffold');
-
   @override
   Widget build(BuildContext context) {
     final RenderBox renderBox = parentContext.findRenderObject();

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -213,7 +213,7 @@ class TaskOverlayEntry extends StatelessWidget {
           top: offsetLeft.dy + (renderBox.size.height / 2),
           left: offsetLeft.dx + (renderBox.size.width / 2),
           child: TaskOverlayContents(
-            parentContext: parentContext,
+            snackbarCallback: Scaffold.of(parentContext).showSnackBar,
             buildState: buildState,
             task: task,
             taskStatus: taskStatus,
@@ -233,17 +233,17 @@ class TaskOverlayEntry extends StatelessWidget {
 class TaskOverlayContents extends StatelessWidget {
   const TaskOverlayContents({
     Key key,
-    @required this.parentContext,
+    @required this.snackbarCallback,
     @required this.buildState,
     @required this.task,
     @required this.taskStatus,
-  })  : assert(parentContext != null),
+  })  : assert(snackbarCallback != null),
         assert(buildState != null),
         assert(task != null),
         super(key: key);
 
-  /// The parent context that has the size of the whole screen
-  final BuildContext parentContext;
+  final ScaffoldFeatureController<SnackBar, SnackBarClosedReason> Function(
+      SnackBar) showSnackbarCallback;
 
   /// A reference to the [FlutterBuildState] for performing operations on this [Task].
   final FlutterBuildState buildState;
@@ -320,7 +320,7 @@ class TaskOverlayContents extends StatelessWidget {
     final Text snackbarText = success
         ? const Text(rerunSuccessMessage)
         : const Text(rerunErrorMessage);
-    Scaffold.of(parentContext).showSnackBar(
+    showSnackbarCallback(
       SnackBar(
         content: snackbarText,
         duration: rerunSnackbarDuration,

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -6,6 +6,7 @@ import 'package:app_flutter/state/flutter_build.dart';
 import 'package:flutter/material.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
+import 'package:flutter_progress_button/flutter_progress_button.dart';
 
 /// Displays information from a [Task].
 ///
@@ -243,13 +244,21 @@ class TaskOverlayContents extends StatelessWidget {
                         // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
                       },
                     ),
-                    IconButton(
-                      icon: const Icon(Icons.redo),
+                    ProgressButton(
+                      defaultWidget: const Text('Rerun task'),
+                      progressWidget: const CircularProgressIndicator(),
+                      width: 120,
+                      height: 50,
                       onPressed: () async {
-                        final bool successful =
-                            await buildState.rerunTask(task);
-                        // TODO(chillers): Do something if it was not successful.
+                        await Future<void>.delayed(const Duration(seconds: 5));
+                        final bool success = await buildState.rerunTask(task);
+                        return () {
+                          if (!success) {
+                            print('Failed to rerun Task ${task.key}');
+                          }
+                        };
                       },
+                      animate: false,
                     ),
                   ],
                 ),

--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -61,6 +61,9 @@ String _luciSourceConfigurationUrl(Task task) {
   return luciUrl;
 }
 
+/// Whether [Task] is run in the devicelab or not.
+bool isDevicelab(Task task) => task.stageName.contains(StageName.devicelab);
+
 /// Whether the information from [Task] is available publically.
 ///
 /// Only devicelab tasks are not available publically.

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 
   cocoon_service:
     path: ../app_dart
+  flutter_progress_button: ^1.0.0
   google_sign_in_all: ^0.0.3
   provider: ^3.0.0
   url_launcher: ^5.1.0

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -224,7 +224,8 @@ void main() {
       });
 
       test('should return false if task key is null', () async {
-        expect(service.rerunTask(Task(), null), throwsA(const TypeMatcher<AssertionError>()));
+        expect(service.rerunTask(Task(), null),
+            throwsA(const TypeMatcher<AssertionError>()));
       });
     });
   });

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -195,5 +195,9 @@ void main() {
           await service.fetchTreeBuildStatus();
       expect(response.error, isNotNull);
     });
+
+    group('AppEngine Cocoon Service rerun task', () {
+      test('should return true if succeeds', () async {});
+    });
   });
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -8,7 +8,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'package:cocoon_service/protos.dart'
-    show Commit, CommitStatus, Stage, Task;
+    show Commit, CommitStatus, RootKey, Stage, Task;
 
 import 'package:app_flutter/service/appengine_cocoon.dart';
 import 'package:app_flutter/service/cocoon.dart';
@@ -197,7 +197,35 @@ void main() {
     });
 
     group('AppEngine Cocoon Service rerun task', () {
-      test('should return true if succeeds', () async {});
+      AppEngineCocoonService service;
+
+      setUp(() {
+        service =
+            AppEngineCocoonService(client: MockClient((Request request) async {
+          return Response('', 200);
+        }));
+      });
+
+      test('should return true if request succeeds', () async {
+        expect(
+            await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
+            true);
+      });
+
+      test('should return false if request failed', () async {
+        service =
+            AppEngineCocoonService(client: MockClient((Request request) async {
+          return Response('', 500);
+        }));
+
+        expect(
+            await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
+            false);
+      });
+
+      test('should return false if task key is null', () async {
+        expect(service.rerunTask(Task(), null), throwsA(const TypeMatcher<AssertionError>()));
+      });
     });
   });
 }

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -55,6 +55,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
+                buildState: FlutterBuildState(),
                 statuses: statuses,
                 taskMatrix: taskMatrix,
               ),
@@ -81,6 +82,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
+                buildState: FlutterBuildState(),
                 statuses: statuses,
                 taskMatrix: taskMatrix,
               ),
@@ -100,6 +102,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
+                buildState: FlutterBuildState(),
                 statuses: statuses,
                 taskMatrix: taskMatrix,
               ),

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
 
+import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/task_box.dart';
 
 void main() {
@@ -15,6 +16,11 @@ void main() {
       ..attempts = 3
       ..name = 'Tasky McTaskFace'
       ..reason = 'Because I said so';
+    FlutterBuildState buildState;
+
+    setUpAll(() {
+      buildState = FlutterBuildState();
+    });
 
     // Table Driven Approach to ensure every message does show the corresponding color
     TaskBox.statusColor.forEach((String message, Color color) {
@@ -27,7 +33,9 @@ void main() {
     testWidgets('shows loading indicator for In Progress task',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
-          home: TaskBox(task: Task()..status = TaskBox.statusInProgress)));
+          home: TaskBox(
+              buildState: buildState,
+              task: Task()..status = TaskBox.statusInProgress)));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
@@ -38,7 +46,8 @@ void main() {
         ..status = 'New'
         ..attempts = 2;
 
-      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
+      await tester.pumpWidget(
+          MaterialApp(home: TaskBox(buildState: buildState, task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -53,7 +62,8 @@ void main() {
         ..status = 'In Progress'
         ..attempts = 2;
 
-      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
+      await tester.pumpWidget(
+          MaterialApp(home: TaskBox(buildState: buildState, task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -66,6 +76,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
           home: TaskBox(
+              buildState: buildState,
               task: Task()
                 ..status = TaskBox.statusSucceeded
                 ..isFlaky = true)));
@@ -78,6 +89,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
           home: TaskBox(
+              buildState: buildState,
               task: Task()
                 ..status = TaskBox.statusInProgress
                 ..isFlaky = true)));
@@ -92,7 +104,8 @@ void main() {
         ..status = 'Succeeded'
         ..attempts = 2;
 
-      await tester.pumpWidget(MaterialApp(home: TaskBox(task: repeatTask)));
+      await tester.pumpWidget(
+          MaterialApp(home: TaskBox(buildState: buildState, task: repeatTask)));
 
       final Container taskBoxWidget =
           find.byType(Container).evaluate().first.widget;
@@ -108,6 +121,7 @@ void main() {
     testWidgets('shows overlay on click', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: TaskBox(
+          buildState: buildState,
           task: expectedTask,
         ),
       ));
@@ -133,6 +147,7 @@ void main() {
     testWidgets('closes overlay on click out', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: TaskBox(
+          buildState: buildState,
           task: expectedTask,
         ),
       ));
@@ -156,8 +171,14 @@ void main() {
 
 Future<void> expectTaskBoxColorWithMessage(
     WidgetTester tester, String message, Color expectedColor) async {
-  await tester
-      .pumpWidget(MaterialApp(home: TaskBox(task: Task()..status = message)));
+  await tester.pumpWidget(
+    MaterialApp(
+      home: TaskBox(
+        buildState: FlutterBuildState(),
+        task: Task()..status = message,
+      ),
+    ),
+  );
 
   final Container taskBoxWidget =
       find.byType(Container).evaluate().first.widget;

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -122,12 +122,16 @@ void main() {
     });
 
     testWidgets('shows overlay on click', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: TaskBox(
-          buildState: buildState,
-          task: expectedTask,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: expectedTask,
+            ),
+          ),
         ),
-      ));
+      );
 
       final String expectedTaskInfoString =
           'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
@@ -148,12 +152,16 @@ void main() {
     });
 
     testWidgets('closes overlay on click out', (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: TaskBox(
-          buildState: buildState,
-          task: expectedTask,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: expectedTask,
+            ),
+          ),
         ),
-      ));
+      );
 
       // Open the overlay
       await tester.tap(find.byType(TaskBox));

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -194,13 +194,17 @@ void main() {
       // Click the rerun task button
       await tester.tap(find.byType(ProgressButton));
       await tester.pump();
+      await tester
+          .pump(const Duration(milliseconds: 750)); // 750ms open animation
 
       expect(
           find.text(TaskOverlayContents.rerunSuccessMessage), findsOneWidget);
 
-      // Snackbar should go away after its duration
-      await tester.pump(TaskOverlayContents.rerunSnackbarDuration);
-      await tester.pump();
+      // Snackbar message should go away after its duration
+      await tester.pumpAndSettle(
+          TaskOverlayContents.rerunSnackbarDuration); // wait the duration
+      await tester.pump(); // schedule animation
+      await tester.pump(const Duration(milliseconds: 1500)); // close animation
 
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
     });
@@ -230,13 +234,17 @@ void main() {
       // Click the rerun task button
       await tester.tap(find.byType(ProgressButton));
       await tester.pump();
+      await tester
+          .pump(const Duration(milliseconds: 750)); // 750ms open animation
 
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
       expect(find.text(TaskOverlayContents.rerunErrorMessage), findsOneWidget);
 
       // Snackbar message should go away after its duration
-      await tester.pump(TaskOverlayContents.rerunSnackbarDuration);
-      await tester.pump();
+      await tester.pumpAndSettle(
+          TaskOverlayContents.rerunSnackbarDuration); // wait the duration
+      await tester.pump(); // schedule animation
+      await tester.pump(const Duration(milliseconds: 1500)); // close animation
 
       expect(find.text(TaskOverlayContents.rerunErrorMessage), findsNothing);
     });

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -33,5 +33,12 @@ void main() {
       expect(sourceConfigurationUrl(cirrusTask),
           'https://cirrus-ci.com/github/flutter/flutter/master');
     });
+
+    test('is devicelab', () {
+      expect(isDevicelab(Task()..stageName = 'devicelab'), true);
+      expect(isDevicelab(Task()..stageName = 'devicelab_win'), true);
+
+      expect(isDevicelab(Task()..stageName = 'cirrus'), false);
+    });
   });
 }


### PR DESCRIPTION
Waiting on https://github.com/flutter/cocoon/pull/502 for integration testing.

Fixes https://github.com/flutter/flutter/issues/43109 leaving just viewing logs for feature parity with the v1 dashboard.

Added dependency on `flutter_progress_button` for pretty async buttons (MIT license) and added UI for rerunning a `Task` for devicelab tasks in `TaskOverlay`.

Added to `FlutterBuildState` the ability to rerun tasks (forwards to `CocoonService`). `CocoonService` has code for making authenticated requests.

When an error occurs, it will show a `SnackBar` saying an error occurred rerunning the task. Otherwise, it will show a `SnackBar` saying the task is rerunning and it may take a minute to propagate. This is because `/api/public/get-status` cache TTL is 1 minute, and we do not want to mutate the local state to have it pop back to failed.

![task_rerunning](https://user-images.githubusercontent.com/2148558/68044912-957f8600-fc95-11e9-84a8-d6005333cb9a.gif)
