### PR TITLE
View Task Logs

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/task_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_progress_button/flutter_progress_button.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
 
 import 'state/flutter_build.dart';
+import 'task_helper.dart';
 
 /// Displays information from a [Task].
 ///
@@ -294,11 +295,13 @@ class TaskOverlayContents extends StatelessWidget {
           ),
           ButtonBar(
             children: <Widget>[
-              IconButton(
-                icon: const Icon(Icons.receipt),
-                onPressed: () {
-                  // TODO(chillers): Open log in new window. https://github.com/flutter/cocoon/issues/436
-                },
+              ProgressButton(
+                defaultWidget: const Text('View log'),
+                progressWidget: const CircularProgressIndicator(),
+                width: 100,
+                height: 50,
+                onPressed: _viewLog,
+                animate: false,
               ),
               if (isDevicelab(task))
                 ProgressButton(
@@ -327,5 +330,15 @@ class TaskOverlayContents extends StatelessWidget {
         duration: rerunSnackbarDuration,
       ),
     );
+  }
+
+  Future<void> _viewLog() async {
+    // Only send access token for devicelab tasks since they require authentication
+    final Map<String, String> headers = isDevicelab(task)
+        ? <String, String>{
+            'X-Flutter-AccessToken': buildState.authService.accessToken,
+          }
+        : null;
+    launch(logUrl(task), headers: headers);
   }
 }

--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/protos.dart' show Task;
 /// Base URLs for various endpoints that can relate to a [Task].
 const String flutterGithubSourceUrl =
     'https://github.com/flutter/flutter/blob/master';
+const String flutterDashboardUrl = 'https://flutter-dashboard.appspot.com';
 const String cirrusUrl = 'https://cirrus-ci.com/github/flutter/flutter';
 const String luciUrl = 'https://ci.chromium.org/p/flutter';
 
@@ -20,6 +21,18 @@ class StageName {
   static const String devicelab = 'devicelab';
   static const String devicelabWin = 'devicelab_win';
   static const String devicelabIOs = 'devicelab_ios';
+}
+
+/// Get the URL for [Task] to view its log.
+///
+/// Devicelab tasks can be retrieved via an authenticated API endpoint.
+/// Otherwise, we can redirect to the page that is closest to the logs for [Task].
+String logUrl(Task task) {
+  if (_isExternal(task)) {
+    return sourceConfigurationUrl(task);
+  }
+
+  return '$flutterDashboardUrl/api/get-log?ownerKey=${task.key}';
 }
 
 /// Get the URL for [Task] that shows its configuration.

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -267,7 +267,7 @@ void main() {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);
       });
-      final Task publicTask = Task()..stageName='cirrus';
+      final Task publicTask = Task()..stageName = 'cirrus';
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -372,4 +372,5 @@ Future<void> expectTaskBoxColorWithMessage(
 }
 
 class MockFlutterBuildState extends Mock implements FlutterBuildState {}
+
 class MockGoogleSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/service/google_authentication.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +9,7 @@ import 'package:mockito/mockito.dart';
 
 import 'package:cocoon_service/protos.dart' show Task;
 
+import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/task_box.dart';
 import 'package:app_flutter/task_helper.dart';
@@ -267,7 +267,7 @@ void main() {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);
       });
-      final Task publicTask = Task()..stageName = 'cirrus';
+      final Task publicTask = Task()..stageName='cirrus';
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -372,5 +372,4 @@ Future<void> expectTaskBoxColorWithMessage(
 }
 
 class MockFlutterBuildState extends Mock implements FlutterBuildState {}
-
 class MockGoogleSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_progress_button/flutter_progress_button.dart';
+import 'package:app_flutter/service/google_authentication.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:mockito/mockito.dart';
@@ -11,6 +12,7 @@ import 'package:cocoon_service/protos.dart' show Task;
 
 import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/task_box.dart';
+import 'package:app_flutter/task_helper.dart';
 
 void main() {
   group('TaskBox', () {
@@ -200,7 +202,7 @@ void main() {
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
 
       // Click the rerun task button
-      await tester.tap(find.byType(ProgressButton));
+      await tester.tap(find.text('Rerun task'));
       await tester.pump();
       await tester
           .pump(const Duration(milliseconds: 750)); // 750ms open animation
@@ -240,7 +242,7 @@ void main() {
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
 
       // Click the rerun task button
-      await tester.tap(find.byType(ProgressButton));
+      await tester.tap(find.text('Rerun task'));
       await tester.pump();
       await tester
           .pump(const Duration(milliseconds: 750)); // 750ms open animation
@@ -255,6 +257,99 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1500)); // close animation
 
       expect(find.text(TaskOverlayContents.rerunErrorMessage), findsNothing);
+    });
+
+    testWidgets('view log button opens log url for public log',
+        (WidgetTester tester) async {
+      const MethodChannel channel =
+          MethodChannel('plugins.flutter.io/url_launcher');
+      final List<MethodCall> log = <MethodCall>[];
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+      });
+      final Task publicTask = Task()..stageName = 'cirrus';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: publicTask,
+            ),
+          ),
+        ),
+      );
+
+      // Open the overlay
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      // View log
+      await tester.tap(find.text('View log'));
+      await tester.pump();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('launch', arguments: <String, Object>{
+            'url': logUrl(publicTask),
+            'useSafariVC': true,
+            'useWebView': false,
+            'enableJavaScript': false,
+            'enableDomStorage': false,
+            'universalLinksOnly': false,
+            'headers': <String, String>{}
+          })
+        ],
+      );
+    });
+
+    testWidgets('view log button opens log url for devicelab log',
+        (WidgetTester tester) async {
+      const MethodChannel channel =
+          MethodChannel('plugins.flutter.io/url_launcher');
+      final List<MethodCall> log = <MethodCall>[];
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+      });
+
+      final GoogleSignInService mockAuth = MockGoogleSignInService();
+      when(mockAuth.accessToken).thenReturn('abc123');
+      when(buildState.authService).thenReturn(mockAuth);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: expectedTask,
+            ),
+          ),
+        ),
+      );
+
+      // Open the overlay
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      // View log
+      await tester.tap(find.text('View log'));
+      await tester.pump();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('launch', arguments: <String, Object>{
+            'url': logUrl(expectedTask),
+            'useSafariVC': true,
+            'useWebView': false,
+            'enableJavaScript': false,
+            'enableDomStorage': false,
+            'universalLinksOnly': false,
+            'headers': <String, String>{
+              'X-Flutter-AccessToken': 'abc123',
+            }
+          })
+        ],
+      );
     });
   });
 }
@@ -277,3 +372,5 @@ Future<void> expectTaskBoxColorWithMessage(
 }
 
 class MockFlutterBuildState extends Mock implements FlutterBuildState {}
+
+class MockGoogleSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -10,6 +10,28 @@ import 'package:app_flutter/task_helper.dart';
 
 void main() {
   group('TaskHelper', () {
+    test('log url for external tasks redirects to source configuration', () {
+      final Task luciTask = Task()
+        ..stageName = 'chromebot'
+        ..name = 'mac_bot';
+
+      expect(logUrl(luciTask),
+          'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
+      final Task cirrusTask = Task()..stageName = 'cirrus';
+
+      expect(logUrl(cirrusTask),
+          'https://cirrus-ci.com/github/flutter/flutter/master');
+    });
+
+    test('log url for devicelab tasks redirects to cocoon backend', () {
+      final Task devicelabTask = Task()
+        ..stageName = 'devicelab'
+        ..name = 'test';
+
+      expect(logUrl(devicelabTask),
+          'https://flutter-dashboard.appspot.com/api/get-log?ownerKey=${devicelabTask.key}');
+    });
+
     test('source configuration for devicelab', () {
       final Task devicelabTask = Task()
         ..stageName = 'devicelab'


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/43106

Ports the logic from the Angular Dart Build Dashboard for viewing logs.

## Preview
![view_log](https://user-images.githubusercontent.com/2148558/68159019-c36b0180-ff05-11e9-9d22-51c870354692.png)
