### PR TITLE
[DO NOT SUBMIT] StatusGrid benchmarking experiments

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -18,6 +18,8 @@ class BuildDashboardPage extends StatefulWidget {
 class _BuildDashboardPageState extends State<BuildDashboardPage> {
   final FlutterBuildState buildState = FlutterBuildState();
 
+  String gridImplementation = 'GridView.builder';
+
   @override
   void initState() {
     super.initState();
@@ -42,7 +44,17 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 ///
 /// The tree's current build status is reflected in the color of [AppBar].
 /// The results from tasks run on individual commits is shown in [StatusGrid].
-class BuildDashboard extends StatelessWidget {
+class BuildDashboard extends StatefulWidget {
+  const BuildDashboard({Key key, this.gridImplementation = 'GridView.builder'})
+      : super(key: key);
+
+  final String gridImplementation;
+
+  @override
+  _BuildDashboardState createState() => _BuildDashboardState();
+}
+
+class _BuildDashboardState extends State<BuildDashboard> {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -54,12 +66,27 @@ class BuildDashboard extends StatelessWidget {
               ? theme.primaryColor
               : theme.errorColor,
           actions: <Widget>[
+            DropdownButton<String>(
+              value: widget.gridImplementation,
+              onChanged: (String newValue) {
+                setState(() {
+                  widget.gridImplementation = newValue;
+                });
+              },
+              items: <String>['GridView.builder', 'ListView<ListView>']
+                  .map<DropdownMenuItem<String>>((String value) =>
+                      DropdownMenuItem<String>(
+                          value: value, child: Text(value)))
+                  .toList(),
+            ),
             UserAvatar(buildState: buildState),
           ],
         ),
         body: Column(
           children: const <Widget>[
-            StatusGridContainer(),
+            StatusGridContainer(
+              gridImplementation: widget.gridImplementation,
+            ),
           ],
         ),
       ),

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -72,7 +72,12 @@ class _BuildDashboardState extends State<BuildDashboard> {
                   _gridImplementation = newValue;
                 });
               },
-              items: <String>['GridView.builder', 'ListView<ListView>']
+              items: <String>[
+                'GridView.builder',
+                'GridView.builder addRepaintBoundaries',
+                'ListView<ListView>',
+                'ListView<ListView> addRepaintBoundaries'
+              ]
                   .map<DropdownMenuItem<String>>((String value) =>
                       DropdownMenuItem<String>(
                           value: value, child: Text(value)))

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -76,7 +76,9 @@ class _BuildDashboardState extends State<BuildDashboard> {
                 'GridView.builder',
                 'GridView.builder addRepaintBoundaries',
                 'ListView<ListView>',
-                'ListView<ListView> addRepaintBoundaries'
+                'ListView<ListView> addRepaintBoundaries',
+                'ListView<ListView> sync scroller',
+                'ListView<ListView> sync scroller addRepaintBoundaries'
               ]
                   .map<DropdownMenuItem<String>>((String value) =>
                       DropdownMenuItem<String>(

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -30,7 +30,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<FlutterBuildState>(
-        builder: (_) => buildState, child: BuildDashboard());
+        builder: (_) => buildState, child: const BuildDashboard());
   }
 
   @override
@@ -45,16 +45,15 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 /// The tree's current build status is reflected in the color of [AppBar].
 /// The results from tasks run on individual commits is shown in [StatusGrid].
 class BuildDashboard extends StatefulWidget {
-  const BuildDashboard({Key key, this.gridImplementation = 'GridView.builder'})
-      : super(key: key);
-
-  final String gridImplementation;
+  const BuildDashboard({Key key}) : super(key: key);
 
   @override
   _BuildDashboardState createState() => _BuildDashboardState();
 }
 
 class _BuildDashboardState extends State<BuildDashboard> {
+  String _gridImplementation = 'GridView.builder';
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -67,10 +66,10 @@ class _BuildDashboardState extends State<BuildDashboard> {
               : theme.errorColor,
           actions: <Widget>[
             DropdownButton<String>(
-              value: widget.gridImplementation,
+              value: _gridImplementation,
               onChanged: (String newValue) {
                 setState(() {
-                  widget.gridImplementation = newValue;
+                  _gridImplementation = newValue;
                 });
               },
               items: <String>['GridView.builder', 'ListView<ListView>']
@@ -83,9 +82,9 @@ class _BuildDashboardState extends State<BuildDashboard> {
           ],
         ),
         body: Column(
-          children: const <Widget>[
+          children: <Widget>[
             StatusGridContainer(
-              gridImplementation: widget.gridImplementation,
+              gridImplementation: _gridImplementation,
             ),
           ],
         ),

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -18,9 +18,9 @@ abstract class CocoonService {
   /// Production uses the Cocoon backend running on AppEngine.
   /// Otherwise, it uses fake data populated from a fake service.
   factory CocoonService() {
-    // if (kReleaseMode) {
-    //   return AppEngineCocoonService();
-    // }
+    if (kReleaseMode) {
+      return AppEngineCocoonService();
+    }
 
     // TODO(chillers): LocalCocoonService. https://github.com/flutter/cocoon/issues/442
 

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -18,9 +18,9 @@ abstract class CocoonService {
   /// Production uses the Cocoon backend running on AppEngine.
   /// Otherwise, it uses fake data populated from a fake service.
   factory CocoonService() {
-    if (kReleaseMode) {
-      return AppEngineCocoonService();
-    }
+    // if (kReleaseMode) {
+    //   return AppEngineCocoonService();
+    // }
 
     // TODO(chillers): LocalCocoonService. https://github.com/flutter/cocoon/issues/442
 

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -64,7 +64,7 @@ class FakeCocoonService implements CocoonService {
       ..commit = commit
       ..name = 'devicelab'
       ..tasks.addAll(
-          List<Task>.generate(15, (int i) => _createFakeTask(i, 'devicelab'))));
+          List<Task>.generate(80, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -63,8 +63,8 @@ class FakeCocoonService implements CocoonService {
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(
-          List<Task>.generate(200, (int i) => _createFakeTask(i, 'devicelab'))));
+      ..tasks.addAll(List<Task>.generate(
+          200, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -63,8 +63,8 @@ class FakeCocoonService implements CocoonService {
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab'
-      ..tasks.addAll(List<Task>.generate(
-          200, (int i) => _createFakeTask(i, 'devicelab'))));
+      ..tasks.addAll(
+          List<Task>.generate(80, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -64,7 +64,7 @@ class FakeCocoonService implements CocoonService {
       ..commit = commit
       ..name = 'devicelab'
       ..tasks.addAll(
-          List<Task>.generate(80, (int i) => _createFakeTask(i, 'devicelab'))));
+          List<Task>.generate(200, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -17,7 +17,8 @@ import 'task_matrix.dart' as task_matrix;
 ///
 /// If there's no data for [StatusGrid], it shows [CircularProgressIndicator].
 class StatusGridContainer extends StatelessWidget {
-  const StatusGridContainer({Key key, @required this.gridImplementation}) : super(key: key);
+  const StatusGridContainer({Key key, @required this.gridImplementation})
+      : super(key: key);
 
   final String gridImplementation;
 
@@ -51,10 +52,12 @@ class StatusGridContainer extends StatelessWidget {
             task_matrix.TaskMatrix(statuses: statuses);
         matrix.sort(compareRecentlyFailed);
 
-        // return Experiment(
-        //   statuses: statuses,
-        //   taskMatrix: matrix,
-        // );
+        if (gridImplementation == 'ListView<ListView>') {
+          return Experiment(
+            statuses: statuses,
+            taskMatrix: matrix,
+          );
+        }
 
         return StatusGrid(
           statuses: statuses,

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -17,7 +17,9 @@ import 'task_matrix.dart' as task_matrix;
 ///
 /// If there's no data for [StatusGrid], it shows [CircularProgressIndicator].
 class StatusGridContainer extends StatelessWidget {
-  const StatusGridContainer({Key key}) : super(key: key);
+  const StatusGridContainer({Key key, @required this.gridImplementation}) : super(key: key);
+
+  final String gridImplementation;
 
   @visibleForTesting
   static const String errorCocoonBackend = 'Cocoon Backend is having issues';
@@ -49,15 +51,15 @@ class StatusGridContainer extends StatelessWidget {
             task_matrix.TaskMatrix(statuses: statuses);
         matrix.sort(compareRecentlyFailed);
 
-        return Experiment(
-          statuses: statuses,
-          taskMatrix: matrix,
-        );
-
-        // return StatusGrid(
+        // return Experiment(
         //   statuses: statuses,
         //   taskMatrix: matrix,
         // );
+
+        return StatusGrid(
+          statuses: statuses,
+          taskMatrix: matrix,
+        );
       },
     );
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -59,7 +59,7 @@ class StatusGridContainer extends StatelessWidget {
           return StatusGridListViewListView(
             statuses: statuses,
             taskMatrix: matrix,
-            addRepaintBoundaries: addRepaintBoundaries,
+            addRepaintBoundariesValue: addRepaintBoundaries,
           );
         }
 
@@ -172,12 +172,12 @@ class StatusGrid extends StatelessWidget {
 }
 
 /// StatusGrid built using a ListView<ListView> approach.
-class StatusGridListViewListView extends StatefulWidget {
+class StatusGridListViewListView extends StatelessWidget {
   const StatusGridListViewListView({
     Key key,
     @required this.statuses,
     @required this.taskMatrix,
-    this.addRepaintBoundaries = false,
+    this.addRepaintBoundariesValue = false,
   }) : super(key: key);
 
   /// The build status data to display in the grid.
@@ -188,24 +188,16 @@ class StatusGridListViewListView extends StatefulWidget {
 
   /// It is more efficient to not add repaint boundaries since the grid cells
   /// are very simple to draw.
-  final bool addRepaintBoundaries;
-
-  @override
-  _StatusGridListViewListViewState createState() =>
-      _StatusGridListViewListViewState();
-}
-
-class _StatusGridListViewListViewState
-    extends State<StatusGridListViewListView> {
+  final bool addRepaintBoundariesValue;
   @override
   Widget build(BuildContext context) {
     final List<Widget> rows = <Widget>[];
 
-    for (int rowIndex = 0; rowIndex < widget.taskMatrix.rows; rowIndex++) {
+    for (int rowIndex = 0; rowIndex < taskMatrix.rows; rowIndex++) {
       final List<TaskBox> tasks = <TaskBox>[];
-      for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++) {
+      for (int colIndex = 0; colIndex < taskMatrix.columns; colIndex++) {
         tasks.add(TaskBox(
-          task: widget.taskMatrix.task(rowIndex, colIndex),
+          task: taskMatrix.task(rowIndex, colIndex),
         ));
       }
 
@@ -218,12 +210,12 @@ class _StatusGridListViewListViewState
               return Container(
                 width: 50,
                 child: TaskBox(
-                  task: widget.taskMatrix.task(rowIndex, colIndex),
+                  task: taskMatrix.task(rowIndex, colIndex),
                 ),
               );
             },
             shrinkWrap: false,
-            addRepaintBoundaries: widget.addRepaintBoundaries,
+            addRepaintBoundaries: addRepaintBoundariesValue,
           ),
         ),
       );
@@ -233,7 +225,7 @@ class _StatusGridListViewListViewState
       child: ListView(
         children: rows,
         shrinkWrap: false,
-        addRepaintBoundaries: widget.addRepaintBoundaries,
+        addRepaintBoundaries: addRepaintBoundariesValue,
       ),
     );
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -49,10 +49,15 @@ class StatusGridContainer extends StatelessWidget {
             task_matrix.TaskMatrix(statuses: statuses);
         matrix.sort(compareRecentlyFailed);
 
-        return StatusGrid(
+        return Experiment(
           statuses: statuses,
           taskMatrix: matrix,
         );
+
+        // return StatusGrid(
+        //   statuses: statuses,
+        //   taskMatrix: matrix,
+        // );
       },
     );
   }
@@ -149,6 +154,59 @@ class StatusGrid extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Display results from flutter/flutter repository's continuous integration.
+///
+/// Results are displayed in a matrix format. Rows are commits and columns
+/// are the results from tasks.
+class Experiment extends StatelessWidget {
+  const Experiment({
+    Key key,
+    @required this.statuses,
+    @required this.taskMatrix,
+  }) : super(key: key);
+
+  /// The build status data to display in the grid.
+  final List<CommitStatus> statuses;
+
+  /// Computed matrix of [Task] to make it easy to retrieve and sort tasks.
+  final task_matrix.TaskMatrix taskMatrix;
+
+  @override
+  Widget build(BuildContext context) {
+    /// The grid needs to know its dimensions. Column is based off how many tasks are
+    /// in a row (+ 1 to account for [CommitBox]).
+    final int columnCount = taskMatrix.columns + 1;
+
+    final List<Widget> rows = <Widget>[];
+    final ScrollController horizontalController = ScrollController();
+
+    for (int rowIndex = 0; rowIndex < taskMatrix.rows; rowIndex++) {
+      final List<TaskBox> tasks = <TaskBox>[];
+      for (int colIndex = 0; colIndex < taskMatrix.columns; colIndex++) {
+        tasks.add(TaskBox(
+          task: taskMatrix.task(rowIndex, colIndex),
+        ));
+      }
+
+      rows.add(
+        Container(
+          height: 50,
+          child: ListView(
+            scrollDirection: Axis.horizontal,
+            controller: horizontalController,
+            children: tasks,
+            addRepaintBoundaries: false,
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: rows,
     );
   }
 }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -163,7 +163,7 @@ class StatusGrid extends StatelessWidget {
 /// Results are displayed in a matrix format. Rows are commits and columns
 /// are the results from tasks.
 class Experiment extends StatelessWidget {
-  const Experiment({
+  Experiment({
     Key key,
     @required this.statuses,
     @required this.taskMatrix,
@@ -175,14 +175,11 @@ class Experiment extends StatelessWidget {
   /// Computed matrix of [Task] to make it easy to retrieve and sort tasks.
   final task_matrix.TaskMatrix taskMatrix;
 
+  static final ScrollController _horizontalController = ScrollController();
+
   @override
   Widget build(BuildContext context) {
-    /// The grid needs to know its dimensions. Column is based off how many tasks are
-    /// in a row (+ 1 to account for [CommitBox]).
-    final int columnCount = taskMatrix.columns + 1;
-
     final List<Widget> rows = <Widget>[];
-    final ScrollController horizontalController = ScrollController();
 
     for (int rowIndex = 0; rowIndex < taskMatrix.rows; rowIndex++) {
       final List<TaskBox> tasks = <TaskBox>[];
@@ -194,19 +191,29 @@ class Experiment extends StatelessWidget {
 
       rows.add(
         Container(
-          height: 50,
-          child: ListView(
+          height: 60,
+          child: ListView.builder(
             scrollDirection: Axis.horizontal,
-            controller: horizontalController,
-            children: tasks,
+            controller: _horizontalController,
+            itemBuilder: (BuildContext context, int colIndex) {
+              return TaskBox(task: taskMatrix.task(rowIndex, colIndex));
+            },
+            shrinkWrap: false,
             addRepaintBoundaries: false,
           ),
         ),
       );
     }
 
-    return Column(
-      children: rows,
+    return Expanded(
+      child: ListView.builder(
+        itemBuilder: (BuildContext context, int row) {
+          return rows[row];
+        },
+        itemCount: taskMatrix.rows,
+        shrinkWrap: false,
+        addRepaintBoundaries: false,
+      ),
     );
   }
 }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -193,6 +193,17 @@ class StatusGridListViewListView extends StatelessWidget {
   Widget build(BuildContext context) {
     final List<Widget> rows = <Widget>[];
 
+    final List<Widget> taskIcons = <Widget>[];
+    taskIcons.add(Container());
+    for (int colIndex = 0; colIndex < taskMatrix.columns; colIndex++) {
+      taskIcons.add(
+        TaskIcon(
+          task: taskMatrix.sampleTask(colIndex),
+        ),
+      );
+    }
+    // rows.add(ListView(children: taskIcons, scrollDirection: Axis.horizontal,));
+
     for (int rowIndex = 0; rowIndex < taskMatrix.rows; rowIndex++) {
       final List<TaskBox> tasks = <TaskBox>[];
       for (int colIndex = 0; colIndex < taskMatrix.columns; colIndex++) {
@@ -207,10 +218,15 @@ class StatusGridListViewListView extends StatelessWidget {
           child: ListView.builder(
             scrollDirection: Axis.horizontal,
             itemBuilder: (BuildContext context, int colIndex) {
+              if (colIndex == 0) {
+                return CommitBox(
+                  commit: statuses[rowIndex].commit,
+                );
+              }
               return Container(
                 width: 50,
                 child: TaskBox(
-                  task: taskMatrix.task(rowIndex, colIndex),
+                  task: taskMatrix.task(rowIndex, colIndex - 1),
                 ),
               );
             },

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -82,8 +82,8 @@ class _TaskBoxState extends State<TaskBox> {
             ? TaskBox.statusColor[status]
             : Colors.black,
         child: taskIndicators(widget.task, status),
-        width: 20,
-        height: 20,
+        width: 30,
+        height: 40,
       ),
     );
   }

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -38,7 +38,9 @@ void main() {
             children: <Widget>[
               ChangeNotifierProvider<FlutterBuildState>(
                 builder: (_) => FlutterBuildState(),
-                child: const StatusGridContainer(),
+                child: const StatusGridContainer(
+                  gridImplementation: 'GridView.builder',
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
This adds a way to configure the underlying widget tree of the StatusGrid. The current implementations are GridView.builder and a ListView of ListViews. Includes whether to add repaint boundaries to these widgets.

Feel free to give feedback on other implementations to try, or different approaches that may be more efficient.

This is not intended for production use of the build dashboard, but a way to use the build dashboard in benchmarking Flutter for web.

## Preview

No visible changes to the StatusGrid. Only a dropdown in the AppBar for configuring what method to use.

![statusgrid_experiment_dropdown](https://user-images.githubusercontent.com/2148558/68243813-32109380-ffc8-11e9-8de3-e1b3dcb3acd7.png)

Flutter for Web build: http://webtest.flutter-dashboard.appspot.com/v2/

Flutter for Web build using Skia: http://webtestskia.flutter-dashboard.appspot.com/v2/
  - Manually deployed using my flutter fork that allows for building web to use skia

