### PR TITLE
Fix negative colored Google avatars

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -81,7 +81,8 @@ class UserAvatar extends StatelessWidget {
     final GoogleSignInService authService = buildState.authService;
 
     if (authService.isAuthenticated) {
-      return Image.network(authService.avatarUrl);
+      /// Size needs to be specified
+      return Image.network(authService.avatarUrl + '=s100');
     }
 
     return FlatButton(


### PR DESCRIPTION
Size needs to be specified, so for now defaulting to 100px.

Before:
<img width="81" alt="Screen Shot 2019-11-06 at 3 20 32 PM" src="https://user-images.githubusercontent.com/2148558/68346491-18934880-00a9-11ea-8b60-5d6f6a9f8024.png">

After:
<img width="108" alt="Screen Shot 2019-11-06 at 3 19 53 PM" src="https://user-images.githubusercontent.com/2148558/68346501-1fba5680-00a9-11ea-8a97-faa6ced9764b.png">
