### PR TITLE
Set url launcher to version working on web

### DIFF
--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   flutter_progress_button: ^1.0.0
   google_sign_in_all: ^0.0.3
   provider: ^3.0.0
-  url_launcher: ^5.1.0
+  url_launcher: 5.2.4
   url_launcher_web:
     git:
       url: git://github.com/flutter/plugins.git


### PR DESCRIPTION
`url_launcher` will resolve to a version that does not work on web. This is a temporary fix as I presume this is just from the work being done for federated plugins.

See https://github.com/flutter/flutter/issues/44012#issuecomment-549611173 for more information.