### PR TITLE
Implement StatusGrid performance improvements

### DIFF
--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -30,13 +30,16 @@ class _CommitBoxState extends State<CommitBox> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: _handleTap,
-      child: Container(
-        margin: const EdgeInsets.all(1.0),
-        child: Image.network(
-          widget.commit.authorAvatarUrl,
-          height: 40,
+    return SizedBox(
+      width: 50,
+      height: 50,
+      child: GestureDetector(
+        onTap: _handleTap,
+        child: Container(
+          margin: const EdgeInsets.all(1.0),
+          child: Image.network(
+            widget.commit.authorAvatarUrl,
+          ),
         ),
       ),
     );

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -7,6 +7,8 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit;
 
+import 'status_grid.dart';
+
 /// Displays Git commit information.
 ///
 /// On click, it will open an [OverlayEntry] with [CommitOverlayContents]
@@ -31,8 +33,8 @@ class _CommitBoxState extends State<CommitBox> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 50,
-      height: 50,
+      width: StatusGrid.cellSize,
+      height: StatusGrid.cellSize,
       child: GestureDetector(
         onTap: _handleTap,
         child: Container(

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -69,13 +69,13 @@ class FakeCocoonService implements CocoonService {
       ..commit = commit
       ..name = 'devicelab'
       ..tasks.addAll(
-          List<Task>.generate(15, (int i) => _createFakeTask(i, 'devicelab'))));
+          List<Task>.generate(40, (int i) => _createFakeTask(i, 'devicelab'))));
 
     stages.add(Stage()
       ..commit = commit
       ..name = 'devicelab_win'
       ..tasks.addAll(List<Task>.generate(
-          3, (int i) => _createFakeTask(i, 'devicelab_win'))));
+          30, (int i) => _createFakeTask(i, 'devicelab_win'))));
 
     return stages;
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -99,6 +99,8 @@ class StatusGrid extends StatefulWidget {
   /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
   final FlutterBuildState buildState;
 
+  static const double cellSize = 50;
+
   @override
   _StatusGridState createState() => _StatusGridState();
 }
@@ -130,7 +132,7 @@ class _StatusGridState extends State<StatusGrid> {
 
     rows.add(
       Container(
-        height: 50,
+        height: StatusGrid.cellSize,
         child: NotificationListener<ScrollNotification>(
           child: ListView(
             controller: controllers[0],
@@ -157,7 +159,7 @@ class _StatusGridState extends State<StatusGrid> {
 
       rows.add(
         Container(
-          height: 50,
+          height: StatusGrid.cellSize,
           child: NotificationListener<ScrollNotification>(
             child: ListView(
               controller: controllers[rowIndex + 1],
@@ -180,10 +182,10 @@ class _StatusGridState extends State<StatusGrid> {
   List<Widget> _buildTaskIcons() {
     return <Widget>[
       /// The top left corner of the grid has nothing.
-      Container(width: 50),
+      Container(width: StatusGrid.cellSize),
       for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
         Container(
-          width: 50,
+          width: StatusGrid.cellSize,
           child: TaskIcon(
             task: widget.taskMatrix.sampleTask(colIndex),
           ),

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -132,10 +132,9 @@ class _StatusGridState extends State<StatusGrid> {
       Container(
         height: 50,
         child: NotificationListener<ScrollNotification>(
-          child: ListView(
+          child: SingleChildScrollView(
             controller: controllers[0],
-            itemExtent: 50,
-            children: _buildTaskIconRow(),
+            child: _buildTaskIconRow(),
             scrollDirection: Axis.horizontal,
           ),
           onNotification: (ScrollNotification scrollInfo) {
@@ -178,17 +177,20 @@ class _StatusGridState extends State<StatusGrid> {
     return rows;
   }
 
-  List<Widget> _buildTaskIconRow() {
-    return <Widget>[
-      Container(width: 50),
-      for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
-        Container(
-          width: 50,
-          child: TaskIcon(
-            task: widget.taskMatrix.sampleTask(colIndex),
+  Row _buildTaskIconRow() {
+    return Row(
+      children: <Widget>[
+        /// The top left corner of the grid has nothing.
+        Container(width: 50),
+        for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
+          Container(
+            width: 50,
+            child: TaskIcon(
+              task: widget.taskMatrix.sampleTask(colIndex),
+            ),
           ),
-        ),
-    ];
+      ],
+    );
   }
 }
 
@@ -225,7 +227,8 @@ class SyncScrollController {
         _scrollingActive = false;
       } else if (notification is ScrollUpdateNotification) {
         for (ScrollController controller in _registeredScrollControllers) {
-          if (!identical(_scrollingController, controller)) {
+          if (!identical(_scrollingController, controller) &&
+              controller.hasClients) {
             controller.jumpTo(_scrollingController.offset);
           }
         }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -136,6 +136,7 @@ class _StatusGridState extends State<StatusGrid> {
         child: NotificationListener<ScrollNotification>(
           child: ListView(
             controller: controllers[0],
+            itemExtent: 50,
             children: _buildTaskIconRow(),
             scrollDirection: Axis.horizontal,
           ),
@@ -164,6 +165,7 @@ class _StatusGridState extends State<StatusGrid> {
               controller: controllers[rowIndex + 1],
               scrollDirection: Axis.horizontal,
               itemCount: widget.taskMatrix.columns + 1,
+              itemExtent: 50,
               itemBuilder: (BuildContext context, int colIndex) {
                 if (colIndex == 0) {
                   return CommitBox(

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -132,9 +132,9 @@ class _StatusGridState extends State<StatusGrid> {
       Container(
         height: 50,
         child: NotificationListener<ScrollNotification>(
-          child: SingleChildScrollView(
+          child: ListView(
             controller: controllers[0],
-            child: _buildTaskIconRow(),
+            children: _buildTaskIcons(),
             scrollDirection: Axis.horizontal,
           ),
           onNotification: (ScrollNotification scrollInfo) {
@@ -159,10 +159,10 @@ class _StatusGridState extends State<StatusGrid> {
         Container(
           height: 50,
           child: NotificationListener<ScrollNotification>(
-            child: SingleChildScrollView(
+            child: ListView(
               controller: controllers[rowIndex + 1],
               scrollDirection: Axis.horizontal,
-              child: Row(children: tasks),
+              children: tasks,
             ),
             onNotification: (ScrollNotification scrollInfo) {
               _syncScroller.processNotification(
@@ -177,20 +177,18 @@ class _StatusGridState extends State<StatusGrid> {
     return rows;
   }
 
-  Row _buildTaskIconRow() {
-    return Row(
-      children: <Widget>[
-        /// The top left corner of the grid has nothing.
-        Container(width: 50),
-        for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
-          Container(
-            width: 50,
-            child: TaskIcon(
-              task: widget.taskMatrix.sampleTask(colIndex),
-            ),
+  List<Widget> _buildTaskIcons() {
+    return <Widget>[
+      /// The top left corner of the grid has nothing.
+      Container(width: 50),
+      for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
+        Container(
+          width: 50,
+          child: TaskIcon(
+            task: widget.taskMatrix.sampleTask(colIndex),
           ),
-      ],
-    );
+        ),
+    ];
   }
 }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -117,11 +117,9 @@ class _StatusGridState extends State<StatusGrid> {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> rows = _buildRows();
-
     return Expanded(
       child: ListView(
-        children: rows,
+        children: _buildRows(),
         shrinkWrap: false,
       ),
     );

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -191,20 +191,16 @@ class _StatusGridState extends State<StatusGrid> {
   }
 
   List<Widget> _buildTaskIconRow() {
-    final List<Widget> taskIcons = <Widget>[];
-    taskIcons.add(Container(width: 50));
-    for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++) {
-      taskIcons.add(
+    return <Widget>[
+      Container(width: 50),
+      for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
         Container(
           width: 50,
           child: TaskIcon(
             task: widget.taskMatrix.sampleTask(colIndex),
           ),
         ),
-      );
-    }
-
-    return taskIcons;
+    ];
   }
 }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -90,6 +90,7 @@ class StatusGrid extends StatefulWidget {
     @required this.taskMatrix,
   }) : super(key: key);
 
+  /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
   final FlutterBuildState buildState;
 
   /// The build status data to display in the grid.
@@ -112,27 +113,26 @@ class _StatusGridState extends State<StatusGrid> {
         widget.taskMatrix.rows + 1, (_) => ScrollController());
     _syncScroller = SyncScrollController(controllers);
 
+    final List<ListView> rows = _buildRows();
+
+    return Expanded(
+      child: ListView(
+        children: rows,
+        shrinkWrap: false,
+      ),
+    );
+  }
+
+  List<ListView> _buildRows() {
     final List<Widget> rows = <Widget>[];
 
-    final List<Widget> taskIcons = <Widget>[];
-    taskIcons.add(Container(width: 50));
-    for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++) {
-      taskIcons.add(
-        Container(
-          width: 50,
-          child: TaskIcon(
-            task: widget.taskMatrix.sampleTask(colIndex),
-          ),
-        ),
-      );
-    }
     rows.add(
       Container(
         height: 50,
         child: NotificationListener<ScrollNotification>(
           child: ListView(
             controller: controllers[0],
-            children: taskIcons,
+            children: _buildTaskIconRow(),
             scrollDirection: Axis.horizontal,
           ),
           onNotification: (ScrollNotification scrollInfo) {
@@ -186,12 +186,24 @@ class _StatusGridState extends State<StatusGrid> {
       );
     }
 
-    return Expanded(
-      child: ListView(
-        children: rows,
-        shrinkWrap: false,
-      ),
-    );
+    return rows;
+  }
+
+  List<Widget> _buildTaskIconRow() {
+    final List<Widget> taskIcons = <Widget>[];
+    taskIcons.add(Container(width: 50));
+    for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++) {
+      taskIcons.add(
+        Container(
+          width: 50,
+          child: TaskIcon(
+            task: widget.taskMatrix.sampleTask(colIndex),
+          ),
+        ),
+      );
+    }
+
+    return taskIcons;
   }
 }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -113,7 +113,7 @@ class _StatusGridState extends State<StatusGrid> {
         widget.taskMatrix.rows + 1, (_) => ScrollController());
     _syncScroller = SyncScrollController(controllers);
 
-    final List<ListView> rows = _buildRows();
+    final List<Widget> rows = _buildRows();
 
     return Expanded(
       child: ListView(
@@ -123,7 +123,7 @@ class _StatusGridState extends State<StatusGrid> {
     );
   }
 
-  List<ListView> _buildRows() {
+  List<Widget> _buildRows() {
     final List<Widget> rows = <Widget>[];
 
     rows.add(
@@ -210,7 +210,7 @@ class _StatusGridState extends State<StatusGrid> {
 // https://stackoverflow.com/questions/54859779/scroll-multiple-scrollable-widgets-in-sync
 class SyncScrollController {
   SyncScrollController(List<ScrollController> controllers) {
-    controllers.forEach((controller) => registerScrollController(controller));
+    controllers.forEach(registerScrollController);
   }
 
   final List<ScrollController> _registeredScrollControllers =
@@ -239,11 +239,11 @@ class SyncScrollController {
       }
 
       if (notification is ScrollUpdateNotification) {
-        _registeredScrollControllers.forEach((controller) => {
-              if (!identical(_scrollingController, controller))
-                controller..jumpTo(_scrollingController.offset)
-            });
-        return;
+        for (ScrollController controller in _registeredScrollControllers) {
+          if (!identical(_scrollingController, controller)) {
+            controller..jumpTo(_scrollingController.offset);
+          }
+        }
       }
     }
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -151,10 +151,13 @@ class _StatusGridState extends State<StatusGrid> {
       final List<Widget> tasks = <Widget>[
         CommitBox(commit: widget.statuses[rowIndex].commit),
         for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
-          TaskBox(
-            buildState: widget.buildState,
-            task: widget.taskMatrix.task(rowIndex, colIndex),
-          )
+          if (widget.taskMatrix.task(rowIndex, colIndex) != null)
+            TaskBox(
+              buildState: widget.buildState,
+              task: widget.taskMatrix.task(rowIndex, colIndex),
+            )
+          else
+            const SizedBox()
       ];
 
       rows.add(

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -170,12 +170,9 @@ class _StatusGridState extends State<StatusGrid> {
                     commit: widget.statuses[rowIndex].commit,
                   );
                 }
-                return Container(
-                  width: 50,
-                  child: TaskBox(
-                    buildState: widget.buildState,
-                    task: widget.taskMatrix.task(rowIndex, colIndex - 1),
-                  ),
+                return TaskBox(
+                  buildState: widget.buildState,
+                  task: widget.taskMatrix.task(rowIndex, colIndex - 1),
                 );
               },
               shrinkWrap: false,
@@ -238,17 +235,11 @@ class SyncScrollController {
     if (notification is ScrollStartNotification && !_scrollingActive) {
       _scrollingController = sender;
       _scrollingActive = true;
-      return;
-    }
-
-    if (identical(sender, _scrollingController) && _scrollingActive) {
+    } else if (identical(sender, _scrollingController) && _scrollingActive) {
       if (notification is ScrollEndNotification) {
         _scrollingController = null;
         _scrollingActive = false;
-        return;
-      }
-
-      if (notification is ScrollUpdateNotification) {
+      } else if (notification is ScrollUpdateNotification) {
         for (ScrollController controller in _registeredScrollControllers) {
           if (!identical(_scrollingController, controller)) {
             controller..jumpTo(_scrollingController.offset);

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -90,14 +90,14 @@ class StatusGrid extends StatefulWidget {
     @required this.taskMatrix,
   }) : super(key: key);
 
-  /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
-  final FlutterBuildState buildState;
-
   /// The build status data to display in the grid.
   final List<CommitStatus> statuses;
 
   /// Computed matrix of [Task] to make it easy to retrieve and sort tasks.
   final task_matrix.TaskMatrix taskMatrix;
+
+  /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
+  final FlutterBuildState buildState;
 
   @override
   _StatusGridState createState() => _StatusGridState();

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -108,11 +108,15 @@ class _StatusGridState extends State<StatusGrid> {
   SyncScrollController _syncScroller;
 
   @override
-  Widget build(BuildContext context) {
+  void initState() {
     controllers = List<ScrollController>.generate(
         widget.taskMatrix.rows + 1, (_) => ScrollController());
     _syncScroller = SyncScrollController(controllers);
+    super.initState();
+  }
 
+  @override
+  Widget build(BuildContext context) {
     final List<Widget> rows = _buildRows();
 
     return Expanded(
@@ -207,7 +211,13 @@ class _StatusGridState extends State<StatusGrid> {
   }
 }
 
-// https://stackoverflow.com/questions/54859779/scroll-multiple-scrollable-widgets-in-sync
+/// A ScrollController that makes all ScrollControllers added to it have the same state.
+///
+/// A ListView of ListViews by default has ScrollControllers that are independent of each other.
+/// To get around this, this helper class makes all the independent ScrollControllers
+/// keep each other updated.
+///
+/// Source: https://stackoverflow.com/questions/54859779/scroll-multiple-scrollable-widgets-in-sync
 class SyncScrollController {
   SyncScrollController(List<ScrollController> controllers) {
     controllers.forEach(registerScrollController);

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -147,35 +147,23 @@ class _StatusGridState extends State<StatusGrid> {
     );
 
     for (int rowIndex = 0; rowIndex < widget.taskMatrix.rows; rowIndex++) {
-      final List<TaskBox> tasks = <TaskBox>[];
-      for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++) {
-        tasks.add(TaskBox(
-          buildState: widget.buildState,
-          task: widget.taskMatrix.task(rowIndex, colIndex),
-        ));
-      }
+      final List<Widget> tasks = <Widget>[
+        CommitBox(commit: widget.statuses[rowIndex].commit),
+        for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
+          TaskBox(
+            buildState: widget.buildState,
+            task: widget.taskMatrix.task(rowIndex, colIndex),
+          )
+      ];
 
       rows.add(
         Container(
           height: 50,
           child: NotificationListener<ScrollNotification>(
-            child: ListView.builder(
+            child: SingleChildScrollView(
               controller: controllers[rowIndex + 1],
               scrollDirection: Axis.horizontal,
-              itemCount: widget.taskMatrix.columns + 1,
-              itemExtent: 50,
-              itemBuilder: (BuildContext context, int colIndex) {
-                if (colIndex == 0) {
-                  return CommitBox(
-                    commit: widget.statuses[rowIndex].commit,
-                  );
-                }
-                return TaskBox(
-                  buildState: widget.buildState,
-                  task: widget.taskMatrix.task(rowIndex, colIndex - 1),
-                );
-              },
-              shrinkWrap: false,
+              child: Row(children: tasks),
             ),
             onNotification: (ScrollNotification scrollInfo) {
               _syncScroller.processNotification(
@@ -238,7 +226,7 @@ class SyncScrollController {
       } else if (notification is ScrollUpdateNotification) {
         for (ScrollController controller in _registeredScrollControllers) {
           if (!identical(_scrollingController, controller)) {
-            controller..jumpTo(_scrollingController.offset);
+            controller.jumpTo(_scrollingController.offset);
           }
         }
       }

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -106,19 +106,21 @@ class _TaskBoxState extends State<TaskBox> {
       children: <Widget>[
         if (task.isFlaky)
           const Padding(
-              padding: EdgeInsets.all(12.0),
-              child: Icon(
-                Icons.help,
-                color: Colors.white60,
-                size: 25,
-              )),
+            padding: EdgeInsets.all(12.0),
+            child: Icon(
+              Icons.help,
+              color: Colors.white60,
+              size: 25,
+            ),
+          ),
         if (status == TaskBox.statusInProgress ||
             status == TaskBox.statusUnderperformedInProgress)
           const Padding(
-            padding: EdgeInsets.all(15.0),
-            child: CircularProgressIndicator(
-              strokeWidth: 3.0,
-              backgroundColor: Colors.white70,
+            padding: EdgeInsets.all(12.0),
+            child: Icon(
+              Icons.timelapse,
+              color: Colors.white60,
+              size: 25,
             ),
           ),
       ],

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -9,6 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:cocoon_service/protos.dart' show Task;
 
 import 'state/flutter_build.dart';
+import 'status_grid.dart';
 import 'task_helper.dart';
 
 /// Displays information from a [Task].
@@ -84,8 +85,8 @@ class _TaskBoxState extends State<TaskBox> {
     }
 
     return SizedBox(
-      width: 50,
-      height: 50,
+      width: StatusGrid.cellSize,
+      height: StatusGrid.cellSize,
       child: GestureDetector(
         onTap: _handleTap,
         child: Container(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -83,16 +83,18 @@ class _TaskBoxState extends State<TaskBox> {
       }
     }
 
-    return GestureDetector(
-      onTap: _handleTap,
-      child: Container(
-        margin: const EdgeInsets.all(1.0),
-        color: TaskBox.statusColor.containsKey(status)
-            ? TaskBox.statusColor[status]
-            : Colors.black,
-        child: taskIndicators(widget.task, status),
-        width: 20,
-        height: 20,
+    return SizedBox(
+      width: 50,
+      height: 50,
+      child: GestureDetector(
+        onTap: _handleTap,
+        child: Container(
+          margin: const EdgeInsets.all(1.0),
+          color: TaskBox.statusColor.containsKey(status)
+              ? TaskBox.statusColor[status]
+              : Colors.black,
+          child: taskIndicators(widget.task, status),
+        ),
       ),
     );
   }

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -94,30 +94,5 @@ void main() {
       final TaskBox firstTask = find.byType(TaskBox).evaluate().first.widget;
       expect(firstTask.task, statuses[0].stages[0].tasks[0]);
     });
-
-    testWidgets('last task in grid is the last task given',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Column(
-            children: <Widget>[
-              StatusGrid(
-                buildState: FlutterBuildState(),
-                statuses: statuses,
-                taskMatrix: taskMatrix,
-              ),
-            ],
-          ),
-        ),
-      );
-
-      final TaskBox lastTaskWidget =
-          find.byType(TaskBox).evaluate().last.widget;
-
-      final Task lastTask =
-          taskMatrix.task(taskMatrix.rows - 1, taskMatrix.columns - 1);
-
-      expect(lastTaskWidget.task, lastTask);
-    });
   });
 }

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
-import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
+import 'package:cocoon_service/protos.dart' show CommitStatus;
 
 import 'package:app_flutter/service/cocoon.dart';
 import 'package:app_flutter/service/fake_cocoon.dart';

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -42,7 +42,7 @@ void main() {
               buildState: buildState,
               task: Task()..status = TaskBox.statusInProgress)));
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.timelapse), findsOneWidget);
     });
 
     testWidgets('show orange when New but already attempted',
@@ -74,7 +74,7 @@ void main() {
           find.byType(Container).evaluate().first.widget;
       final BoxDecoration decoration = taskBoxWidget.decoration;
       expect(decoration.color, Colors.orange);
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.timelapse), findsOneWidget);
     });
 
     testWidgets('shows question mark for task marked flaky',
@@ -99,7 +99,7 @@ void main() {
                 ..status = TaskBox.statusInProgress
                 ..isFlaky = true)));
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.timelapse), findsOneWidget);
       expect(find.byIcon(Icons.help), findsOneWidget);
     });
 


### PR DESCRIPTION
Follow up from the experimenting at https://github.com/flutter/cocoon/pull/511. Ideally, we want to use Skia, but the support is not there yet.

## Improvements
- Convert `StatusGrid` to be built with a `ListView` of `ListView`
- Convert Task in progress indicator to a static icon to reduce perceived jank
- Made fake data similar to production size

## Tested

Should be the same as the previous StatusGrid. Removed last task test because of weirdness with ListView ListView

Demo: https://testchillers-dot-flutter-dashboard.appspot.com/v2/#/