### PR TITLE
Revert "Dart project builds `app` project and serves it (#513)"

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -12,6 +12,10 @@ import 'package:neat_cache/neat_cache.dart';
 
 Future<void> main() async {
   await withAppEngineServices(() async {
+    /// The location for the Flutter application
+    // TODO(chillers): Remove this when deployed for production use. https://github.com/flutter/cocoon/issues/472
+    const String flutterBetaUrlPrefix = '/v2';
+
     final Config config = Config(dbService);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);
     final BuildBucketClient buildBucketClient = BuildBucketClient(
@@ -55,19 +59,42 @@ Future<void> main() async {
       '/api/public/get-status': CacheRequestHandler<Body>(
         cache: redisCache,
         config: config,
-        delegate: GetStatus(config),
+        delegate: GetStatus(config), 
       ),
       '/api/public/get-timeseries-history': GetTimeSeriesHistory(config),
     };
 
+    final ProxyRequestHandler legacyBackendProxyHandler = ProxyRequestHandler(
+      config: config,
+      scheme: await config.forwardScheme,
+      host: await config.forwardHost,
+      port: await config.forwardPort,
+    );
+
+    /// Check if the requested URI is for the Flutter Application
+    /// 
+    /// Currently the Flutter application will run at
+    /// https://flutter-dashboard.appspot.com/v2/
+    bool isRequestForFlutterApplicationBeta(HttpRequest request) {
+      return request.uri.path.startsWith(flutterBetaUrlPrefix);
+    }
+
     return await runAppEngine((HttpRequest request) async {
+      if (isRequestForFlutterApplicationBeta(request)) {
+        String filePath = request.uri.toFilePath();
+        // TODO(chillers): Remove this when deployed for production use. https://github.com/flutter/cocoon/issues/472
+        filePath = filePath.replaceFirst(flutterBetaUrlPrefix, '');
+        
+        await StaticFileHandler(filePath, config: config).service(request);
+
+        return;
+      }
+
       final RequestHandler<dynamic> handler = handlers[request.uri.path];
       if (handler != null) {
         await handler.service(request);
       } else {
-        final String filePath = request.uri.toFilePath();
-
-        await StaticFileHandler(filePath, config: config).service(request);
+        await legacyBackendProxyHandler.service(request);
       }
     }, onAcceptingConnections: (InternetAddress address, int port) {
       final String host = address.isLoopback ? 'localhost' : address.host;

--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:pedantic/pedantic.dart';
 
-const String angularDartProjectDirectory = '../app';
 const String flutterProjectDirectory = '../app_flutter';
 
 const String gcloudProjectIdFlag = 'project';
@@ -41,83 +40,34 @@ bool _getArgs(ArgParser argParser, List<String> arguments) {
   return true;
 }
 
-/// Build app Angular Dart project
-Future<bool> _buildAngularDartApp() async {
-  /// Clean up previous build files to ensure this codebase is deployed.
-  await Process.run(
-    'rm',
-    <String>['-rf', 'build/'],
-    workingDirectory: angularDartProjectDirectory,
-  );
-
-  final Process pubProcess = await Process.start('pub', <String>['get'],
-      workingDirectory: angularDartProjectDirectory);
-  await stdout.addStream(pubProcess.stdout);
-  if (await pubProcess.exitCode != 0) {
-    return false;
-  }
-
-  final Process buildProcess = await Process.start(
-    'pub',
-    <String>['run', 'build_runner', 'build', '--release', '--output', 'build'],
-    workingDirectory: angularDartProjectDirectory,
-  );
-  await stdout.addStream(buildProcess.stdout);
-
-  // The Angular Dart build dashboard page has been replaced with a Flutter
-  // version. There are some administrative features missing in the Flutter
-  // version so we still offer the old build dashboard.
-  await Process.run(
-      'mv', <String>['build/web/build.html', 'build/web/build-old.html'],
-      workingDirectory: angularDartProjectDirectory);
-
-  return await buildProcess.exitCode == 0;
-}
-
 /// Build app_flutter for web.
 Future<bool> _buildFlutterWebApp() async {
   /// Clean up previous build files to ensure this codebase is deployed.
-  await Process.run('rm', <String>['-rf', 'build/'],
-      workingDirectory: flutterProjectDirectory);
-
+  await Process.run('rm', <String>['-r', 'build/'], workingDirectory: flutterProjectDirectory);
+  
   final Process process = await Process.start(
       'flutter', <String>['build', 'web'],
       workingDirectory: flutterProjectDirectory);
   await stdout.addStream(process.stdout);
 
-  final bool successfulReturn = await process.exitCode == 0;
-
-  // Move the build dashboard project to build.html to replace the Angular Dart
-  // build dashboard page. Just changing the name is fine as its assets do not
-  // have conflicts.
-  await Process.run(
-      'mv', <String>['build/web/index.html', 'build/web/build.html'],
-      workingDirectory: flutterProjectDirectory);
-
-  return successfulReturn;
-}
-
-/// Copy the built project from app to this app_dart project.
-Future<bool> _copyAngularDartProject() async {
-  final ProcessResult result = await Process.run('cp',
-      <String>['-r', '$angularDartProjectDirectory/build/web/', 'build/web']);
-
-  return result.exitCode == 0;
+  return await process.exitCode == 0;
 }
 
 /// Copy the built project from app_flutter to this app_dart project.
 Future<bool> _copyFlutterApp() async {
-  final ProcessResult result = await Process.run(
-      'cp', <String>['-r', '$flutterProjectDirectory/build', 'build/']);
+  /// Clean up previous build files to ensure this codebase is deployed.
+  await Process.run('rm', <String>['-r', 'build/']);
+
+  final ProcessResult result =
+      await Process.run('cp', <String>['-r', '$flutterProjectDirectory/build', 'build']);
 
   return result.exitCode == 0;
 }
 
-/// Run the Google Cloud CLI tool to deploy to [_gcloudProjectId] under
+/// Run the Google Cloud CLI tool to deploy to [_gcloudProjectId] under 
 /// version [_gcloudProjectVersion].
 Future<bool> _deployToAppEngine() async {
   stdout.writeln('Deploying to AppEngine');
-
   /// The Google Cloud deployment command is an interactive process. It will
   /// print out what it is about to do, and ask for confirmation (Y/n).
   final Process process = await Process.start(
@@ -151,27 +101,14 @@ Future<void> main(List<String> arguments) async {
   if (!_getArgs(argParser, arguments)) {
     exit(1);
   }
-
-  if (!await _buildAngularDartApp()) {
-    stderr.writeln('Failed to build Angular Dart project');
-    exit(1);
-  }
-
+  
   if (!await _buildFlutterWebApp()) {
     stderr.writeln('Failed to build Flutter app');
     exit(1);
   }
 
-  /// Clean up previous build files to ensure the latest files are deployed.
-  await Process.run('rm', <String>['-rf', 'build/']);
-
   if (!await _copyFlutterApp()) {
     stderr.writeln('Failed to copy Flutter app over');
-    exit(1);
-  }
-
-  if (!await _copyAngularDartProject()) {
-    stderr.writeln('Failed to copy Angular Dart project over');
     exit(1);
   }
 

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -212,7 +212,7 @@ packages:
     source: hosted
     version: "1.1.7"
   googleapis:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: googleapis
       url: "https://pub.dartlang.org"


### PR DESCRIPTION
This reverts commit fc8f82d3ffd48c7fe66a604bb9901b093913dcb4.

Committed this too early. Supposed to stay open until we officially make the switch. Otherwise, any new deploys will make the switch to the new build dashboard.