### PR TITLE
Switch to federated google sign in plugin

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:google_sign_in/widgets.dart';
 import 'package:provider/provider.dart';
 
 import 'service/google_authentication.dart';
@@ -81,12 +82,20 @@ class UserAvatar extends StatelessWidget {
     final GoogleSignInService authService = buildState.authService;
 
     if (authService.isAuthenticated) {
-      /// Size needs to be specified
-      return Image.network(authService.avatarUrl + '=s100');
+      return SizedBox(
+        width: 50,
+        height: 50,
+        child: GoogleUserCircleAvatar(
+          identity: authService.user,
+        ),
+      );
     }
 
     return FlatButton(
-      child: const Text('Sign in'),
+      child: const Text(
+        'Sign in',
+        style: TextStyle(color: Colors.white),
+      ),
       onPressed: () => buildState.signIn(),
     );
   }

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -54,7 +54,7 @@ class BuildDashboard extends StatelessWidget {
               ? theme.primaryColor
               : theme.errorColor,
           actions: <Widget>[
-            SignInButton(buildState: buildState),
+            SignInButton(authService: buildState.authService),
           ],
         ),
         body: Column(

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -3,10 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:google_sign_in/widgets.dart';
 import 'package:provider/provider.dart';
 
-import 'service/google_authentication.dart';
+import 'sign_in_button.dart';
 import 'state/flutter_build.dart';
 import 'status_grid.dart';
 
@@ -55,7 +54,7 @@ class BuildDashboard extends StatelessWidget {
               ? theme.primaryColor
               : theme.errorColor,
           actions: <Widget>[
-            UserAvatar(buildState: buildState),
+            SignInButton(buildState: buildState),
           ],
         ),
         body: Column(
@@ -64,39 +63,6 @@ class BuildDashboard extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-/// Widget for displaying sign in information for the current user.
-///
-/// If logged in, it will display the user's avatar. Otherwise, it will show
-/// a button for sign in.
-class UserAvatar extends StatelessWidget {
-  const UserAvatar({@required this.buildState, Key key}) : super(key: key);
-
-  final FlutterBuildState buildState;
-
-  @override
-  Widget build(BuildContext context) {
-    final GoogleSignInService authService = buildState.authService;
-
-    if (authService.isAuthenticated) {
-      return SizedBox(
-        width: 50,
-        height: 50,
-        child: GoogleUserCircleAvatar(
-          identity: authService.user,
-        ),
-      );
-    }
-
-    return FlatButton(
-      child: const Text(
-        'Sign in',
-        style: TextStyle(color: Colors.white),
-      ),
-      onPressed: () => buildState.signIn(),
     );
   }
 }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -91,7 +91,7 @@ class AppEngineCocoonService implements CocoonService {
     /// This endpoint only returns a status code.
     final http.Response response = await _client.post(postResetTaskUrl,
         headers: <String, String>{
-          'X-Flutter-AccessToken': accessToken,
+          'X-Flutter-IdToken': accessToken,
         },
         body: jsonEncode(<String, String>{
           'Key': task.key.child.name,

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -190,7 +190,7 @@ class AppEngineCocoonService implements CocoonService {
     final List<Task> tasks = <Task>[];
 
     for (Map<String, Object> jsonTask in json) {
-      tasks.add(_taskFromJson(jsonTask));
+      tasks.add(_taskFromJson(jsonTask['Task']));
     }
 
     return tasks;

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -190,7 +190,7 @@ class AppEngineCocoonService implements CocoonService {
     final List<Task> tasks = <Task>[];
 
     for (Map<String, Object> jsonTask in json) {
-      tasks.add(_taskFromJson(jsonTask['Task']));
+      tasks.add(_taskFromJson(jsonTask));
     }
 
     return tasks;

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -84,14 +84,14 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   @override
-  Future<bool> rerunTask(Task task, String accessToken) async {
-    assert(accessToken != null);
+  Future<bool> rerunTask(Task task, String idToken) async {
+    assert(idToken != null);
     final String postResetTaskUrl = _apiEndpoint('/api/reset-devicelab-task');
 
     /// This endpoint only returns a status code.
     final http.Response response = await _client.post(postResetTaskUrl,
         headers: <String, String>{
-          'X-Flutter-IdToken': accessToken,
+          'X-Flutter-IdToken': idToken,
         },
         body: jsonEncode(<String, String>{
           'Key': task.key.child.name,

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -41,9 +41,9 @@ class GoogleSignInService {
   /// Whether or not the application has been signed in to.
   bool get isAuthenticated => user != null;
 
-  /// The Google Account for the signed in user,
+  /// The Google Account for the signed in user, null if no user is signed in.
   ///
-  /// Null if no user is signed in.
+  /// Read only object with only access to clear client auth tokens.
   GoogleSignInAccount user;
 
   /// Authentication token to be sent to Cocoon Backend to verify API calls.

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -2,18 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:google_sign_in_all/google_sign_in_all.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 
 /// Service class for interacting with Google Sign In authentication for Cocoon backend.
 class GoogleSignInService {
   /// Creates a new [GoogleSignIn].
   GoogleSignInService({GoogleSignIn googleSignIn})
       : _googleSignIn = googleSignIn ??
-            setupGoogleSignIn(
+            GoogleSignIn(
               scopes: _googleScopes,
-              webClientId:
-                  '308150028417-vlj9mqlm3gk1d03fb0efif1fu5nagdtt.apps.googleusercontent.com',
-            );
+            ) {
+    _googleSignIn
+        .signInSilently()
+        .then((GoogleSignInAccount accountValue) => user = accountValue);
+  }
 
   /// A list of Google API OAuth Scopes this project needs access to.
   ///
@@ -24,30 +26,25 @@ class GoogleSignInService {
   static const List<String> _googleScopes = <String>[
     'https://www.googleapis.com/auth/userinfo.email',
     'https://www.googleapis.com/auth/userinfo.profile',
+    'openid',
   ];
 
-  // TODO(chillers): Switch to official Flutter plugin when it supports web.
   final GoogleSignIn _googleSignIn;
 
-  AuthCredentials _credentials;
-
-  GoogleAccount _user;
-
   /// Whether or not the application has been signed in to.
-  bool get isAuthenticated => _credentials?.accessToken != null;
+  bool get isAuthenticated => user != null;
 
-  /// The profile photo url of the current user signed in.
-  String get avatarUrl => _user?.photoUrl;
-
-  /// The email of the current user signed in.
-  String get email => _user?.email;
+  /// The Google Account for the signed in user
+  ///
+  /// Null if no user is signed in
+  GoogleSignInAccount user;
 
   /// Authentication token to be sent to Cocoon Backend to verify API calls.
-  String get accessToken => _credentials?.accessToken;
+  Future<String> get idToken =>
+      user.authentication.then((GoogleSignInAuthentication key) => key.idToken);
 
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {
-    _credentials = await _googleSignIn.signIn();
-    _user = await _googleSignIn.getCurrentUser();
+    user = await _googleSignIn.signIn();
   }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -41,9 +41,9 @@ class GoogleSignInService {
   /// Whether or not the application has been signed in to.
   bool get isAuthenticated => user != null;
 
-  /// The Google Account for the signed in user
+  /// The Google Account for the signed in user,
   ///
-  /// Null if no user is signed in
+  /// Null if no user is signed in.
   GoogleSignInAccount user;
 
   /// Authentication token to be sent to Cocoon Backend to verify API calls.

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -12,9 +12,12 @@ class GoogleSignInService {
             GoogleSignIn(
               scopes: _googleScopes,
             ) {
-    _googleSignIn
-        .signInSilently()
-        .then((GoogleSignInAccount accountValue) => user = accountValue);
+    user = _googleSignIn.currentUser;
+    if (user == null) {
+      _googleSignIn
+          .signInSilently()
+          .then((GoogleSignInAccount accountValue) => user = accountValue);
+    }
   }
 
   /// A list of Google API OAuth Scopes this project needs access to.

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -39,7 +39,7 @@ class GoogleSignInService {
   final GoogleSignIn _googleSignIn;
 
   /// Whether or not the application has been signed in to.
-  bool get isAuthenticated => user != null;
+  Future<bool> get isAuthenticated => _googleSignIn.isSignedIn();
 
   /// The Google Account for the signed in user, null if no user is signed in.
   ///
@@ -57,6 +57,5 @@ class GoogleSignInService {
 
   Future<void> signOut() async {
     await _googleSignIn.signOut();
-    user = null;
   }
 }

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -10,7 +10,7 @@ import 'service/google_authentication.dart';
 /// Widget for displaying sign in information for the current user.
 ///
 /// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logging out.
-/// Otherwise, it a sign in button will show.
+/// Otherwise, a sign in button will show.
 class SignInButton extends StatefulWidget {
   const SignInButton({@required this.authService, Key key}) : super(key: key);
 

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -20,6 +20,7 @@ class SignInButton extends StatelessWidget {
   Widget build(BuildContext context) {
     if (authService.isAuthenticated) {
       return PopupMenuButton<String>(
+        // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
         child: Image.network(authService.user.photoUrl),
         offset: const Offset(0, 50),
         itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -18,31 +18,36 @@ class SignInButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (authService.isAuthenticated) {
-      return PopupMenuButton<String>(
-        // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
-        child: Image.network(authService.user.photoUrl),
-        offset: const Offset(0, 50),
-        itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-          const PopupMenuItem<String>(
-            value: 'logout',
-            child: Text('Log out'),
-          ),
-        ],
-        onSelected: (String value) {
-          if (value == 'logout') {
-            authService.signOut();
-          }
-        },
-      );
-    }
-
-    return FlatButton(
-      child: const Text(
-        'Sign in',
-        style: TextStyle(color: Colors.white),
-      ),
-      onPressed: () => authService.signIn(),
+    return FutureBuilder<bool>(
+      future: authService.isAuthenticated,
+      builder: (BuildContext context, AsyncSnapshot<bool> isAuthenticated) {
+        /// On sign out, there's a second where the user is null before isAuthenticated catches up.
+        if (isAuthenticated.data && authService.user != null)
+          return PopupMenuButton<String>(
+            // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
+            child: Image.network(authService.user?.photoUrl),
+            offset: const Offset(0, 50),
+            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+              const PopupMenuItem<String>(
+                value: 'logout',
+                child: Text('Log out'),
+              ),
+            ],
+            onSelected: (String value) {
+              if (value == 'logout') {
+                authService.signOut();
+              }
+            },
+          );
+        else
+          return FlatButton(
+            child: const Text(
+              'Sign in',
+              style: TextStyle(color: Colors.white),
+            ),
+            onPressed: () => authService.signIn(),
+          );
+      },
     );
   }
 }

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:google_sign_in/widgets.dart';

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -11,29 +11,28 @@ import 'service/google_authentication.dart';
 ///
 /// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logging out.
 /// Otherwise, a sign in button will show.
-class SignInButton extends StatefulWidget {
+class SignInButton extends StatelessWidget {
   const SignInButton({@required this.authService, Key key}) : super(key: key);
 
   final GoogleSignInService authService;
 
   @override
-  _SignInButtonState createState() => _SignInButtonState();
-}
-
-class _SignInButtonState extends State<SignInButton> {
-  @override
   Widget build(BuildContext context) {
-    final GoogleSignInService authService = widget.authService;
-
     if (authService.isAuthenticated) {
-      return PopupMenuButton<Future<void>>(
+      return PopupMenuButton<String>(
         child: Image.network(authService.user.photoUrl),
-        itemBuilder: (BuildContext context) => <PopupMenuEntry<Future<void>>>[
-          PopupMenuItem<Future<void>>(
-            value: authService.signOut(),
-            child: const Text('Log out'),
+        offset: const Offset(0, 50),
+        itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+          const PopupMenuItem<String>(
+            value: 'logout',
+            child: Text('Log out'),
           ),
         ],
+        onSelected: (String value) {
+          if (value == 'logout') {
+            authService.signOut();
+          }
+        },
       );
     }
 

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -20,9 +20,9 @@ class SignInButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return FutureBuilder<bool>(
       future: authService.isAuthenticated,
-      builder: (BuildContext context, AsyncSnapshot<bool> isAuthenticated) {
+      builder: (_, AsyncSnapshot<bool> isAuthenticated) {
         /// On sign out, there's a second where the user is null before isAuthenticated catches up.
-        if (isAuthenticated.data && authService.user != null)
+        if (isAuthenticated.data == true && authService.user != null) {
           return PopupMenuButton<String>(
             // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
             child: Image.network(authService.user?.photoUrl),
@@ -39,14 +39,14 @@ class SignInButton extends StatelessWidget {
               }
             },
           );
-        else
-          return FlatButton(
-            child: const Text(
-              'Sign in',
-              style: TextStyle(color: Colors.white),
-            ),
-            onPressed: () => authService.signIn(),
-          );
+        }
+        return FlatButton(
+          child: const Text(
+            'Sign in',
+            style: TextStyle(color: Colors.white),
+          ),
+          onPressed: () => authService.signIn(),
+        );
       },
     );
   }

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:google_sign_in/widgets.dart';
+
+import 'service/google_authentication.dart';
+import 'state/flutter_build.dart';
+
+/// Widget for displaying sign in information for the current user.
+///
+/// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logout.
+/// Otherwise, it a sign in button will show.
+class SignInButton extends StatefulWidget {
+  const SignInButton({@required this.buildState, Key key}) : super(key: key);
+
+  final FlutterBuildState buildState;
+
+  @override
+  _SignInButtonState createState() => _SignInButtonState();
+}
+
+class _SignInButtonState extends State<SignInButton> {
+  @override
+  Widget build(BuildContext context) {
+    final GoogleSignInService authService = widget.buildState.authService;
+
+    if (authService.isAuthenticated) {
+      return SizedBox(
+        width: 50,
+        height: 50,
+        child: GoogleUserCircleAvatar(
+          identity: authService.user,
+        ),
+      );
+    }
+
+    return FlatButton(
+      child: const Text(
+        'Sign in',
+        style: TextStyle(color: Colors.white),
+      ),
+      onPressed: () => widget.buildState.signIn(),
+    );
+  }
+}

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -7,7 +7,7 @@ import 'state/flutter_build.dart';
 
 /// Widget for displaying sign in information for the current user.
 ///
-/// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logout.
+/// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logging out.
 /// Otherwise, it a sign in button will show.
 class SignInButton extends StatefulWidget {
   const SignInButton({@required this.buildState, Key key}) : super(key: key);
@@ -24,12 +24,16 @@ class _SignInButtonState extends State<SignInButton> {
     final GoogleSignInService authService = widget.buildState.authService;
 
     if (authService.isAuthenticated) {
-      return SizedBox(
-        width: 50,
-        height: 50,
+      return PopupMenuButton<Future<void>>(
         child: GoogleUserCircleAvatar(
           identity: authService.user,
         ),
+        itemBuilder: (BuildContext context) => <PopupMenuEntry<Future<void>>>[
+          PopupMenuItem<Future<void>>(
+            value: widget.buildState.signOut(),
+            child: const Text('Log out'),
+          ),
+        ],
       );
     }
 

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -4,19 +4,17 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:google_sign_in/widgets.dart';
 
 import 'service/google_authentication.dart';
-import 'state/flutter_build.dart';
 
 /// Widget for displaying sign in information for the current user.
 ///
 /// If logged in, it will display the user's avatar. Clicking it opens a dropdown for logging out.
 /// Otherwise, it a sign in button will show.
 class SignInButton extends StatefulWidget {
-  const SignInButton({@required this.buildState, Key key}) : super(key: key);
+  const SignInButton({@required this.authService, Key key}) : super(key: key);
 
-  final FlutterBuildState buildState;
+  final GoogleSignInService authService;
 
   @override
   _SignInButtonState createState() => _SignInButtonState();
@@ -25,16 +23,14 @@ class SignInButton extends StatefulWidget {
 class _SignInButtonState extends State<SignInButton> {
   @override
   Widget build(BuildContext context) {
-    final GoogleSignInService authService = widget.buildState.authService;
+    final GoogleSignInService authService = widget.authService;
 
     if (authService.isAuthenticated) {
       return PopupMenuButton<Future<void>>(
-        child: GoogleUserCircleAvatar(
-          identity: authService.user,
-        ),
+        child: Image.network(authService.user.photoUrl),
         itemBuilder: (BuildContext context) => <PopupMenuEntry<Future<void>>>[
           PopupMenuItem<Future<void>>(
-            value: widget.buildState.signOut(),
+            value: authService.signOut(),
             child: const Text('Log out'),
           ),
         ],
@@ -46,7 +42,7 @@ class _SignInButtonState extends State<SignInButton> {
         'Sign in',
         style: TextStyle(color: Colors.white),
       ),
-      onPressed: () => widget.buildState.signIn(),
+      onPressed: () => authService.signIn(),
     );
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -93,8 +93,8 @@ class FlutterBuildState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<bool> rerunTask(Task task) {
-    return _cocoonService.rerunTask(task, authService.accessToken);
+  Future<bool> rerunTask(Task task) async {
+    return _cocoonService.rerunTask(task, await authService.idToken);
   }
 
   @override

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -17,16 +17,18 @@ class FlutterBuildState extends ChangeNotifier {
   ///
   /// If [CocoonService] is not specified, a new [CocoonService] instance is created.
   FlutterBuildState({
-    CocoonService cocoonService,
-    GoogleSignInService authService,
-  })  : authService = authService ?? GoogleSignInService(),
-        _cocoonService = cocoonService ?? CocoonService();
+    CocoonService cocoonServiceValue,
+    GoogleSignInService authServiceValue,
+  }) : _cocoonService = cocoonServiceValue ?? CocoonService() {
+    authService = authServiceValue ??
+        GoogleSignInService(notifyListeners: notifyListeners);
+  }
 
   /// Cocoon backend service that retrieves the data needed for this state.
   final CocoonService _cocoonService;
 
   /// Authentication service for managing Google Sign In.
-  final GoogleSignInService authService;
+  GoogleSignInService authService;
 
   /// How often to query the Cocoon backend for the current build state.
   @visibleForTesting
@@ -88,10 +90,8 @@ class FlutterBuildState extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> signIn() async {
-    await authService.signIn();
-    notifyListeners();
-  }
+  Future<void> signIn() => authService.signIn();
+  Future<void> signOut() => authService.signOut();
 
   Future<bool> rerunTask(Task task) async {
     return _cocoonService.rerunTask(task, await authService.idToken);

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -341,7 +341,7 @@ class TaskOverlayContents extends StatelessWidget {
     // Only send access token for devicelab tasks since they require authentication
     final Map<String, String> headers = isDevicelab(task)
         ? <String, String>{
-            'X-Flutter-AccessToken': buildState.authService.accessToken,
+            'X-Flutter-IdToken': await buildState.authService.idToken,
           }
         : null;
     launch(logUrl(task), headers: headers);

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -31,7 +31,10 @@ dependencies:
   cocoon_service:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
-  google_sign_in_all: ^0.0.3
+  google_sign_in:
+    path: /usr/local/google/home/chillers/plugins-ditman/packages/google_sign_in/google_sign_in/
+  google_sign_in_web:
+        path: /usr/local/google/home/chillers/plugins-ditman/packages/google_sign_in/google_sign_in_web/
   provider: ^3.0.0
   url_launcher: 5.2.4
   url_launcher_web:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -31,6 +31,10 @@ dependencies:
   cocoon_service:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
+  # TODO(chillers): https://github.com/ditman/plugins/pull/101 and the Google Sign In plugin
+  # publishes the update switch to the latest version.
+  # For now, locally clone this branch and have it in the same folder as the
+  # Cocoon parent folder.
   google_sign_in:
     path: ../../plugins-ditman/packages/google_sign_in/google_sign_in/
   google_sign_in_web:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -31,14 +31,14 @@ dependencies:
   cocoon_service:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
-  # TODO(chillers): https://github.com/ditman/plugins/pull/101 and the Google Sign In plugin
-  # publishes the update switch to the latest version.
-  # For now, locally clone this branch and have it in the same folder as the
-  # Cocoon parent folder.
-  google_sign_in:
-    path: ../../plugins-ditman/packages/google_sign_in/google_sign_in/
+  google_sign_in: ^4.0.14
   google_sign_in_web:
-        path: ../../plugins-ditman/packages/google_sign_in/google_sign_in_web/
+    git:
+      # TODO(chillers): https://github.com/flutter/plugins/pull/2280 and the Google Sign In plugin
+      # publishes the update switch to the official version.
+      url: git://github.com/ditman/plugins.git
+      ref: federated_google_sign_in_web
+      path: packages/google_sign_in/google_sign_in_web
   provider: ^3.0.0
   url_launcher: 5.2.4
   url_launcher_web:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -32,9 +32,9 @@ dependencies:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
   google_sign_in:
-    path: /usr/local/google/home/chillers/plugins-ditman/packages/google_sign_in/google_sign_in/
+    path: ../../plugins-ditman/packages/google_sign_in/google_sign_in/
   google_sign_in_web:
-        path: /usr/local/google/home/chillers/plugins-ditman/packages/google_sign_in/google_sign_in_web/
+        path: ../../plugins-ditman/packages/google_sign_in/google_sign_in_web/
   provider: ^3.0.0
   url_launcher: 5.2.4
   url_launcher_web:

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -4,73 +4,20 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_sign_in/google_sign_in.dart';
-import 'package:mockito/mockito.dart';
-import 'package:test/test.dart' as test;
 
 import 'package:app_flutter/build_dashboard.dart';
-import 'package:app_flutter/service/google_authentication.dart';
-import 'package:app_flutter/service/fake_cocoon.dart';
-import 'package:app_flutter/state/flutter_build.dart';
+import 'package:app_flutter/sign_in_button.dart';
 
 void main() {
-  group('UserAvatar', () {
-    GoogleSignInService authService;
+  testWidgets('shows sign in button', (WidgetTester tester) async {
+    final BuildDashboardPage buildDashboard = BuildDashboardPage();
+    await tester.pumpWidget(MaterialApp(
+      home: buildDashboard,
+    ));
 
-    setUp(() {
-      authService = MockGoogleSignInService();
-    });
+    expect(find.byType(SignInButton), findsOneWidget);
 
-    testWidgets('shows sign in button when not signed in',
-        (WidgetTester tester) async {
-      when(authService.isAuthenticated).thenReturn(false);
-      final FlutterBuildState buildState = FlutterBuildState(
-          authService: authService, cocoonService: FakeCocoonService());
-      await tester.pumpWidget(MaterialApp(
-        home: SignInButton(
-          buildState: buildState,
-        ),
-      ));
-
-      expect(find.text('Sign in'), findsOneWidget);
-    });
-
-    testWidgets('sign in button activates google sign in when pressed',
-        (WidgetTester tester) async {
-      when(authService.isAuthenticated).thenReturn(false);
-      final FlutterBuildState buildState = FlutterBuildState(
-          authService: authService, cocoonService: FakeCocoonService());
-      await tester.pumpWidget(MaterialApp(
-        home: SignInButton(
-          buildState: buildState,
-        ),
-      ));
-
-      verifyNever(authService.signIn());
-
-      await tester.tap(find.byType(GoogleUserCircleAvatar));
-
-      verify(authService.signIn()).called(1);
-    });
-
-    testWidgets('shows user avatar when signed in',
-        (WidgetTester tester) async {
-      when(authService.isAuthenticated).thenReturn(true);
-      when(authService.user).thenReturn(null);
-      final FlutterBuildState buildState = FlutterBuildState(
-          authService: authService, cocoonService: FakeCocoonService());
-      await tester.pumpWidget(MaterialApp(
-        home: SignInButton(
-          buildState: buildState,
-        ),
-      ));
-
-      expect(tester.takeException(),
-          const test.TypeMatcher<NetworkImageLoadException>());
-      expect(find.byType(Image), findsOneWidget);
-    });
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(seconds: 100));
   });
 }
-
-/// Mock [GoogleSignInService] for testing interactions.
-class MockGoogleSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -27,7 +27,7 @@ void main() {
       final FlutterBuildState buildState = FlutterBuildState(
           authService: authService, cocoonService: FakeCocoonService());
       await tester.pumpWidget(MaterialApp(
-        home: UserAvatar(
+        home: SignInButton(
           buildState: buildState,
         ),
       ));
@@ -41,7 +41,7 @@ void main() {
       final FlutterBuildState buildState = FlutterBuildState(
           authService: authService, cocoonService: FakeCocoonService());
       await tester.pumpWidget(MaterialApp(
-        home: UserAvatar(
+        home: SignInButton(
           buildState: buildState,
         ),
       ));
@@ -60,7 +60,7 @@ void main() {
       final FlutterBuildState buildState = FlutterBuildState(
           authService: authService, cocoonService: FakeCocoonService());
       await tester.pumpWidget(MaterialApp(
-        home: UserAvatar(
+        home: SignInButton(
           buildState: buildState,
         ),
       ));

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart' as test;
 
@@ -47,7 +48,7 @@ void main() {
 
       verifyNever(authService.signIn());
 
-      await tester.tap(find.byType(UserAvatar));
+      await tester.tap(find.byType(GoogleUserCircleAvatar));
 
       verify(authService.signIn()).called(1);
     });
@@ -55,7 +56,7 @@ void main() {
     testWidgets('shows user avatar when signed in',
         (WidgetTester tester) async {
       when(authService.isAuthenticated).thenReturn(true);
-      when(authService.avatarUrl).thenReturn('https://flutter.dev');
+      when(authService.user).thenReturn(null);
       final FlutterBuildState buildState = FlutterBuildState(
           authService: authService, cocoonService: FakeCocoonService());
       await tester.pumpWidget(MaterialApp(

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -4,20 +4,22 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 import 'package:app_flutter/build_dashboard.dart';
 import 'package:app_flutter/sign_in_button.dart';
+import 'package:app_flutter/state/flutter_build.dart';
 
 void main() {
   testWidgets('shows sign in button', (WidgetTester tester) async {
-    final BuildDashboardPage buildDashboard = BuildDashboardPage();
+    final FlutterBuildState buildState = FlutterBuildState();
+
     await tester.pumpWidget(MaterialApp(
-      home: buildDashboard,
-    ));
+        home: ChangeNotifierProvider<FlutterBuildState>(
+      builder: (_) => buildState,
+      child: BuildDashboard(),
+    )));
 
     expect(find.byType(SignInButton), findsOneWidget);
-
-    await tester.pumpWidget(const SizedBox());
-    await tester.pump(const Duration(seconds: 100));
   });
 }

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -19,7 +19,13 @@ void main() {
       mockSignIn = MockGoogleSignIn();
       when(mockSignIn.onCurrentUserChanged)
           .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
+      when(mockSignIn.isSignedIn())
+          .thenAnswer((_) => Future<bool>.value(false));
       authService = GoogleSignInService(googleSignIn: mockSignIn);
+    });
+
+    test('not authenticated', () async {
+      expect(await authService.isAuthenticated, false);
     });
 
     test('no user information', () {
@@ -39,6 +45,7 @@ void main() {
       when(mockSignIn.signIn())
           .thenAnswer((_) => Future<GoogleSignInAccount>.value(testAccount));
       when(mockSignIn.currentUser).thenReturn(testAccount);
+      when(mockSignIn.isSignedIn()).thenAnswer((_) => Future<bool>.value(true));
       when(mockSignIn.onCurrentUserChanged)
           .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
 
@@ -48,6 +55,7 @@ void main() {
     test('is authenticated after successful sign in', () async {
       await authService.signIn();
 
+      expect(await authService.isAuthenticated, true);
       expect(authService.user, testAccount);
     });
 

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -13,9 +13,13 @@ import '../utils/fake_google_account.dart';
 void main() {
   group('GoogleSignInService not signed in', () {
     GoogleSignInService authService;
+    GoogleSignIn mockSignIn;
 
     setUp(() {
-      authService = GoogleSignInService(googleSignIn: MockGoogleSignIn());
+      mockSignIn = MockGoogleSignIn();
+      when(mockSignIn.onCurrentUserChanged)
+          .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
+      authService = GoogleSignInService(googleSignIn: mockSignIn);
     });
 
     test('not authenticated', () {

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -63,8 +63,6 @@ void main() {
       expect(authService.user.id, 'test123');
       expect(authService.user.photoUrl,
           'https://lh3.googleusercontent.com/-ukEAtRyRhw8/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rfhID9XACtdb9q_xK43VSXQvBV11Q.CMID');
-
-      expect(authService.idToken, 'fake id token');
     });
 
     test('id token available with logged in user', () async {

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:google_sign_in_all/google_sign_in_all.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -21,9 +21,8 @@ void main() {
     });
 
     test('no user information', () {
-      expect(authService.avatarUrl, null);
-      expect(authService.email, null);
-      expect(authService.accessToken, null);
+      expect(authService.user, null);
+      expect(authService.idToken, null);
     });
   });
 
@@ -52,23 +51,20 @@ void main() {
     test('there is user information after successful sign in', () async {
       await authService.signIn();
 
-      expect(authService.email, 'fake@fake.com');
-      expect(authService.avatarUrl, 'fake://fake.png');
-      expect(authService.accessToken, 'fake');
+      expect(authService.idToken, 'fake id token');
     });
 
     test('is not authenticated after failure in sign in', () async {
+      when(mockSignIn.signInSilently())
+          .thenAnswer((_) => Future<GoogleSignInAccount>.value(null));
       when(mockSignIn.signIn())
-          .thenAnswer((_) => Future<AuthCredentials>.value(null));
-      when(mockSignIn.getCurrentUser())
-          .thenAnswer((_) => Future<GoogleAccount>.value(null));
+          .thenAnswer((_) => Future<GoogleSignInAccount>.value(null));
 
       await authService.signIn();
 
       expect(authService.isAuthenticated, false);
-      expect(authService.email, null);
-      expect(authService.avatarUrl, null);
-      expect(authService.accessToken, null);
+      expect(authService.user, null);
+      expect(authService.idToken, null);
     });
   });
 }

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -22,10 +22,6 @@ void main() {
       authService = GoogleSignInService(googleSignIn: mockSignIn);
     });
 
-    test('not authenticated', () {
-      expect(authService.isAuthenticated, false);
-    });
-
     test('no user information', () {
       expect(authService.user, null);
       expect(authService.idToken, null);
@@ -52,7 +48,7 @@ void main() {
     test('is authenticated after successful sign in', () async {
       await authService.signIn();
 
-      expect(authService.isAuthenticated, true);
+      expect(authService.user, testAccount);
     });
 
     test('there is user information after successful sign in', () async {
@@ -83,7 +79,6 @@ void main() {
 
       await authService.signIn();
 
-      expect(authService.isAuthenticated, false);
       expect(authService.user, null);
       expect(authService.idToken, null);
     });

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -32,11 +32,10 @@ void main() {
 
     setUp(() {
       mockSignIn = MockGoogleSignIn();
-      final AuthCredentials fakeCredentials = FakeAuthCredentials();
-      when(mockSignIn.signIn())
-          .thenAnswer((_) => Future<AuthCredentials>.value(fakeCredentials));
-      when(mockSignIn.getCurrentUser()).thenAnswer((_) =>
-          Future<GoogleAccount>.value(GoogleAccount(
+      when(mockSignIn.signIn()).thenAnswer(
+          (_) => Future<GoogleSignInAccount>.value(fakeCredentials));
+      when(mockSignIn.currentUser).thenAnswer((_) =>
+          Future<GoogleSignInAccount>.value(GoogleSignInAccount(
               email: 'fake@fake.com', photoUrl: 'fake://fake.png')));
 
       authService = GoogleSignInService(googleSignIn: mockSignIn);
@@ -71,12 +70,3 @@ void main() {
 
 /// Mock [GoogleSignIn] for testing interactions.
 class MockGoogleSignIn extends Mock implements GoogleSignIn {}
-
-/// Fake [AuthCredentials] for [MockGoogleSignIn].
-class FakeAuthCredentials implements AuthCredentials {
-  @override
-  final String accessToken = 'fake';
-
-  @override
-  final String idToken = 'faker';
-}

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -102,8 +102,6 @@ void main() {
         ),
       ),
     );
-    expect(tester.takeException(),
-        const test.TypeMatcher<NetworkImageLoadException>());
 
     await tester.tap(find.byType(Image));
     await tester.pumpAndSettle();

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart' as test;
+
+import 'package:app_flutter/service/google_authentication.dart';
+import 'package:app_flutter/sign_in_button.dart';
+import 'package:app_flutter/state/flutter_build.dart';
+
+void main() {
+  FlutterBuildState mockBuildState;
+  GoogleSignInService mockSignIn;
+
+  setUp(() {
+    mockBuildState = MockFlutterBuildState();
+    mockSignIn = MockGoogleSignInService();
+
+    when(mockBuildState.authService).thenReturn(mockSignIn);
+  });
+
+  tearDown(() {
+    clearInteractions(mockBuildState);
+    clearInteractions(mockSignIn);
+  });
+
+  testWidgets('shows sign in when not authenticated',
+      (WidgetTester tester) async {
+    when(mockSignIn.isAuthenticated).thenReturn(false);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SignInButton(
+          buildState: mockBuildState,
+        ),
+      ),
+    );
+
+    expect(find.byType(GoogleUserCircleAvatar), findsNothing);
+    expect(find.text('Sign in'), findsOneWidget);
+  });
+
+  testWidgets('calls sign in on tap when not authenticated',
+      (WidgetTester tester) async {
+    when(mockSignIn.isAuthenticated).thenReturn(false);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SignInButton(
+          buildState: mockBuildState,
+        ),
+      ),
+    );
+
+    verifyNever(mockBuildState.signIn());
+
+    await tester.tap(find.text('Sign in'));
+    await tester.pump();
+
+    verify(mockBuildState.signIn()).called(1);
+  });
+
+  testWidgets('shows avatar when authenticated', (WidgetTester tester) async {
+    when(mockSignIn.isAuthenticated).thenReturn(true);
+
+    final GoogleSignInAccount user = TestGoogleSignInAccount();
+    when(mockSignIn.user).thenReturn(user);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppBar(
+          leading: SignInButton(
+            buildState: mockBuildState,
+          ),
+        ),
+      ),
+    );
+    tester.takeException();
+
+    expect(find.text('Sign in'), findsNothing);
+    expect(find.byType(GoogleUserCircleAvatar), findsOneWidget);
+  });
+
+  testWidgets('calls sign out on tap when authenticated',
+      (WidgetTester tester) async {});
+}
+
+class TestGoogleSignInAccount implements GoogleSignInAccount {
+  @override
+  String get displayName => 'Dr. Test';
+
+  @override
+  String get email => 'test@flutter.dev';
+
+  @override
+  String get id => 'test123';
+
+  @override
+  String get photoUrl => 'https://flutter.dev/test.png';
+
+  @override
+  Future<Map<String, String>> get authHeaders => null;
+
+  @override
+  Future<GoogleSignInAuthentication> get authentication => null;
+
+  @override
+  Future<void> clearAuthCache() => null;
+}
+
+class MockFlutterBuildState extends Mock implements FlutterBuildState {}
+
+class MockGoogleSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -13,6 +13,8 @@ import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/sign_in_button.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 
+import 'utils/fake_google_account.dart';
+
 void main() {
   GoogleSignInService mockAuthService;
 
@@ -65,7 +67,7 @@ void main() {
   testWidgets('shows avatar when authenticated', (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated).thenReturn(true);
 
-    final GoogleSignInAccount user = TestGoogleSignInAccount();
+    final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
 
     await tester.pumpWidget(
@@ -88,7 +90,7 @@ void main() {
       (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated).thenReturn(true);
 
-    final GoogleSignInAccount user = TestGoogleSignInAccount();
+    final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
 
     await tester.pumpWidget(
@@ -112,30 +114,6 @@ void main() {
 
     verify(mockAuthService.signOut()).called(1);
   });
-}
-
-class TestGoogleSignInAccount implements GoogleSignInAccount {
-  @override
-  String get displayName => 'Dr. Test';
-
-  @override
-  String get email => 'test@flutter.dev';
-
-  @override
-  String get id => 'test123';
-
-  @override
-  String get photoUrl =>
-      'https://lh3.googleusercontent.com/-ukEAtRyRhw8/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rfhID9XACtdb9q_xK43VSXQvBV11Q.CMID';
-
-  @override
-  Future<Map<String, String>> get authHeaders => null;
-
-  @override
-  Future<GoogleSignInAuthentication> get authentication => null;
-
-  @override
-  Future<void> clearAuthCache() => null;
 }
 
 class MockFlutterBuildState extends Mock implements FlutterBuildState {}

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -29,7 +29,7 @@ void main() {
   testWidgets('shows sign in when not authenticated',
       (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated)
-        .thenAnswer((_) => Future<bool>.value(false));
+        .thenAnswer((_) async => Future<bool>.value(false));
 
     await tester.pumpWidget(
       Directionality(
@@ -48,7 +48,7 @@ void main() {
   testWidgets('calls sign in on tap when not authenticated',
       (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated)
-        .thenAnswer((_) => Future<bool>.value(false));
+        .thenAnswer((_) async => Future<bool>.value(false));
 
     await tester.pumpWidget(
       Directionality(
@@ -70,7 +70,7 @@ void main() {
 
   testWidgets('shows avatar when authenticated', (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated)
-        .thenAnswer((_) => Future<bool>.value(true));
+        .thenAnswer((_) async => Future<bool>.value(true));
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
@@ -95,7 +95,7 @@ void main() {
   testWidgets('calls sign out on tap when authenticated',
       (WidgetTester tester) async {
     when(mockAuthService.isAuthenticated)
-        .thenAnswer((_) => Future<bool>.value(true));
+        .thenAnswer((_) async => Future<bool>.value(true));
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -28,7 +28,8 @@ void main() {
 
   testWidgets('shows sign in when not authenticated',
       (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenReturn(false);
+    when(mockAuthService.isAuthenticated)
+        .thenAnswer((_) => Future<bool>.value(false));
 
     await tester.pumpWidget(
       Directionality(
@@ -38,6 +39,7 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     expect(find.byType(GoogleUserCircleAvatar), findsNothing);
     expect(find.text('Sign in'), findsOneWidget);
@@ -45,7 +47,8 @@ void main() {
 
   testWidgets('calls sign in on tap when not authenticated',
       (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenReturn(false);
+    when(mockAuthService.isAuthenticated)
+        .thenAnswer((_) => Future<bool>.value(false));
 
     await tester.pumpWidget(
       Directionality(
@@ -55,6 +58,7 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     verifyNever(mockAuthService.signIn());
 
@@ -65,7 +69,8 @@ void main() {
   });
 
   testWidgets('shows avatar when authenticated', (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenReturn(true);
+    when(mockAuthService.isAuthenticated)
+        .thenAnswer((_) => Future<bool>.value(true));
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
@@ -79,6 +84,7 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
     expect(tester.takeException(),
         const test.TypeMatcher<NetworkImageLoadException>());
 
@@ -88,7 +94,8 @@ void main() {
 
   testWidgets('calls sign out on tap when authenticated',
       (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenReturn(true);
+    when(mockAuthService.isAuthenticated)
+        .thenAnswer((_) => Future<bool>.value(true));
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
@@ -102,6 +109,7 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     await tester.tap(find.byType(Image));
     await tester.pumpAndSettle();

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -14,30 +14,25 @@ import 'package:app_flutter/sign_in_button.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 
 void main() {
-  FlutterBuildState mockBuildState;
-  GoogleSignInService mockSignIn;
+  GoogleSignInService mockAuthService;
 
   setUp(() {
-    mockBuildState = MockFlutterBuildState();
-    mockSignIn = MockGoogleSignInService();
-
-    when(mockBuildState.authService).thenReturn(mockSignIn);
+    mockAuthService = MockGoogleSignInService();
   });
 
   tearDown(() {
-    clearInteractions(mockBuildState);
-    clearInteractions(mockSignIn);
+    clearInteractions(mockAuthService);
   });
 
   testWidgets('shows sign in when not authenticated',
       (WidgetTester tester) async {
-    when(mockSignIn.isAuthenticated).thenReturn(false);
+    when(mockAuthService.isAuthenticated).thenReturn(false);
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: SignInButton(
-          buildState: mockBuildState,
+          authService: mockAuthService,
         ),
       ),
     );
@@ -48,48 +43,75 @@ void main() {
 
   testWidgets('calls sign in on tap when not authenticated',
       (WidgetTester tester) async {
-    when(mockSignIn.isAuthenticated).thenReturn(false);
+    when(mockAuthService.isAuthenticated).thenReturn(false);
 
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: SignInButton(
-          buildState: mockBuildState,
+          authService: mockAuthService,
         ),
       ),
     );
 
-    verifyNever(mockBuildState.signIn());
+    verifyNever(mockAuthService.signIn());
 
     await tester.tap(find.text('Sign in'));
     await tester.pump();
 
-    verify(mockBuildState.signIn()).called(1);
+    verify(mockAuthService.signIn()).called(1);
   });
 
   testWidgets('shows avatar when authenticated', (WidgetTester tester) async {
-    when(mockSignIn.isAuthenticated).thenReturn(true);
+    when(mockAuthService.isAuthenticated).thenReturn(true);
 
     final GoogleSignInAccount user = TestGoogleSignInAccount();
-    when(mockSignIn.user).thenReturn(user);
+    when(mockAuthService.user).thenReturn(user);
 
     await tester.pumpWidget(
       MaterialApp(
         home: AppBar(
           leading: SignInButton(
-            buildState: mockBuildState,
+            authService: mockAuthService,
           ),
         ),
       ),
     );
-    tester.takeException();
+    expect(tester.takeException(),
+        const test.TypeMatcher<NetworkImageLoadException>());
 
     expect(find.text('Sign in'), findsNothing);
-    expect(find.byType(GoogleUserCircleAvatar), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
   });
 
   testWidgets('calls sign out on tap when authenticated',
-      (WidgetTester tester) async {});
+      (WidgetTester tester) async {
+    when(mockAuthService.isAuthenticated).thenReturn(true);
+
+    final GoogleSignInAccount user = TestGoogleSignInAccount();
+    when(mockAuthService.user).thenReturn(user);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppBar(
+          leading: SignInButton(
+            authService: mockAuthService,
+          ),
+        ),
+      ),
+    );
+    expect(tester.takeException(),
+        const test.TypeMatcher<NetworkImageLoadException>());
+
+    await tester.tap(find.byType(Image));
+    await tester.pumpAndSettle();
+
+    verifyNever(mockAuthService.signOut());
+
+    await tester.tap(find.text('Log out'));
+
+    verify(mockAuthService.signOut()).called(1);
+  });
 }
 
 class TestGoogleSignInAccount implements GoogleSignInAccount {
@@ -103,7 +125,8 @@ class TestGoogleSignInAccount implements GoogleSignInAccount {
   String get id => 'test123';
 
   @override
-  String get photoUrl => 'https://flutter.dev/test.png';
+  String get photoUrl =>
+      'https://lh3.googleusercontent.com/-ukEAtRyRhw8/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rfhID9XACtdb9q_xK43VSXQvBV11Q.CMID';
 
   @override
   Future<Map<String, String>> get authHeaders => null;

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     setUp(() {
       mockService = MockCocoonService();
-      buildState = FlutterBuildState(cocoonService: mockService);
+      buildState = FlutterBuildState(cocoonServiceValue: mockService);
 
       when(mockService.fetchCommitStatuses()).thenAnswer((_) =>
           Future<CocoonResponse<List<CommitStatus>>>.value(

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -313,7 +313,7 @@ void main() {
       });
 
       final GoogleSignInService mockAuth = MockGoogleSignInService();
-      when(mockAuth.accessToken).thenReturn('abc123');
+      when(mockAuth.idToken).thenReturn(Future<String>.value('abc123'));
       when(buildState.authService).thenReturn(mockAuth);
       await tester.pumpWidget(
         MaterialApp(

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -313,7 +313,7 @@ void main() {
       });
 
       final GoogleSignInService mockAuth = MockGoogleSignInService();
-      when(mockAuth.idToken).thenReturn(Future<String>.value('abc123'));
+      when(mockAuth.idToken).thenAnswer((_) => Future<String>.value('abc123'));
       when(buildState.authService).thenReturn(mockAuth);
       await tester.pumpWidget(
         MaterialApp(
@@ -345,7 +345,7 @@ void main() {
             'enableDomStorage': false,
             'universalLinksOnly': false,
             'headers': <String, String>{
-              'X-Flutter-AccessToken': 'abc123',
+              'X-Flutter-IdToken': 'abc123',
             }
           })
         ],

--- a/app_flutter/test/utils/fake_google_account.dart
+++ b/app_flutter/test/utils/fake_google_account.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:google_sign_in/google_sign_in.dart';
+
+class FakeGoogleSignInAccount implements GoogleSignInAccount {
+  @override
+  String get displayName => 'Dr. Test';
+
+  @override
+  String get email => 'test@flutter.dev';
+
+  @override
+  String get id => 'test123';
+
+  @override
+  String get photoUrl =>
+      'https://lh3.googleusercontent.com/-ukEAtRyRhw8/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rfhID9XACtdb9q_xK43VSXQvBV11Q.CMID';
+
+  @override
+  Future<Map<String, String>> get authHeaders => null;
+
+  @override
+  Future<GoogleSignInAuthentication> authentication;
+
+  @override
+  Future<void> clearAuthCache() => null;
+}

--- a/app_flutter/web/index.html
+++ b/app_flutter/web/index.html
@@ -5,6 +5,7 @@ found in the LICENSE file. -->
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="google-signin-client_id" content="308150028417-vlj9mqlm3gk1d03fb0efif1fu5nagdtt.apps.googleusercontent.com">
   <title>app_flutter</title>
   <!-- This application normally gets displayed on a TV that is hard to reach.
   Refreshing this page once a day (in seconds) makes it so the TV stays relatively


### PR DESCRIPTION
The Flutter Google Sign In plugin should be getting official web support very soon. The open source fork the Flutter app was using did not get id tokens which required adding a new authentication method to the backend. This updates all the places in the Flutter app that reference the `GoogleSignInService` to use the new methods (using `GoogleSignInAccount` instead of separate fields).

Right now the web version is in the review stage, so this uses a forked version of it by the @ditman the PR owner.

Added ability to sign out by clicking the user avatar, and then clicking log out in the drop down.

Waiting on ~https://github.com/flutter/plugins/pull/2266~ and preferably https://github.com/flutter/plugins/pull/2280

## Preview

Demo available at http://testchillers.flutter-dashboard.appspot.com/v2/

![logout screenshot](https://user-images.githubusercontent.com/2148558/68977933-592c4980-07ae-11ea-8684-ede0e99df4c9.png)