### PR TITLE
Run flutter clean at the end of every task.

### DIFF
--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -131,6 +131,7 @@ class ContinuousIntegrationCommand extends Command {
           stderr.writeln('ERROR: $error\n$stackTrace');
         } finally {
           await _screensOff();
+          await flutter('clean');
           await forceQuitRunningProcesses();
         }
 

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -66,6 +66,7 @@ class RunCommand extends Command {
     } catch (error, stackTrace) {
       logger.error('ERROR: $error\n$stackTrace');
     } finally {
+      await flutter('clean');
       await forceQuitRunningProcesses();
     }
     section('Task result');


### PR DESCRIPTION
This is to remove build caches and make the tests more hermetic.