### PR TITLE
Add iOS signing health check.

### DIFF
--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'adb.dart';
 import 'agent.dart';
 import 'utils.dart';
+import 'package:path/path.dart' as path;
 
 final RegExp _kLinuxIpAddrExp = RegExp(r'inet +(\d+\.\d+\.\d+.\d+)/\d+');
 final RegExp _kWindowsIpAddrExp =
@@ -41,6 +42,28 @@ Future<AgentHealth> performHealthChecks(Agent agent) async {
         results['cocoon-authentication'] = HealthCheckResult.success();
       }
     });
+    if (Platform.isMacOS && config.deviceOperatingSystem==DeviceOperatingSystem.ios) {
+      results['ios'] = await _captureErrors(() async {
+        final Directory tempDir = Directory.systemTemp.createTempSync('health_tmp');
+        final Directory projectDir = Directory(path.join(tempDir.path, 'hello'));
+        try {
+          await inDirectory(tempDir, () async {
+            await flutter('create', options: <String>['hello']);
+          });
+
+          await inDirectory(projectDir, () async {
+             int exitCode = await flutter('build', options: <String>['ios']);
+             if (exitCode == 0) {
+               results['able-to-build-and-sign'] = HealthCheckResult.success();
+             } else {
+               results['able-to-build-and-sign'] = HealthCheckResult.failure(
+                   'Failed to build and sign iOS app.');
+             }});
+        } finally {
+          rrm(tempDir);
+        }
+      });
+    }
   });
 
   return results;


### PR DESCRIPTION
This will use ~1 extra minute for health checks but will prevent test
beds that are not able to sign apps to pick up new tasks.

This solves https://github.com/flutter/flutter/issues/43817 and helps
to mitigate false positives on Mac/iOS test beds.