### PR TITLE
Fix skipped tasks being collated in ListView's TaskBoxes

### DIFF
--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -157,7 +157,7 @@ class _StatusGridState extends State<StatusGrid> {
               task: widget.taskMatrix.task(rowIndex, colIndex),
             )
           else
-            const SizedBox()
+            const SizedBox(width: StatusGrid.cellSize)
       ];
 
       rows.add(

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -88,6 +88,7 @@ class StatusGrid extends StatefulWidget {
     @required this.buildState,
     @required this.statuses,
     @required this.taskMatrix,
+    this.insertCellKeys = false,
   }) : super(key: key);
 
   /// The build status data to display in the grid.
@@ -98,6 +99,10 @@ class StatusGrid extends StatefulWidget {
 
   /// Reference to the build state to perform actions on [TaskMatrix], like rerunning tasks.
   final FlutterBuildState buildState;
+
+  /// Used for testing to lookup the widget corresponding to a position in [StatusGrid].
+  @visibleForTesting
+  final bool insertCellKeys;
 
   static const double cellSize = 50;
 
@@ -153,11 +158,19 @@ class _StatusGridState extends State<StatusGrid> {
         for (int colIndex = 0; colIndex < widget.taskMatrix.columns; colIndex++)
           if (widget.taskMatrix.task(rowIndex, colIndex) != null)
             TaskBox(
+              key: widget.insertCellKeys
+                  ? Key('cell-$rowIndex-$colIndex')
+                  : null,
               buildState: widget.buildState,
               task: widget.taskMatrix.task(rowIndex, colIndex),
             )
           else
-            const SizedBox(width: StatusGrid.cellSize)
+            SizedBox(
+              key: widget.insertCellKeys
+                  ? Key('cell-$rowIndex-$colIndex')
+                  : null,
+              width: StatusGrid.cellSize,
+            )
       ];
 
       rows.add(

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -193,7 +193,8 @@ void main() {
       expect(lastTask.task, statusesWithSkips[2].stages[0].tasks[0]);
     });
 
-    testWidgets('all cells in the grid have the same size even when grid has skipped tasks',
+    testWidgets(
+        'all cells in the grid have the same size even when grid has skipped tasks',
         (WidgetTester tester) async {
       final TaskMatrix taskMatrix = TaskMatrix(statuses: statusesWithSkips);
 
@@ -216,8 +217,8 @@ void main() {
       // the same size
       final Element taskBox =
           find.byKey(const Key('cell-0-0')).evaluate().first;
-      for (int rowIndex = 0; rowIndex < statusesWithSkips.length; rowIndex++) {
-        for (int colIndex = 0; colIndex < 3; colIndex++) {
+      for (int rowIndex = 0; rowIndex < taskMatrix.rows; rowIndex++) {
+        for (int colIndex = 0; colIndex < taskMatrix.columns; colIndex++) {
           final Element cell =
               find.byKey(Key('cell-$rowIndex-$colIndex')).evaluate().first;
 

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -102,6 +102,9 @@ void main() {
       /// ✓☐☐
       /// ☐✓☐
       /// ☐☐✓
+      /// To construct the matrix from this diagram, each [CommitStatus] must have a unique [Task] 
+      /// that does not share its name with any other [Task]. This will make that [CommitStatus] have
+      /// its task on its own unique row and column.
       final List<CommitStatus> statuses = <CommitStatus>[
         CommitStatus()
           ..stages.add(Stage()

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -102,7 +102,7 @@ void main() {
       /// ✓☐☐
       /// ☐✓☐
       /// ☐☐✓
-      /// To construct the matrix from this diagram, each [CommitStatus] must have a unique [Task] 
+      /// To construct the matrix from this diagram, each [CommitStatus] must have a unique [Task]
       /// that does not share its name with any other [Task]. This will make that [CommitStatus] have
       /// its task on its own unique row and column.
       final List<CommitStatus> statuses = <CommitStatus>[

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -193,9 +193,8 @@ void main() {
       expect(lastTask.task, statusesWithSkips[2].stages[0].tasks[0]);
     });
 
-    testWidgets('all cells in the grid have the same size',
+    testWidgets('all cells in the grid have the same size even when grid has skipped tasks',
         (WidgetTester tester) async {
-      /// Use [statusesWithSkips] to check edge cases with skipped tasks.
       final TaskMatrix taskMatrix = TaskMatrix(statuses: statusesWithSkips);
 
       await tester.pumpWidget(


### PR DESCRIPTION
A bug that started in https://github.com/flutter/cocoon/pull/518 where tasks that should be skipped or collated. This lead to skipped tasks not showing correctly and the grid becoming messed up.

The cause was becaused `SizedBox()` was not given a size for skipped tasks. With `GridView` this was okay as everything was constrained, however, this lead to them becoming hidden when switching to the `ListView` implementation.

## Tested

The only way I could think of regression testing this would be tapping at certain points on the screen and checking the task overlay to be correct. However, I did not know if this would become more so E2E testing of the application which is out of scope of the project.

Demo: https://testskipfix-dot-flutter-dashboard.appspot.com/v2/