### PR TITLE
Explicit tree status in AppBar

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -49,9 +49,11 @@ class BuildDashboard extends StatelessWidget {
     return Consumer<FlutterBuildState>(
       builder: (_, FlutterBuildState buildState, Widget child) => Scaffold(
         appBar: AppBar(
-          title: const Text('Flutter Build Dashboard v2'),
+          title: buildState.isTreeBuilding.data
+              ? const Text('Tree is Open')
+              : const Text('Tree is Closed'),
           backgroundColor: buildState.isTreeBuilding.data
-              ? theme.primaryColor
+              ? theme.appBarTheme.color
               : theme.errorColor,
           actions: <Widget>[
             SignInButton(authService: buildState.authService),

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -8,7 +8,7 @@ import 'build_dashboard.dart';
 
 void main() => runApp(MyApp());
 
-ThemeData theme = ThemeData(
+final ThemeData theme = ThemeData(
   appBarTheme: AppBarTheme(color: Colors.green),
   primarySwatch: Colors.blue,
 );

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -8,14 +8,17 @@ import 'build_dashboard.dart';
 
 void main() => runApp(MyApp());
 
+ThemeData theme = ThemeData(
+  appBarTheme: AppBarTheme(color: Colors.green),
+  primarySwatch: Colors.blue,
+);
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Build Dashboard',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
+      theme: theme,
       home: BuildDashboardPage(),
     );
   }

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -2,11 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
+import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
+
+import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/build_dashboard.dart';
+import 'package:app_flutter/main.dart' as app show theme;
+import 'package:app_flutter/service/cocoon.dart';
 import 'package:app_flutter/sign_in_button.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 
@@ -22,4 +29,73 @@ void main() {
 
     expect(find.byType(SignInButton), findsOneWidget);
   });
+
+  testWidgets('shows tree closed when fetch tree status is false',
+      (WidgetTester tester) async {
+    final FlutterBuildState fakeBuildState = FakeFlutterBuildState();
+
+    await tester.pumpWidget(MaterialApp(
+        theme: app.theme,
+        home: ChangeNotifierProvider<FlutterBuildState>(
+          builder: (_) => fakeBuildState,
+          child: BuildDashboard(),
+        )));
+
+    expect(find.text('Tree is Closed'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget;
+    expect(appbarWidget.backgroundColor, app.theme.errorColor);
+  });
+
+  testWidgets('shows tree open when fetch tree status is true',
+      (WidgetTester tester) async {
+    final FlutterBuildState fakeBuildState = FakeFlutterBuildState()
+      ..isTreeBuilding = (CocoonResponse<bool>()..data = true);
+
+    await tester.pumpWidget(MaterialApp(
+        theme: app.theme,
+        home: ChangeNotifierProvider<FlutterBuildState>(
+          builder: (_) => fakeBuildState,
+          child: BuildDashboard(),
+        )));
+
+    expect(find.text('Tree is Open'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget;
+    expect(appbarWidget.backgroundColor, app.theme.appBarTheme.color);
+  });
+}
+
+class FakeFlutterBuildState extends ChangeNotifier
+    implements FlutterBuildState {
+  @override
+  GoogleSignInService authService = GoogleSignInService();
+
+  @override
+  Timer refreshTimer;
+
+  @override
+  bool hasError = false;
+
+  @override
+  CocoonResponse<bool> isTreeBuilding = CocoonResponse<bool>()..data = false;
+
+  @override
+  Duration get refreshRate => null;
+
+  @override
+  Future<bool> rerunTask(Task task) => null;
+
+  @override
+  Future<void> signIn() => null;
+
+  @override
+  Future<void> signOut() => null;
+
+  @override
+  Future<void> startFetchingBuildStateUpdates() => null;
+
+  @override
+  CocoonResponse<List<CommitStatus>> statuses =
+      CocoonResponse<List<CommitStatus>>()..data = <CommitStatus>[];
 }


### PR DESCRIPTION
Replaces the "Build Dashboard v2" title in `AppBar` to be `Tree is Open` or `Tree is Closed`. Additionally, when the tree is open it is set to match the color of a successful task box (green).

Recommended by @digiter 

## Tested

Added tests to check the text and color change of the AppBar based on tree status.

## Preview

Demo: https://testsummary-dot-flutter-dashboard.appspot.com

<img width="174" alt="Tree is Open" src="https://user-images.githubusercontent.com/2148558/69158163-d7cd0380-0a9a-11ea-861f-05a895ceabad.png">

<img width="154" alt="Tree is Closed" src="https://user-images.githubusercontent.com/2148558/69158161-d7cd0380-0a9a-11ea-98fc-876aff2cee04.png">
