### PR TITLE
Update google sign in web to official version

### DIFF
--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -32,16 +32,13 @@ dependencies:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
   google_sign_in: ^4.0.14
-  google_sign_in_web:
-    git:
-      # TODO(chillers): https://github.com/flutter/plugins/pull/2280 and the Google Sign In plugin
-      # publishes the update switch to the official version.
-      url: git://github.com/ditman/plugins.git
-      ref: federated_google_sign_in_web
-      path: packages/google_sign_in/google_sign_in_web
+  google_sign_in_web: ^0.8.0
   provider: ^3.0.0
   url_launcher: 5.2.4
-  url_launcher_web: ^0.8.0
+  url_launcher_web:
+    git:
+      url: git://github.com/flutter/plugins.git
+      path: packages/url_launcher/url_launcher_web
 
 dev_dependencies:
   flutter_test:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -41,10 +41,7 @@ dependencies:
       path: packages/google_sign_in/google_sign_in_web
   provider: ^3.0.0
   url_launcher: 5.2.4
-  url_launcher_web:
-    git:
-      url: git://github.com/flutter/plugins.git
-      path: packages/url_launcher/url_launcher_web
+  url_launcher_web: ^0.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
No new PRs can go through until this update is made since the forked branch got deleted.