### PR TITLE
Update url launcher web to official plugin

### DIFF
--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -34,11 +34,8 @@ dependencies:
   google_sign_in: ^4.0.14
   google_sign_in_web: ^0.8.0
   provider: ^3.0.0
-  url_launcher: 5.2.4
-  url_launcher_web:
-    git:
-      url: git://github.com/flutter/plugins.git
-      path: packages/url_launcher/url_launcher_web
+  url_launcher: ^5.2.4
+  url_launcher_web: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I noticed this in #535 and @ditman published the web version today.

This is the last plugin in our dependencies that wasn't using a published plugin.