### PR TITLE
Commit Overlay and Task Overlay UI Cleanup

### DIFF
--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_progress_button/flutter_progress_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit;
@@ -121,24 +122,20 @@ class CommitOverlayContents extends StatelessWidget {
                     backgroundColor: Colors.transparent,
                   ),
                   // TODO(chillers): Show commit message here instead: https://github.com/flutter/cocoon/issues/435
-                  title: Text(commit.sha),
+                  // Shorten the SHA as we only need first 7 digits to be able
+                  // to lookup the commit.
+                  title: SelectableText(commit.sha.substring(0, 7)),
                   subtitle: Text(commit.author),
                 ),
                 ButtonBar(
                   children: <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.repeat),
-                      onPressed: () {
-                        // TODO(chillers): rerun all tests for this commit
-                      },
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.open_in_new),
-                      onPressed: () async {
-                        final String githubUrl =
-                            'https://github.com/${commit.repository}/commit/${commit.sha}';
-                        launch(githubUrl);
-                      },
+                    ProgressButton(
+                      defaultWidget: const Text('GitHub'),
+                      progressWidget: const CircularProgressIndicator(),
+                      width: 100,
+                      height: 50,
+                      onPressed: _openGithub,
+                      animate: false,
                     ),
                   ],
                 ),
@@ -148,5 +145,11 @@ class CommitOverlayContents extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _openGithub() async {
+    final String githubUrl =
+        'https://github.com/${commit.repository}/commit/${commit.sha}';
+    launch(githubUrl);
   }
 }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -75,6 +75,7 @@ class FlutterBuildState extends ChangeNotifier {
         } else {
           _statuses = response;
         }
+        notifyListeners();
       }),
       _cocoonService
           .fetchTreeBuildStatus()
@@ -84,10 +85,9 @@ class FlutterBuildState extends ChangeNotifier {
         } else {
           _isTreeBuilding = response;
         }
+        notifyListeners();
       }),
     ]);
-
-    notifyListeners();
   }
 
   Future<void> signIn() => authService.signIn();

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -323,7 +323,7 @@ class TaskOverlayContents extends StatelessWidget {
                 ProgressButton(
                   defaultWidget: const Text('Rerun'),
                   progressWidget: const CircularProgressIndicator(),
-                  width: 120,
+                  width: 70,
                   height: 50,
                   onPressed: _rerunTask,
                   animate: false,

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -292,6 +292,8 @@ class TaskOverlayContents extends StatelessWidget {
   Widget build(BuildContext context) {
     final int taskDurationInSeconds =
         (task.endTimestamp - task.startTimestamp).toInt() ~/ 100;
+    final int taskDurationInMinutes = taskDurationInSeconds ~/ 60;
+
     return Card(
       child: Column(
         mainAxisSize: MainAxisSize.max,
@@ -300,9 +302,11 @@ class TaskOverlayContents extends StatelessWidget {
             leading:
                 Tooltip(message: taskStatus, child: statusIcon[taskStatus]),
             title: Text(task.name),
-            subtitle: Text('Attempts: ${task.attempts}\n'
-                'Duration: $taskDurationInSeconds seconds\n'
-                'Agent: ${task.reservedForAgentId}'),
+            subtitle: isDevicelab(task)
+                ? Text('Attempts: ${task.attempts}\n'
+                    'Duration: $taskDurationInMinutes minutes\n'
+                    'Agent: ${task.reservedForAgentId}')
+                : const Text('Task was run outside of devicelab'),
             contentPadding: const EdgeInsets.all(16.0),
           ),
           ButtonBar(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -290,6 +290,8 @@ class TaskOverlayContents extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final int taskDurationInSeconds =
+        (task.endTimestamp - task.startTimestamp).toInt() ~/ 100;
     return Card(
       child: Column(
         mainAxisSize: MainAxisSize.max,
@@ -299,8 +301,9 @@ class TaskOverlayContents extends StatelessWidget {
                 Tooltip(message: taskStatus, child: statusIcon[taskStatus]),
             title: Text(task.name),
             subtitle: Text('Attempts: ${task.attempts}\n'
-                'Duration: ${task.endTimestamp - task.startTimestamp} seconds\n'
+                'Duration: $taskDurationInSeconds seconds\n'
                 'Agent: ${task.reservedForAgentId}'),
+            contentPadding: const EdgeInsets.all(16.0),
           ),
           ButtonBar(
             children: <Widget>[
@@ -314,7 +317,7 @@ class TaskOverlayContents extends StatelessWidget {
               ),
               if (isDevicelab(task))
                 ProgressButton(
-                  defaultWidget: const Text('Rerun task'),
+                  defaultWidget: const Text('Rerun'),
                   progressWidget: const CircularProgressIndicator(),
                   width: 120,
                   height: 50,

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -40,13 +40,14 @@ void main() {
         ),
       ));
 
-      expect(find.text(expectedCommit.sha), findsNothing);
+      final String shortSha = expectedCommit.sha.substring(0, 7);
+      expect(find.text(shortSha), findsNothing);
       expect(find.text(expectedCommit.author), findsNothing);
 
       await tester.tap(find.byType(CommitBox));
       await tester.pump();
 
-      expect(find.text(expectedCommit.sha), findsOneWidget);
+      expect(find.text(shortSha), findsOneWidget);
       expect(find.text(expectedCommit.author), findsOneWidget);
     });
 
@@ -69,7 +70,7 @@ void main() {
       expect(find.text(expectedCommit.sha), findsNothing);
     });
 
-    testWidgets('tapping redirect button should redirect to Github',
+    testWidgets('tapping GitHub button should redirect to GitHub',
         (WidgetTester tester) async {
       // The url_launcher calls get logged in this channel
       const MethodChannel channel =
@@ -90,7 +91,7 @@ void main() {
       await tester.pump();
 
       // Tap the redirect button
-      await tester.tap(find.byIcon(Icons.open_in_new));
+      await tester.tap(find.text('GitHub'));
       await tester.pump();
 
       expect(

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -206,7 +206,7 @@ void main() {
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
 
       // Click the rerun task button
-      await tester.tap(find.text('Rerun task'));
+      await tester.tap(find.text('Rerun'));
       await tester.pump();
       await tester
           .pump(const Duration(milliseconds: 750)); // 750ms open animation
@@ -246,7 +246,7 @@ void main() {
       expect(find.text(TaskOverlayContents.rerunSuccessMessage), findsNothing);
 
       // Click the rerun task button
-      await tester.tap(find.text('Rerun task'));
+      await tester.tap(find.text('Rerun'));
       await tester.pump();
       await tester
           .pump(const Duration(milliseconds: 750)); // 750ms open animation

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -140,7 +140,7 @@ void main() {
       );
 
       final String expectedTaskInfoString =
-          'Attempts: ${expectedTask.attempts}\nDuration: 0 seconds\nAgent: ${expectedTask.reservedForAgentId}';
+          'Attempts: ${expectedTask.attempts}\nDuration: 0 minutes\nAgent: ${expectedTask.reservedForAgentId}';
       expect(find.text(expectedTask.name), findsNothing);
       expect(find.text(expectedTaskInfoString), findsNothing);
 
@@ -155,6 +155,34 @@ void main() {
 
       // Since the overlay is on screen, the indicator should be showing
       expect(find.byKey(const Key('task-overlay-key')), findsOneWidget);
+    });
+
+    testWidgets('overlay message for nondevicelab tasks',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: Task()
+                ..stageName = 'cirrus'
+                ..status = 'Succeeeded',
+            ),
+          ),
+        ),
+      );
+
+      const String expectedTaskInfoString = 'Task was run outside of devicelab';
+      expect(find.text(expectedTask.name), findsNothing);
+      expect(find.text(expectedTaskInfoString), findsNothing);
+
+      // Ensure the task indicator isn't showing when overlay is not shown
+      expect(find.byKey(const Key('task-overlay-key')), findsNothing);
+
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      expect(find.text(expectedTaskInfoString), findsOneWidget);
     });
 
     testWidgets('closes overlay on click out', (WidgetTester tester) async {


### PR DESCRIPTION
These changes are to help make the app more explicit and concise. This was feedback given from the team with the v1 dashboard.

Removed the place holder button for rerunning all failed tasks for a commit: Requires a day of work to handle the errors that occur, as right now worst case you will get 10 minutes of error snackbars if the application is not signed in.

Expanded the open in GitHub icon button a button that just says GitHub.

Shortened commit sha in to just show the first 7 characters which is unique enough to lookup a flutter/flutter commit.

Renamed the "Rerun task" button to "Rerun".

Fixed the duration in the task overlay to be in minutes

## Open Questions

- Is there a way to make text copyable on web?

## Preview

Demo: https://testui-dot-flutter-dashboard.appspot.com/v2/

![image](https://user-images.githubusercontent.com/2148558/69208038-f2d55d00-0b06-11ea-9f2e-25777039f5a7.png)

![image](https://user-images.githubusercontent.com/2148558/69260597-015a5d80-0b75-11ea-9cec-d98fbf922361.png)

![image](https://user-images.githubusercontent.com/2148558/69260650-1505c400-0b75-11ea-817d-09df52c73d1f.png)
