### PR TITLE
[agent] Update retry logic to kill adb server in windows.

### DIFF
--- a/agent/lib/src/adb.dart
+++ b/agent/lib/src/adb.dart
@@ -115,7 +115,6 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   @override
   Future<List<Device>> discoverDevices({int retriesDelayMs=10000}) async {
     int retry = 0;
-    bool adbOk = false;
     List<String> output;
     while (true) {
       try {

--- a/agent/test/src/adb_test.dart
+++ b/agent/test/src/adb_test.dart
@@ -38,7 +38,7 @@ void main() {
       deviceDiscovery.outputs = <dynamic>[
         new TimeoutException('a'), new TimeoutException('b'),
         sb.toString()];
-      List<Device> devices = await deviceDiscovery.discoverDevices(retriesDelay: 1);
+      List<Device> devices = await deviceDiscovery.discoverDevices(retriesDelayMs: 1);
       expect(devices.length, equals(1));
       expect(devices[0].deviceId, equals('ZY223JQNMR'));
     });
@@ -48,7 +48,7 @@ void main() {
         new TimeoutException('a'), new TimeoutException('b'),
         new TimeoutException('c')];
       expect(() => deviceDiscovery.discoverDevices(
-        retriesDelay: 1),
+        retriesDelayMs: 1),
         throwsA(TypeMatcher<TimeoutException>()));
     });
   });


### PR DESCRIPTION
Windows machines keep hanging on "adb devices -l" there is no way to fix
it other than just killing the adb server. Unfortunately for windows
"adb kill-server" does not work as expected and we need to explicitly
kill the process.

This is to fix:

https://github.com/flutter/flutter/issues/43930