### PR TITLE
Pipe Commit through TaskBox for Cirrus logs

### DIFF
--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -97,13 +97,7 @@ class FlutterBuildState extends ChangeNotifier {
     return _cocoonService.rerunTask(task, await authService.idToken);
   }
 
-  Future<bool> downloadLog(Task task) async {
-    // In production use, this usually goes through the last 5 CommitStatus.
-    // Worst case it can be O(N), but it is inexpensive.
-    final Commit commit = statuses.data
-        .firstWhere(
-            (CommitStatus status) => status.commit.key == task.commitKey)
-        .commit;
+  Future<bool> downloadLog(Task task, Commit commit) async {
     return _cocoonService.downloadLog(
         task, await authService.idToken, commit.sha);
   }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -163,6 +163,7 @@ class _StatusGridState extends State<StatusGrid> {
                   : null,
               buildState: widget.buildState,
               task: widget.taskMatrix.task(rowIndex, colIndex),
+              commit: widget.statuses[rowIndex].commit,
             )
           else
             SizedBox(

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -385,6 +385,6 @@ class TaskOverlayContents extends StatelessWidget {
     }
 
     /// Tasks outside of devicelab have public logs that we just redirect to.
-    launch(logUrl(task, commit));
+    launch(logUrl(task, commit: commit));
   }
 }

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_progress_button/flutter_progress_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:cocoon_service/protos.dart' show Task;
+import 'package:cocoon_service/protos.dart' show Commit, Task;
 
 import 'state/flutter_build.dart';
 import 'status_grid.dart';
@@ -18,7 +18,8 @@ import 'task_helper.dart';
 /// with a [CircularProgressIndicator] in the box.
 /// Shows a black box for unknown statuses.
 class TaskBox extends StatefulWidget {
-  const TaskBox({Key key, @required this.buildState, @required this.task})
+  const TaskBox(
+      {Key key, @required this.buildState, @required this.task, this.commit})
       : assert(task != null),
         assert(buildState != null),
         super(key: key);
@@ -28,6 +29,9 @@ class TaskBox extends StatefulWidget {
 
   /// [Task] to show information from.
   final Task task;
+
+  /// [Commit] for cirrus tasks to show log.
+  final Commit commit;
 
   /// Status messages that map to TaskStatus enums.
   // TODO(chillers): Remove these and use TaskStatus enum when available. https://github.com/flutter/cocoon/issues/441
@@ -138,6 +142,7 @@ class _TaskBoxState extends State<TaskBox> {
         task: widget.task,
         taskStatus: status,
         closeCallback: _closeOverlay,
+        commit: widget.commit,
       ),
     );
 
@@ -159,6 +164,7 @@ class TaskOverlayEntry extends StatelessWidget {
     @required this.taskStatus,
     @required this.closeCallback,
     @required this.buildState,
+    this.commit,
   })  : assert(parentContext != null),
         assert(buildState != null),
         assert(task != null),
@@ -173,6 +179,9 @@ class TaskOverlayEntry extends StatelessWidget {
 
   /// The [Task] to display in the overlay
   final Task task;
+
+  /// [Commit] for cirrus tasks to show log.
+  final Commit commit;
 
   /// [Task.status] modified to take into account [Task.attempts] to create
   /// a more descriptive status.
@@ -223,6 +232,7 @@ class TaskOverlayEntry extends StatelessWidget {
             buildState: buildState,
             task: task,
             taskStatus: taskStatus,
+            commit: commit,
           ),
         ),
       ],
@@ -243,6 +253,7 @@ class TaskOverlayContents extends StatelessWidget {
     @required this.buildState,
     @required this.task,
     @required this.taskStatus,
+    this.commit,
   })  : assert(showSnackbarCallback != null),
         assert(buildState != null),
         assert(task != null),
@@ -260,6 +271,9 @@ class TaskOverlayContents extends StatelessWidget {
   /// [Task.status] modified to take into account [Task.attempts] to create
   /// a more descriptive status.
   final String taskStatus;
+
+  /// [Commit] for cirrus tasks to show log.
+  final Commit commit;
 
   @visibleForTesting
   static const String rerunErrorMessage = 'Failed to rerun task.';
@@ -354,7 +368,7 @@ class TaskOverlayContents extends StatelessWidget {
   /// If a devicelab log fails to download, show an error snackbar.
   Future<void> _viewLog() async {
     if (isDevicelab(task)) {
-      final bool success = await buildState.downloadLog(task);
+      final bool success = await buildState.downloadLog(task, commit);
 
       if (!success) {
         /// Only show [Snackbar] on failure since the user's device will
@@ -371,6 +385,6 @@ class TaskOverlayContents extends StatelessWidget {
     }
 
     /// Tasks outside of devicelab have public logs that we just redirect to.
-    launch(logUrl(task));
+    launch(logUrl(task, commit));
   }
 }

--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -28,10 +28,11 @@ class StageName {
 /// Devicelab tasks can be retrieved via an authenticated API endpoint.
 /// Cirrus logs are located via their [Commit.sha].
 /// Otherwise, we can redirect to the page that is closest to the logs for [Task].
-String logUrl(Task task, Commit commit) {
-  if (task.stageName == StageName.cirrus) {
+String logUrl(Task task, {Commit commit}) {
+  if (task.stageName == StageName.cirrus && commit != null) {
     return '$cirrusUrl/${commit.sha}';
   } else if (_isExternal(task)) {
+    // Currently this is just LUCI, but is a catch all if new stages are added.
     return sourceConfigurationUrl(task);
   }
 

--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/protos.dart' show Task;
+import 'package:cocoon_service/protos.dart' show Commit, Task;
 
 /// A collection of common utilities done with a [Task].
 
@@ -26,9 +26,12 @@ class StageName {
 /// Get the URL for [Task] to view its log.
 ///
 /// Devicelab tasks can be retrieved via an authenticated API endpoint.
+/// Cirrus logs are located via their [Commit.sha].
 /// Otherwise, we can redirect to the page that is closest to the logs for [Task].
-String logUrl(Task task) {
-  if (_isExternal(task)) {
+String logUrl(Task task, Commit commit) {
+  if (task.stageName == StageName.cirrus) {
+    return '$cirrusUrl/${commit.sha}';
+  } else if (_isExternal(task)) {
     return sourceConfigurationUrl(task);
   }
 

--- a/app_flutter/lib/task_helper.dart
+++ b/app_flutter/lib/task_helper.dart
@@ -11,6 +11,7 @@ const String flutterGithubSourceUrl =
     'https://github.com/flutter/flutter/blob/master';
 const String flutterDashboardUrl = 'https://flutter-dashboard.appspot.com';
 const String cirrusUrl = 'https://cirrus-ci.com/github/flutter/flutter';
+const String cirrusLogUrl = 'https://cirrus-ci.com/build/flutter/flutter';
 const String luciUrl = 'https://ci.chromium.org/p/flutter';
 
 /// [Task.stageName] that maps to StageName enums.
@@ -30,7 +31,7 @@ class StageName {
 /// Otherwise, we can redirect to the page that is closest to the logs for [Task].
 String logUrl(Task task, {Commit commit}) {
   if (task.stageName == StageName.cirrus && commit != null) {
-    return '$cirrusUrl/${commit.sha}';
+    return '$cirrusLogUrl/${commit.sha}';
   } else if (_isExternal(task)) {
     // Currently this is just LUCI, but is a catch all if new stages are added.
     return sourceConfigurationUrl(task);

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
-import 'package:cocoon_service/protos.dart' show CommitStatus, Task;
+import 'package:cocoon_service/protos.dart' show Commit, CommitStatus, Task;
 
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/build_dashboard.dart';
@@ -100,5 +100,5 @@ class FakeFlutterBuildState extends ChangeNotifier
       CocoonResponse<List<CommitStatus>>()..data = <CommitStatus>[];
 
   @override
-  Future<bool> downloadLog(Task task) => null;
+  Future<bool> downloadLog(Task task, Commit commit) => null;
 }

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -325,7 +325,7 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('launch', arguments: <String, Object>{
-            'url': logUrl(publicTask, commit),
+            'url': logUrl(publicTask, commit: commit),
             'useSafariVC': true,
             'useWebView': false,
             'enableJavaScript': false,

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:mockito/mockito.dart';
 
-import 'package:cocoon_service/protos.dart' show Task;
+import 'package:cocoon_service/protos.dart' show Commit, Task;
 
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/state/flutter_build.dart';
@@ -300,12 +300,14 @@ void main() {
         log.add(methodCall);
       });
       final Task publicTask = Task()..stageName = 'cirrus';
+      final Commit commit = Commit()..sha = 'github123';
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: TaskBox(
               buildState: buildState,
               task: publicTask,
+              commit: commit,
             ),
           ),
         ),
@@ -323,7 +325,7 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('launch', arguments: <String, Object>{
-            'url': logUrl(publicTask),
+            'url': logUrl(publicTask, commit),
             'useSafariVC': true,
             'useWebView': false,
             'enableJavaScript': false,
@@ -337,7 +339,7 @@ void main() {
 
     testWidgets('log button calls build state to download devicelab log',
         (WidgetTester tester) async {
-      when(buildState.downloadLog(any))
+      when(buildState.downloadLog(any, any))
           .thenAnswer((_) => Future<bool>.value(true));
       await tester.pumpWidget(
         MaterialApp(
@@ -354,18 +356,18 @@ void main() {
       await tester.tap(find.byType(TaskBox));
       await tester.pump();
 
-      verifyNever(buildState.downloadLog(any));
+      verifyNever(buildState.downloadLog(any, any));
 
       // Click log button
       await tester.tap(find.text('Log'));
       await tester.pump();
 
-      verify(buildState.downloadLog(any)).called(1);
+      verify(buildState.downloadLog(any, any)).called(1);
     });
 
     testWidgets('failing to download devicelab log shows error snackbar',
         (WidgetTester tester) async {
-      when(buildState.downloadLog(any))
+      when(buildState.downloadLog(any, any))
           .thenAnswer((_) => Future<bool>.value(false));
       await tester.pumpWidget(
         MaterialApp(

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -20,7 +20,10 @@ void main() {
       final Task cirrusTask = Task()..stageName = 'cirrus';
 
       expect(logUrl(cirrusTask, commit: Commit()..sha = 'abc123'),
-          'https://cirrus-ci.com/github/flutter/flutter/abc123');
+          'https://cirrus-ci.com/build/flutter/flutter/abc123');
+
+      expect(logUrl(cirrusTask),
+          'https://cirrus-ci.com/github/flutter/flutter/master');
     });
 
     test('log url for devicelab tasks redirects to cocoon backend', () {

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:test/test.dart';
 
-import 'package:cocoon_service/protos.dart' show Task;
+import 'package:cocoon_service/protos.dart' show Commit, Task;
 
 import 'package:app_flutter/task_helper.dart';
 
@@ -15,12 +15,12 @@ void main() {
         ..stageName = 'chromebot'
         ..name = 'mac_bot';
 
-      expect(logUrl(luciTask),
+      expect(logUrl(luciTask, Commit()),
           'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
       final Task cirrusTask = Task()..stageName = 'cirrus';
 
-      expect(logUrl(cirrusTask),
-          'https://cirrus-ci.com/github/flutter/flutter/master');
+      expect(logUrl(cirrusTask, Commit()..sha = 'abc123'),
+          'https://cirrus-ci.com/github/flutter/flutter/abc123');
     });
 
     test('log url for devicelab tasks redirects to cocoon backend', () {
@@ -28,7 +28,7 @@ void main() {
         ..stageName = 'devicelab'
         ..name = 'test';
 
-      expect(logUrl(devicelabTask),
+      expect(logUrl(devicelabTask, Commit()),
           'https://flutter-dashboard.appspot.com/api/get-log?ownerKey=${devicelabTask.key}');
     });
 

--- a/app_flutter/test/task_helper_test.dart
+++ b/app_flutter/test/task_helper_test.dart
@@ -15,11 +15,11 @@ void main() {
         ..stageName = 'chromebot'
         ..name = 'mac_bot';
 
-      expect(logUrl(luciTask, Commit()),
+      expect(logUrl(luciTask),
           'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
       final Task cirrusTask = Task()..stageName = 'cirrus';
 
-      expect(logUrl(cirrusTask, Commit()..sha = 'abc123'),
+      expect(logUrl(cirrusTask, commit: Commit()..sha = 'abc123'),
           'https://cirrus-ci.com/github/flutter/flutter/abc123');
     });
 
@@ -28,7 +28,7 @@ void main() {
         ..stageName = 'devicelab'
         ..name = 'test';
 
-      expect(logUrl(devicelabTask, Commit()),
+      expect(logUrl(devicelabTask),
           'https://flutter-dashboard.appspot.com/api/get-log?ownerKey=${devicelabTask.key}');
     });
 


### PR DESCRIPTION
Cirrus needs the Commit sha appended to the end of the Cirrus URL to end up on the log specific for that Cirrus task.

Plumbed `Commit` variable to this location to make it easier to expand the `TaskOverlay` with more information regarding the task in a later commit.

## Tested

Added tests for checking the cirrus log redirects to the sha url when Commit is given instead of master.

## Preview

Demo: https://testchillers-dot-flutter-dashboard.appspot.com/build.html