### PR TITLE
Do not use the MERGEABLE flag

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -169,7 +169,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       }
       final String id = pullRequest['id'];
       final int number = pullRequest['number'];
-      final bool mergeable = pullRequest['mergeable'] == 'MERGEABLE';
       final bool hasApproval = pullRequest['approvedReviews']['nodes'].isNotEmpty;
       final bool hasChangesRequested = pullRequest['changeRequestReviews']['nodes'].isNotEmpty;
       final String sha = commit['oid'];
@@ -179,7 +178,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         ciSuccessful: ciSuccessful,
         hasApprovedReview: hasApproval,
         hasChangesRequested: hasChangesRequested,
-        mergeable: mergeable,
         number: number,
         sha: sha,
         labelId: labelId,
@@ -197,7 +195,6 @@ class _AutoMergeQueryResult {
     @required this.graphQLId,
     @required this.hasApprovedReview,
     @required this.hasChangesRequested,
-    @required this.mergeable,
     @required this.ciSuccessful,
     @required this.number,
     @required this.sha,
@@ -205,7 +202,6 @@ class _AutoMergeQueryResult {
   })  : assert(graphQLId != null),
         assert(hasApprovedReview != null),
         assert(hasChangesRequested != null),
-        assert(mergeable != null),
         assert(ciSuccessful != null),
         assert(number != null),
         assert(sha != null),
@@ -220,9 +216,6 @@ class _AutoMergeQueryResult {
   /// Whether the pull request has at least one change request review.
   final bool hasChangesRequested;
 
-  /// Whether the pull request is mergeable, i.e. has merge conflicts or not.
-  final bool mergeable;
-
   /// Whether CI has run successfully on the pull request.
   final bool ciSuccessful;
 
@@ -236,10 +229,10 @@ class _AutoMergeQueryResult {
   final String labelId;
 
   /// Whether it is sane to automatically merge this PR.
-  bool get shouldMerge => ciSuccessful && mergeable && hasApprovedReview && !hasChangesRequested;
+  bool get shouldMerge => ciSuccessful && hasApprovedReview && !hasChangesRequested;
 
   /// Whether the auto-merge label should be removed from this PR.
-  bool get shouldRemoveLabel => !mergeable || !hasApprovedReview || hasChangesRequested;
+  bool get shouldRemoveLabel => !hasApprovedReview || hasChangesRequested;
 
   /// An appropriate message to leave when removing the label.
   String get removalMessage {
@@ -250,9 +243,6 @@ class _AutoMergeQueryResult {
     buffer.writeln('This pull request is not suitable for automatic merging in its '
         'current state.');
     buffer.writeln();
-    if (!mergeable) {
-      buffer.writeln('- Please resolve merge conflicts before re-applying this label.');
-    }
     if (!hasApprovedReview) {
       buffer.writeln('- Please get at least one approved review before re-applying this '
           'label. __Reviewers__: If you left a comment approving, please use '
@@ -273,7 +263,6 @@ class _AutoMergeQueryResult {
         'ciSuccessful: $ciSuccessful, '
         'hasApprovedReview: $hasApprovedReview, '
         'hasChangesRequested: $hasChangesRequested, '
-        'mergeable: $mergeable, '
         'labelId: $labelId, '
         'shouldMerge: $shouldMerge}';
   }

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -171,15 +171,11 @@ void main() {
       );
       final PullRequestHelper prNoReviews =
           PullRequestHelper(hasApprovedReview: false);
-      final PullRequestHelper prMergeConflict = PullRequestHelper(
-        mergeable: false,
-      );
       final PullRequestHelper prRed = PullRequestHelper(
         lastCommitSuccess: false,
       );
       final PullRequestHelper prEverythingWrong = PullRequestHelper(
         lastCommitSuccess: false,
-        mergeable: false,
         hasApprovedReview: false,
         hasChangeRequestReview: true,
       );
@@ -187,7 +183,6 @@ void main() {
       flutterRepoPRs.add(prOneBadReview);
       flutterRepoPRs.add(prOneGoodOneBadReview);
       flutterRepoPRs.add(prNoReviews);
-      flutterRepoPRs.add(prMergeConflict);
       flutterRepoPRs.add(prRed); // ignored.
       flutterRepoPRs.add(prEverythingWrong);
 
@@ -237,23 +232,10 @@ void main() {
           MutationOptions(
             document: removeLabelMutation,
             variables: <String, dynamic>{
-              'id': prMergeConflict.id,
-              'sBody':
-                  '''This pull request is not suitable for automatic merging in its current state.
-
-- Please resolve merge conflicts before re-applying this label.
-''',
-              'labelId': base64LabelId,
-            },
-          ),
-          MutationOptions(
-            document: removeLabelMutation,
-            variables: <String, dynamic>{
               'id': prEverythingWrong.id,
               'sBody':
                   '''This pull request is not suitable for automatic merging in its current state.
 
-- Please resolve merge conflicts before re-applying this label.
 - Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 - This pull request has changes requested. Please resolve those before re-applying the label.
 ''',
@@ -321,7 +303,6 @@ class FakeGraphQLClient implements GraphQLClient {
 
 class PullRequestHelper {
   PullRequestHelper({
-    this.mergeable = true,
     this.hasApprovedReview = true,
     this.hasChangeRequestReview = false,
     this.lastCommitHash = oid,
@@ -334,7 +315,6 @@ class PullRequestHelper {
   final int _count;
   String get id => _count.toString();
 
-  final bool mergeable;
   final bool hasApprovedReview;
   final bool hasChangeRequestReview;
   final String lastCommitHash;
@@ -345,7 +325,6 @@ class PullRequestHelper {
     return <String, dynamic>{
       'id': id,
       'number': id.hashCode,
-      'mergeable': mergeable ? 'MERGEABLE' : 'CONFLICT',
       'approvedReviews': <String, dynamic>{
         'nodes': hasApprovedReview
             ? <dynamic>[


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/45357

The API does not return the flag in a useable way for this.  If the PR isn't actually mergeable we'll know when we try to merge it anyway.