### PR TITLE
Push version constraint for Stream.value

### DIFF
--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -639,4 +639,4 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.5.0 <3.0.0"

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/flutter/cocoon
 publish_to: none
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.5.0 <3.0.0'
 
 dependencies:
   appengine: ^0.10.0


### PR DESCRIPTION
https://api.dartlang.org/stable/2.6.1/dart-async/Stream/Stream.value.html - Stream.value requires at least 2.5.0. 