### PR TITLE
Path typo in the deploy script

### DIFF
--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -100,7 +100,7 @@ Future<bool> _buildFlutterWebApp() async {
 /// Copy the built project from app to this app_dart project.
 Future<bool> _copyAngularDartProject() async {
   final ProcessResult result = await Process.run('cp',
-      <String>['-r', '$angularDartProjectDirectory/build/web/', 'build/']);
+      <String>['-r', '$angularDartProjectDirectory/build/', 'build/']);
 
   return result.exitCode == 0;
 }


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/523 introduced this issue. Somehow everything got deployed correctly, but when I did a wipe on my machine this issue manifested. There's a regression test for this already in the deploy script (delete the build folder that will be uploaded before rerunning the build scripts). However, I don't know how we managed to deploy everything yesterday when switching over the dashboard.