### PR TITLE
Tree status for loading

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -83,12 +83,14 @@ class BuildDashboard extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
 
+    /// Color of [AppBar] based on [buildState.isTreeBuilding].
     final Map<bool, Color> colorTable = <bool, Color>{
       null: Colors.grey,
       false: theme.errorColor,
       true: theme.appBarTheme.color,
     };
 
+    /// Message to show on [AppBar] based on [buildState.isTreeBuilding].
     const Map<bool, Text> statusTable = <bool, Text>{
       null: Text('Loading...'),
       false: Text('Tree is Closed'),

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -82,16 +82,25 @@ class BuildDashboard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+
+    final Map<bool, Color> colorTable = <bool, Color>{
+      null: Colors.grey,
+      false: theme.errorColor,
+      true: theme.appBarTheme.color,
+    };
+
+    const Map<bool, Text> statusTable = <bool, Text>{
+      null: Text('Loading...'),
+      false: Text('Tree is Closed'),
+      true: Text('Tree is Open'),
+    };
+
     return Consumer<FlutterBuildState>(
       builder: (_, FlutterBuildState buildState, Widget child) => Scaffold(
         key: scaffoldKey,
         appBar: AppBar(
-          title: buildState.isTreeBuilding
-              ? const Text('Tree is Open')
-              : const Text('Tree is Closed'),
-          backgroundColor: buildState.isTreeBuilding
-              ? theme.appBarTheme.color
-              : theme.errorColor,
+          title: statusTable[buildState.isTreeBuilding],
+          backgroundColor: colorTable[buildState.isTreeBuilding],
           actions: <Widget>[
             SignInButton(authService: buildState.authService),
           ],

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -72,7 +72,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
 
 /// Shows information about the current build status of flutter/flutter.
 ///
-/// The tree's current build status is reflected in the color of [AppBar].
+/// The tree's current build status is reflected in [AppBar].
 /// The results from tasks run on individual commits is shown in [StatusGrid].
 class BuildDashboard extends StatelessWidget {
   const BuildDashboard({this.scaffoldKey});

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -43,7 +43,7 @@ class FlutterBuildState extends ChangeNotifier {
   List<CommitStatus> get statuses => _statuses;
 
   /// Whether or not flutter/flutter currently passes tests.
-  bool _isTreeBuilding = false;
+  bool _isTreeBuilding;
   bool get isTreeBuilding => _isTreeBuilding;
 
   /// A [ChangeNotifer] for knowing when errors occur that relate to this [FlutterBuildState].

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -26,6 +26,24 @@ void main() {
     expect(find.byType(SignInButton), findsOneWidget);
   });
 
+  testWidgets('shows loading when fetch tree status is null',
+      (WidgetTester tester) async {
+    final FlutterBuildState fakeBuildState = FakeFlutterBuildState()
+      ..isTreeBuilding = null;
+
+    await tester.pumpWidget(MaterialApp(
+        theme: app.theme,
+        home: ChangeNotifierProvider<FlutterBuildState>(
+          builder: (_) => fakeBuildState,
+          child: const BuildDashboard(),
+        )));
+
+    expect(find.text('Loading...'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget;
+    expect(appbarWidget.backgroundColor, Colors.grey);
+  });
+
   testWidgets('shows tree closed when fetch tree status is false',
       (WidgetTester tester) async {
     final FlutterBuildState fakeBuildState = FakeFlutterBuildState();

--- a/app_flutter/test/build_dashboard_test.dart
+++ b/app_flutter/test/build_dashboard_test.dart
@@ -46,7 +46,8 @@ void main() {
 
   testWidgets('shows tree closed when fetch tree status is false',
       (WidgetTester tester) async {
-    final FlutterBuildState fakeBuildState = FakeFlutterBuildState();
+    final FlutterBuildState fakeBuildState = FakeFlutterBuildState()
+      ..isTreeBuilding = false;
 
     await tester.pumpWidget(MaterialApp(
         theme: app.theme,

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -23,7 +23,7 @@ class FakeFlutterBuildState extends ChangeNotifier
   FlutterBuildStateErrors errors = FlutterBuildStateErrors();
 
   @override
-  bool isTreeBuilding = false;
+  bool isTreeBuilding;
 
   @override
   Duration get refreshRate => null;


### PR DESCRIPTION
Update the tree status to use the null value. This is used on initialization to let users know that we're loading the value. During this state, it shows a grey `AppBar` that says loading.

Originally, we just showed the failed status since that's the worst case. However, it was marginally noticeable as `/api/public/build-status` would return in a few seconds. Lately, it has been averaging at ~7 seconds.

## Issues

Fixes https://github.com/flutter/flutter/issues/45285

## Preview

![loading_appbar](https://user-images.githubusercontent.com/2148558/69575799-d2caf100-0f7f-11ea-88b5-259e93589e2d.png)

Demo at https://testchillers-dot-flutter-dashboard.appspot.com/build.html