### PR TITLE
Angular Dart state fixes

### DIFF
--- a/app/lib/build/status_card.dart
+++ b/app/lib/build/status_card.dart
@@ -56,15 +56,18 @@ class StatusCard extends ComponentState implements OnInit, OnDestroy {
   void show(AgentStatus value) {
     _checkHealth();
     agentStatus = value;
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 
   /// Hide the agent status card.
   void hide() {
     agentStatus = null;
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 
   void _checkHealth([Object _]) {
     _lastHealthCheck = new DateTime.now();
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 }
 

--- a/app/lib/build/task_guide.dart
+++ b/app/lib/build/task_guide.dart
@@ -15,6 +15,7 @@ class TaskGuideComponent extends ComponentState {
   set headerRow(HeaderRow value) {
     if (value == _headerRow) return;
     _headerRow = value;
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 
   List<BuildStatus> get headerCol => _headerCol;
@@ -23,5 +24,6 @@ class TaskGuideComponent extends ComponentState {
   set headerCol(List<BuildStatus> value) {
     if (value == headerCol) return;
     _headerCol = value;
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 }

--- a/app/lib/build/task_legend.dart
+++ b/app/lib/build/task_legend.dart
@@ -16,5 +16,6 @@ class TaskLegend extends ComponentState {
 
   void toggleVisibility() {
     legendVisible = !legendVisible;
+    deliverStateChanges(); // ignore: deprecated_member_use
   }
 }

--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -100,7 +100,7 @@ Future<bool> _buildFlutterWebApp() async {
 /// Copy the built project from app to this app_dart project.
 Future<bool> _copyAngularDartProject() async {
   final ProcessResult result = await Process.run('cp',
-      <String>['-r', '$angularDartProjectDirectory/build/', 'build/']);
+      <String>['-r', '$angularDartProjectDirectory/build/web', 'build/']);
 
   return result.exitCode == 0;
 }


### PR DESCRIPTION
Introduced in https://github.com/flutter/cocoon/pull/404. The deprecation mention messages these can be just removed, but doing that breaks the functionality. Since Cocoon is switching over to Flutter, I am just adding an ignore statement. The ideal approach would be to restructure the state of the Angular apps to work with the Angular state system.

The switch to using just the Dart runtime on AppEngine caused this issue to become evident. We never really redeployed the Go runtime with the latest Angular changes. Now that the latest changes are being served from Dart, users were able to notice some missing functionality.

For example, showing agent status messages was not working since the state was not being called to update.

## Issues

Fixes https://github.com/flutter/flutter/issues/45549

## Tested

Manually tested at the preview site

## Preview

Demo: https://testchillers-dot-flutter-dashboard.appspot.com/old_build.html