### PR TITLE
Fix error logging

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show jsonEncode;
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
@@ -94,7 +93,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     );
 
     if (result.hasErrors) {
-      log.error(jsonEncode(result.errors));
+      for (GraphQLError error in result.errors) {
+        log.error(error.toString());
+      }
       throw const BadRequestException('GraphQL query failed');
     }
 
@@ -116,7 +117,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       },
     ));
     if (result.hasErrors) {
-      log.error(jsonEncode(result.errors));
+      for (GraphQLError error in result.errors) {
+        log.error(error.toString());
+      }
       return false;
     }
     return true;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -93,7 +93,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     );
 
     if (result.hasErrors) {
-    for (GraphQLError error in result.errors) {
+      for (GraphQLError error in result.errors) {
         log.error(error.toString());
       }
       throw const BadRequestException('GraphQL query failed');
@@ -117,7 +117,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       },
     ));
     if (result.hasErrors) {
-      log.error(jsonEncode(result.errors));
+      for (GraphQLError error in result.errors) {
+        log.error(error.toString());
+      }
       return false;
     }
     return true;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -137,7 +137,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     ));
 
     if (result.hasErrors) {
-      log.error(jsonEncode(result.errors));
+      for (GraphQLError error in result.errors) {
+        log.error(error.toString());
+      }
       return false;
     }
     return true;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -93,7 +93,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     );
 
     if (result.hasErrors) {
-      for (GraphQLError error in result.errors) {
+    for (GraphQLError error in result.errors) {
         log.error(error.toString());
       }
       throw const BadRequestException('GraphQL query failed');
@@ -117,9 +117,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       },
     ));
     if (result.hasErrors) {
-      for (GraphQLError error in result.errors) {
-        log.error(error.toString());
-      }
+      log.error(jsonEncode(result.errors));
       return false;
     }
     return true;

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -102,6 +102,20 @@ void main() {
       );
     }
 
+    test('Errors can be logged', () async {
+      flutterRepoPRs.add(PullRequestHelper());
+      final List<GraphQLError> errors = <GraphQLError>[
+        GraphQLError(raw: <String, String>{}, message: 'message'),
+      ];
+      githubGraphQLClient._mutateResultForOptions = (_) => QueryResult(errors: errors);
+
+      await tester.get(handler);
+      expect(log.records.length, errors.length);
+      for (int i = 0; i < errors.length; i++) {
+        expect(log.records[i].message, errors[i].toString());
+      }
+    });
+
     test('Merges first PR in list, all successful', () async {
       flutterRepoPRs.add(PullRequestHelper());
       flutterRepoPRs.add(PullRequestHelper()); // will be ignored.


### PR DESCRIPTION
The objects returned by the actual client are not jsonEncode-able, results in errors like:

```
Converting object to an encodable object failed: Instance of 'GraphQLError'
#0      _JsonStringifier.writeObject (dart:convert/json.dart:647:7)
#1      _JsonStringifier.writeList (dart:convert/json.dart:695:7)
#2      _JsonStringifier.writeJsonValue (dart:convert/json.dart:677:7)
#3      _JsonStringifier.writeObject (dart:convert/json.dart:638:9)
#4      _JsonStringStringifier.printOn (dart:convert/json.dart:834:17)
#5      _JsonStringStringifier.stringify (dart:convert/json.dart:819:5)
#6      JsonEncoder.convert (dart:convert/json.dart:255:30)
#7      JsonCodec.encode (dart:convert/json.dart:166:45)
#8      jsonEncode (dart:convert/json.dart:80:10)
#9      CheckForWaitingPullRequests._mergePullRequest (package:cocoon_service/src/request_handlers/check_for_waiting_pull_requests.dart:140:17)
```

