### PR TITLE
Show user icon when logged in so CanvasKit shows a logged in state

### DIFF
--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -25,7 +25,13 @@ class SignInButton extends StatelessWidget {
         if (isAuthenticated.data == true && authService.user != null) {
           return PopupMenuButton<String>(
             // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
-            child: Image.network(authService.user?.photoUrl),
+            // TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
+            // CanvasKit currently cannot render a NetworkImage because of CORS issues.
+            // child: Image.network(authService.user?.photoUrl),
+            child: Icon(
+              Icons.account_circle,
+              size: 42,
+            ),
             offset: const Offset(0, 50),
             itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
               const PopupMenuItem<String>(

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -86,15 +86,17 @@ void main() {
       ),
     );
     await tester.pump();
-
+    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
     // TODO(chillers): Remove this web check once issue is resolved. https://github.com/flutter/flutter/issues/44370
-    if (!kIsWeb) {
-      expect(tester.takeException(),
-          const test.TypeMatcher<NetworkImageLoadException>());
-    }
+    // if (kIsWeb) {
+    //   expect(tester.takeException(),
+    //       const test.TypeMatcher<NetworkImageLoadException>());
+    // }
 
     expect(find.text('Sign in'), findsNothing);
-    expect(find.byType(Image), findsOneWidget);
+    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
+    // expect(find.byType(Image), findsOneWidget);
+    expect(find.byType(Icon), findsOneWidget);
   });
 
   testWidgets('calls sign out on tap when authenticated',
@@ -116,7 +118,9 @@ void main() {
     );
     await tester.pump();
 
-    await tester.tap(find.byType(Image));
+    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
+    // await tester.tap(find.byType(Image));
+    await tester.tap(find.byIcon(Icons.account_circle));
     await tester.pumpAndSettle();
 
     verifyNever(mockAuthService.signOut());

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart' as test;
 
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/sign_in_button.dart';

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -88,7 +88,7 @@ void main() {
     await tester.pump();
     // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
     // TODO(chillers): Remove this web check once issue is resolved. https://github.com/flutter/flutter/issues/44370
-    // if (kIsWeb) {
+    // if (!kIsWeb) {
     //   expect(tester.takeException(),
     //       const test.TypeMatcher<NetworkImageLoadException>());
     // }


### PR DESCRIPTION
If signed in at https://flutter-dashboard.appspot.com/build.html#/ you'll notice nothing showing you are logged in.

This is left over from switching over to CanvasKit.