### PR TITLE
Await cache operations and close cache when done to avoid Stream errors

### DIFF
--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:neat_cache/neat_cache.dart';
-import 'package:pedantic/pedantic.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../request_handling/request_handler.dart';

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -54,7 +54,7 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
           .expand<int>((Uint8List chunk) => chunk)
           .toList();
       final Uint8List bytes = Uint8List.fromList(rawBytes);
-      unawaited(responseCache[responseKey].set(bytes, ttl));
+      await responseCache[responseKey].set(bytes, ttl);
 
       return body;
     }

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -5,27 +5,31 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
 import 'package:neat_cache/cache_provider.dart';
 import 'package:neat_cache/neat_cache.dart';
 
 import '../datastore/cocoon_config.dart';
 
-@immutable
 class CacheService {
-  const CacheService(this.config);
+  CacheService(this.config);
 
   final Config config;
 
+  CacheProvider<List<int>> _provider;
+
   Future<Cache<Uint8List>> redisCache() async {
-    final CacheProvider<List<int>> provider =
+    _provider =
         Cache.redisCacheProvider(await config.redisUrl);
-    return Cache<List<int>>(provider).withCodec<Uint8List>(const _CacheCodec());
+    return Cache<List<int>>(_provider).withCodec<Uint8List>(const _CacheCodec());
   }
 
   Future<Cache<Uint8List>> inMemoryCache(int size) async {
-    final CacheProvider<List<int>> provider = Cache.inMemoryCacheProvider(size);
-    return Cache<List<int>>(provider).withCodec<Uint8List>(const _CacheCodec());
+    _provider = Cache.inMemoryCacheProvider(size);
+    return Cache<List<int>>(_provider).withCodec<Uint8List>(const _CacheCodec());
+  }
+
+  void dispose() {
+    _provider.close();
   }
 }
 


### PR DESCRIPTION
Requests that take advantage of the `CacheRequestHandler` throw 500s when there are several operations going on the cache. To prevent this, we should be waiting for all cache operations to finish (they are fast!).

## Issues

Fixes https://github.com/flutter/flutter/issues/43762