### PR TITLE
Unlock keychain before running a task.

### DIFF
--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -39,6 +39,8 @@ class ContinuousIntegrationCommand extends Command {
     // is wrong.
     AgentHealth health = await performHealthChecks(agent);
     section('Pre-flight checks:');
+    // Ensure keychain is unlocked before running health checks.
+    await _unlockKeyChain();
     health
         .toString()
         .split('\n')
@@ -66,6 +68,7 @@ class ContinuousIntegrationCommand extends Command {
         // console.
         try {
           section('Preflight checks');
+          
           await devices.performPreflightTasks();
 
           // Check health before requesting a new task.
@@ -114,6 +117,8 @@ class ContinuousIntegrationCommand extends Command {
               // the task timeout.
               await getFlutterAt(task.revision).timeout(_kInstallationTimeout);
               await _cleanBuildDirectories(agent, task);
+              // Ensure keychain is unlocked before running task.
+              await _unlockKeyChain();
               // Ensure the phone's screen is on before running a task.
               await _screensOn();
 
@@ -225,6 +230,15 @@ class ContinuousIntegrationCommand extends Command {
         logger.info('\nReceived SIGTERM. Shutting down.');
         _stop(ProcessSignal.sigterm);
       }));
+    }
+  }
+
+  Future<Null> _unlockKeyChain() async {
+    if (Platform.isMacOS) {
+      await exec(
+        'security',
+        <String>['unlock-keychain', '-p', '\$SECRET', 'login.keychain'],
+        canFail: false);
     }
   }
 

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -237,7 +237,8 @@ class ContinuousIntegrationCommand extends Command {
     if (Platform.isMacOS) {
       await exec(
         'security',
-        <String>['unlock-keychain', '-p', '\$SECRET', 'login.keychain'],
+        <String>['unlock-keychain', '-p', '\$FLUTTER_USER_SECRET',
+                 'login.keychain'],
         canFail: false);
     }
   }

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -234,6 +234,9 @@ class ContinuousIntegrationCommand extends Command {
   }
 
   Future<Null> _unlockKeyChain() async {
+    // Unlocking the keychain is required to:
+    //   * Enable Xcode to access the certificate for code signing.
+    //   * Mitigate "Your session has expired" issue. See flutter/flutter#17860.
     if (Platform.isMacOS) {
       await exec(
         'security',


### PR DESCRIPTION
This is a prerequisite for auto-restart agents when they become
unhealthy. Also we will add functionality for nightly reboots of
devicelab host machines to improve testbed stability.

https://github.com/flutter/flutter/issues/43125