### PR TITLE
Cache CocoonConfig

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -20,6 +20,7 @@ Future<void> main() async {
 
     final CacheService cacheService = CacheService(config);
     final Cache<Uint8List> redisCache = await cacheService.redisCache();
+    config.cache = redisCache;
 
     final Map<String, RequestHandler<dynamic>> handlers =
         <String, RequestHandler<dynamic>>{

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -18,7 +18,8 @@ Future<void> main() async {
       accessTokenProvider: AccessTokenProvider(config),
     );
 
-    final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
+    final Map<String, RequestHandler<dynamic>> handlers =
+        <String, RequestHandler<dynamic>>{
       '/api/append-log': AppendLog(config, authProvider),
       '/api/authorize-agent': AuthorizeAgent(config, authProvider),
       '/api/check-waiting-pull-requests':

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -107,10 +107,6 @@ class Config {
 
   Future<String> get cqLabelName => _getSingleValue('CqLabelName');
 
-  /// The name of the subcache in the Redis instance that stores responses.
-  Future<String> get redisResponseSubcache =>
-      _getSingleValue('RedisResponseSubcache');
-
   Future<String> get waitingForTreeToGoGreenLabelName =>
       _getSingleValue('WaitingForTreeToGreenLabelName');
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -107,12 +107,6 @@ class Config {
 
   Future<String> get cqLabelName => _getSingleValue('CqLabelName');
 
-  /// The URL to connect to the Redis instance for this Cocoon instance.
-  ///
-  /// For example, "redis://10.0.0.4:6379" is the default URL on AppEngine
-  /// projects.
-  Future<String> get redisUrl => _getSingleValue('RedisConnectionSpec');
-
   /// The name of the subcache in the Redis instance that stores responses.
   Future<String> get redisResponseSubcache =>
       _getSingleValue('RedisResponseSubcache');

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -68,46 +68,45 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  String get nonMasterPullRequestMessage => '''
-This pull request was opened against a branch other than _master_. 
-Since Flutter pull requests should not normally be opened against branches other than master, I have changed the base to master. 
-If this was intended, you may modify the base back to {{branch}}. 
-See the [Release Process](https://github.com/flutter/flutter/wiki/Release-process) for information about how other branches get updated.
-
-__Reviewers__: Use caution before merging pull requests to branches other than master. The circumstances where this is valid are very rare.
-
-
-/cc @dnfield''';
+  String get nonMasterPullRequestMessage => 'This pull request was opened '
+      'against a branch other than _master_. Since Flutter pull requests should '
+      'not normally be opened against branches other than master, I have changed '
+      'the base to master. If this was intended, you may modify the base back to '
+      '{{branch}}. See the [Release Process]'
+      '(https://github.com/flutter/flutter/wiki/Release-process) for information '
+      'about how other branches get updated.\n\n'
+      '__Reviewers__: Use caution before merging pull requests to branches other '
+      'than master. The circumstances where this is valid are very rare.\n\n'
+      '/cc @dnfield';
 
   Future<String> get webhookKey => _getSingleValue('WebhookKey');
 
-  String get missingTestsPullRequestMessage => '''
-It looks like this pull request may not have tests. 
-Please make sure to add tests before merging. If you need an exemption to this rule, contact Hixie.
+  String get missingTestsPullRequestMessage => 'It looks like this pull '
+      'request may not have tests. Please make sure to add tests before merging. '
+      'If you need an exemption to this rule, contact Hixie.\n\n'
+      '__Reviewers__: Read the [Tree Hygiene page]'
+      '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
+      'and make sure this patch meets those guidelines before LGTMing.';
 
-__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) and make sure this patch meets those guidelines before LGTMing.''';
+  String get goldenBreakingChangeMessage => 'It looks like this pull request '
+      'includes a golden file change. Please make sure to follow '
+      '[Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes). '
+      'While there are exceptions to this rule, if this patch modifies an existing '
+      'golden file, it is probably not an exception. Only new golden files are not '
+      'considered breaking changes.\n\n'
+      '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter) '
+      'may also provide guidance for this change.\n\n'
+      '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
+      'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get goldenBreakingChangeMessage => '''
-It looks like this pull request includes a golden file change. 
-Please make sure to follow [Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes). 
-While there are exceptions to this rule, if this patch modifies an existing golden file, it is probably not an exception. 
-Only new golden files are not considered breaking changes.
-
-
-[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter) may also provide guidance for this change.
-
-__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) and make sure this patch meets those guidelines before LGTMing.''';
-
-  String get goldenTriageMessage => '''
-Nice merge! 🎉
-
-It looks like this PR made changes to golden files. 
-Be sure to visit [Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) to triage the results when post-submit testing has completed. 
-The status of these tests can be seen on the [Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).
-
-
-For more information about working with golden files, see the wiki page 
-[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).''';
+  String get goldenTriageMessage => 'Nice merge! 🎉\n'
+      'It looks like this PR made changes to golden files. Be sure to visit '
+      '[Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) '
+      'to triage the results when post-submit testing has completed. The status '
+      'of these tests can be seen on the '
+      '[Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).\n\n'
+      'For more information about working with golden files, see the wiki page '
+      '[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).';
 
   int get maxTaskRetries => 2;
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -37,7 +37,7 @@ class Config {
   Logging get loggingService => ss.lookup(#appengine.logging);
 
   Future<String> _getSingleValue(String id) async {
-    final Uint8List cacheValue = await _cache.get(
+    final Uint8List cacheValue = await _cache.getOrCreate(
       configCacheName,
       id,
       createFn: () => _getValueFromDatastore(id),

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -68,31 +68,46 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  String get nonMasterPullRequestMessage =>
-      '''This pull request was opened against a branch other than _master_. Since Flutter pull requests should not normally be opened against branches other than master, I have changed the base to master. If this was intended, you may modify the base back to {{branch}}. See the [Release Process](https://github.com/flutter/flutter/wiki/Release-process) for information about how other branches get updated.
+  String get nonMasterPullRequestMessage => '''
+This pull request was opened against a branch other than _master_. 
+Since Flutter pull requests should not normally be opened against branches other than master, I have changed the base to master. 
+If this was intended, you may modify the base back to {{branch}}. 
+See the [Release Process](https://github.com/flutter/flutter/wiki/Release-process) for information about how other branches get updated.
 
- __Reviewers__: Use caution before merging pull requests to branches other than master. The circumstances where this is valid are very rare.
+__Reviewers__: Use caution before merging pull requests to branches other than master. The circumstances where this is valid are very rare.
 
- /cc @dnfield''';
+
+/cc @dnfield''';
 
   Future<String> get webhookKey => _getSingleValue('WebhookKey');
 
-  String get missingTestsPullRequestMessage =>
-      '''It looks like this pull request may not have tests. Please make sure to add tests before merging. If you need an exemption to this rule, contact Hixie.
+  String get missingTestsPullRequestMessage => '''
+It looks like this pull request may not have tests. 
+Please make sure to add tests before merging. If you need an exemption to this rule, contact Hixie.
 
 __Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) and make sure this patch meets those guidelines before LGTMing.''';
 
-  String get goldenBreakingChangeMessage =>
-      '''It looks like this pull request includes a golden file change. Please make sure to follow [Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes). While there are exceptions to this rule, if this patch modifies an existing golden file, it is probably not an exception. Only new golden files are not considered breaking changes.
+  String get goldenBreakingChangeMessage => '''
+It looks like this pull request includes a golden file change. 
+Please make sure to follow [Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes). 
+While there are exceptions to this rule, if this patch modifies an existing golden file, it is probably not an exception. 
+Only new golden files are not considered breaking changes.
+
 
 [Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter) may also provide guidance for this change.
 
 __Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) and make sure this patch meets those guidelines before LGTMing.''';
 
-  String get goldenTriageMessage => '''Nice merge! 🎉
-It looks like this PR made changes to golden files. Be sure to visit [Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) to triage the results when post-submit testing has completed. The status of these tests can be seen on the [Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).
+  String get goldenTriageMessage => '''
+Nice merge! 🎉
 
-For more information about working with golden files, see the wiki page [Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).''';
+It looks like this PR made changes to golden files. 
+Be sure to visit [Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) to triage the results when post-submit testing has completed. 
+The status of these tests can be seen on the [Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).
+
+
+For more information about working with golden files, see the wiki page 
+[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).''';
 
   int get maxTaskRetries => 2;
 

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -78,7 +78,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     Logging log,
     GraphQLClient client,
   ) async {
-    final String labelName = await config.waitingForTreeToGoGreenLabelName;
+    final String labelName = config.waitingForTreeToGoGreenLabelName;
 
     final QueryResult result = await client.query(
       QueryOptions(

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -225,7 +225,7 @@ class GithubWebhook extends RequestHandler<Body> {
       }
     }
 
-    final List<Map<String, dynamic>> builders = await config.luciTryBuilders;
+    final List<Map<String, dynamic>> builders = config.luciTryBuilders;
     final List<String> builderNames = builders
         .where(
             (Map<String, dynamic> builder) => builder['repo'] == repositoryName)
@@ -270,7 +270,7 @@ class GithubWebhook extends RequestHandler<Body> {
 
   /// Checks the issue in the given repository for `config.cqLabelName`.
   Future<bool> _checkForCqLabel(List<IssueLabel> labels) async {
-    final String cqLabelName = await config.cqLabelName;
+    final String cqLabelName = config.cqLabelName;
     return labels.any((IssueLabel label) => label.name == cqLabelName);
   }
 
@@ -365,7 +365,7 @@ class GithubWebhook extends RequestHandler<Body> {
 
   Future<void> _pingForTriage(
       GitHub gitHubClient, PullRequestEvent event) async {
-    final String body = await config.goldenTriageMessage;
+    final String body = config.goldenTriageMessage;
     final RepositorySlug slug = event.repository.slug();
     await gitHubClient.issues.createComment(slug, event.number, body);
   }
@@ -478,14 +478,14 @@ class GithubWebhook extends RequestHandler<Body> {
 
     if (!hasTests && needsTests && !isDraft) {
       // Googlers can edit this at http://shortn/_GjZ5AgUqV2
-      final String body = await config.missingTestsPullRequestMessage;
+      final String body = config.missingTestsPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, event, slug, body)) {
         await gitHubClient.issues.createComment(slug, event.number, body);
       }
     }
 
     if (isGoldenChange) {
-      final String body = await config.goldenBreakingChangeMessage;
+      final String body = config.goldenBreakingChangeMessage;
       if (!await _alreadyCommented(gitHubClient, event, slug, body)) {
         await gitHubClient.issues.createComment(slug, event.number, body);
       }
@@ -528,7 +528,7 @@ class GithubWebhook extends RequestHandler<Body> {
   }
 
   Future<String> _getWrongBaseComment(String base) async {
-    final String messageTemplate = await config.nonMasterPullRequestMessage;
+    final String messageTemplate = config.nonMasterPullRequestMessage;
     return messageTemplate.replaceAll('{{branch}}', base);
   }
 

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -100,7 +100,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
   }
 
   Future<RepositorySlug> _getRepoNameForBuilder(String builderName) async {
-    final List<Map<String, dynamic>> builders = await config.luciBuilders;
+    final List<Map<String, dynamic>> builders = config.luciBuilders;
     final String repoName = builders.firstWhere(
         (Map<String, dynamic> builder) =>
             builder['name'] == builderName)['repo'];

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -79,7 +79,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
     if (newStatus == Task.statusFailed) {
       // Attempt to de-flake the test.
-      final int maxRetries = await config.maxTaskRetries;
+      final int maxRetries = config.maxTaskRetries;
       if (task.attempts >= maxRetries) {
         task.status = Task.statusFailed;
         task.reason = 'Task failed on agent';

--- a/app_dart/lib/src/request_handlers/vacuum-clean.dart
+++ b/app_dart/lib/src/request_handlers/vacuum-clean.dart
@@ -38,7 +38,7 @@ class VacuumClean extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final int maxRetries = await config.maxTaskRetries;
+    final int maxRetries = config.maxTaskRetries;
     final List<Task> tasks = await datastoreProvider()
         .queryRecentTasks(taskStatus: Task.statusInProgress)
         .map<Task>((FullTask fullTask) => fullTask.task)

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -49,8 +49,15 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
     return Body.forStream(Stream<Uint8List>.value(cachedResponse));
   }
 
+  /// Get a Uint8List that contains the bytes of the response from [delegate]
+  /// so it can be stored in [cache].
   Future<Uint8List> getBodyBytesFromDelegate(RequestHandler<T> delegate) async {
     final Body body = await delegate.get();
+    
+    // Body only offers getting a Stream<Uint8List> since it just sends
+    // the data out usually to a client. In this case, we want to store
+    // the bytes in the cache which requires several conversions to get a
+    // Uint8List that contains the bytes of the response.
     final List<int> rawBytes =
         await body.serialize().expand<int>((Uint8List chunk) => chunk).toList();
     return Uint8List.fromList(rawBytes);

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -42,7 +42,7 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   @override
   Future<T> get() async {
     final String responseKey = '${request.uri.path}:${request.uri.query}';
-    final Uint8List cachedResponse = await cache.get(
+    final Uint8List cachedResponse = await cache.getOrCreate(
         responseSubcacheName, responseKey,
         createFn: () => getBodyBytesFromDelegate(delegate), ttl: ttl);
 

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -53,7 +53,7 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   /// so it can be stored in [cache].
   Future<Uint8List> getBodyBytesFromDelegate(RequestHandler<T> delegate) async {
     final Body body = await delegate.get();
-    
+
     // Body only offers getting a Stream<Uint8List> since it just sends
     // the data out usually to a client. In this case, we want to store
     // the bytes in the cache which requires several conversions to get a

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -9,12 +9,16 @@ import 'package:meta/meta.dart';
 import 'package:neat_cache/cache_provider.dart';
 import 'package:neat_cache/neat_cache.dart';
 
+/// Service for reading and writing values to a cache for quick access of data.
+///
+/// If [inMemory] is true, a cache with [inMemoryMaxNumberEntries] number
+/// of entries will be created. Otherwise, it will use the default redis cache.
 class CacheService {
   CacheService({
     bool inMemory = false,
-    int inMemoryMaxSize = 256,
+    int inMemoryMaxNumberEntries = 256,
   }) : _provider = inMemory
-            ? Cache.inMemoryCacheProvider(inMemoryMaxSize)
+            ? Cache.inMemoryCacheProvider(inMemoryMaxNumberEntries)
             : Cache.redisCacheProvider(memorystoreUrl);
 
   final CacheProvider<List<int>> _provider;

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -49,7 +49,7 @@ class CacheService {
   /// handle this racy condition, this attempts to get the value [maxCacheGetAttempts]
   /// times before giving up. This is because the cache is magnitudes faster
   /// than the fallback operation (usually a Datastore query).
-  Future<Uint8List> get(
+  Future<Uint8List> getOrCreate(
     String subcacheName,
     String key, {
     int attempt = 1,
@@ -63,7 +63,7 @@ class CacheService {
       value = await subcache[key].get();
     } catch (e) {
       if (attempt < maxCacheGetAttempts) {
-        return get(subcacheName, key, attempt: ++attempt);
+        return getOrCreate(subcacheName, key, attempt: ++attempt, createFn: createFn);
       } else {
         // Give up on trying to get the value from the cache.
         value = null;

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -9,8 +9,6 @@ import 'package:meta/meta.dart';
 import 'package:neat_cache/cache_provider.dart';
 import 'package:neat_cache/neat_cache.dart';
 
-typedef Function<Uint8List> = Uint8List Function();
-
 class CacheService {
   CacheService({
     bool inMemory = false,

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -63,7 +63,12 @@ class CacheService {
       value = await subcache[key].get();
     } catch (e) {
       if (attempt < maxCacheGetAttempts) {
-        return getOrCreate(subcacheName, key, attempt: ++attempt, createFn: createFn);
+        return getOrCreate(
+          subcacheName,
+          key,
+          attempt: ++attempt,
+          createFn: createFn,
+        );
       } else {
         // Give up on trying to get the value from the cache.
         value = null;

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -140,7 +140,7 @@ class LuciBuilder {
 
   /// Loads and returns the list of known builders from the Cocoon [config].
   static Future<List<LuciBuilder>> getBuilders(Config config) async {
-    final List<dynamic> builders = await config.luciBuilders;
+    final List<dynamic> builders = config.luciBuilders;
     return builders
         .map<LuciBuilder>((dynamic json) => LuciBuilder.fromJson(json))
         .toList();

--- a/app_dart/test/request_handling/cache_request_handler_test.dart
+++ b/app_dart/test/request_handling/cache_request_handler_test.dart
@@ -27,8 +27,7 @@ void main() {
     const String testHttpPath = '/cache_request_handler_test';
 
     setUp(() async {
-      config =
-          FakeConfig();
+      config = FakeConfig();
       tester = RequestHandlerTester(
           request: FakeHttpRequest(
         path: testHttpPath,
@@ -46,7 +45,8 @@ void main() {
 
       final Uint8List serializedBody = await expectedBody.serialize().first;
 
-      await cache.set(CacheRequestHandler.responseSubcacheName, responseKey, serializedBody);
+      await cache.set(CacheRequestHandler.responseSubcacheName, responseKey,
+          serializedBody);
 
       final CacheRequestHandler<Body> cacheRequestHandler =
           CacheRequestHandler<Body>(

--- a/app_dart/test/request_handling/cache_request_handler_test.dart
+++ b/app_dart/test/request_handling/cache_request_handler_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     setUp(() async {
       config =
-          FakeConfig(redisResponseSubcacheValue: 'cache_request_handler_test');
+          FakeConfig();
       tester = RequestHandlerTester(
           request: FakeHttpRequest(
         path: testHttpPath,

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -32,7 +32,8 @@ void main() {
 
       await cache.set(testSubcacheName, testKey, expectedValue);
 
-      final Uint8List value = await cache.getOrCreate(testSubcacheName, testKey);
+      final Uint8List value =
+          await cache.getOrCreate(testSubcacheName, testKey);
 
       expect(value, expectedValue);
     });
@@ -46,10 +47,12 @@ void main() {
       await cache.set(testSubcacheName, testKey1, expectedValue1);
       await cache.set(testSubcacheName, testKey2, expectedValue2);
 
-      final Uint8List value1 = await cache.getOrCreate(testSubcacheName, testKey1);
+      final Uint8List value1 =
+          await cache.getOrCreate(testSubcacheName, testKey1);
       expect(value1, null);
 
-      final Uint8List value2 = await cache.getOrCreate(testSubcacheName, testKey2);
+      final Uint8List value2 =
+          await cache.getOrCreate(testSubcacheName, testKey2);
       expect(value2, expectedValue2);
     });
 

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 
 import 'package:cocoon_service/src/service/cache_service.dart';
@@ -10,18 +12,44 @@ void main() {
   group('CacheService', () {
     CacheService cache;
 
+    const String testSubcacheName = 'test';
+
     setUp(() {
       cache = CacheService(inMemory: true, inMemoryMaxSize: 1);
     });
 
     test('returns null when no value exists', () async {
+      final Uint8List value = await cache.get(testSubcacheName, 'abc');
 
+      expect(value, isNull);
     });
 
-    test('returns value when it exists', () async {});
+    test('returns value when it exists', () async {
+      const String testKey = 'abc';
+      final Uint8List expectedValue = Uint8List.fromList('123'.codeUnits);
 
-    test('last used value is rotated out of cache if cache is full', () async {});
-    
+      await cache.set(testSubcacheName, testKey, expectedValue);
+
+      final Uint8List value = await cache.get(testSubcacheName, testKey);
+
+      expect(value, expectedValue);
+    });
+
+    test('last used value is rotated out of cache if cache is full', () async {
+      const String testKey1 = 'abc';
+      const String testKey2 = 'def';
+      final Uint8List expectedValue1 = Uint8List.fromList('123'.codeUnits);
+      final Uint8List expectedValue2 = Uint8List.fromList('456'.codeUnits);
+
+      await cache.set(testSubcacheName, testKey1, expectedValue1);
+      await cache.set(testSubcacheName, testKey2, expectedValue2);
+
+      final Uint8List value1 = await cache.get(testSubcacheName, testKey1);
+      expect(value1, null);
+
+      final Uint8List value2 = await cache.get(testSubcacheName, testKey2);
+      expect(value2, expectedValue2);
+    });    
 
     test('retries when get throws exception', () async {});
 

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -17,7 +17,7 @@ void main() {
     const String testSubcacheName = 'test';
 
     setUp(() {
-      cache = CacheService(inMemory: true, inMemoryMaxSize: 1);
+      cache = CacheService(inMemory: true, inMemoryMaxNumberEntries: 1);
     });
 
     test('returns null when no value exists', () async {

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:cocoon_service/src/service/cache_service.dart';
+
+void main() {
+  group('CacheService', () {
+    CacheService cache;
+
+    setUp(() {
+      cache = CacheService(inMemory: true, inMemoryMaxSize: 1);
+    });
+
+    test('returns null when no value exists', () async {
+
+    });
+
+    test('returns value when it exists', () async {});
+
+    test('last used value is rotated out of cache if cache is full', () async {});
+    
+
+    test('retries when get throws exception', () async {});
+
+    test('returns null if reaches max attempts of retries', () async {});
+    
+  });
+}

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -21,7 +21,7 @@ void main() {
     });
 
     test('returns null when no value exists', () async {
-      final Uint8List value = await cache.get(testSubcacheName, 'abc');
+      final Uint8List value = await cache.getOrCreate(testSubcacheName, 'abc');
 
       expect(value, isNull);
     });
@@ -32,7 +32,7 @@ void main() {
 
       await cache.set(testSubcacheName, testKey, expectedValue);
 
-      final Uint8List value = await cache.get(testSubcacheName, testKey);
+      final Uint8List value = await cache.getOrCreate(testSubcacheName, testKey);
 
       expect(value, expectedValue);
     });
@@ -46,10 +46,10 @@ void main() {
       await cache.set(testSubcacheName, testKey1, expectedValue1);
       await cache.set(testSubcacheName, testKey2, expectedValue2);
 
-      final Uint8List value1 = await cache.get(testSubcacheName, testKey1);
+      final Uint8List value1 = await cache.getOrCreate(testSubcacheName, testKey1);
       expect(value1, null);
 
-      final Uint8List value2 = await cache.get(testSubcacheName, testKey2);
+      final Uint8List value2 = await cache.getOrCreate(testSubcacheName, testKey2);
       expect(value2, expectedValue2);
     });
 
@@ -70,7 +70,7 @@ void main() {
       cache.cacheValue = mockMainCache;
 
       final Uint8List value =
-          await cache.get(testSubcacheName, 'does not matter');
+          await cache.getOrCreate(testSubcacheName, 'does not matter');
       verify(mockTestSubcache[any]).called(2);
       expect(value, Uint8List.fromList('abc123'.codeUnits));
     });
@@ -92,7 +92,7 @@ void main() {
       cache.cacheValue = mockMainCache;
 
       final Uint8List value =
-          await cache.get(testSubcacheName, 'does not matter');
+          await cache.getOrCreate(testSubcacheName, 'does not matter');
       verify(mockTestSubcache[any]).called(CacheService.maxCacheGetAttempts);
       expect(value, isNull);
     });
@@ -102,7 +102,7 @@ void main() {
       Future<Uint8List> createCat() async => cat;
 
       final Uint8List value =
-          await cache.get(testSubcacheName, 'dog', createFn: createCat);
+          await cache.getOrCreate(testSubcacheName, 'dog', createFn: createCat);
 
       expect(value, cat);
     });

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -21,9 +21,6 @@ class FakeConfig implements Config {
     this.maxEntityGroups = 5,
     this.githubClient,
     this.deviceLabServiceAccountValue,
-    this.forwardHostValue,
-    this.forwardPortValue,
-    this.forwardSchemeValue,
     this.maxTaskRetriesValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
@@ -48,9 +45,6 @@ class FakeConfig implements Config {
   GithubService githubService;
   FakeDatastoreDB dbValue;
   ServiceAccountInfo deviceLabServiceAccountValue;
-  String forwardHostValue;
-  int forwardPortValue;
-  String forwardSchemeValue;
   int maxTaskRetriesValue;
   String oauthClientIdValue;
   String githubOAuthTokenValue;
@@ -91,16 +85,7 @@ class FakeConfig implements Config {
       deviceLabServiceAccountValue;
 
   @override
-  Future<String> get forwardHost async => forwardHostValue;
-
-  @override
-  Future<int> get forwardPort async => forwardPortValue;
-
-  @override
-  Future<String> get forwardScheme async => forwardSchemeValue;
-
-  @override
-  Future<int> get maxTaskRetries async => maxTaskRetriesValue;
+  int get maxTaskRetries => maxTaskRetriesValue;
 
   @override
   Future<String> get oauthClientId async => oauthClientIdValue;
@@ -109,39 +94,34 @@ class FakeConfig implements Config {
   Future<String> get githubOAuthToken async => githubOAuthTokenValue;
 
   @override
-  Future<String> get missingTestsPullRequestMessage async =>
-      missingTestsPullRequestMessageValue;
+  String get missingTestsPullRequestMessage => missingTestsPullRequestMessageValue;
 
   @override
-  Future<String> get nonMasterPullRequestMessage async =>
-      nonMasterPullRequestMessageValue;
+  String get nonMasterPullRequestMessage => nonMasterPullRequestMessageValue;
 
   @override
-  Future<String> get goldenBreakingChangeMessage async =>
-      goldenBreakingChangeMessageValue;
+  String get goldenBreakingChangeMessage => goldenBreakingChangeMessageValue;
 
   @override
-  Future<String> get goldenTriageMessage async => goldenTriageMessageValue;
+  String get goldenTriageMessage => goldenTriageMessageValue;
 
   @override
   Future<String> get webhookKey async => webhookKeyValue;
 
   @override
-  Future<String> get cqLabelName async => cqLabelNameValue;
+  String get cqLabelName => cqLabelNameValue;
 
   @override
-  Future<List<Map<String, dynamic>>> get luciBuilders async =>
-      luciBuildersValue;
+  List<Map<String, dynamic>> get luciBuilders => luciBuildersValue;
 
   @override
-  Future<List<Map<String, dynamic>>> get luciTryBuilders async =>
-      luciTryBuildersValue;
+  List<Map<String, dynamic>> get luciTryBuilders => luciTryBuildersValue;
 
   @override
   Logging get loggingService => loggingServiceValue;
 
   @override
-  Future<String> get waitingForTreeToGoGreenLabelName async =>
+  String get waitingForTreeToGoGreenLabelName =>
       waitingForTreeToGoGreenLabelNameValue;
 
   @override

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -36,8 +36,6 @@ class FakeConfig implements Config {
     this.luciBuildersValue,
     this.luciTryBuildersValue,
     this.loggingServiceValue,
-    this.redisUrlValue,
-    this.redisResponseSubcacheValue,
     this.tabledataResourceApi,
     this.githubService,
     this.taskLogServiceAccountValue,
@@ -65,8 +63,6 @@ class FakeConfig implements Config {
   List<Map<String, dynamic>> luciBuildersValue;
   List<Map<String, dynamic>> luciTryBuildersValue;
   Logging loggingServiceValue;
-  String redisUrlValue;
-  String redisResponseSubcacheValue;
   String waitingForTreeToGoGreenLabelNameValue;
   ServiceAccountCredentials taskLogServiceAccountValue;
 
@@ -143,12 +139,6 @@ class FakeConfig implements Config {
 
   @override
   Logging get loggingService => loggingServiceValue;
-
-  @override
-  Future<String> get redisUrl async => redisUrlValue;
-
-  @override
-  Future<String> get redisResponseSubcache async => redisResponseSubcacheValue;
 
   @override
   Future<String> get waitingForTreeToGoGreenLabelName async =>

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -94,7 +94,8 @@ class FakeConfig implements Config {
   Future<String> get githubOAuthToken async => githubOAuthTokenValue;
 
   @override
-  String get missingTestsPullRequestMessage => missingTestsPullRequestMessageValue;
+  String get missingTestsPullRequestMessage =>
+      missingTestsPullRequestMessageValue;
 
   @override
   String get nonMasterPullRequestMessage => nonMasterPullRequestMessageValue;


### PR DESCRIPTION
Most of Cocoon's requests wait on Datastore operations to get config values that usually never change. This updates `CocoonConfig` to take advantage of caching. To make this simple in `CocoonConfig` I refactored `CacheService` to handle more of the cache logic.

After some discussion, this also moves some of the config values to be hard coded. This helps us better track changes made to the config. Any config values that do not need to be private have been pushed from Datastore into the code.

All Cocoon requests will see a speedup based on how many config variables they used (each variable use was a separate datastore query).

## Open Questions

1. ~The current `CacheService` used the Datastore config to get values. To not have a circular dependency on the two resources, I have made the config values hard coded instead of being stored in datastore. Is this okay, or is there a better way to store these config values? (specifically `memorystoreUrl`, `responseSubcacheName`, `configSubcacheName`).~
  - This is actually a better way of storing values that are okay to be public. We can track the changes to the config in version control.
2. Config values are stored in the cache for 12 hours. Should we store them indefinitely and just manually clear the Memorystore cache from GCP when a config value needs to be changed?

## Tested
- Added test for `createFn`
- Added tests for the race condition issue from https://github.com/flutter/flutter/issues/43762. A read to the cache when a write is in process throws an exception.

## Issues
- Fixes https://github.com/flutter/flutter/issues/43762