### PR TITLE
Insert build status to BigQuery

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -39,11 +39,6 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   final LoggingProvider loggingProvider;
   final BuildStatusProvider buildStatusProvider;
 
-  /// const variables for [BigQuery] operations
-  static const String projectId = 'flutter-dashboard';
-  static const String dataset = 'cocoon';
-  static const String table = 'BuildStatus';
-
   @override
   Future<Body> get() async {
     final Logging log = loggingProvider();
@@ -61,7 +56,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     final List<GithubBuildStatusUpdate> updates = <GithubBuildStatusUpdate>[];
     log.debug('Computed build result of $buildStatus');
 
-    // insert build status to bigquery
+    // Insert build status to bigquery.
     await _insertBigquery(buildStatus);
 
     await for (PullRequest pr in github.pullRequests.list(slug)) {
@@ -106,6 +101,11 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   }
 
   Future<void> _insertBigquery(BuildStatus buildStatus) async {
+    // Define const variables for [BigQuery] operations.
+    const String projectId = 'flutter-dashboard';
+    const String dataset = 'cocoon';
+    const String table = 'BuildStatus';
+
     final TabledataResourceApi tabledataResourceApi = await config.createTabledataResourceApi();
     final List<Map<String, Object>> requestRows = <Map<String, Object>>[];
     
@@ -116,7 +116,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       },
     });
 
-    /// [rows] to be inserted to [BigQuery]
+    // Obtain [rows] to be inserted to [BigQuery].
     final TableDataInsertAllRequest request =
       TableDataInsertAllRequest.fromJson(<String, Object>{
       'rows': requestRows

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -106,9 +106,10 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     const String dataset = 'cocoon';
     const String table = 'BuildStatus';
 
-    final TabledataResourceApi tabledataResourceApi = await config.createTabledataResourceApi();
+    final TabledataResourceApi tabledataResourceApi =
+        await config.createTabledataResourceApi();
     final List<Map<String, Object>> requestRows = <Map<String, Object>>[];
-    
+
     requestRows.add(<String, Object>{
       'json': <String, Object>{
         'Timestamp': DateTime.now().millisecondsSinceEpoch,
@@ -118,13 +119,12 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
 
     // Obtain [rows] to be inserted to [BigQuery].
     final TableDataInsertAllRequest request =
-      TableDataInsertAllRequest.fromJson(<String, Object>{
-      'rows': requestRows
-    });
+        TableDataInsertAllRequest.fromJson(
+            <String, Object>{'rows': requestRows});
 
     try {
       await tabledataResourceApi.insertAll(request, projectId, dataset, table);
-    } catch(ApiRequestError){
+    } catch (ApiRequestError) {
       log.warning('Failed to add build status to BigQuery: $ApiRequestError');
     }
   }

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -63,7 +63,8 @@ void main() {
       test('Does nothing', () async {
         config.githubClient = ThrowingGitHub();
         db.onCommit =
-            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) => throw AssertionError();
+            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+                throw AssertionError();
         db.addOnQuery<GithubBuildStatusUpdate>(
             (Iterable<GithubBuildStatusUpdate> results) {
           throw AssertionError();
@@ -112,7 +113,8 @@ void main() {
       group('does not update anything', () {
         setUp(() {
           db.onCommit =
-              (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) => throw AssertionError();
+              (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+                  throw AssertionError();
           when(repositoriesService.createStatus(any, any, any))
               .thenThrow(AssertionError());
         });
@@ -121,10 +123,12 @@ void main() {
           prsFromGitHub = <PullRequest>[];
           buildStatusProvider.cumulativeStatus = BuildStatus.succeeded;
           final Body body = await tester.get<Body>(handler);
-          final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
+          final TableDataList tableDataList =
+              await tabledataResourceApi.list('test', 'test', 'test');
           expect(body, same(Body.empty));
           expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+
           /// Test for [BigQuery] insert
           expect(tableDataList.totalRows, '1');
         });


### PR DESCRIPTION
This PR inserts tree build status to BigQuery via /api/push-build-status-to-github every 1 minutes.

Ultimate goal is to collect/generate Tree Healthiness metrics for future analysis.