### PR TITLE
Insert Cirrus task status to BigQuery

### DIFF
--- a/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
@@ -22,7 +22,8 @@ void main() {
     ApiRequestHandlerTester tester;
     RefreshCirrusStatus handler;
     final FakeDatastoreDB datastoreDB = FakeDatastoreDB();
-    final FakeTabledataResourceApi tabledataResourceApi = FakeTabledataResourceApi();
+    final FakeTabledataResourceApi tabledataResourceApi =
+        FakeTabledataResourceApi();
     tester = ApiRequestHandlerTester();
 
     test('update cirrus status when all tasks succeeded', () async {
@@ -62,7 +63,8 @@ void main() {
 
       expect(task.status, 'New');
       await tester.get(handler);
-      final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
+      final TableDataList tableDataList =
+          await tabledataResourceApi.list('test', 'test', 'test');
       expect(task.status, 'Succeeded');
       expect(tableDataList.totalRows, '1');
     });


### PR DESCRIPTION
This PR inserts cirrus task status to BigQuery whenever cirrus task finishes. 

It also updates startTimestamp and endTimestamp for cirrus task. Based on these info, further statistical analysis is possible.