### PR TITLE
Rollback to previous Dart version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: cirrusci/flutter:latest
+  image: cirrusci/flutter:v1.9.1-hotfix.6
 
 task:
   name: $CWD


### PR DESCRIPTION
The update to Flutter 1.12 made the default version on CI of Dart to 2.5. This creates issues for `app`, and since `app` is being ported away this is just a quick fix to get CI working again.