### PR TITLE
[luci] Remove `pub upgrade` from CI.

### DIFF
--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -12,7 +12,6 @@ set -e
 echo "Running tests from $1"
 pushd $1 > /dev/null
 pub get
-pub upgrade
 
 dartfmt --set-exit-if-changed .
 


### PR DESCRIPTION
The `pub upgrade` shouldn't run on each commit.

Assume a dependency is broken at the latest version, in order to continue building Cocoon, we have to use the old stable version until that dependency fixed the problem and release a new version. Command `pub upgrade` would prevent use from doing that.