### PR TITLE
Update agent health status history in BigQuery

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -45,7 +45,8 @@ Future<void> main() async {
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(config, authProvider),
       '/api/update-agent-health': UpdateAgentHealth(config, authProvider),
-      '/api/update-agent-health-history': UpdateAgentHealthHistory(config, authProvider),
+      '/api/update-agent-health-history':
+          UpdateAgentHealthHistory(config, authProvider),
       '/api/update-benchmark-targets':
           UpdateBenchmarkTargets(config, authProvider),
       '/api/update-task-status': UpdateTaskStatus(config, authProvider),

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -45,6 +45,7 @@ Future<void> main() async {
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(config, authProvider),
       '/api/update-agent-health': UpdateAgentHealth(config, authProvider),
+      '/api/update-agent-health-history': UpdateAgentHealthHistory(config, authProvider),
       '/api/update-benchmark-targets':
           UpdateBenchmarkTargets(config, authProvider),
       '/api/update-task-status': UpdateTaskStatus(config, authProvider),

--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -22,3 +22,6 @@ cron:
 - description: check for mergeable commits waiting for the tree to go green
   url: /api/check-waiting-pull-requests
   schedule: every 5 minutes
+- description: insert agent health status to bigquery
+  url: /api/update-agent-health-history
+  schedule: every 1 minutes

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -25,6 +25,7 @@ export 'src/request_handlers/refresh_github_commits.dart';
 export 'src/request_handlers/reserve_task.dart';
 export 'src/request_handlers/reset_devicelab_task.dart';
 export 'src/request_handlers/update_agent_health.dart';
+export 'src/request_handlers/update_agent_health_history.dart';
 export 'src/request_handlers/update_benchmark_targets.dart';
 export 'src/request_handlers/update_task_status.dart';
 export 'src/request_handlers/update_timeseries.dart';

--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -1,0 +1,92 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:gcloud/db.dart';
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:meta/meta.dart';
+
+import '../datastore/cocoon_config.dart';
+import '../model/appengine/agent.dart';
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/authentication.dart';
+import '../request_handling/body.dart';
+import '../service/datastore.dart';
+
+const Duration maxHealthCheckAge = Duration(minutes: 10);
+
+@immutable
+class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
+  const UpdateAgentHealthHistory(
+    Config config,
+    AuthenticationProvider authenticationProvider, {
+    @visibleForTesting
+        this.datastoreProvider = DatastoreService.defaultProvider,
+  }) : super(config: config, authenticationProvider: authenticationProvider);
+
+  final DatastoreServiceProvider datastoreProvider;
+
+  @override
+  Future<Body> get() async {
+    const String projectId = 'flutter-dashboard';
+    const String dataset = 'cocoon';
+    const String table = 'Agent';
+
+    final TabledataResourceApi tabledataResourceApi =
+        await config.createTabledataResourceApi();
+    final DatastoreService datastore = datastoreProvider();
+    final Query<Agent> agentQuery = datastore.db.query<Agent>()
+      ..order('agentId');
+    final List<Agent> agents =
+        await agentQuery.run().where(_isVisible).toList();
+    agents.sort((Agent a, Agent b) =>
+        compareAsciiLowerCaseNatural(a.agentId, b.agentId));
+
+    final List<Map<String, Object>> tableDataInsertAllRequestRows =
+        <Map<String, Object>>[];
+
+    for (Agent agent in agents) {
+      final bool isHealthy = _isAgentHealthy(agent);
+
+      /// Consolidate [agents] together.
+      ///
+      /// Prepare for bigquery [insertAll].
+      tableDataInsertAllRequestRows.add(<String, Object>{
+        'json': <String, Object>{
+          'Timestamp': agent.healthCheckTimestamp,
+          'AgentID': agent.agentId,
+          'Status': isHealthy ? 'healthy' : 'unhealthy',
+          'Detail': isHealthy ? agent.healthDetails : 'out of date',
+        },
+      });
+    }
+
+    /// Prepare final [rows] to be inserted to `BigQuery`.
+    final TableDataInsertAllRequest rows = TableDataInsertAllRequest.fromJson(
+        <String, Object>{'rows': tableDataInsertAllRequestRows});
+
+    /// Insert [agents] to `BigQuery`.
+    try {
+      await tabledataResourceApi.insertAll(rows, projectId, dataset, table);
+    } catch (ApiRequestError) {
+      log.warning('Failed to add commits to BigQuery: $ApiRequestError');
+    }
+
+    return Body.forJson(<String, dynamic>{
+      'AgentStatuses': agents,
+    });
+  }
+
+  bool _isVisible(Agent agent) => !agent.isHidden;
+
+  bool _isAgentHealthy(Agent agent) {
+    return agent.isHealthy &&
+        agent.healthCheckTimestamp != null &&
+        DateTime.now().difference(DateTime.fromMillisecondsSinceEpoch(
+                agent.healthCheckTimestamp)) <
+            maxHealthCheckAge;
+  }
+}

--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -72,7 +72,7 @@ class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
     try {
       await tabledataResourceApi.insertAll(rows, projectId, dataset, table);
     } catch (ApiRequestError) {
-      log.warning('Failed to add commits to BigQuery: $ApiRequestError');
+      log.error('Failed to add commits to BigQuery: $ApiRequestError');
     }
 
     return Body.forJson(<String, dynamic>{

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -89,7 +89,7 @@ void main() {
       /// Test `BigQuery` insert.
       expect(tableDataList.totalRows, '3');
       expect(log.records[0].message,
-          'Succeeded to insert 3 rows to flutter-dashboard-cocoon-AgentStatusTest');
+          'Succeeded to insert 3 rows to flutter-dashboard-cocoon-Agent');
 
       expect(result['AgentStatuses'], equals(expectedOrderedAgents));
     });

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -89,7 +89,8 @@ void main() {
 
       /// Test `BigQuery` insert.
       expect(tableDataList.totalRows, '3');
-      expect(log.records[0].message, 'Succeeded to insert 3 rows to flutter-dashboard-cocoon-AgentStatusTest');
+      expect(log.records[0].message,
+          'Succeeded to insert 3 rows to flutter-dashboard-cocoon-AgentStatusTest');
 
       expect(result['AgentStatuses'], equals(expectedOrderedAgents));
     });

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -1,0 +1,90 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/appengine/agent.dart';
+import 'package:cocoon_service/src/request_handlers/update_agent_health_history.dart';
+import 'package:cocoon_service/src/request_handling/body.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:test/test.dart';
+
+import '../src/bigquery/fake_tabledata_resource.dart';
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/fake_authentication.dart';
+
+void main() {
+  group('UpdateAgentHealthHistory', () {
+    FakeConfig config;
+    FakeDatastoreDB db;
+    UpdateAgentHealthHistory handler;
+    FakeTabledataResourceApi tabledataResourceApi;
+
+    Future<Object> decodeHandlerBody() async {
+      final Body body = await handler.get();
+      return utf8.decoder.bind(body.serialize()).transform(json.decoder).single;
+    }
+
+    setUp(() {
+      tabledataResourceApi = FakeTabledataResourceApi();
+      config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
+      db = FakeDatastoreDB();
+      handler = UpdateAgentHealthHistory(
+        config,
+        FakeAuthenticationProvider(),
+        datastoreProvider: () => DatastoreService(db: db),
+      );
+    });
+
+    test('inserts agents to bigquery', () async {
+      final Agent linux1 = Agent(
+          agentId: 'linux1',
+          healthCheckTimestamp: 1,
+          isHealthy: true,
+          healthDetails: 'healthy');
+      final Agent mac1 = Agent(
+          agentId: 'mac1',
+          healthCheckTimestamp: 2,
+          isHealthy: true,
+          healthDetails: 'healthy');
+      final Agent linux5 = Agent(
+          agentId: 'linux5',
+          healthCheckTimestamp: 3,
+          isHealthy: false,
+          healthDetails: 'unhealthy');
+      final Agent windows1 = Agent(
+          agentId: 'windows1',
+          healthCheckTimestamp: 1,
+          isHealthy: true,
+          healthDetails: 'healthy',
+          isHidden: true);
+
+      final List<Agent> reportedAgents = <Agent>[
+        linux1,
+        mac1,
+        linux5,
+        windows1,
+      ];
+
+      db.addOnQuery<Agent>((Iterable<Agent> agents) => reportedAgents);
+
+      final Map<String, dynamic> result = await decodeHandlerBody();
+      final TableDataList tableDataList =
+          await tabledataResourceApi.list('test', 'test', 'test');
+      final List<dynamic> expectedOrderedAgents = <dynamic>[
+        linux1.toJson(),
+        linux5.toJson(),
+        mac1.toJson(),
+      ];
+
+      /// Test `BigQuery` insert.
+      expect(tableDataList.totalRows, '3');
+
+      expect(result['AgentStatuses'], equals(expectedOrderedAgents));
+    });
+  });
+}

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:appengine/appengine.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:test/test.dart';
 

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -4,13 +4,14 @@
 
 import 'dart:convert';
 
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:test/test.dart';
+
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/agent.dart';
 import 'package:cocoon_service/src/request_handlers/update_agent_health_history.dart';
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:googleapis/bigquery/v2.dart';
-import 'package:test/test.dart';
 
 import '../src/bigquery/fake_tabledata_resource.dart';
 import '../src/datastore/fake_cocoon_config.dart';

--- a/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/udpate_agent_health_history_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:appengine/appengine.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:test/test.dart';
 
@@ -17,11 +18,13 @@ import '../src/bigquery/fake_tabledata_resource.dart';
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_logging.dart';
 
 void main() {
   group('UpdateAgentHealthHistory', () {
     FakeConfig config;
     FakeDatastoreDB db;
+    FakeLogging log;
     UpdateAgentHealthHistory handler;
     FakeTabledataResourceApi tabledataResourceApi;
 
@@ -34,10 +37,12 @@ void main() {
       tabledataResourceApi = FakeTabledataResourceApi();
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
       db = FakeDatastoreDB();
+      log = FakeLogging();
       handler = UpdateAgentHealthHistory(
         config,
         FakeAuthenticationProvider(),
         datastoreProvider: () => DatastoreService(db: db),
+        loggingProvider: () => log,
       );
     });
 
@@ -84,6 +89,7 @@ void main() {
 
       /// Test `BigQuery` insert.
       expect(tableDataList.totalRows, '3');
+      expect(log.records[0].message, 'Succeeded to insert 3 rows to flutter-dashboard-cocoon-AgentStatusTest');
 
       expect(result['AgentStatuses'], equals(expectedOrderedAgents));
     });


### PR DESCRIPTION
This PR creates an API: /api/update-agent-health-history to update Agent health status history in BigQuery.

The old strategy misses records for cases when Agents hang, or tasks are running. This will make it difficult to tell accurate Agent health status for a certain time period.

This new API will be called via a cronjob every 1 minute, and guarantees continuous records of Agents statuses.