### PR TITLE
Remove bigquery insert from update-agent-health api

### DIFF
--- a/app_dart/lib/src/request_handlers/update_agent_health.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:cocoon_service/src/model/appengine/agent.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:gcloud/db.dart';
-import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
@@ -30,9 +29,6 @@ class UpdateAgentHealth extends ApiRequestHandler<UpdateAgentHealthResponse> {
   static const String agentIdParam = 'AgentID';
   static const String isHealthyParam = 'IsHealthy';
   static const String healthDetailsParam = 'HealthDetails';
-  static const String projectId = 'flutter-dashboard';
-  static const String dataset = 'cocoon';
-  static const String table = 'AgentStatus';
 
   @override
   Future<UpdateAgentHealthResponse> post() async {
@@ -57,38 +53,7 @@ class UpdateAgentHealth extends ApiRequestHandler<UpdateAgentHealthResponse> {
 
     await datastore.db.commit(inserts: <Agent>[agent]);
 
-    /// Insert data to [BigQuery] whenever updating data in [Datastore]
-    await _insertBigquery(agent);
-
     return UpdateAgentHealthResponse(agent);
-  }
-
-  Future<void> _insertBigquery(Agent agent) async {
-    final TabledataResourceApi tabledataResourceApi =
-        await config.createTabledataResourceApi();
-    final List<Map<String, Object>> requestRows = <Map<String, Object>>[];
-
-    requestRows.add(<String, Object>{
-      'json': <String, Object>{
-        'Timestamp': agent.healthCheckTimestamp,
-        'AgentID': agent.agentId,
-        // TODO(keyonghan): add more detailed states https://github.com/flutter/flutter/issues/44213
-        'Status': agent.isHealthy ? 'Healthy' : 'Unhealthy',
-        'Detail': agent.healthDetails,
-      },
-    });
-
-    /// [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest request =
-        TableDataInsertAllRequest.fromJson(
-            <String, Object>{'rows': requestRows});
-
-    try {
-      await tabledataResourceApi.insertAll(request, projectId, dataset, table);
-    } catch (ApiRequestError) {
-      log.warning(
-          'Failed to add ${agent.agentId} status to BigQuery: $ApiRequestError');
-    }
   }
 }
 

--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -66,6 +66,7 @@ class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
         'json': <String, Object>{
           'Timestamp': agent.healthCheckTimestamp,
           'AgentID': agent.agentId,
+          // TODO(keyonghan): add more detailed statuses https://github.com/flutter/flutter/issues/44213
           'Status': isHealthy ? 'healthy' : 'unhealthy',
           'Detail': isHealthy ? agent.healthDetails : 'out of date',
         },

--- a/app_dart/test/request_handlers/update_agent_health_test.dart
+++ b/app_dart/test/request_handlers/update_agent_health_test.dart
@@ -5,10 +5,8 @@
 import 'package:cocoon_service/src/model/appengine/agent.dart';
 import 'package:cocoon_service/src/request_handlers/update_agent_health.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:googleapis/bigquery/v2.dart';
 import 'package:test/test.dart';
 
-import '../src/bigquery/fake_tabledata_resource.dart';
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
@@ -18,11 +16,9 @@ void main() {
     FakeConfig config;
     ApiRequestHandlerTester tester;
     UpdateAgentHealth handler;
-    final FakeTabledataResourceApi tabledataResourceApi =
-        FakeTabledataResourceApi();
 
     setUp(() {
-      config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
+      config = FakeConfig();
       tester = ApiRequestHandlerTester();
       tester.requestData = <String, dynamic>{
         'AgentID': 'test',
@@ -46,13 +42,10 @@ void main() {
       expect(agent.healthDetails, isNot('bar detail'));
 
       final UpdateAgentHealthResponse response = await tester.post(handler);
-      final TableDataList tableDataList =
-          await tabledataResourceApi.list('test', 'test', 'test');
 
       expect(agent.agentId, 'test');
       expect(response.agent.isHealthy, true);
       expect(agent.healthDetails, 'bar detail');
-      expect(tableDataList.totalRows, '1');
     });
   });
 }


### PR DESCRIPTION
A new API: /api/update-agent-health-history has been implemented: https://github.com/flutter/cocoon/pull/580

So, this PR simply removed earlier implementation. The earlier version missed data for certain scenarios, and the above API fixed the issue.