### PR TITLE
Add isFlaky to Task Overlay

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -323,7 +323,8 @@ class TaskOverlayContents extends StatelessWidget {
             subtitle: isDevicelab(task)
                 ? Text('Attempts: ${task.attempts}\n'
                     'Duration: $taskDurationInMinutes minutes\n'
-                    'Agent: ${task.reservedForAgentId}')
+                    'Agent: ${task.reservedForAgentId}\n'
+                    'Flaky: ${task.isFlaky}')
                 : const Text('Task was run outside of devicelab'),
             contentPadding: const EdgeInsets.all(16.0),
           ),

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -195,7 +195,7 @@ void main() {
       expect(find.byKey(const Key('task-overlay-key')), findsOneWidget);
     });
 
-    testWidgets('overlay show flaky is false', (WidgetTester tester) async {
+    testWidgets('overlay show flaky is true', (WidgetTester tester) async {
       final Task flakyTask = Task()
         ..attempts = 3
         ..stageName = 'devicelab'
@@ -216,7 +216,7 @@ void main() {
       );
 
       final String expectedTaskInfoString =
-          'Attempts: ${flakyTask.attempts}\nDuration: 0 minutes\nAgent: ${flakyTask.reservedForAgentId}\nFlaky: ${flakyTask.isFlaky}';
+          'Attempts: ${flakyTask.attempts}\nDuration: 0 minutes\nAgent: ${flakyTask.reservedForAgentId}\nFlaky: true';
       expect(find.text(expectedTaskInfoString), findsNothing);
 
       // Ensure the task indicator isn't showing when overlay is not shown

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -218,8 +218,7 @@ void main() {
         ),
       );
 
-      final String expectedTaskInfoString =
-          'Attempts: ${flakyTask.attempts}\n'
+      final String expectedTaskInfoString = 'Attempts: ${flakyTask.attempts}\n'
           'Duration: 0 minutes\n'
           'Agent: ${flakyTask.reservedForAgentId}\n'
           'Flaky: true';

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -20,7 +20,8 @@ void main() {
       ..attempts = 3
       ..stageName = 'devicelab'
       ..name = 'Tasky McTaskFace'
-      ..reason = 'Because I said so';
+      ..reason = 'Because I said so'
+      ..isFlaky = false;
     FlutterBuildState buildState;
 
     setUpAll(() {
@@ -177,7 +178,7 @@ void main() {
       );
 
       final String expectedTaskInfoString =
-          'Attempts: ${expectedTask.attempts}\nDuration: 0 minutes\nAgent: ${expectedTask.reservedForAgentId}';
+          'Attempts: ${expectedTask.attempts}\nDuration: 0 minutes\nAgent: ${expectedTask.reservedForAgentId}\nFlaky: ${expectedTask.isFlaky}';
       expect(find.text(expectedTask.name), findsNothing);
       expect(find.text(expectedTaskInfoString), findsNothing);
 
@@ -192,6 +193,39 @@ void main() {
 
       // Since the overlay is on screen, the indicator should be showing
       expect(find.byKey(const Key('task-overlay-key')), findsOneWidget);
+    });
+
+    testWidgets('overlay show flaky is false', (WidgetTester tester) async {
+      final Task flakyTask = Task()
+        ..attempts = 3
+        ..stageName = 'devicelab'
+        ..name = 'Tasky McTaskFace'
+        ..reason = 'Because I said so'
+        ..isFlaky = true;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TaskBox(
+              buildState: buildState,
+              task: flakyTask,
+              commit: Commit(),
+            ),
+          ),
+        ),
+      );
+
+      final String expectedTaskInfoString =
+          'Attempts: ${flakyTask.attempts}\nDuration: 0 minutes\nAgent: ${flakyTask.reservedForAgentId}\nFlaky: ${flakyTask.isFlaky}';
+      expect(find.text(expectedTaskInfoString), findsNothing);
+
+      // Ensure the task indicator isn't showing when overlay is not shown
+      expect(find.byKey(const Key('task-overlay-key')), findsNothing);
+
+      await tester.tap(find.byType(TaskBox));
+      await tester.pump();
+
+      expect(find.text(expectedTaskInfoString), findsOneWidget);
     });
 
     testWidgets('overlay message for nondevicelab tasks',

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -178,7 +178,10 @@ void main() {
       );
 
       final String expectedTaskInfoString =
-          'Attempts: ${expectedTask.attempts}\nDuration: 0 minutes\nAgent: ${expectedTask.reservedForAgentId}\nFlaky: ${expectedTask.isFlaky}';
+          'Attempts: ${expectedTask.attempts}\n'
+          'Duration: 0 minutes\n'
+          'Agent: ${expectedTask.reservedForAgentId}\n'
+          'Flaky: ${expectedTask.isFlaky}';
       expect(find.text(expectedTask.name), findsNothing);
       expect(find.text(expectedTaskInfoString), findsNothing);
 
@@ -216,7 +219,10 @@ void main() {
       );
 
       final String expectedTaskInfoString =
-          'Attempts: ${flakyTask.attempts}\nDuration: 0 minutes\nAgent: ${flakyTask.reservedForAgentId}\nFlaky: true';
+          'Attempts: ${flakyTask.attempts}\n'
+          'Duration: 0 minutes\n'
+          'Agent: ${flakyTask.reservedForAgentId}\n'
+          'Flaky: true';
       expect(find.text(expectedTaskInfoString), findsNothing);
 
       // Ensure the task indicator isn't showing when overlay is not shown


### PR DESCRIPTION
Add textual information for whether or a Task is flaky. If Material Icons fails to load, we should still be able to tell if a Task is flaky or not by looking in the overlay.

## Issues

Fixes https://github.com/flutter/flutter/issues/46283

## Tested

Added test for flaky = true and flaky = false

## Preview

![is_flaky_overlay](https://user-images.githubusercontent.com/2148558/71032467-461cda00-20ca-11ea-961d-4864474a1498.png)
