### PR TITLE
Update with only the latest commit status when refreshing chromebot status

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -58,6 +58,8 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
                 final Task update = task.task;
                 update.status = luciTask.status;
                 transaction.queueMutations(inserts: <Task>[update]);
+                // Stop updating task whenever we find the latest status of the same commit.
+                break;
               }
             }
           }

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -54,6 +54,7 @@ void main() {
         key: (dynamic builder) => builder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(commitSha: 'abc', status: Task.statusNew),
+          const LuciTask(commitSha: 'abc', status: Task.statusFailed)
         ],
       );
       when(mockLuciService.getRecentTasks(


### PR DESCRIPTION
Existing logic when refreshing chromebot status is keep updating task status for all executions of the same commit, from the latest to the oldest. This will keep the status on dashboard the same as  the earliest run's status. This is incorrect.

This PR stops updating task status whenever we find the latest status of one commit. This way the status on dashboard is always up-to-date.