### PR TITLE
Make formatting problems easier to spot.

### DIFF
--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -13,7 +13,9 @@ echo "Running tests from $1"
 pushd $1 > /dev/null
 pub get
 
-dartfmt --set-exit-if-changed .
+echo "############# files that require formatting ###########"
+dartfmt -n --set-exit-if-changed .
+echo "#######################################################"
 
 # agent doesn't use build_runner as of this writing.
 if grep -lq "build_runner" pubspec.yaml; then


### PR DESCRIPTION
Currently the if a file needs formatting it prints the entire file.
Even when the step fails it is difficult to spot what is failing and
what needs to get done.