### PR TITLE
CacheService pass through ttl regression fix + flush cache

### DIFF
--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -38,13 +38,20 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   @visibleForTesting
   static const String responseSubcacheName = 'response';
 
+  @visibleForTesting
+  static const String flushCacheQueryParam = 'flushCache';
+
   /// Services a cached request.
   @override
   Future<T> get() async {
     final String responseKey = '${request.uri.path}:${request.uri.query}';
     final Uint8List cachedResponse = await cache.getOrCreate(
-        responseSubcacheName, responseKey,
-        createFn: () => getBodyBytesFromDelegate(delegate), ttl: ttl);
+      responseSubcacheName,
+      responseKey,
+      createFn: () => getBodyBytesFromDelegate(delegate),
+      ttl: ttl,
+      flushCache: request.uri.queryParameters[flushCacheQueryParam] == 'true',
+    );
 
     return Body.forStream(Stream<Uint8List>.value(cachedResponse));
   }

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -42,15 +42,23 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   static const String flushCacheQueryParam = 'flushCache';
 
   /// Services a cached request.
+  ///
+  /// Given the query param [flushCacheQueryParam]=true, it will purge the
+  /// response from the cache before getting it to set the cached response
+  /// to the latest information.
   @override
   Future<T> get() async {
     final String responseKey = '${request.uri.path}:${request.uri.query}';
+
+    if (request.uri.queryParameters[flushCacheQueryParam] == 'true') {
+      await cache.purge(responseSubcacheName, responseKey);
+    }
+
     final Uint8List cachedResponse = await cache.getOrCreate(
       responseSubcacheName,
       responseKey,
       createFn: () => getBodyBytesFromDelegate(delegate),
       ttl: ttl,
-      flushCache: request.uri.queryParameters[flushCacheQueryParam] == 'true',
     );
 
     return Body.forStream(Stream<Uint8List>.value(cachedResponse));

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -75,10 +75,7 @@ class CacheService {
       }
     }
 
-    // If given createFn, we can update the cache value if we are forcing a
-    // cache flush or if the value returned was null.
-    //
-    // Cache flush is a failover to manually fix cache issues in production.
+    // If given createFn, update the cache value if the value returned was null.
     if (createFn != null && value == null) {
       // Try creating the value
       value = await createFn();

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -92,7 +92,7 @@ class CacheService {
     Duration ttl = const Duration(minutes: 1),
   }) async {
     final Cache<Uint8List> subcache = cache.withPrefix(subcacheName);
-    return subcache[key].set(value);
+    return subcache[key].set(value, ttl);
   }
 
   void dispose() {

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -55,7 +55,6 @@ class CacheService {
     int attempt = 1,
     Future<Uint8List> Function() createFn,
     Duration ttl = const Duration(minutes: 1),
-    bool flushCache = false,
   }) async {
     final Cache<Uint8List> subcache = cache.withPrefix(subcacheName);
     Uint8List value;
@@ -80,7 +79,7 @@ class CacheService {
     // cache flush or if the value returned was null.
     //
     // Cache flush is a failover to manually fix cache issues in production.
-    if (createFn != null && (flushCache || value == null)) {
+    if (createFn != null && value == null) {
       // Try creating the value
       value = await createFn();
       await set(subcacheName, key, value, ttl: ttl);
@@ -98,6 +97,12 @@ class CacheService {
   }) async {
     final Cache<Uint8List> subcache = cache.withPrefix(subcacheName);
     return subcache[key].set(value, ttl);
+  }
+
+  /// Clear the value stored in subcache [subcacheName] for key [key].
+  Future<void> purge(String subcacheName, String key) {
+    final Cache<Uint8List> subcache = cache.withPrefix(subcacheName);
+    return subcache[key].purge(retries: maxCacheGetAttempts);
   }
 
   void dispose() {

--- a/app_dart/test/request_handling/cache_request_handler_test.dart
+++ b/app_dart/test/request_handling/cache_request_handler_test.dart
@@ -77,7 +77,7 @@ void main() {
       verify(fallbackHandlerMock.get()).called(1);
     });
 
-    test('flush cache calls create', () async {
+    test('flush cache param calls purge', () async {
       tester = RequestHandlerTester(
           request: FakeHttpRequest(
               path: testHttpPath,
@@ -95,6 +95,7 @@ void main() {
 
       final Uint8List serializedBody = await expectedBody.serialize().first;
 
+      // set an existing response for the request
       await cache.set(CacheRequestHandler.responseSubcacheName, responseKey,
           serializedBody);
 

--- a/app_dart/test/request_handling/cache_request_handler_test.dart
+++ b/app_dart/test/request_handling/cache_request_handler_test.dart
@@ -86,7 +86,6 @@ void main() {
           }));
       final RequestHandler<Body> fallbackHandlerMock = MockRequestHandler();
       // ignore: invalid_use_of_protected_member
-
       when(fallbackHandlerMock.get())
           .thenAnswer((Invocation invocation) async => Body.empty);
 

--- a/app_dart/test/service/cache_service_test.dart
+++ b/app_dart/test/service/cache_service_test.dart
@@ -110,6 +110,24 @@ void main() {
       expect(value, cat);
     });
 
+    test('purge removes value', () async {
+      const String testKey = 'abc';
+      final Uint8List expectedValue = Uint8List.fromList('123'.codeUnits);
+
+      await cache.set(testSubcacheName, testKey, expectedValue);
+
+      final Uint8List value =
+          await cache.getOrCreate(testSubcacheName, testKey);
+
+      expect(value, expectedValue);
+
+      await cache.purge(testSubcacheName, testKey);
+
+      final Uint8List valueAfterPurge =
+          await cache.getOrCreate(testSubcacheName, testKey);
+      expect(valueAfterPurge, isNull);
+    });
+
     test('sets ttl from set', () async {
       final Cache<Uint8List> mockMainCache = MockCache();
       final Cache<Uint8List> mockTestSubcache = MockCache();


### PR DESCRIPTION
When rolling out the CocoonConfig caching changes from https://github.com/flutter/cocoon/pull/569, there was issues with the cache not being cleared. I discovered it was because the TTLs never got set.

Additionally, memorystore GUI has no way to reset keys that have an indefinite ttl (created from this bug). I added `flushCache=true` to cached requests will reset the cache entry for the accessed response.

## Tested

- Added regression tests to ensure TTL is passed through to the final set from the different entry points
- Added test to ensure flush cache param in cache request handler works

## Preview

Broken example: ~https://v336-dot-flutter-dashboard.appspot.com/old_build.html~ - notice that all the agents have timed out

Patched version: https://v338-dot-flutter-dashboard.appspot.com/old_build.html - not all of them should be red now