### PR TITLE
append-log key only available in tests

### DIFF
--- a/app_dart/lib/src/model/appengine/log_chunk.dart
+++ b/app_dart/lib/src/model/appengine/log_chunk.dart
@@ -10,10 +10,14 @@ import 'package:gcloud/db.dart';
 class LogChunk extends Model {
   /// Creates a new [LogChunk].
   LogChunk({
+    Key key,
     this.data,
     this.createTimestamp,
     this.ownerKey,
-  });
+  }) {
+    parentKey = key?.parent;
+    id = key?.id;
+  }
 
   /// The binary data of the log chunk.
   @BlobProperty(propertyName: 'Data', required: true)

--- a/app_dart/lib/src/model/appengine/log_chunk.dart
+++ b/app_dart/lib/src/model/appengine/log_chunk.dart
@@ -10,14 +10,10 @@ import 'package:gcloud/db.dart';
 class LogChunk extends Model {
   /// Creates a new [LogChunk].
   LogChunk({
-    Key key,
     this.data,
     this.createTimestamp,
     this.ownerKey,
-  }) {
-    parentKey = key?.parent;
-    id = key?.id;
-  }
+  });
 
   /// The binary data of the log chunk.
   @BlobProperty(propertyName: 'Data', required: true)

--- a/app_dart/lib/src/model/appengine/log_chunk.dart
+++ b/app_dart/lib/src/model/appengine/log_chunk.dart
@@ -10,13 +10,13 @@ import 'package:gcloud/db.dart';
 class LogChunk extends Model {
   /// Creates a new [LogChunk].
   LogChunk({
-    Key key,
+    Key parentKeyValue,
     this.data,
     this.createTimestamp,
     this.ownerKey,
   }) {
-    parentKey = key?.parent;
-    id = key?.id;
+    // For LogChunks that reference a task, this should be the Checklist key.
+    parentKey = parentKeyValue;
   }
 
   /// The binary data of the log chunk.

--- a/app_dart/lib/src/request_handlers/append_log.dart
+++ b/app_dart/lib/src/request_handlers/append_log.dart
@@ -26,6 +26,7 @@ class AppendLog extends ApiRequestHandler<Body> {
     AuthenticationProvider authenticationProvider, {
     StackdriverLoggerService stackdriverLogger,
     @visibleForTesting Uint8List requestBodyValue,
+    @visibleForTesting this.key,
   })  : stackdriverLogger =
             stackdriverLogger ?? StackdriverLoggerService(config: config),
         super(
@@ -34,6 +35,9 @@ class AppendLog extends ApiRequestHandler<Body> {
             requestBodyValue: requestBodyValue);
 
   final StackdriverLoggerService stackdriverLogger;
+
+  /// Used in tests so [LogChunk] can be appended.
+  final Key key;
 
   static const String ownerKeyParam = 'ownerKey';
 
@@ -56,6 +60,7 @@ class AppendLog extends ApiRequestHandler<Body> {
     });
 
     final LogChunk logChunk = LogChunk(
+      key: key,
       ownerKey: ownerKey,
       createTimestamp: DateTime.now().millisecondsSinceEpoch,
       data: requestBody,

--- a/app_dart/lib/src/request_handlers/append_log.dart
+++ b/app_dart/lib/src/request_handlers/append_log.dart
@@ -60,7 +60,7 @@ class AppendLog extends ApiRequestHandler<Body> {
     });
 
     final LogChunk logChunk = LogChunk(
-      key: key,
+      parentKeyValue: task.commitKey,
       ownerKey: ownerKey,
       createTimestamp: DateTime.now().millisecondsSinceEpoch,
       data: requestBody,

--- a/app_dart/lib/src/request_handlers/append_log.dart
+++ b/app_dart/lib/src/request_handlers/append_log.dart
@@ -56,7 +56,6 @@ class AppendLog extends ApiRequestHandler<Body> {
     });
 
     final LogChunk logChunk = LogChunk(
-      key: ownerKey,
       ownerKey: ownerKey,
       createTimestamp: DateTime.now().millisecondsSinceEpoch,
       data: requestBody,

--- a/app_dart/test/request_handlers/append_log_test.dart
+++ b/app_dart/test/request_handlers/append_log_test.dart
@@ -42,9 +42,6 @@ Deleting build/ directories, if any.
     const String expectedTaskKeyEncoded =
         'ag9zfnR2b2xrZXJ0LXRlc3RyWAsSCUNoZWNrbGlzdCI4Zmx1dHRlci9mbHV0dGVyLzdkMDMzNzE2MTBjMDc5NTNhNWRlZjUwZDUwMDA0NTk0MWRlNTE2YjgMCxIEVGFzaxiAgIDg5eGTCAw';
 
-    Commit commit;
-    Task task;
-
     setUp(() {
       tester = ApiRequestHandlerTester();
       datastoreDB = FakeDatastoreDB();
@@ -52,21 +49,12 @@ Deleting build/ directories, if any.
         dbValue: datastoreDB,
       );
 
-      commit = Commit(
-          key: datastoreDB.emptyKey.append(Commit,
-              id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
-      task = Task(
-          key: commit.key.append(Task, id: 4590522719010816),
-          commitKey: commit.key,
-          requiredCapabilities: <String>['ios']);
-
       mockStackdriverLoggerService = MockStackdriverLoggerService();
       handler = AppendLog(
         config,
         FakeAuthenticationProvider(),
         stackdriverLogger: mockStackdriverLoggerService,
         requestBodyValue: Uint8List.fromList(logData.codeUnits),
-        key: task.key,
       );
     });
 
@@ -86,7 +74,23 @@ Deleting build/ directories, if any.
     });
 
     test('adds log chunk to datastore', () async {
+      final Commit commit = Commit(
+          key: datastoreDB.emptyKey.append(Commit,
+              id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 4590522719010816),
+          commitKey: commit.key,
+          requiredCapabilities: <String>['ios']);
       datastoreDB.values[task.key] = task;
+
+      // Give the task key so the LogChunk can be added to the fake datastore
+      handler = AppendLog(
+        config,
+        FakeAuthenticationProvider(),
+        stackdriverLogger: mockStackdriverLoggerService,
+        requestBodyValue: Uint8List.fromList(logData.codeUnits),
+        key: task.key,
+      );
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
         AppendLog.ownerKeyParam: expectedTaskKeyEncoded,

--- a/app_dart/test/request_handlers/append_log_test.dart
+++ b/app_dart/test/request_handlers/append_log_test.dart
@@ -42,6 +42,9 @@ Deleting build/ directories, if any.
     const String expectedTaskKeyEncoded =
         'ag9zfnR2b2xrZXJ0LXRlc3RyWAsSCUNoZWNrbGlzdCI4Zmx1dHRlci9mbHV0dGVyLzdkMDMzNzE2MTBjMDc5NTNhNWRlZjUwZDUwMDA0NTk0MWRlNTE2YjgMCxIEVGFzaxiAgIDg5eGTCAw';
 
+    Commit commit;
+    Task task;
+
     setUp(() {
       tester = ApiRequestHandlerTester();
       datastoreDB = FakeDatastoreDB();
@@ -49,12 +52,21 @@ Deleting build/ directories, if any.
         dbValue: datastoreDB,
       );
 
+      commit = Commit(
+          key: datastoreDB.emptyKey.append(Commit,
+              id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
+      task = Task(
+          key: commit.key.append(Task, id: 4590522719010816),
+          commitKey: commit.key,
+          requiredCapabilities: <String>['ios']);
+
       mockStackdriverLoggerService = MockStackdriverLoggerService();
       handler = AppendLog(
         config,
         FakeAuthenticationProvider(),
         stackdriverLogger: mockStackdriverLoggerService,
         requestBodyValue: Uint8List.fromList(logData.codeUnits),
+        key: task.key,
       );
     });
 
@@ -74,13 +86,6 @@ Deleting build/ directories, if any.
     });
 
     test('adds log chunk to datastore', () async {
-      final Commit commit = Commit(
-          key: datastoreDB.emptyKey.append(Commit,
-              id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
-      final Task task = Task(
-          key: commit.key.append(Task, id: 4590522719010816),
-          commitKey: commit.key,
-          requiredCapabilities: <String>['ios']);
       datastoreDB.values[task.key] = task;
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{

--- a/app_dart/test/request_handlers/append_log_test.dart
+++ b/app_dart/test/request_handlers/append_log_test.dart
@@ -81,32 +81,25 @@ Deleting build/ directories, if any.
           key: commit.key.append(Task, id: 4590522719010816),
           commitKey: commit.key,
           requiredCapabilities: <String>['ios']);
+      datastoreDB.values[commit.key] = commit;
       datastoreDB.values[task.key] = task;
-
-      // Give the task key so the LogChunk can be added to the fake datastore
-      handler = AppendLog(
-        config,
-        FakeAuthenticationProvider(),
-        stackdriverLogger: mockStackdriverLoggerService,
-        requestBodyValue: Uint8List.fromList(logData.codeUnits),
-        key: task.key,
-      );
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
         AppendLog.ownerKeyParam: expectedTaskKeyEncoded,
       });
 
-      // Only task should exist in the db
-      expect(datastoreDB.values.keys.length, 1);
+      // Only task and commit should exist in the db
+      expect(datastoreDB.values.keys.length, 2);
 
       await tester.post(handler);
 
-      // Now task and a log chunk should exist
-      expect(datastoreDB.values.keys.length, 2);
+      // Now a log chunk should also exist
+      expect(datastoreDB.values.keys.length, 3);
 
-      // To get the log chunk key, remove the known task key
+      // To get the log chunk key, remove the known task and commit key
       final List<Key> dbKeys = datastoreDB.values.keys.toList();
       dbKeys.remove(task.key);
+      dbKeys.remove(commit.key);
       final Key logChunkKey = dbKeys[0];
 
       final LogChunk logChunk =


### PR DESCRIPTION
This moves the append-log code that impacts production so it only runs in tests.

## Issues

https://github.com/flutter/flutter/issues/47453