### PR TITLE
CanvasKit Widget

### DIFF
--- a/app_flutter/lib/canvaskit_widget.dart
+++ b/app_flutter/lib/canvaskit_widget.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// Helper widget for easily switching between the normal widget and
+/// CanvasKit specific widgets. Since CanvasKit is under active development,
+/// the Flutter framework is not fully supported yet.
+// Remove this workaround when the following issues have been removed:
+// TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
+class CanvasKitWidget extends StatelessWidget {
+  const CanvasKitWidget({this.canvaskit, this.other});
+
+  final Widget canvaskit;
+
+  final Widget other;
+
+  @override
+  Widget build(BuildContext context) =>
+      const bool.fromEnvironment('FLUTTER_WEB_USE_SKIA') ? canvaskit : other;
+}

--- a/app_flutter/lib/canvaskit_widget.dart
+++ b/app_flutter/lib/canvaskit_widget.dart
@@ -10,13 +10,16 @@ import 'package:flutter/widgets.dart';
 // Remove this workaround when the following issues have been removed:
 // TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
 class CanvasKitWidget extends StatelessWidget {
-  const CanvasKitWidget({this.canvaskit, this.other});
+  const CanvasKitWidget({this.canvaskit, this.other, bool useCanvasKit})
+      : useCanvasKit =
+            useCanvasKit ?? const bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+
+  final bool useCanvasKit;
 
   final Widget canvaskit;
 
   final Widget other;
 
   @override
-  Widget build(BuildContext context) =>
-      const bool.fromEnvironment('FLUTTER_WEB_USE_SKIA') ? canvaskit : other;
+  Widget build(BuildContext context) => useCanvasKit ? canvaskit : other;
 }

--- a/app_flutter/lib/commit_box.dart
+++ b/app_flutter/lib/commit_box.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit;
 
+import 'canvaskit_widget.dart';
 import 'status_grid.dart';
 
 /// Displays Git commit information.
@@ -39,27 +40,29 @@ class _CommitBoxState extends State<CommitBox> {
       height: StatusGrid.cellSize,
       child: GestureDetector(
         onTap: _handleTap,
-        // TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
-        // CanvasKit currently cannot render a NetworkImage because of CORS issues.
-        // As a work around, we just show the first letter of the contributor's username.
-        child: Container(
-          margin: const EdgeInsets.all(1.0),
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: Color.fromRGBO(authorHash & 255, authorHash >>= 8 & 255,
-                authorHash >>= 8 & 255, 1),
-          ),
-          child: Center(
-            child: Text(
-              widget.commit.author.substring(0, 1).toUpperCase(),
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 24.0,
-                fontWeight: FontWeight.bold,
+        // TODO(chillers): Show a Network Image in CanvasKit. https://github.com/flutter/flutter/issues/45955
+        // Just show the first letter of the contributor's username.
+        child: CanvasKitWidget(
+          canvaskit: Container(
+            margin: const EdgeInsets.all(1.0),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Color.fromRGBO(authorHash & 255, authorHash >>= 8 & 255,
+                  authorHash >>= 8 & 255, 1),
+            ),
+            child: Center(
+              child: Text(
+                widget.commit.author.substring(0, 1).toUpperCase(),
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24.0,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
           ),
+          other: Image.network(widget.commit.authorAvatarUrl),
         ),
       ),
     );

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:app_flutter/canvaskit_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -24,13 +25,18 @@ class SignInButton extends StatelessWidget {
         /// On sign out, there's a second where the user is null before isAuthenticated catches up.
         if (isAuthenticated.data == true && authService.user != null) {
           return PopupMenuButton<String>(
-            // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
             // TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
             // CanvasKit currently cannot render a NetworkImage because of CORS issues.
-            // child: Image.network(authService.user?.photoUrl),
-            child: Icon(
-              Icons.account_circle,
-              size: 42,
+            child: CanvasKitWidget(
+              canvaskit: Padding(
+                child: Icon(
+                  Icons.account_circle,
+                  size: 42,
+                ),
+                padding: const EdgeInsets.only(right: 10.0),
+              ),
+              // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
+              other: Image.network(authService.user?.photoUrl),
             ),
             offset: const Offset(0, 50),
             itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[

--- a/app_flutter/test/canvaskit_widget_test.dart
+++ b/app_flutter/test/canvaskit_widget_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:app_flutter/canvaskit_widget.dart';
+
+void main() {
+  group('CanvasKitWidget', () {
+    testWidgets('use canvaskit child when FLUTTER_WEB_USE_SKIA=true',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CanvasKitWidget(
+            useCanvasKit: true,
+            canvaskit: Text('canvaskit'),
+            other: Text('not canvaskit'),
+          ),
+        ),
+      );
+
+      expect(find.text('canvaskit'), findsOneWidget);
+      expect(find.text('not canvaskit'), findsNothing);
+    });
+    testWidgets('use canvaskit child when FLUTTER_WEB_USE_SKIA=false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CanvasKitWidget(
+            useCanvasKit: false,
+            canvaskit: Text('canvaskit'),
+            other: Text('not canvaskit'),
+          ),
+        ),
+      );
+
+      expect(find.text('canvaskit'), findsNothing);
+      expect(find.text('not canvaskit'), findsOneWidget);
+    });
+  });
+}

--- a/app_flutter/test/commit_box_test.dart
+++ b/app_flutter/test/commit_box_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/protos.dart' show Commit;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,13 +28,11 @@ void main() {
       ));
 
       // Image.Network throws a 400 exception in tests
-      // TODO(chillers): Uncomment when images added back. https://github.com/flutter/flutter/issues/45955
-      // expect(find.byType(Image), findsOneWidget);
-      // if (kIsWeb) {
-      //   expect(tester.takeException(),
-      //       const test.TypeMatcher<NetworkImageLoadException>());
-      // }
-      expect(find.text('A'), findsOneWidget);
+      expect(find.byType(Image), findsOneWidget);
+      if (!kIsWeb) {
+        expect(tester.takeException(),
+            const test.TypeMatcher<NetworkImageLoadException>());
+      }
     });
 
     testWidgets('shows overlay on click', (WidgetTester tester) async {
@@ -49,9 +48,6 @@ void main() {
 
       await tester.tap(find.byType(CommitBox));
       await tester.pump();
-
-      expect(tester.takeException(),
-          const test.TypeMatcher<NetworkImageLoadException>());
 
       expect(find.text(shortSha), findsOneWidget);
       expect(find.text(expectedCommit.author), findsOneWidget);

--- a/app_flutter/test/sign_in_button_test.dart
+++ b/app_flutter/test/sign_in_button_test.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
+import 'package:test/test.dart' as test;
 
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/sign_in_button.dart';
@@ -84,17 +86,14 @@ void main() {
       ),
     );
     await tester.pump();
-    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
     // TODO(chillers): Remove this web check once issue is resolved. https://github.com/flutter/flutter/issues/44370
-    // if (!kIsWeb) {
-    //   expect(tester.takeException(),
-    //       const test.TypeMatcher<NetworkImageLoadException>());
-    // }
+    if (!kIsWeb) {
+      expect(tester.takeException(),
+          const test.TypeMatcher<NetworkImageLoadException>());
+    }
 
     expect(find.text('Sign in'), findsNothing);
-    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
-    // expect(find.byType(Image), findsOneWidget);
-    expect(find.byType(Icon), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
   });
 
   testWidgets('calls sign out on tap when authenticated',
@@ -116,9 +115,7 @@ void main() {
     );
     await tester.pump();
 
-    // TODO(chillers): Uncomment when resolved. https://github.com/flutter/flutter/issues/45955
-    // await tester.tap(find.byType(Image));
-    await tester.tap(find.byIcon(Icons.account_circle));
+    await tester.tap(find.byType(Image));
     await tester.pumpAndSettle();
 
     verifyNever(mockAuthService.signOut());

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:test/test.dart' as test;
 
 import 'package:cocoon_service/protos.dart'
     show Commit, CommitStatus, Stage, Task;
@@ -152,11 +154,10 @@ void main() {
         ),
       );
 
-      // TODO(chillers): Uncomment when images added back. https://github.com/flutter/flutter/issues/45955
-      // if (kIsWeb) {
-      //   expect(tester.takeException(),
-      //       const test.TypeMatcher<NetworkImageLoadException>());
-      // }
+      if (!kIsWeb) {
+        expect(tester.takeException(),
+            const test.TypeMatcher<NetworkImageLoadException>());
+      }
       expect(find.byType(TaskBox), findsNWidgets(3));
 
       // Row 1: ✓☐☐


### PR DESCRIPTION
This moves the CanvasKit changes from https://github.com/flutter/cocoon/pull/558 to a toggleable widget. When CanvasKit is currently in use, it will use the workarounds. Otherwise, it will use the previous widgets.

## Open Questions

- Any ideas for a better name for `CanvasKitWidget`?

## Preview

Demo: https://testchillers1-dot-flutter-dashboard.appspot.com/build.html

When running locally on an emulator, it defaults to the previous method (showing images).
![canvaskit_widget](https://user-images.githubusercontent.com/2148558/71196490-0b8b7c80-2245-11ea-8e62-a5c0ee0b6ffd.png)
