### PR TITLE
Task run and queue time in build dashboard

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -308,9 +308,15 @@ class TaskOverlayContents extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final int taskDurationInSeconds =
-        (task.endTimestamp - task.startTimestamp).toInt() ~/ 100;
-    final int taskDurationInMinutes = taskDurationInSeconds ~/ 60;
+    final DateTime createTime =
+        DateTime.fromMillisecondsSinceEpoch(task.createTimestamp.toInt());
+    final DateTime startTime =
+        DateTime.fromMillisecondsSinceEpoch(task.startTimestamp.toInt());
+    final DateTime endTime =
+        DateTime.fromMillisecondsSinceEpoch(task.endTimestamp.toInt());
+
+    final Duration queueDuration = startTime.difference(createTime);
+    final Duration runDuration = endTime.difference(startTime);
 
     return Card(
       child: Column(
@@ -322,7 +328,8 @@ class TaskOverlayContents extends StatelessWidget {
             title: Text(task.name),
             subtitle: isDevicelab(task)
                 ? Text('Attempts: ${task.attempts}\n'
-                    'Duration: $taskDurationInMinutes minutes\n'
+                    'Run time: ${runDuration.inMinutes} minutes\n'
+                    'Queue time: ${queueDuration.inSeconds} seconds\n'
                     'Agent: ${task.reservedForAgentId}\n'
                     'Flaky: ${task.isFlaky}')
                 : const Text('Task was run outside of devicelab'),


### PR DESCRIPTION
Fixes the run time in task summary and adds queue time.

## Issues

Fixes https://github.com/flutter/flutter/issues/47490

## Preview

https://testchillers-dot-flutter-dashboard.appspot.com/#/build

![queue_time](https://user-images.githubusercontent.com/2148558/71278645-042fa600-230d-11ea-8f1c-2c3a51840b66.png)
