### PR TITLE
Add agent id for task in bigquery

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -146,6 +146,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
         'IsFlaky': task.isFlaky,
         'TimeoutInMinutes': task.timeoutInMinutes,
         'RequiredCapabilities': task.requiredCapabilities,
+        'ReservedForAgentID': task.reservedForAgentId,
         'StageName': task.stageName,
         'Status': task.status,
       },


### PR DESCRIPTION
This is used to easily query task results based on platform.