### PR TITLE
Create Google Sign In Service only once

### DIFF
--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:app_flutter/service/google_authentication.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -12,8 +13,10 @@ import 'status_grid.dart';
 
 /// [BuildDashboard] parent widget that manages the state of the dashboard.
 class BuildDashboardPage extends StatefulWidget {
-  BuildDashboardPage({FlutterBuildState buildState})
-      : buildState = buildState ?? FlutterBuildState();
+  BuildDashboardPage(
+      {FlutterBuildState buildState, GoogleSignInService signInService})
+      : buildState =
+            buildState ?? FlutterBuildState(authServiceValue: signInService);
 
   final FlutterBuildState buildState;
 

--- a/app_flutter/lib/build_dashboard.dart
+++ b/app_flutter/lib/build_dashboard.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/service/google_authentication.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'navigation_drawer.dart';
+import 'service/google_authentication.dart';
 import 'sign_in_button.dart';
 import 'state/flutter_build.dart';
 import 'status_grid.dart';

--- a/app_flutter/lib/index_page.dart
+++ b/app_flutter/lib/index_page.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:app_flutter/service/google_authentication.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -11,7 +12,8 @@ import 'sign_in_button.dart';
 import 'state/index.dart';
 
 class IndexPage extends StatefulWidget {
-  IndexPage({IndexState indexState}) : indexState = indexState ?? IndexState();
+  IndexPage({IndexState indexState, GoogleSignInService signInService})
+      : indexState = indexState ?? IndexState(authServiceValue: signInService);
 
   final IndexState indexState;
 

--- a/app_flutter/lib/index_page.dart
+++ b/app_flutter/lib/index_page.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/service/google_authentication.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'navigation_drawer.dart';
+import 'service/google_authentication.dart';
 import 'sign_in_button.dart';
 import 'state/index.dart';
 

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import 'build_dashboard.dart';
 import 'index_page.dart';
+import 'service/google_authentication.dart';
 
 void main() => runApp(MyApp());
 
@@ -17,13 +18,16 @@ final ThemeData theme = ThemeData(
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final GoogleSignInService signInService = GoogleSignInService();
+
     return MaterialApp(
       title: 'Flutter Build Dashboard',
       theme: theme,
       initialRoute: '/',
       routes: <String, WidgetBuilder>{
-        '/': (BuildContext context) => IndexPage(),
-        '/build': (BuildContext context) => BuildDashboardPage(),
+        '/': (BuildContext context) => IndexPage(signInService: signInService),
+        '/build': (BuildContext context) =>
+            BuildDashboardPage(signInService: signInService),
       },
     );
   }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -16,10 +16,11 @@ class GoogleSignInService {
     _googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
+      print('GoogleSignIn currentUserChanged');
       print(user);
       notifyListeners();
     });
-    _googleSignIn.signInSilently(suppressErrors: false);
+    _googleSignIn.signInSilently();
   }
 
   /// A callback for notifying listeners there has been an update.
@@ -55,7 +56,15 @@ class GoogleSignInService {
       ?.then((GoogleSignInAuthentication key) => key.idToken);
 
   /// Initiate the Google Sign In process.
-  Future<void> signIn() async => await _googleSignIn.signIn();
+  Future<void> signIn() async {
+    print('calling sign in');
+    await _googleSignIn.signIn();
+    print('sign in complete');
+  }
 
-  Future<void> signOut() async => await _googleSignIn.signOut();
+  Future<void> signOut() async {
+    print('calling sign out');
+    await _googleSignIn.signOut();
+    print('sign out complete');
+  }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -54,9 +54,11 @@ class GoogleSignInService {
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {
     user = await _googleSignIn.signIn();
+    notifyListeners();
   }
 
   Future<void> signOut() async {
     user = await _googleSignIn.signOut();
+    notifyListeners();
   }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -22,7 +22,7 @@ class GoogleSignInService {
   }
 
   /// A callback for notifying listeners there has been an update.
-  final VoidCallback notifyListeners;
+  VoidCallback notifyListeners;
 
   /// A list of Google API OAuth Scopes this project needs access to.
   ///
@@ -53,9 +53,11 @@ class GoogleSignInService {
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {
     user = await _googleSignIn.signIn();
+    notifyListeners();
   }
 
   Future<void> signOut() async {
     await _googleSignIn.signOut();
+    notifyListeners();
   }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -16,8 +16,6 @@ class GoogleSignInService {
     _googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
-      print('GoogleSignIn currentUserChanged');
-      print(user);
       notifyListeners();
     });
     _googleSignIn.signInSilently();
@@ -57,14 +55,10 @@ class GoogleSignInService {
 
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {
-    print('calling sign in');
-    await _googleSignIn.signIn();
-    print('sign in complete');
+    user = await _googleSignIn.signIn();
   }
 
   Future<void> signOut() async {
-    print('calling sign out');
-    await _googleSignIn.signOut();
-    print('sign out complete');
+    user = await _googleSignIn.signOut();
   }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -53,11 +53,9 @@ class GoogleSignInService {
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {
     user = await _googleSignIn.signIn();
-    notifyListeners();
   }
 
   Future<void> signOut() async {
     await _googleSignIn.signOut();
-    notifyListeners();
   }
 }

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -8,7 +8,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 /// Service class for interacting with Google Sign In authentication for Cocoon backend.
 class GoogleSignInService {
   /// Creates a new [GoogleSignIn].
-  GoogleSignInService({GoogleSignIn googleSignIn, this.notifyListeners})
+  GoogleSignInService({GoogleSignIn googleSignIn})
       : _googleSignIn = googleSignIn ??
             GoogleSignIn(
               scopes: _googleScopes,

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -42,9 +42,7 @@ class GoogleSignInService {
   /// Whether or not the application has been signed in to.
   Future<bool> get isAuthenticated => _googleSignIn.isSignedIn();
 
-  /// The Google Account for the signed in user.
-  ///
-  /// If any of the fields are null, the current session is not signed in.
+  /// The Google Account for the signed in user, null if no user is signed in.
   ///
   /// Read only object with only access to clear client auth tokens.
   GoogleSignInAccount user;

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -16,9 +16,10 @@ class GoogleSignInService {
     _googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
+      print(user);
       notifyListeners();
     });
-    _googleSignIn.signInSilently();
+    _googleSignIn.signInSilently(suppressErrors: false);
   }
 
   /// A callback for notifying listeners there has been an update.
@@ -36,12 +37,15 @@ class GoogleSignInService {
     'openid',
   ];
 
+  /// The instance of the GoogleSignIn plugin to use.
   final GoogleSignIn _googleSignIn;
 
   /// Whether or not the application has been signed in to.
   Future<bool> get isAuthenticated => _googleSignIn.isSignedIn();
 
-  /// The Google Account for the signed in user, null if no user is signed in.
+  /// The Google Account for the signed in user.
+  ///
+  /// If any of the fields are null, the current session is not signed in.
   ///
   /// Read only object with only access to clear client auth tokens.
   GoogleSignInAccount user;
@@ -51,11 +55,7 @@ class GoogleSignInService {
       ?.then((GoogleSignInAuthentication key) => key.idToken);
 
   /// Initiate the Google Sign In process.
-  Future<void> signIn() async {
-    user = await _googleSignIn.signIn();
-  }
+  Future<void> signIn() async => await _googleSignIn.signIn();
 
-  Future<void> signOut() async {
-    await _googleSignIn.signOut();
-  }
+  Future<void> signOut() async => await _googleSignIn.signOut();
 }

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -5,6 +5,7 @@
 import 'package:app_flutter/canvaskit_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_progress_button/flutter_progress_button.dart';
 
 import 'service/google_authentication.dart';
 
@@ -49,12 +50,20 @@ class SignInButton extends StatelessWidget {
             },
           );
         }
-        return FlatButton(
-          child: const Text(
-            'Sign in',
-            style: TextStyle(color: Colors.white),
+        return SizedBox(
+          width: 100,
+          child: ProgressButton(
+            defaultWidget: const Text(
+              'Sign in',
+              style: TextStyle(color: Colors.white),
+            ),
+            color: Colors.transparent,
+            progressWidget: const CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+            ),
+            animate: false,
+            onPressed: authService.signIn,
           ),
-          onPressed: () => authService.signIn(),
         );
       },
     );

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -22,6 +22,7 @@ class FlutterBuildState extends ChangeNotifier {
   }) : _cocoonService = cocoonServiceValue ?? CocoonService() {
     authService = authServiceValue ??
         GoogleSignInService(notifyListeners: notifyListeners);
+    authService.notifyListeners = notifyListeners;
   }
 
   /// Cocoon backend service that retrieves the data needed for this state.

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -19,9 +19,8 @@ class FlutterBuildState extends ChangeNotifier {
   FlutterBuildState({
     CocoonService cocoonServiceValue,
     GoogleSignInService authServiceValue,
-  }) : _cocoonService = cocoonServiceValue ?? CocoonService() {
-    authService = authServiceValue ??
-        GoogleSignInService(notifyListeners: notifyListeners);
+  })  : _cocoonService = cocoonServiceValue ?? CocoonService(),
+        authService = authServiceValue ?? GoogleSignInService() {
     authService.notifyListeners = notifyListeners;
   }
 

--- a/app_flutter/lib/state/index.dart
+++ b/app_flutter/lib/state/index.dart
@@ -16,9 +16,7 @@ class IndexState extends ChangeNotifier {
   /// If [CocoonService] is not specified, a new [CocoonService] instance is created.
   IndexState({
     GoogleSignInService authServiceValue,
-  }) {
-    authService = authServiceValue ??
-        GoogleSignInService(notifyListeners: notifyListeners);
+  }) : authService = authServiceValue ?? GoogleSignInService() {
     authService.notifyListeners = notifyListeners;
   }
 

--- a/app_flutter/lib/state/index.dart
+++ b/app_flutter/lib/state/index.dart
@@ -19,6 +19,7 @@ class IndexState extends ChangeNotifier {
   }) {
     authService = authServiceValue ??
         GoogleSignInService(notifyListeners: notifyListeners);
+    authService.notifyListeners = notifyListeners;
   }
 
   /// Authentication service for managing Google Sign In.

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -49,7 +49,8 @@ void main() {
       when(mockSignIn.onCurrentUserChanged)
           .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
 
-      authService = GoogleSignInService(googleSignIn: mockSignIn);
+      authService = GoogleSignInService(googleSignIn: mockSignIn)
+        ..notifyListeners = () => null;
     });
 
     test('is authenticated after successful sign in', () async {

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -15,8 +15,6 @@ import 'package:app_flutter/service/cocoon.dart';
 import 'package:app_flutter/service/fake_cocoon.dart';
 import 'package:app_flutter/state/flutter_build.dart';
 
-import '../utils/fake_google_account.dart';
-
 void main() {
   group('FlutterBuildState', () {
     FlutterBuildState buildState;

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -122,8 +122,6 @@ void main() {
     final MockGoogleSignInPlugin mockSignInPlugin = MockGoogleSignInPlugin();
     when(mockSignInPlugin.onCurrentUserChanged)
         .thenAnswer((_) => Stream<GoogleSignInAccount>.value(null));
-    when(mockSignInPlugin.signIn()).thenAnswer((_) async => null);
-    when(mockSignInPlugin.signOut()).thenAnswer((_) async => null);
     final GoogleSignInService signInService =
         GoogleSignInService(googleSignIn: mockSignInPlugin);
     final FlutterBuildState buildState =

--- a/app_flutter/test/state/index_test.dart
+++ b/app_flutter/test/state/index_test.dart
@@ -43,7 +43,6 @@ void main() {
     final MockGoogleSignInPlugin mockSignInPlugin = MockGoogleSignInPlugin();
     when(mockSignInPlugin.onCurrentUserChanged)
         .thenAnswer((_) => Stream<GoogleSignInAccount>.value(null));
-    when(mockSignInPlugin.signIn()).thenAnswer((_) async => null);
     final GoogleSignInService signInService =
         GoogleSignInService(googleSignIn: mockSignInPlugin);
     final IndexState indexState = IndexState(authServiceValue: signInService);


### PR DESCRIPTION
This creates `GoogleSignInService` in `main.dart` and passes it around instead of recreating it on each page.

Updated sign in button to be a progress button to show if the sign in is in progress (good for issues when the plugin is being buggy). However, in CanvasKit this shows a weird color issue with the transparent color.

# Issues

Mitigates https://github.com/flutter/flutter/issues/47832

- Seems to be an issue with the web implementation of sign in silently where it causes it to hang.

## Tested

Checked for the states to have `notifyListener()` called when the sign in functions are called.

# Preview

https://testchillers1-dot-flutter-dashboard.appspot.com