### PR TITLE
Check checkSuites

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -249,6 +249,9 @@ class Config {
   Future<GraphQLClient> createGitHubGraphQLClient() async {
     final HttpLink httpLink = HttpLink(
       uri: 'https://api.github.com/graphql',
+      headers: <String, String>{
+        'Accept': 'application/vnd.github.antiope-preview+json',
+      },
     );
 
     final String token = await githubOAuthToken;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -186,7 +186,13 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       final bool hasChangesRequested =
           pullRequest['changeRequestReviews']['nodes'].isNotEmpty;
       final String sha = commit['oid'];
-      final bool ciSuccessful = commit['status']['state'] == 'SUCCESS';
+      final List<Map<String, dynamic>> checkSuites =
+          commit['checkSuites']['nodes'].cast<Map<String, dynamic>>();
+      final bool checkSuitesSuccessful = checkSuites.every(
+          (Map<String, dynamic> checkSuiteConclusion) =>
+              checkSuiteConclusion['conclusion'] == 'SUCCESS');
+      final bool ciSuccessful =
+          checkSuitesSuccessful && commit['status']['state'] == 'SUCCESS';
       list.add(_AutoMergeQueryResult(
         graphQLId: id,
         ciSuccessful: ciSuccessful,

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -23,6 +23,11 @@ query LabeledPullRequestsWithReviews($sOwner: String!, $sName: String!, $sLabelN
                   status {
                     state
                   }
+                  checkSuites(first: 100) {
+                    nodes {
+                      conclusion
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
We're ignoring checkSuites currently when we check to see if the PR is green, which means we're ignoring the Cirrus check suites (and, presumably, other checks if we ever migrate flutter-build or the LUCI checks to checkSuites).

This makes sure that all statuses AND all check suites are successful before landing a waiting PR.