### PR TITLE
make agents timestamp same for bigquery insert

### DIFF
--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -55,6 +55,7 @@ class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
 
     final List<Map<String, Object>> tableDataInsertAllRequestRows =
         <Map<String, Object>>[];
+    final int healthCheckTimestamp = DateTime.now().millisecondsSinceEpoch;
 
     for (Agent agent in agents) {
       final bool isHealthy = _isAgentHealthy(agent);
@@ -64,7 +65,7 @@ class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
       /// Prepare for bigquery [insertAll].
       tableDataInsertAllRequestRows.add(<String, Object>{
         'json': <String, Object>{
-          'Timestamp': agent.healthCheckTimestamp,
+          'Timestamp': healthCheckTimestamp,
           'AgentID': agent.agentId,
           // TODO(keyonghan): add more detailed statuses https://github.com/flutter/flutter/issues/44213
           'Status': isHealthy ? 'healthy' : 'unhealthy',

--- a/app_dart/test/request_handlers/update_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/update_agent_health_history_test.dart
@@ -80,6 +80,8 @@ void main() {
       final Map<String, dynamic> result = await decodeHandlerBody();
       final TableDataList tableDataList =
           await tabledataResourceApi.list('test', 'test', 'test');
+      final Map<String, Object> value1 = tableDataList.rows[0].f[0].v;
+      final Map<String, Object> value2 = tableDataList.rows[1].f[0].v;
       final List<dynamic> expectedOrderedAgents = <dynamic>[
         linux1.toJson(),
         linux5.toJson(),
@@ -88,6 +90,7 @@ void main() {
 
       /// Test `BigQuery` insert.
       expect(tableDataList.totalRows, '3');
+      expect(value1['Timestamp'], value2['Timestamp']);
       expect(log.records[0].message,
           'Succeeded to insert 3 rows to flutter-dashboard-cocoon-Agent');
 

--- a/app_dart/test/src/bigquery/fake_tabledata_resource.dart
+++ b/app_dart/test/src/bigquery/fake_tabledata_resource.dart
@@ -29,11 +29,13 @@ class FakeTabledataResourceApi implements TabledataResourceApi {
       String startIndex,
       String pageToken,
       String $fields}) async {
-    final Map<String, Object> value = rows[0].json;
-    final List<Map<String, Object>> tableCellList = <Map<String, Object>>[];
-    tableCellList.add(<String, Object>{'v': value});
     final List<Map<String, Object>> tableRowList = <Map<String, Object>>[];
-    tableRowList.add(<String, Object>{'f': tableCellList});
+    for (TableDataInsertAllRequestRows tableDataInsertAllRequestRows in rows) {
+      final Map<String, Object> value = tableDataInsertAllRequestRows.json;
+      final List<Map<String, Object>> tableCellList = <Map<String, Object>>[];
+      tableCellList.add(<String, Object>{'v': value});
+      tableRowList.add(<String, Object>{'f': tableCellList});
+    }
 
     return TableDataList.fromJson(<String, Object>{
       'totalRows': rows.length.toString(),


### PR DESCRIPTION
Existing logic inserts agents health status to BigQuery every 1 min via a cronjob. However, the insertion timestamp is different for different agents.

This PR makes the insertion timestamp the same for all agents whenever the cronjob is called. This is helpful when we collect metric: percentage of time test beds that are over 90% healthiness (daily).