### PR TITLE
Temporarily disable silent sign in

### DIFF
--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -18,7 +18,9 @@ class GoogleSignInService {
       user = accountValue;
       notifyListeners();
     });
-    _googleSignIn.signInSilently();
+
+    // TODO(chillers): Uncomment following line when issue fixed. https://github.com/flutter/flutter/issues/47832
+    // _googleSignIn.signInSilently();
   }
 
   /// A callback for notifying listeners there has been an update.

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -24,6 +24,10 @@ void main() {
       authService = GoogleSignInService(googleSignIn: mockSignIn);
     });
 
+    tearDown(() {
+      clearInteractions(mockSignIn);
+    });
+
     test('not authenticated', () async {
       expect(await authService.isAuthenticated, false);
     });
@@ -32,6 +36,10 @@ void main() {
       expect(authService.user, null);
       expect(authService.idToken, null);
     });
+
+    test('sign in silently called', () async {
+      verify(mockSignIn.signInSilently()).called(1);
+    }, skip: true);
   });
 
   group('GoogleSignInService sign in', () {


### PR DESCRIPTION
The Google Sign In web plugin has an issue where it can occasionally hang calling `signInSilently()`. As a work around, everyone will be required to manually sign in so everyone can sign in.

# Issues

https://github.com/flutter/flutter/issues/47832

# Tested

Added a test to check sign in is called in constructor, and skipped it :)