### PR TITLE
[engine] Enable mac builders on luci try jobs.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -230,6 +230,30 @@ class Config {
           'repo': 'engine',
         },
         <String, String>{
+          'name': 'Mac Host Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Android AOT Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Android Debug Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac iOS Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac iOS Engine Profile',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac iOS Engine Release',
+          'repo': 'engine',
+        },
+        <String, String>{
           'name': 'Windows Host Engine',
           'repo': 'engine',
         },


### PR DESCRIPTION
LUCI builders have been running automatically on every PR from LUCI but
mac builders were not enabled because of lack of capacity. We moved half
of the capacity from prod pool to try and now we are ready to start
running LUCI tests by default in presubmit for engine repo.

Bug: https://github.com/flutter/flutter/issues/45562