### PR TITLE
Update to federated plugins and re-enable silent sign in

### DIFF
--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -19,8 +19,7 @@ class GoogleSignInService {
       notifyListeners();
     });
 
-    // TODO(chillers): Uncomment following line when issue fixed. https://github.com/flutter/flutter/issues/47832
-    // _googleSignIn.signInSilently();
+    _googleSignIn.signInSilently();
   }
 
   /// A callback for notifying listeners there has been an update.

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -5,7 +5,6 @@
 import 'package:app_flutter/canvaskit_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_progress_button/flutter_progress_button.dart';
 
 import 'service/google_authentication.dart';
 

--- a/app_flutter/lib/sign_in_button.dart
+++ b/app_flutter/lib/sign_in_button.dart
@@ -50,20 +50,12 @@ class SignInButton extends StatelessWidget {
             },
           );
         }
-        return SizedBox(
-          width: 100,
-          child: ProgressButton(
-            defaultWidget: const Text(
-              'Sign in',
-              style: TextStyle(color: Colors.white),
-            ),
-            color: Colors.transparent,
-            progressWidget: const CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-            ),
-            animate: false,
-            onPressed: authService.signIn,
+        return FlatButton(
+          child: const Text(
+            'Sign in',
+            style: TextStyle(color: Colors.white),
           ),
+          onPressed: authService.signIn,
         );
       },
     );

--- a/app_flutter/pubspec.lock
+++ b/app_flutter/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.14"
+    version: "4.1.1"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
@@ -206,12 +206,12 @@ packages:
     source: hosted
     version: "1.0.0"
   google_sign_in_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: google_sign_in_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.1"
+    version: "0.8.3"
   googleapis:
     dependency: transitive
     description:
@@ -436,6 +436,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   pool:
     dependency: transitive
     description:
@@ -608,21 +615,28 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.7"
+    version: "5.4.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.5"
   url_launcher_web:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.0+2"
   uuid_enhanced:
     dependency: transitive
     description:
@@ -681,4 +695,4 @@ packages:
     version: "2.2.0"
 sdks:
   dart: ">=2.6.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -31,11 +31,9 @@ dependencies:
   cocoon_service:
     path: ../app_dart
   flutter_progress_button: ^1.0.0
-  google_sign_in: ^4.0.14
-  google_sign_in_web: ^0.8.0
+  google_sign_in: ^4.1.0
   provider: ^3.0.0
-  url_launcher: ^5.2.4
-  url_launcher_web: ^0.1.0
+  url_launcher: ^5.4.1
 
 dev_dependencies:
   flutter_test:

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -39,7 +39,7 @@ void main() {
 
     test('sign in silently called', () async {
       verify(mockSignIn.signInSilently()).called(1);
-    }, skip: true);
+    });
   });
 
   group('GoogleSignInService sign in', () {


### PR DESCRIPTION
Thank you @ditman for fixing the Google sign in web bug with silent sign in the dashboard was facing. This just updates the dependencies and re-enables the sign in code with their patch.

Reverts the sign in button back to a basic button so it doesn't have the CanvasKit issue.

## Issues

Fixes https://github.com/flutter/flutter/issues/47832

## Preview

https://testchillers1-dot-flutter-dashboard.appspot.com