### PR TITLE
Mark tree build status failed when tasks are rerunning

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -52,7 +52,12 @@ Future<void> main() async {
       '/api/debug/get-task-by-id': DebugGetTaskById(config, authProvider),
       '/api/debug/reset-pending-tasks':
           DebugResetPendingTasks(config, authProvider),
-      '/api/public/build-status': GetBuildStatus(config),
+      '/api/public/build-status': CacheRequestHandler<Body>(
+        cache: cache,
+        config: config,
+        delegate: GetBuildStatus(config),
+        ttl: const Duration(seconds: 15),
+      ),
       '/api/public/get-benchmarks': CacheRequestHandler<Body>(
         cache: cache,
         config: config,

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -54,7 +54,7 @@ class Task extends Model {
   static const String statusFailed = 'Failed';
 
   /// The task was skipped or canceled while running.
-  /// 
+  ///
   /// This status is only used by LUCI tasks.
   static const String statusSkipped = 'Skipped';
 

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -54,6 +54,8 @@ class Task extends Model {
   static const String statusFailed = 'Failed';
 
   /// The task was skipped or canceled while running.
+  /// 
+  /// This status is only used by LUCI tasks.
   static const String statusSkipped = 'Skipped';
 
   /// The list of legal values for the [status] property.

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -56,10 +56,8 @@ class BuildStatusProvider {
           /// commit may be done that we can base off of.
           final bool checked = checkedTasks[task.name] ?? false;
 
-          if (isRelevantToLatestStatus && task.isFlaky) {
-            checkedTasks[task.name] = true;
-          } else if (isRelevantToLatestStatus && !checked) {
-            if (_isSuccessful(task)) {
+          if (isRelevantToLatestStatus && !checked) {
+            if (task.isFlaky || _isSuccessful(task)) {
               checkedTasks[task.name] = true;
             } else if (_isFailed(task) || _isRerunning(task)) {
               return BuildStatus.failed;

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -44,6 +44,11 @@ class BuildStatusProvider {
             checkedTasks[task.name] = false;
           }
 
+          /// All tasks in the latest [CommitStatus] are relevant to the build
+          /// status. However, not all tasks are relevant to the latest status.
+          ///
+          /// If a task [isRelevantToLatestStatus] but has not run yet, we look
+          /// for a previous run of the task from the previous commit.
           final bool isRelevantToLatestStatus =
               checkedTasks.containsKey(task.name);
 

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -31,6 +31,22 @@ class BuildStatusProvider {
   ///
   /// This calculation operates by looking for the most recent success or
   /// failure for every (non-flaky) task in the manifest.
+  ///
+  /// Take the example build dashboard below:
+  /// ✔ = passed, ✖ = failed, ☐ = new, ░ = in progress, s = skipped
+  /// +---+---+---+---+
+  /// | A | B | C | D |
+  /// +---+---+---+---+
+  /// | ✔ | ☐ | ░ | s |
+  /// +---+---+---+---+
+  /// | ✔ | ░ | ✔ | ✖ |
+  /// +---+---+---+---+
+  /// | ✔ | ✖ | ✔ | ✔ |
+  /// +---+---+---+---+
+  /// This build will fail because only of Task B. Task D is not included in
+  /// the latest commit status, so it does not impact the build status.
+  /// Task B fails because its last known status was to be failing, even though
+  /// there is currently a newer version that is in progress.
   Future<BuildStatus> calculateCumulativeStatus() async {
     final Map<String, bool> tasksInProgress = <String, bool>{};
     bool isLatestCommitStatus = true;

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -32,6 +32,12 @@ List<Task> allGreen = <Task>[
   Task(stageName: 'stage2', name: 'task3', status: Task.statusSucceeded),
 ];
 
+List<Task> allRed = <Task>[
+  Task(stageName: 'stage1', name: 'task1', status: Task.statusFailed),
+  Task(stageName: 'stage2', name: 'task2', status: Task.statusFailed),
+  Task(stageName: 'stage2', name: 'task3', status: Task.statusFailed),
+];
+
 List<Task> middleTaskFailed = <Task>[
   Task(stageName: 'stage1', name: 'task1', status: Task.statusSucceeded),
   Task(stageName: 'stage2', name: 'task2', status: Task.statusFailed),
@@ -57,6 +63,16 @@ List<Task> middleTaskInProgress = <Task>[
 List<Task> middleTaskRerunning = <Task>[
   Task(stageName: 'stage1', name: 'task1', status: Task.statusSucceeded),
   Task(stageName: 'stage2', name: 'task2', status: Task.statusNew, attempts: 2),
+  Task(stageName: 'stage2', name: 'task3', status: Task.statusSucceeded),
+];
+
+List<Task> middleTaskRerunGreen = <Task>[
+  Task(stageName: 'stage1', name: 'task1', status: Task.statusSucceeded),
+  Task(
+      stageName: 'stage2',
+      name: 'task2',
+      status: Task.statusSucceeded,
+      attempts: 2),
   Task(stageName: 'stage2', name: 'task3', status: Task.statusSucceeded),
 ];
 
@@ -149,6 +165,17 @@ void main() {
         final BuildStatus status =
             await buildStatusProvider.calculateCumulativeStatus();
         expect(status, BuildStatus.failed);
+      });
+
+      test('returns success when all green with a successful rerun', () async {
+        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
+        int row = 0;
+        db.addOnQuery<Task>((Iterable<Task> results) {
+          return row++ == 0 ? middleTaskRerunGreen : allRed;
+        });
+        final BuildStatus status =
+            await buildStatusProvider.calculateCumulativeStatus();
+        expect(status, BuildStatus.succeeded);
       });
     });
   });


### PR DESCRIPTION
This updates the build status algorithm to return failed if a task is having to rerun. 

Additionally, it reduces the amount of commits query from 100 to only the latest 20. Additionally, it caches this build status for 15 seconds. These changes are to remove unnecessary Datastore reads.

## Issues

Fixes https://github.com/flutter/flutter/issues/45735

## Preview

https://testchillers-dot-flutter-dashboard.appspot.com/#/build