### PR TITLE
Remove unused Datastore composite indexes

### DIFF
--- a/app_dart/index.yaml
+++ b/app_dart/index.yaml
@@ -2,8 +2,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# This file must be manually deployed to updates the Datastore index with:
+# This file must be manually deployed to update Datastore
+# Ensure gcloud sdk is configured to the Cocoon GCP project:
+# $ gcloud config list
+# Then deploy to Datastore for the project:
 # $ gcloud datastore indexes create index.yaml
+# If indexes are removed:
+# $ gcloud datastore indexes cleanup index.yaml
 indexes:
 - kind: Checklist
   ancestor: yes

--- a/app_dart/index.yaml
+++ b/app_dart/index.yaml
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# This file must be manually deployed to updates the Datastore index with:
+# $ gcloud datastore indexes create index.yaml
 indexes:
 - kind: Checklist
   ancestor: yes
@@ -13,22 +15,6 @@ indexes:
   properties:
     - name: StageName
       direction: desc
-- kind: Task
-  properties:
-  - name: Status
-  - name: CreateTimestamp
-    direction: desc
-- kind: Task
-  properties:
-  - name: ReservedForAgentID
-  - name: CreateTimestamp
-    direction: desc
-- kind: Task
-  ancestor: yes
-  properties:
-  - name: Name
-  - name: CreateTimestamp
-    direction: desc
 - kind: Task
   ancestor: yes
   properties:


### PR DESCRIPTION
According to [Datastore best practices](https://cloud.google.com/datastore/docs/best-practices#indexes)

> Avoid having too many composite indexes. Excessive use of composite indexes could result in increased latency and increased storage costs of index entries. If you need to execute ad hoc queries on large datasets without previously defined indexes, use BigQuery.

This will help reduce the latency on Datastore operations for `Task`. It seems like a few of these were added in https://github.com/flutter/cocoon/pull/321 for future features, but the indexes were never used. We have a few cases where we stack simple indexes that could take advantage of these composite index.