### PR TITLE
Prompt sign in process when making authenticated requests if necessary

### DIFF
--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -57,8 +57,11 @@ class GoogleSignInService {
       await signIn();
     }
 
-    return user?.authentication
+    final String idToken = await user?.authentication
         ?.then((GoogleSignInAuthentication key) => key.idToken);
+    assert(idToken != null && idToken.isNotEmpty);
+
+    return idToken;
   }
 
   /// Initiate the Google Sign In process.

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -49,8 +49,17 @@ class GoogleSignInService {
   GoogleSignInAccount user;
 
   /// Authentication token to be sent to Cocoon Backend to verify API calls.
-  Future<String> get idToken => user?.authentication
-      ?.then((GoogleSignInAuthentication key) => key.idToken);
+  ///
+  /// If there is no currently signed in user, it will prompt the sign in
+  /// process before attempting to return an id token.
+  Future<String> get idToken async {
+    if (!await isAuthenticated) {
+      await signIn();
+    }
+
+    return user?.authentication
+        ?.then((GoogleSignInAuthentication key) => key.idToken);
+  }
 
   /// Initiate the Google Sign In process.
   Future<void> signIn() async {

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -21,8 +21,7 @@ void main() {
           .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
       when(mockSignIn.isSignedIn())
           .thenAnswer((_) => Future<bool>.value(false));
-      authService = GoogleSignInService(googleSignIn: mockSignIn)
-        ..notifyListeners = () => null;
+      authService = GoogleSignInService(googleSignIn: mockSignIn);
     });
 
     tearDown(() {
@@ -42,10 +41,18 @@ void main() {
     });
 
     test('id token will prompt sign in', () async {
+      final GoogleSignInAccount testAccountWithAuthentication =
+          FakeGoogleSignInAccount()
+            ..authentication = Future<GoogleSignInAuthentication>.value(
+                FakeGoogleSignInAuthentication());
+      when(mockSignIn.signIn()).thenAnswer((_) =>
+          Future<GoogleSignInAccount>.value(testAccountWithAuthentication));
+      authService.notifyListeners = () => null;
+
       verifyNever(mockSignIn.isSignedIn());
       verifyNever(mockSignIn.signIn());
 
-      await authService.idToken;
+      expect(await authService.idToken, 'id123');
 
       verify(mockSignIn.isSignedIn()).called(1);
       verify(mockSignIn.signIn()).called(1);

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -21,7 +21,8 @@ void main() {
           .thenAnswer((_) => const Stream<GoogleSignInAccount>.empty());
       when(mockSignIn.isSignedIn())
           .thenAnswer((_) => Future<bool>.value(false));
-      authService = GoogleSignInService(googleSignIn: mockSignIn);
+      authService = GoogleSignInService(googleSignIn: mockSignIn)
+        ..notifyListeners = () => null;
     });
 
     tearDown(() {
@@ -34,11 +35,20 @@ void main() {
 
     test('no user information', () {
       expect(authService.user, null);
-      expect(authService.idToken, null);
     });
 
     test('sign in silently called', () async {
       verify(mockSignIn.signInSilently()).called(1);
+    });
+
+    test('id token will prompt sign in', () async {
+      verifyNever(mockSignIn.isSignedIn());
+      verifyNever(mockSignIn.signIn());
+
+      await authService.idToken;
+
+      verify(mockSignIn.isSignedIn()).called(1);
+      verify(mockSignIn.signIn()).called(1);
     });
   });
 
@@ -97,7 +107,6 @@ void main() {
       await authService.signIn();
 
       expect(authService.user, null);
-      expect(authService.idToken, null);
     });
   });
 }


### PR DESCRIPTION
If a user is not signed in, and goes to make an authenticated request in Cocoon they will see an error snackbar prompting them to sign in. This updates it so whenever we attempt to make an authenticated request and the user is not signed in, we start the sign in process.

## Issues

Fixes https://github.com/flutter/flutter/issues/44854

## Tested

Since this creates special behavior for id token, I removed some of the basic checks for id token.