### PR TITLE
Enable flexibility to reduce dashboard commit number according to input parameter

### DIFF
--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -68,7 +68,8 @@ class BuildStatusProvider {
   Stream<CommitStatus> retrieveCommitStatus() async* {
     const int maxRecords = 50;
     final DatastoreService datastore = datastoreProvider();
-    await for (Commit commit in datastore.queryRecentCommits(limit: maxRecords)) {
+    await for (Commit commit
+        in datastore.queryRecentCommits(limit: maxRecords)) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -66,8 +66,9 @@ class BuildStatusProvider {
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
   Stream<CommitStatus> retrieveCommitStatus() async* {
+    const int maxRecords = 50;
     final DatastoreService datastore = datastoreProvider();
-    await for (Commit commit in datastore.queryRecentCommits()) {
+    await for (Commit commit in datastore.queryRecentCommits(limit: maxRecords)) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);


### PR DESCRIPTION
This PR solves the following two issues: reducing dashboard commit number from 100 to 50.

https://github.com/flutter/flutter/issues/43098
https://github.com/flutter/flutter/issues/44478