### PR TITLE
CanvasKit UI tweak for the task matrix icons and test fixes

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -119,7 +119,7 @@ class _TaskBoxState extends State<TaskBox> {
       children: <Widget>[
         if (task.isFlaky)
           const Padding(
-            padding: EdgeInsets.all(12.0),
+            padding: EdgeInsets.fromLTRB(10.0, 12.0, 10.0, 12.0),
             child: Icon(
               Icons.help,
               color: Colors.white60,
@@ -129,7 +129,7 @@ class _TaskBoxState extends State<TaskBox> {
         if (status == TaskBox.statusInProgress ||
             status == TaskBox.statusUnderperformedInProgress)
           const Padding(
-            padding: EdgeInsets.all(12.0),
+            padding: EdgeInsets.fromLTRB(10.0, 12.0, 10.0, 12.0),
             child: Icon(
               Icons.timelapse,
               color: Colors.white60,

--- a/app_flutter/test/agent_dashboard_page_test.dart
+++ b/app_flutter/test/agent_dashboard_page_test.dart
@@ -20,13 +20,11 @@ import 'package:app_flutter/state/agent.dart';
 
 void main() {
   testWidgets('shows sign in button', (WidgetTester tester) async {
-    final AgentState agentState = AgentState();
-
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: ChangeNotifierProvider<AgentState>(
-            create: (_) => agentState,
+            create: (_) => FakeAgentState(),
             child: const AgentDashboard(),
           ),
         ),
@@ -55,13 +53,18 @@ void main() {
 
   testWidgets('create agent dialog calls create agent',
       (WidgetTester tester) async {
-    final CocoonService mockCocoonService = MockCocoonService();
+    final MockCocoonService mockCocoonService = MockCocoonService();
+    final AgentState agentState = AgentState(
+      cocoonServiceValue: mockCocoonService,
+      authServiceValue: MockSignInService(),
+    );
+
     await tester.pumpWidget(
       MaterialApp(
         home: ChangeNotifierProvider<AgentState>(
-          create: (_) => AgentState(cocoonServiceValue: mockCocoonService),
+          create: (_) => agentState,
           child: AgentDashboard(
-            agentState: AgentState(cocoonServiceValue: mockCocoonService),
+            agentState: agentState,
           ),
         ),
       ),
@@ -136,7 +139,7 @@ void main() {
 
 class FakeAgentState extends ChangeNotifier implements AgentState {
   @override
-  GoogleSignInService authService = GoogleSignInService();
+  GoogleSignInService authService = MockSignInService();
 
   @override
   AgentStateErrors errors = AgentStateErrors();
@@ -171,3 +174,5 @@ class FakeAgentState extends ChangeNotifier implements AgentState {
 }
 
 class MockCocoonService extends Mock implements CocoonService {}
+
+class MockSignInService extends Mock implements GoogleSignInService {}

--- a/app_flutter/test/state/agent_test.dart
+++ b/app_flutter/test/state/agent_test.dart
@@ -18,14 +18,22 @@ void main() {
   group('AgentState', () {
     AgentState agentState;
     MockCocoonService mockService;
+    MockGoogleSignInService mockSignInService;
 
     setUp(() {
+      mockSignInService = MockGoogleSignInService();
       mockService = MockCocoonService();
-      agentState = AgentState(cocoonServiceValue: mockService);
+      agentState = AgentState(
+          cocoonServiceValue: mockService, authServiceValue: mockSignInService);
 
       when(mockService.fetchAgentStatuses()).thenAnswer((_) =>
           Future<CocoonResponse<List<Agent>>>.value(
               CocoonResponse<List<Agent>>()..data = <Agent>[Agent()]));
+    });
+
+    tearDown(() {
+      clearInteractions(mockSignInService);
+      clearInteractions(mockService);
     });
 
     testWidgets('timer should periodically fetch updates',
@@ -105,10 +113,6 @@ void main() {
     });
 
     test('auth functions call auth service', () async {
-      final MockGoogleSignInService mockSignInService =
-          MockGoogleSignInService();
-      agentState = AgentState(authServiceValue: mockSignInService);
-
       verifyNever(mockSignInService.signIn());
       verifyNever(mockSignInService.signOut());
 


### PR DESCRIPTION
When deploying, I noticed some offset issues on the task icons. I looked at the skia and engine rolls, and it seems there have been some updates that would have caused this. I presume this is intended, but let me know if I should file a bug.

Also, there are some failing tests this fixes that were introduced with https://github.com/flutter/cocoon/pull/594 and https://github.com/flutter/cocoon/pull/620 being landed right next to each other. The presubmit tests were passing but postsubmit failed.

## Preview

https://v348-dot-flutter-dashboard.appspot.com/#/build