### PR TITLE
Reduce commit rows in dashboard

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -114,7 +114,7 @@ class Config {
   int get maxTaskRetries => 2;
 
   /// The default number of commit shown in flutter build dashboard.
-  int get commitNumber => 25;
+  int get commitNumber => 1;
 
   // TODO(keyonghan): update all existing APIs to use this reference, https://github.com/flutter/flutter/issues/48987.
   KeyHelper get keyHelper =>

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -112,6 +112,11 @@ class Config {
 
   int get maxTaskRetries => 2;
 
+  /// The default number of commit shown in flutter build dashboard.
+  int get commitNumber => 25;
+
+  AppEngineContext get applicationContext => context.applicationContext;
+
   String get cqLabelName => 'CQ+1';
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -16,6 +16,7 @@ import 'package:googleapis/bigquery/v2.dart' as bigquery;
 import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';
+import '../model/appengine/key_helper.dart';
 import '../model/appengine/service_account_info.dart';
 import '../service/access_client_provider.dart';
 import '../service/bigquery.dart';
@@ -115,7 +116,7 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 25;
 
-  AppEngineContext get applicationContext => context.applicationContext;
+  KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
 
   String get cqLabelName => 'CQ+1';
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -116,6 +116,7 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 25;
 
+  // TODO(keyonghan): update all existing APIs to use this reference, https://github.com/flutter/flutter/issues/48987.
   KeyHelper get keyHelper =>
       KeyHelper(applicationContext: context.applicationContext);
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -114,7 +114,7 @@ class Config {
   int get maxTaskRetries => 2;
 
   /// The default number of commit shown in flutter build dashboard.
-  int get commitNumber => 1;
+  int get commitNumber => 30;
 
   // TODO(keyonghan): update all existing APIs to use this reference, https://github.com/flutter/flutter/issues/48987.
   KeyHelper get keyHelper =>

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -116,7 +116,8 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 25;
 
-  KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
+  KeyHelper get keyHelper =>
+      KeyHelper(applicationContext: context.applicationContext);
 
   String get cqLabelName => 'CQ+1';
 

--- a/app_dart/lib/src/model/appengine/commit.g.dart
+++ b/app_dart/lib/src/model/appengine/commit.g.dart
@@ -8,5 +8,6 @@ part of 'commit.dart';
 
 Map<String, dynamic> _$SerializableCommitToJson(SerializableCommit instance) =>
     <String, dynamic>{
+      'Key': const KeyConverter().toJson(instance.key),
       'Checklist': instance.facade,
     };

--- a/app_dart/lib/src/model/appengine/commit.g.dart
+++ b/app_dart/lib/src/model/appengine/commit.g.dart
@@ -8,6 +8,5 @@ part of 'commit.dart';
 
 Map<String, dynamic> _$SerializableCommitToJson(SerializableCommit instance) =>
     <String, dynamic>{
-      'Key': const KeyConverter().toJson(instance.key),
       'Checklist': instance.facade,
     };

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -112,11 +112,7 @@ class BuildStatusProvider {
   }) async* {
     final DatastoreService datastore = datastoreProvider();
     await for (Commit commit
-<<<<<<< HEAD
-        in datastore.queryRecentCommits(limit: numberOfCommitsToReference)) {
-=======
-        in datastore.queryRecentCommits(limit: maxRecords)) {
->>>>>>> dartfmt
+        in datastore.queryRecentCommits(limit: limit, timestamp: timestamp)) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -112,7 +112,11 @@ class BuildStatusProvider {
   }) async* {
     final DatastoreService datastore = datastoreProvider();
     await for (Commit commit
+<<<<<<< HEAD
         in datastore.queryRecentCommits(limit: numberOfCommitsToReference)) {
+=======
+        in datastore.queryRecentCommits(limit: maxRecords)) {
+>>>>>>> dartfmt
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -47,7 +47,7 @@ class BuildStatusProvider {
   /// there is currently a newer version that is in progress.
   Future<BuildStatus> calculateCumulativeStatus() async {
     final List<CommitStatus> statuses = await retrieveCommitStatus(
-      numberOfCommitsToReference: numberOfCommitsToReferenceForTreeStatus,
+      limit: numberOfCommitsToReferenceForTreeStatus,
     ).toList();
     if (statuses.isEmpty) {
       return BuildStatus.failed;
@@ -107,9 +107,7 @@ class BuildStatusProvider {
   ///
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
-  Stream<CommitStatus> retrieveCommitStatus({
-    int numberOfCommitsToReference = 100,
-  }) async* {
+  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp}) async* {
     final DatastoreService datastore = datastoreProvider();
     await for (Commit commit
         in datastore.queryRecentCommits(limit: limit, timestamp: timestamp)) {

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -42,10 +42,12 @@ class DatastoreService {
   /// The [limit] argument specifies the maximum number of commits to retrieve.
   ///
   /// The returned commits will be ordered by most recent [Commit.timestamp].
-  Stream<Commit> queryRecentCommits({int limit = 100}) {
+  Stream<Commit> queryRecentCommits({int limit = 100, int timestamp}) {
+    timestamp ??= DateTime.now().millisecondsSinceEpoch;
     final Query<Commit> query = db.query<Commit>()
       ..limit(limit)
-      ..order('-timestamp');
+      ..order('-timestamp')
+      ..filter('timestamp <', timestamp);
     return query.run();
   }
 

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -156,7 +156,6 @@ void main() {
         },
         'Stages': <String>[]
       });
-      //expect(value['RequiredCapabilities'], <String>['ios']);
     });
   });
 }

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -5,6 +5,8 @@
 import 'dart:convert';
 
 import 'package:cocoon_service/src/model/appengine/agent.dart';
+import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/appengine/stage.dart';
 import 'package:cocoon_service/src/request_handlers/get_status.dart';
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
@@ -12,29 +14,34 @@ import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_cocoon_config.dart';
-import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_http.dart';
+import '../src/request_handling/request_handler_tester.dart';
 import '../src/service/fake_build_status_provider.dart';
 
 void main() {
   group('GetStatus', () {
     FakeConfig config;
-    FakeDatastoreDB db;
+    FakeClientContext clientContext;
     FakeBuildStatusProvider buildStatusProvider;
+    RequestHandlerTester tester;
     GetStatus handler;
 
     Future<Object> decodeHandlerBody() async {
-      final Body body = await handler.get();
+      final Body body = await tester.get(handler);
       return utf8.decoder.bind(body.serialize()).transform(json.decoder).single;
     }
 
     setUp(() {
-      config = FakeConfig();
+      clientContext = FakeClientContext();
+      tester = RequestHandlerTester();
+      config =
+          FakeConfig(applicationContextValue: clientContext.applicationContext);
       buildStatusProvider =
           FakeBuildStatusProvider(commitStatuses: <CommitStatus>[]);
-      db = FakeDatastoreDB();
       handler = GetStatus(
         config,
-        datastoreProvider: () => DatastoreService(db: db),
+        datastoreProvider: () => DatastoreService(db: config.db),
         buildStatusProvider: buildStatusProvider,
       );
     });
@@ -60,7 +67,7 @@ void main() {
         windows1,
       ];
 
-      db.addOnQuery<Agent>((Iterable<Agent> agents) => reportedAgents);
+      config.db.addOnQuery<Agent>((Iterable<Agent> agents) => reportedAgents);
       final Map<String, dynamic> result = await decodeHandlerBody();
 
       expect(result['Statuses'], isEmpty);
@@ -73,6 +80,66 @@ void main() {
       ];
 
       expect(result['AgentStatuses'], equals(expectedOrderedAgents));
+    });
+
+    test('reports statuses without input commit key', () async {
+      final Commit commit1 = Commit(
+          key: config.db.emptyKey.append(Commit,
+              id: 'flutter/flutter/ea28a9c34dc701de891eaf74503ca4717019f829'),
+          timestamp: 3);
+      final Commit commit2 = Commit(
+          key: config.db.emptyKey.append(Commit,
+              id: 'flutter/flutter/d5b0b3c8d1c5fd89302089077ccabbcfaae045e4'),
+          timestamp: 1);
+      config.db.values[commit1.key] = commit1;
+      config.db.values[commit2.key] = commit2;
+      buildStatusProvider = FakeBuildStatusProvider(
+          commitStatuses: <CommitStatus>[
+            CommitStatus(commit1, const <Stage>[]),
+            CommitStatus(commit2, const <Stage>[])
+          ]);
+      handler = GetStatus(
+        config,
+        datastoreProvider: () => DatastoreService(db: config.db),
+        buildStatusProvider: buildStatusProvider,
+      );
+
+      final Map<String, dynamic> result = await decodeHandlerBody();
+      
+      expect(result['Statuses'].length, 2);
+    });
+
+    test('reports statuses with input commit key', () async {
+      final Commit commit1 = Commit(
+          key: config.db.emptyKey.append(Commit,
+              id: 'flutter/flutter/ea28a9c34dc701de891eaf74503ca4717019f829'),
+          timestamp: 3);
+      final Commit commit2 = Commit(
+          key: config.db.emptyKey.append(Commit,
+              id: 'flutter/flutter/d5b0b3c8d1c5fd89302089077ccabbcfaae045e4'),
+          timestamp: 1);
+      config.db.values[commit1.key] = commit1;
+      config.db.values[commit2.key] = commit2;
+      buildStatusProvider = FakeBuildStatusProvider(
+          commitStatuses: <CommitStatus>[
+            CommitStatus(commit1, const <Stage>[]),
+            CommitStatus(commit2, const <Stage>[])
+          ]);
+      handler = GetStatus(
+        config,
+        datastoreProvider: () => DatastoreService(db: config.db),
+        buildStatusProvider: buildStatusProvider,
+      );
+
+      const String expectedCommitKeyEncoded =
+          'ahNzfmZsdXR0ZXItZGFzaGJvYXJkckcLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci9lYTI4YTljMzRkYzcwMWRlODkxZWFmNzQ1MDNjYTQ3MTcwMTlmODI5DA';
+
+      tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
+        GetStatus.ownerKeyParam: expectedCommitKeyEncoded,
+      });
+      final Map<String, dynamic> result = await decodeHandlerBody();
+
+      expect(result['Statuses'].length, 1);
     });
   });
 }

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -23,6 +23,7 @@ void main() {
   group('GetStatus', () {
     FakeConfig config;
     FakeClientContext clientContext;
+    FakeKeyHelper keyHelper;
     FakeBuildStatusProvider buildStatusProvider;
     RequestHandlerTester tester;
     GetStatus handler;
@@ -34,9 +35,9 @@ void main() {
 
     setUp(() {
       clientContext = FakeClientContext();
+      keyHelper = FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
-      config =
-          FakeConfig(applicationContextValue: clientContext.applicationContext);
+      config = FakeConfig(keyHelperValue: keyHelper);
       buildStatusProvider =
           FakeBuildStatusProvider(commitStatuses: <CommitStatus>[]);
       handler = GetStatus(
@@ -105,7 +106,7 @@ void main() {
       );
 
       final Map<String, dynamic> result = await decodeHandlerBody();
-      
+
       expect(result['Statuses'].length, 2);
     });
 

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -35,7 +35,8 @@ void main() {
 
     setUp(() {
       clientContext = FakeClientContext();
-      keyHelper = FakeKeyHelper(applicationContext: clientContext.applicationContext);
+      keyHelper =
+          FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
       config = FakeConfig(keyHelperValue: keyHelper);
       buildStatusProvider =

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -140,8 +140,23 @@ void main() {
         GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
       });
       final Map<String, dynamic> result = await decodeHandlerBody();
+      //final Map<String, dynamic> result
 
-      expect(result['Statuses'].length, 1);
+      expect(result['Statuses'].first, <String, dynamic>{
+        'Checklist': <String, dynamic>{
+          'Key': '',
+          'Checklist': <String, dynamic>{
+            'FlutterRepositoryPath': null,
+            'CreateTimestamp': 1,
+            'Commit': <String, dynamic>{
+              'Sha': null,
+              'Author': <String, dynamic>{'Login': null, 'avatar_url': null}
+            }
+          }
+        },
+        'Stages': <String>[]
+      });
+      //expect(value['RequiredCapabilities'], <String>['ios']);
     });
   });
 }

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -133,11 +133,11 @@ void main() {
         buildStatusProvider: buildStatusProvider,
       );
 
-      const String expectedCommitKeyEncoded =
+      const String expectedLastCommitKeyEncoded =
           'ahNzfmZsdXR0ZXItZGFzaGJvYXJkckcLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci9lYTI4YTljMzRkYzcwMWRlODkxZWFmNzQ1MDNjYTQ3MTcwMTlmODI5DA';
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
-        GetStatus.ownerKeyParam: expectedCommitKeyEncoded,
+        GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
       });
       final Map<String, dynamic> result = await decodeHandlerBody();
 

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -6,13 +6,13 @@ import 'dart:async';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/datastore/cocoon_config.dart';
+import 'package:cocoon_service/src/model/appengine/key_helper.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/server.dart';
 import 'package:googleapis_auth/auth.dart';
 import 'package:graphql/client.dart';
 import 'package:googleapis/bigquery/v2.dart';
-
 import '../request_handling/fake_authentication.dart';
 import 'fake_datastore.dart';
 
@@ -24,7 +24,7 @@ class FakeConfig implements Config {
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
     this.commitNumberValue,
-    this.applicationContextValue,
+    this.keyHelperValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
     this.missingTestsPullRequestMessageValue,
@@ -51,7 +51,7 @@ class FakeConfig implements Config {
   ServiceAccountInfo deviceLabServiceAccountValue;
   int maxTaskRetriesValue;
   int commitNumberValue;
-  FakeAppEngineContext applicationContextValue;
+  FakeKeyHelper keyHelperValue;
   String oauthClientIdValue;
   String githubOAuthTokenValue;
   String missingTestsPullRequestMessageValue;
@@ -98,7 +98,7 @@ class FakeConfig implements Config {
   int get commitNumber => commitNumberValue;
 
   @override
-  AppEngineContext get applicationContext => applicationContextValue;
+  KeyHelper get keyHelper => keyHelperValue;
 
   @override
   Future<String> get oauthClientId async => oauthClientIdValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -13,6 +13,7 @@ import 'package:googleapis_auth/auth.dart';
 import 'package:graphql/client.dart';
 import 'package:googleapis/bigquery/v2.dart';
 
+import '../request_handling/fake_authentication.dart';
 import 'fake_datastore.dart';
 
 // ignore: must_be_immutable
@@ -22,6 +23,8 @@ class FakeConfig implements Config {
     this.githubClient,
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
+    this.commitNumberValue,
+    this.applicationContextValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
     this.missingTestsPullRequestMessageValue,
@@ -47,6 +50,8 @@ class FakeConfig implements Config {
   FakeDatastoreDB dbValue;
   ServiceAccountInfo deviceLabServiceAccountValue;
   int maxTaskRetriesValue;
+  int commitNumberValue;
+  FakeAppEngineContext applicationContextValue;
   String oauthClientIdValue;
   String githubOAuthTokenValue;
   String missingTestsPullRequestMessageValue;
@@ -88,6 +93,12 @@ class FakeConfig implements Config {
 
   @override
   int get maxTaskRetries => maxTaskRetriesValue;
+
+  @override
+  int get commitNumber => commitNumberValue;
+
+  @override
+  AppEngineContext get applicationContext => applicationContextValue;
 
   @override
   Future<String> get oauthClientId async => oauthClientIdValue;

--- a/app_dart/test/src/request_handling/fake_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_authentication.dart
@@ -4,10 +4,14 @@
 
 import 'dart:io';
 
+
+import 'package:appengine/appengine.dart';
+import 'package:gcloud/db.dart';
+
 import 'package:cocoon_service/src/model/appengine/agent.dart';
+import 'package:cocoon_service/src/model/appengine/key_helper.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:appengine/appengine.dart';
 
 // ignore: must_be_immutable
 class FakeAuthenticationProvider implements AuthenticationProvider {
@@ -105,4 +109,15 @@ class FakeAppEngineContext implements AppEngineContext {
 
   @override
   String version;
+}
+
+class FakeKeyHelper extends KeyHelper {
+  FakeKeyHelper({
+    AppEngineContext applicationContext,
+  })  : super(applicationContext: applicationContext);
+
+  @override
+  String encode(Key key){
+      return '';
+  }
 }

--- a/app_dart/test/src/request_handling/fake_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_authentication.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-
 import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
 
@@ -114,10 +113,10 @@ class FakeAppEngineContext implements AppEngineContext {
 class FakeKeyHelper extends KeyHelper {
   FakeKeyHelper({
     AppEngineContext applicationContext,
-  })  : super(applicationContext: applicationContext);
+  }) : super(applicationContext: applicationContext);
 
   @override
-  String encode(Key key){
-      return '';
+  String encode(Key key) {
+    return '';
   }
 }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -27,9 +27,7 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
   }
 
   @override
-  Stream<CommitStatus> retrieveCommitStatus({
-    int numberOfCommitsToReference = 100,
-  }) {
+  Stream<CommitStatus> retrieveCommitStatus({int limit = 100, int timestamp}) {
     if (commitStatuses == null) {
       throw AssertionError();
     }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -33,6 +33,10 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
     if (commitStatuses == null) {
       throw AssertionError();
     }
-    return Stream<CommitStatus>.fromIterable(commitStatuses);
+    commitStatuses.sort((CommitStatus a, CommitStatus b) =>
+        a.commit.timestamp.compareTo(b.commit.timestamp));
+
+    return Stream<CommitStatus>.fromIterable(commitStatuses
+        .where((CommitStatus commitStatuse) => commitStatuse.commit.timestamp < timestamp));
   }
 }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -36,7 +36,8 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
     commitStatuses.sort((CommitStatus a, CommitStatus b) =>
         a.commit.timestamp.compareTo(b.commit.timestamp));
 
-    return Stream<CommitStatus>.fromIterable(commitStatuses
-        .where((CommitStatus commitStatuse) => commitStatuse.commit.timestamp < timestamp));
+    return Stream<CommitStatus>.fromIterable(commitStatuses.where(
+        (CommitStatus commitStatuse) =>
+            commitStatuse.commit.timestamp < timestamp));
   }
 }


### PR DESCRIPTION
This PR reduces the default commit records shown on build dashboard from 100 to 25. 

This is the backend change, and enables `/api/public/get-status` to support input variable: ownerKey (commit). When the input variable is specified, this API will return the next 25 records whose timestamp is smaller than that of the input commit.

This will make it possible to append more records to build page when requested, and effectively reduce datastore queries.