### PR TITLE
Fix /api/public/get-status only returning 20 commits

### DIFF
--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -27,7 +27,9 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
   }
 
   @override
-  Stream<CommitStatus> retrieveCommitStatus() {
+  Stream<CommitStatus> retrieveCommitStatus({
+    int numberOfCommitsToReference = 100,
+  }) {
     if (commitStatuses == null) {
       throw AssertionError();
     }


### PR DESCRIPTION
Introduced in https://github.com/flutter/cocoon/pull/617 where `retrieveCommitStatus` had a hard coded value for the number of commits to store. Instead it needed it to be passed in as a variable.

The reason for 20 commits is that's how many the build status algorithm looks at to validate the current tree state. Before it used to be 100.

# Preview

https://v350-dot-flutter-dashboard.appspot.com/#/build