### PR TITLE
Add infinite scroll to the build dashboard

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -35,8 +35,15 @@ class AppEngineCocoonService implements CocoonService {
   final Downloader _downloader;
 
   @override
-  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses() async {
-    final String getStatusUrl = _apiEndpoint('/api/public/get-status');
+  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
+    CommitStatus lastCommitStatus,
+  }) async {
+    String getStatusUrl = _apiEndpoint('/api/public/get-status');
+
+    if (lastCommitStatus != null) {
+      getStatusUrl +=
+          '?lastCommitKey=' + lastCommitStatus.commit.key.child.name;
+    }
 
     /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
     final http.Response response = await _client.get(getStatusUrl);

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -327,27 +327,30 @@ class AppEngineCocoonService implements CocoonService {
     final List<CommitStatus> statuses = <CommitStatus>[];
 
     for (Map<String, Object> jsonCommitStatus in jsonCommitStatuses) {
-      final Map<String, Object> commit = jsonCommitStatus['Checklist'];
+      final Map<String, Object> checklist = jsonCommitStatus['Checklist'];
       statuses.add(CommitStatus()
-        ..commit = _commitFromJson(commit['Checklist'])
+        ..commit = _commitFromJson(checklist)
         ..stages.addAll(_stagesFromJson(jsonCommitStatus['Stages'])));
     }
 
     return statuses;
   }
 
-  Commit _commitFromJson(Map<String, Object> jsonCommit) {
-    assert(jsonCommit != null);
+  Commit _commitFromJson(Map<String, Object> jsonChecklist) {
+    assert(jsonChecklist != null);
 
-    final Map<String, Object> commit = jsonCommit['Commit'];
+    final Map<String, Object> checklist = jsonChecklist['Checklist'];
+
+    final Map<String, Object> commit = checklist['Commit'];
     final Map<String, Object> author = commit['Author'];
 
     return Commit()
-      ..timestamp = Int64() + jsonCommit['CreateTimestamp']
+      ..key = (RootKey()..child = (Key()..name = jsonChecklist['Key']))
+      ..timestamp = Int64() + checklist['CreateTimestamp']
       ..sha = commit['Sha']
       ..author = author['Login']
       ..authorAvatarUrl = author['avatar_url']
-      ..repository = jsonCommit['FlutterRepositoryPath'];
+      ..repository = checklist['FlutterRepositoryPath'];
   }
 
   List<Stage> _stagesFromJson(List<Object> json) {

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -25,10 +25,13 @@ abstract class CocoonService {
     return FakeCocoonService();
   }
 
-  /// Gets build information from the last 200 commits.
+  /// Gets build information on the most recent commits.
   ///
-  // TODO(chillers): Make configurable to get range of commits, https://github.com/flutter/cocoon/issues/458
-  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses();
+  /// If [lastCommitStatus] is given, it will return the next page of
+  /// [List<CommitStatus>] after [lastCommitStatus], not including it.
+  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
+    CommitStatus lastCommitStatus,
+  });
 
   /// Gets the current build status of flutter/flutter.
   Future<CocoonResponse<bool>> fetchTreeBuildStatus();

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -19,7 +19,9 @@ class FakeCocoonService implements CocoonService {
   final Random random;
 
   @override
-  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses() async {
+  Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
+    CommitStatus lastCommitStatus,
+  }) async {
     return CocoonResponse<List<CommitStatus>>()
       ..data = _createFakeCommitStatuses();
   }
@@ -83,7 +85,7 @@ class FakeCocoonService implements CocoonService {
 
     final int baseTimestamp = DateTime.now().millisecondsSinceEpoch;
 
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 25; i++) {
       final Commit commit = _createFakeCommit(i, baseTimestamp);
 
       final CommitStatus status = CommitStatus()

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -22,7 +22,10 @@ class FakeCocoonService implements CocoonService {
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
   }) async {
-    await Future<void>.delayed(const Duration(seconds: 5));
+    if (lastCommitStatus != null) {
+      return CocoonResponse<List<CommitStatus>>()..data = <CommitStatus>[];
+    }
+
     return CocoonResponse<List<CommitStatus>>()
       ..data = _createFakeCommitStatuses();
   }

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -22,6 +22,7 @@ class FakeCocoonService implements CocoonService {
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
   }) async {
+    await Future<void>.delayed(const Duration(seconds: 5));
     return CocoonResponse<List<CommitStatus>>()
       ..data = _createFakeCommitStatuses();
   }

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -22,10 +22,6 @@ class FakeCocoonService implements CocoonService {
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
   }) async {
-    if (lastCommitStatus != null) {
-      return CocoonResponse<List<CommitStatus>>()..data = <CommitStatus>[];
-    }
-
     return CocoonResponse<List<CommitStatus>>()
       ..data = _createFakeCommitStatuses();
   }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -82,7 +82,6 @@ class FlutterBuildState extends ChangeNotifier {
           errors.message = errorMessageFetchingStatuses;
           errors.notifyListeners();
         } else {
-          _statuses = response.data;
           _mergeRecentCommitStatusesWithStoredStatuses(response.data);
         }
         notifyListeners();
@@ -104,6 +103,11 @@ class FlutterBuildState extends ChangeNotifier {
 
   void _mergeRecentCommitStatusesWithStoredStatuses(
       List<CommitStatus> recentStatuses) {
+    if (_statuses.isEmpty) {
+      _statuses = recentStatuses;
+      return;
+    }
+
     final List<CommitStatus> mergedStatuses =
         List<CommitStatus>.from(recentStatuses);
 
@@ -119,14 +123,14 @@ class FlutterBuildState extends ChangeNotifier {
     }
     assert(lastKnownIndex != -1);
 
-    final List<CommitStatus> remainingStatuses = _statuses.getRange(lastKnownIndex, _statuses.length).toList();
-    print(remainingStatuses);
-    print(lastKnownIndex);
+    final int firstIndex = lastKnownIndex + 1;
+    final int lastIndex = _statuses.length;
+    final List<CommitStatus> remainingStatuses = (firstIndex < lastIndex)
+        ? _statuses.getRange(firstIndex, lastIndex).toList()
+        : <CommitStatus>[];
     mergedStatuses.addAll(remainingStatuses);
 
     _statuses = mergedStatuses;
-
-    print('Number of statuses: ${_statuses.length}');
   }
 
   Future<void> fetchMoreCommitStatuses() async {

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -221,7 +221,7 @@ class FlutterBuildState extends ChangeNotifier {
 
   /// Assert that [statuses] is ordered from newest commit to oldest.
   bool _statusesInOrder(List<CommitStatus> statuses) {
-    for (int i = 0; i < statuses.length; i++) {
+    for (int i = 0; i < statuses.length - 1; i++) {
       final Commit current = statuses[i].commit;
       final Commit next = statuses[i + 1].commit;
 

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -136,8 +136,6 @@ class FlutterBuildState extends ChangeNotifier {
   Future<void> fetchMoreCommitStatuses() async {
     assert(_statuses.isNotEmpty);
 
-    print('fetching more!');
-
     final CocoonResponse<List<CommitStatus>> response = await _cocoonService
         .fetchCommitStatuses(lastCommitStatus: _statuses.last);
     if (response.error != null) {

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -119,9 +119,14 @@ class FlutterBuildState extends ChangeNotifier {
     }
     assert(lastKnownIndex != -1);
 
-    mergedStatuses.addAll(_statuses.getRange(lastKnownIndex, _statuses.length));
+    final List<CommitStatus> remainingStatuses = _statuses.getRange(lastKnownIndex, _statuses.length).toList();
+    print(remainingStatuses);
+    print(lastKnownIndex);
+    mergedStatuses.addAll(remainingStatuses);
 
     _statuses = mergedStatuses;
+
+    print('Number of statuses: ${_statuses.length}');
   }
 
   Future<void> fetchMoreCommitStatuses() async {

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -198,6 +198,9 @@ class StatusGrid extends StatelessWidget {
     );
   }
 
+  /// Check whether the current [gridIndex] resides in the last row.
+  ///
+  /// Used for checking if logic needs to be performed for the loader row.
   bool _isLastRow({
     @required int gridIndex,
     @required int columnCount,

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -120,7 +120,7 @@ class StatusGrid extends StatelessWidget {
           child: GridView.builder(
             addRepaintBoundaries: false,
 
-            /// The grid has as many rows as there are status. Additionally,
+            /// The grid has as many rows as there are statuses. Additionally,
             /// one row for task descriptions, and one at the bottom to show
             /// a loader for more data.
             itemCount: columnCount * (statuses.length + 2),
@@ -134,12 +134,18 @@ class StatusGrid extends StatelessWidget {
                 return const SizedBox();
               }
 
-              if (gridIndex >= (columnCount * (statuses.length + 1))) {
-                if (gridIndex == (columnCount * (statuses.length + 1))) {
+              /// Loader row at the bottom of the grid.
+              if (_isLastRow(
+                gridIndex: gridIndex,
+                columnCount: columnCount,
+              )) {
+                /// Only trigger [fetchMoreCommitStatuses] API call once for
+                /// this loading row.
+                if (gridIndex % columnCount == 0) {
                   buildState.fetchMoreCommitStatuses();
                 }
 
-                return Container(color: Colors.tealAccent);
+                return Container(color: Colors.grey);
               }
 
               /// This [GridView] is composed of a row of [TaskIcon] and a subgrid
@@ -179,5 +185,15 @@ class StatusGrid extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  bool _isLastRow({
+    @required int gridIndex,
+    @required int columnCount,
+  }) {
+    assert(gridIndex != null && gridIndex >= 0);
+    assert(columnCount != null && columnCount >= 0);
+
+    return gridIndex >= (columnCount * (statuses.length + 1));
   }
 }

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -125,7 +125,8 @@ class StatusGrid extends StatelessWidget {
             /// a loader for more data.
             itemCount: columnCount * (statuses.length + 2),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: columnCount),
+              crossAxisCount: columnCount,
+            ),
             itemBuilder: (BuildContext context, int gridIndex) {
               if (gridIndex == 0) {
                 /// The top left corner of the grid is nothing since
@@ -139,13 +140,18 @@ class StatusGrid extends StatelessWidget {
                 gridIndex: gridIndex,
                 columnCount: columnCount,
               )) {
+                final int loaderIndex = gridIndex % columnCount;
+
                 /// Only trigger [fetchMoreCommitStatuses] API call once for
                 /// this loading row.
-                if (gridIndex % columnCount == 0) {
+                if (loaderIndex == 0) {
                   buildState.fetchMoreCommitStatuses();
                 }
 
-                return Container(color: Colors.grey);
+                return Container(
+                  key: insertCellKeys ? Key('loader-$loaderIndex') : null,
+                  color: Colors.blueGrey,
+                );
               }
 
               /// This [GridView] is composed of a row of [TaskIcon] and a subgrid
@@ -156,7 +162,12 @@ class StatusGrid extends StatelessWidget {
               /// row of [TaskIcon] introduces.
               final int index = gridIndex - columnCount;
               if (index < 0) {
-                return TaskIcon(task: taskMatrix.sampleTask(gridIndex - 1));
+                return TaskIcon(
+                  key: insertCellKeys
+                      ? Key('taskicon-${index % columnCount}')
+                      : null,
+                  task: taskMatrix.sampleTask(gridIndex - 1),
+                );
               }
 
               final int row = index ~/ columnCount;

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -119,7 +119,11 @@ class StatusGrid extends StatelessWidget {
           // TODO(chillers): Refactor this to a separate TaskView widget. https://github.com/flutter/flutter/issues/43376
           child: GridView.builder(
             addRepaintBoundaries: false,
-            itemCount: columnCount * (statuses.length + 1),
+
+            /// The grid has as many rows as there are status. Additionally,
+            /// one row for task descriptions, and one at the bottom to show
+            /// a loader for more data.
+            itemCount: columnCount * (statuses.length + 2),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: columnCount),
             itemBuilder: (BuildContext context, int gridIndex) {
@@ -128,6 +132,14 @@ class StatusGrid extends StatelessWidget {
                 /// the left column is for [CommitBox] and the top
                 /// row is for [TaskIcon].
                 return const SizedBox();
+              }
+
+              if (gridIndex >= (columnCount * (statuses.length + 1))) {
+                if (gridIndex == (columnCount * (statuses.length + 1))) {
+                  buildState.fetchMoreCommitStatuses();
+                }
+
+                return Container(color: Colors.tealAccent);
               }
 
               /// This [GridView] is composed of a row of [TaskIcon] and a subgrid

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -141,6 +141,7 @@ class StatusGrid extends StatelessWidget {
                 columnCount: columnCount,
               )) {
                 final int loaderIndex = gridIndex % columnCount;
+                const String loadingText = 'LOADING ';
 
                 /// Only trigger [fetchMoreCommitStatuses] API call once for
                 /// this loading row.
@@ -148,9 +149,20 @@ class StatusGrid extends StatelessWidget {
                   buildState.fetchMoreCommitStatuses();
                 }
 
+                /// This loader row will spell out [loadingText].
                 return Container(
                   key: insertCellKeys ? Key('loader-$loaderIndex') : null,
                   color: Colors.blueGrey,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(10.0, 14.0, 10.0, 14.0),
+                    child: Text(
+                      loadingText[loaderIndex % loadingText.length],
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20,
+                      ),
+                    ),
+                  ),
                 );
               }
 

--- a/app_flutter/lib/status_grid.dart
+++ b/app_flutter/lib/status_grid.dart
@@ -157,7 +157,7 @@ class StatusGrid extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(10.0, 14.0, 10.0, 14.0),
                     child: Text(
                       loadingText[loaderIndex % loadingText.length],
-                      style: TextStyle(
+                      style: const TextStyle(
                         color: Colors.white,
                         fontSize: 20,
                       ),

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -168,6 +168,28 @@ void main() {
       }
     });
 
+    test(
+        'given last commit status should query correct endpoint whether web or mobile',
+        () async {
+      final Client mockClient = MockHttpClient();
+      when(mockClient.get(any))
+          .thenAnswer((_) => Future<Response>.value(Response('', 200)));
+      service = AppEngineCocoonService(client: mockClient);
+
+      final CommitStatus status = CommitStatus()
+        ..commit = (Commit()
+          ..key = (RootKey()..child = (Key()..name = 'iamatestkey')));
+      await service.fetchCommitStatuses(lastCommitStatus: status);
+
+      if (kIsWeb) {
+        verify(
+            mockClient.get('/api/public/get-status?lastCommitKey=iamatestkey'));
+      } else {
+        verify(mockClient.get(
+            'https://flutter-dashboard.appspot.com/api/public/get-status?lastCommitKey=iamatestkey'));
+      }
+    });
+
     test('should have error if given non-200 response', () async {
       service = AppEngineCocoonService(
           client: MockClient((Request request) async => Response('', 404)));

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -124,6 +124,7 @@ void main() {
       final CommitStatus expectedStatus = CommitStatus()
         ..commit = (Commit()
           ..timestamp = Int64(123456789)
+          ..key = (RootKey()..child = (Key()..name = 'iamatestkey'))
           ..sha = 'ShaShankHash'
           ..author = 'ShaSha'
           ..authorAvatarUrl = 'https://flutter.dev'

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -116,6 +116,25 @@ void main() {
       buildState.dispose();
     });
 
+    testWidgets('fetch more commit statuses appends', (WidgetTester tester) async {
+      when(mockService.fetchCommitStatuses(
+              lastCommitStatus: anyNamed('lastCommitStatus')))
+          .thenAnswer((_) async =>
+              CocoonResponse<List<CommitStatus>>()..data = <CommitStatus>[CommitStatus()]);
+
+      buildState.startFetchingBuildStateUpdates();
+
+      await tester.pump(buildState.refreshRate * 2);
+
+      expect(buildState.statuses, isEmpty);
+
+      buildState.fetchMoreCommitStatuses();
+
+      expect(buildState.statuses.length, 1);
+
+      buildState.dispose();
+    });
+
     test('auth functions call auth service', () async {
       final MockGoogleSignInService mockSignInService =
           MockGoogleSignInService();

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -192,6 +192,8 @@ void main() {
 CommitStatus _createCommitStatusWithKey(String keyValue) {
   return CommitStatus()
     ..commit = (Commit()
+      // Author is set so we don't have to dig through all the nested fields
+      // while debugging
       ..author = keyValue
       ..key = (RootKey()..child = (Key()..name = keyValue)));
 }

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -124,13 +124,17 @@ void main() {
 
       buildState.startFetchingBuildStateUpdates();
 
-      await tester.pump(buildState.refreshRate * 2);
+      await tester.pump(buildState.refreshRate);
 
-      expect(buildState.statuses, isEmpty);
+      expect(buildState.statuses.length, 2);
 
-      buildState.fetchMoreCommitStatuses();
+      await buildState.fetchMoreCommitStatuses();
 
-      expect(buildState.statuses.length, 1);
+      expect(buildState.statuses.length, 3);
+
+      await tester.pump(buildState.refreshRate * 10);
+
+      expect(buildState.statuses.length, 3);
 
       buildState.dispose();
     });

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -19,6 +19,8 @@ import 'package:app_flutter/status_grid.dart';
 import 'package:app_flutter/task_box.dart';
 import 'package:app_flutter/task_matrix.dart' show TaskMatrix;
 
+import 'utils/fake_flutter_build.dart';
+
 void main() {
   group('StatusGrid', () {
     List<CommitStatus> statuses;
@@ -45,7 +47,7 @@ void main() {
           home: Column(
             children: <Widget>[
               ChangeNotifierProvider<FlutterBuildState>(
-                create: (_) => FlutterBuildState(),
+                create: (_) => FakeFlutterBuildState(),
                 child: const StatusGridContainer(),
               ),
             ],
@@ -63,7 +65,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
-                buildState: FlutterBuildState(),
+                buildState: FakeFlutterBuildState(),
                 statuses: statuses,
                 taskMatrix: taskMatrix,
               ),
@@ -94,7 +96,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
-                buildState: FlutterBuildState(),
+                buildState: FakeFlutterBuildState(),
                 statuses: statuses,
                 taskMatrix: taskMatrix,
               ),
@@ -158,7 +160,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
-                buildState: FlutterBuildState(),
+                buildState: FakeFlutterBuildState(),
                 statuses: statusesWithSkips,
                 taskMatrix: taskMatrix,
                 insertCellKeys: true,
@@ -225,7 +227,7 @@ void main() {
           home: Column(
             children: <Widget>[
               StatusGrid(
-                buildState: FlutterBuildState(),
+                buildState: FakeFlutterBuildState(),
                 statuses: statusesWithSkips,
                 taskMatrix: taskMatrix,
                 insertCellKeys: true,

--- a/app_flutter/test/status_grid_test.dart
+++ b/app_flutter/test/status_grid_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/task_icon.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,6 +17,7 @@ import 'package:app_flutter/state/flutter_build.dart';
 import 'package:app_flutter/commit_box.dart';
 import 'package:app_flutter/status_grid.dart';
 import 'package:app_flutter/task_box.dart';
+import 'package:app_flutter/task_icon.dart';
 import 'package:app_flutter/task_matrix.dart' show TaskMatrix;
 
 import 'utils/fake_flutter_build.dart';

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -45,4 +45,7 @@ class FakeFlutterBuildState extends ChangeNotifier
 
   @override
   Future<bool> downloadLog(Task task, Commit commit) => null;
+
+  @override
+  Future<void> fetchMoreCommitStatuses() => null;
 }


### PR DESCRIPTION
Implement pagination on the build dashboard. This uses the backend query from https://github.com/flutter/cocoon/pull/624 to get the data based on the last commit. Then it appends this data to the end of the statuses. Additionally, the polling for data merges new data into the statuses list. This is done by introducing a loader row at the bottom of `StatusGrid`.

I tried to implement a smoother experience with slivers via a `SliverGrid` and `SliverBox`, where the box was a `CircularLoadingIndicator` that made the call to `fetchMoreCommitStatuses()` on being built. However, the sliver approach did not play nicely since `StatusGrid` needs both horizontal and vertical scrolls.

# Issues

Closes https://github.com/flutter/flutter/issues/43098
https://github.com/flutter/flutter/issues/44478

See https://flutter.dev/go/build-dashboard-v2 for infinite scrolling feature

# Tested

Check that merging refreshed data works with older statuses.
Check that `lastCommitStatus` in `fetchCommitStatuses` is handled correctly in the url
Check that loader row is created in `StatusGrid`
  Added missing check for task icon row being created

I did a manual test comparing the build dashboard with the commit history on flutter/flutter and the scroll worked.

# Future Work

This sets up the merge algorithm where we can do the reverse, where we request only the latest new changes from the dashboard. If there was an endpoint on the backend, we could get the diff based on a timestamp and only return the changed rows. This would reduce the ~100 KB call every 10 seconds down to only the changes (ideally <5 KB).

# Preview

https://testchillers-dot-flutter-dashboard.appspot.com/#/build

Scroll to the bottom and you should see some blue grey boxes for a few seconds. After the request is finished, the data will be appended. If you wait for new data to come in, you will see it is merged in.