### PR TITLE
improve review handling logic

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -228,12 +228,14 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 ///
 /// Returns true if at least one approved review and no outstanding change
 /// request reviews.
-bool _checkApproval(List<Map<String, dynamic>> reviewNodes, Set<String> changeRequestAuthors) {
+bool _checkApproval(
+    List<Map<String, dynamic>> reviewNodes, Set<String> changeRequestAuthors) {
   assert(changeRequestAuthors != null && changeRequestAuthors.isEmpty);
   bool hasAtLeastOneApprove = false;
   for (Map<String, dynamic> review in reviewNodes) {
     // Ignore reviews from non-members/owners.
-    if (review['authorAssociation'] != 'MEMBER' && review['authorAssociation'] != 'OWNER') {
+    if (review['authorAssociation'] != 'MEMBER' &&
+        review['authorAssociation'] != 'OWNER') {
       continue;
     }
 
@@ -297,7 +299,8 @@ class _AutoMergeQueryResult {
       ciSuccessful && hasApprovedReview && changeRequestAuthors.isEmpty;
 
   /// Whether the auto-merge label should be removed from this PR.
-  bool get shouldRemoveLabel => !hasApprovedReview || changeRequestAuthors.isNotEmpty;
+  bool get shouldRemoveLabel =>
+      !hasApprovedReview || changeRequestAuthors.isNotEmpty;
 
   /// An appropriate message to leave when removing the label.
   String get removalMessage {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -34,13 +34,12 @@ query LabeledPullRequestsWithReviews($sOwner: String!, $sName: String!, $sLabelN
                 }
               }
             }
-            changeRequestReviews: reviews(first: 1, states: [CHANGES_REQUESTED]) {
+            reviews(first: 100, states: [APPROVED, CHANGES_REQUESTED]) {
               nodes {
-                state
-              }
-            }
-            approvedReviews: reviews(first: 1, states: [APPROVED]) {
-              nodes {
+                author {
+                  login
+                }
+                authorAssociation
                 state
               }
             }

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -292,12 +292,11 @@ void main() {
       githubGraphQLClient.verifyMutations(
         <MutationOptions>[
           MutationOptions(
-            document: mergePullRequestMutation,
-            variables: <String, dynamic>{
-              'id': prChangedReview.id,
-              'oid': oid,
-            }
-          ),
+              document: mergePullRequestMutation,
+              variables: <String, dynamic>{
+                'id': prChangedReview.id,
+                'oid': oid,
+              }),
         ],
       );
     });
@@ -313,7 +312,8 @@ void main() {
           nonMemberChangeRequest,
         ],
       );
-      final PullRequestHelper prNonMemberChangeRequestWithMemberApprove = PullRequestHelper(
+      final PullRequestHelper prNonMemberChangeRequestWithMemberApprove =
+          PullRequestHelper(
         reviews: <PullRequestReviewHelper>[
           ownerApprove,
           nonMemberChangeRequest,
@@ -358,12 +358,11 @@ void main() {
             },
           ),
           MutationOptions(
-            document: mergePullRequestMutation,
-            variables: <String, dynamic>{
-              'id': prNonMemberChangeRequestWithMemberApprove.id,
-              'oid': oid,
-            }
-          ),
+              document: mergePullRequestMutation,
+              variables: <String, dynamic>{
+                'id': prNonMemberChangeRequestWithMemberApprove.id,
+                'oid': oid,
+              }),
         ],
       );
     });


### PR DESCRIPTION
The old logic allows for non-members/owners to approve

It also doesn't handle when someone goes from changes requested to approved.

This does that and adds tests.