### PR TITLE
Unlabel PRs with failing checks

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 const String labeledPullRequestsWithReviewsQuery = r'''
-query LabeledPullRequestsWithReviews($sOwner: String!, $sName: String!, $sLabelName: String!) {
+query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLabelName: String!) {
   repository(owner: $sOwner, name: $sName) {
     labels(first: 1, query: $sLabelName) {
       nodes {
@@ -24,10 +24,16 @@ query LabeledPullRequestsWithReviews($sOwner: String!, $sName: String!, $sLabelN
                   committedDate
                   pushedDate
                   status {
-                    state
+                    contexts {
+                      context
+                      state
+                    }
                   }
                   checkSuites(first: 100) {
                     nodes {
+                      app {
+                        name
+                      }
                       conclusion
                     }
                   }


### PR DESCRIPTION
This change makes the bot unlabel PRs that have statsuses or checks that are failing _other than_ luci-engine or flutter-build.

The idea is that if any other check/status is failing, the author needs to take action to actually fix those (as opposed to luci-engine and flutter-build, which get resolved without additional action on the PR).

This is important for autorollers, as they will otherwise not know when to close their PR.

@rmistry

fixes https://github.com/flutter/flutter/issues/49061