### PR TITLE
Write X-Flutter-IdToken cookie on sign in changes

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -143,7 +143,7 @@ class AppEngineCocoonService implements CocoonService {
 
     final String fileName = '${task.name}_${shortSha}_${task.attempts}.log';
 
-    return _downloader.download(getTaskLogUrl, fileName, idToken: idToken);
+    return _downloader.download(getTaskLogUrl, fileName);
   }
 
   @override

--- a/app_flutter/lib/service/cookie.dart
+++ b/app_flutter/lib/service/cookie.dart
@@ -1,0 +1,5 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'cookie_interface.dart' if (dart.library.js) 'cookie_web.dart';

--- a/app_flutter/lib/service/cookie_interface.dart
+++ b/app_flutter/lib/service/cookie_interface.dart
@@ -1,0 +1,9 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Utility service for managing HTML cookies.
+class Cookie {
+  Future<void> set(String name, String value, {String options}) async =>
+      print('CookieService not implemented for this platform');
+}

--- a/app_flutter/lib/service/cookie_web.dart
+++ b/app_flutter/lib/service/cookie_web.dart
@@ -9,9 +9,9 @@ import 'cookie_interface.dart' as i;
 /// Utility service for managing HTML cookies.
 class Cookie implements i.Cookie {
   @override
-  Future<void> set(String name, String value, {String options}) async {
+  Future<void> set(String name, String value, {String options = ''}) async {
     // This line is dangerous as it fails silently. Be careful.
-    html.document.cookie = '$name=$value;path=/';
+    html.document.cookie = '$name=$value;$options';
 
     // This wait is a work around as the above line is not synchronous.
     // The cookie needs to be set for the request to be authenticated.

--- a/app_flutter/lib/service/cookie_web.dart
+++ b/app_flutter/lib/service/cookie_web.dart
@@ -1,0 +1,23 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'cookie_interface.dart' as i;
+
+/// Utility service for managing HTML cookies.
+class Cookie implements i.Cookie {
+  @override
+  Future<void> set(String name, String value, {String options}) async {
+    // This line is dangerous as it fails silently. Be careful.
+    html.document.cookie = '$name=$value;path=/';
+
+    // This wait is a work around as the above line is not synchronous.
+    // The cookie needs to be set for the request to be authenticated.
+    //
+    // dart:html will say the cookie has been written, but the browser
+    // is still writing it.
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+  }
+}

--- a/app_flutter/lib/service/downloader_interface.dart
+++ b/app_flutter/lib/service/downloader_interface.dart
@@ -4,6 +4,6 @@
 
 /// Utility service for agnostically downloading files locally onto a device.
 class Downloader {
-  Future<bool> download(String href, String fileName, {String idToken}) async =>
-      throw Exception('Download not implemented for this platofrm');
+  Future<bool> download(String href, String fileName) async =>
+      throw Exception('Download not implemented for this platform');
 }

--- a/app_flutter/lib/service/downloader_web.dart
+++ b/app_flutter/lib/service/downloader_web.dart
@@ -19,21 +19,9 @@ class Downloader implements i.Downloader {
   ///    it will be downloaded to.
   /// 3. Click the anchor element to trigger the browser to download the file.
   @override
-  Future<bool> download(String href, String fileName, {String idToken}) async {
+  Future<bool> download(String href, String fileName) async {
     assert(href != null);
     assert(fileName != null);
-
-    if (idToken != null) {
-      // This line is dangerous as it fails silently. Be careful.
-      html.document.cookie = 'X-Flutter-IdToken=$idToken;path=/';
-
-      // This wait is a work around as the above line is not synchronous.
-      // The cookie needs to be set for the request to be authenticated.
-      //
-      // dart:html will say the cookie has been written, but the browser
-      // is still writing it.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-    }
 
     html.AnchorElement()
       ..href = href

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -20,6 +20,13 @@ class GoogleSignInService {
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
       notifyListeners();
+
+      if (user != null) {
+        user.authentication.then((GoogleSignInAuthentication auth) {
+          cookieService.set('X-Flutter-IdToken', auth.idToken,
+              options: 'path=/');
+        });
+      }
     });
 
     _googleSignIn.signInSilently();

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -10,12 +10,14 @@ import 'cookie_interface.dart';
 /// Service class for interacting with Google Sign In authentication for Cocoon backend.
 class GoogleSignInService {
   /// Creates a new [GoogleSignIn].
-  GoogleSignInService({GoogleSignIn googleSignIn})
-      : _googleSignIn = googleSignIn ??
+  GoogleSignInService({
+    GoogleSignIn googleSignIn,
+    Cookie cookieService,
+  })  : _googleSignIn = googleSignIn ??
             GoogleSignIn(
               scopes: _googleScopes,
             ),
-        cookieService = Cookie() {
+        _cookieService = cookieService ?? Cookie() {
     _googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
@@ -53,7 +55,7 @@ class GoogleSignInService {
   /// Service for handling HTML cookies.
   ///
   /// Used to set the id token as a cookie so manual API requests can be made.
-  final Cookie cookieService;
+  final Cookie _cookieService;
 
   /// Whether or not the application has been signed in to.
   Future<bool> get isAuthenticated => _googleSignIn.isSignedIn();

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/rendering.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
+import 'cookie_interface.dart';
+
 /// Service class for interacting with Google Sign In authentication for Cocoon backend.
 class GoogleSignInService {
   /// Creates a new [GoogleSignIn].
@@ -12,7 +14,8 @@ class GoogleSignInService {
       : _googleSignIn = googleSignIn ??
             GoogleSignIn(
               scopes: _googleScopes,
-            ) {
+            ),
+        cookieService = Cookie() {
     _googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount accountValue) {
       user = accountValue;
@@ -39,6 +42,11 @@ class GoogleSignInService {
 
   /// The instance of the GoogleSignIn plugin to use.
   final GoogleSignIn _googleSignIn;
+
+  /// Service for handling HTML cookies.
+  ///
+  /// Used to set the id token as a cookie so manual API requests can be made.
+  final Cookie cookieService;
 
   /// Whether or not the application has been signed in to.
   Future<bool> get isAuthenticated => _googleSignIn.isSignedIn();

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -25,8 +25,11 @@ class GoogleSignInService {
 
       if (user != null) {
         user.authentication.then((GoogleSignInAuthentication auth) {
-          cookieService.set('X-Flutter-IdToken', auth.idToken,
-              options: 'path=/');
+          _cookieService.set(
+            'X-Flutter-IdToken',
+            auth.idToken,
+            options: 'path=/',
+          );
         });
       }
     });

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -337,10 +337,9 @@ void main() {
       test('should send correct request to downloader service', () async {
         final Downloader mockDownloader = MockDownloader();
         when(mockDownloader.download(
-                argThat(contains('/api/get-log?ownerKey=')),
-                'test_task_shashan_1.log',
-                idToken: 'abc123'))
-            .thenAnswer((_) => Future<bool>.value(true));
+          argThat(contains('/api/get-log?ownerKey=')),
+          'test_task_shashan_1.log',
+        )).thenAnswer((_) => Future<bool>.value(true));
         service = AppEngineCocoonService(
             client: MockClient((Request request) async {
               return Response('', 200);

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -130,8 +130,10 @@ void main() {
       await untilCalled(mockSignIn.onCurrentUserChanged);
 
       verify(mockCookieService.set(
-          'X-Flutter-IdToken', FakeGoogleSignInAuthentication().idToken,
-          options: 'path=/'));
+        'X-Flutter-IdToken',
+        FakeGoogleSignInAuthentication().idToken,
+        options: 'path=/',
+      ));
     });
   });
 }


### PR DESCRIPTION
The cookie `X-Flutter-IdToken` is used by the Angular Dart dashboards for authenticating with Cocoon. The new Flutter app sends it as a header instead so that authentication in the app works on both mobile and web. When making direct requests to the api and using only the Flutter app, the request will fail when it previously worked on the old dashboards. This is because this cookie isn't being set.

This updates the code to write the auth cookie in the same fashion as the old dashboard so API requests can be made from the browser. That is, when the signed in user changes, write their id token as a cookie.

This removes the arbitrary wait on the cookie being written for downloading logs.

# Tested

With the main functionality being the html cookie, I was only able to test that the cookie service is called correctly when the signed in user changes.