### PR TITLE
Remove agent id composite index on task

### DIFF
--- a/app_dart/index.yaml
+++ b/app_dart/index.yaml
@@ -19,11 +19,6 @@ indexes:
   - name: CreateTimestamp
     direction: desc
 - kind: Task
-  properties:
-  - name: ReservedForAgentID
-  - name: CreateTimestamp
-    direction: desc
-- kind: Task
   ancestor: yes
   properties:
   - name: Name


### PR DESCRIPTION
I scanned all of `app_dart` and could not find any `order('reservedForAgentID')` or `filter('reservedForArgentID')` calls. I believe this is safe to remove.

# Issues

https://github.com/flutter/flutter/issues/48914