### PR TITLE
Do 2 PRs per cycle, oldest first (by create date)

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -18,6 +18,11 @@ import '../request_handling/body.dart';
 
 import 'check_for_waiting_pull_requests_queries.dart';
 
+/// Maximum number of pull requests to merge on each check.
+/// This should be kept reasonably low to avoid flooding infra when the tree
+/// goes green.
+const int _kMergeCountPerCycle = 2;
+
 @immutable
 class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
   const CheckForWaitingPullRequests(
@@ -54,7 +59,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       client,
     );
     for (_AutoMergeQueryResult queryResult in _parseQueryData(data)) {
-      if (mergeCount < 2 && queryResult.shouldMerge) {
+      if (mergeCount < _kMergeCountPerCycle && queryResult.shouldMerge) {
         final bool merged = await _mergePullRequest(
           queryResult.graphQLId,
           queryResult.sha,

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -8,7 +8,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
     labels(first: 1, query: $sLabelName) {
       nodes {
         id
-        pullRequests(first: 100, states: OPEN) {
+        pullRequests(first: 100, states: OPEN, orderBy: {direction: ASC, field: CREATED_AT}) {
           nodes {
             author {
               login

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -206,7 +206,8 @@ void main() {
       );
     });
 
-    test('Merges first PR in list, all successful', () async {
+    test('Merges first 2 PRs in list, all successful', () async {
+      flutterRepoPRs.add(PullRequestHelper());
       flutterRepoPRs.add(PullRequestHelper());
       flutterRepoPRs.add(PullRequestHelper()); // will be ignored.
       engineRepoPRs.add(PullRequestHelper());
@@ -220,7 +221,14 @@ void main() {
           MutationOptions(
             document: mergePullRequestMutation,
             variables: <String, dynamic>{
-              'id': flutterRepoPRs.first.id,
+              'id': flutterRepoPRs[0].id,
+              'oid': oid,
+            },
+          ),
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: <String, dynamic>{
+              'id': flutterRepoPRs[1].id,
               'oid': oid,
             },
           ),

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -243,7 +243,7 @@ void main() {
       );
     });
 
-    test('Merges first 2 PRs in list, one not successful', () async {
+    test('Merges 1st and 3rd PR, 2nd failed', () async {
       flutterRepoPRs.add(PullRequestHelper());
       flutterRepoPRs.add(PullRequestHelper(
           lastCommitStatuses: const <StatusHelper>[


### PR DESCRIPTION
Right now, the bot is not specifying a sort order when querying for PRs, which can starve older PRs.

Also bumps the number of PRs we merge every 5 minutes to 2 instead of 1.