### PR TITLE
reduce nodes touched

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -29,7 +29,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                       state
                     }
                   }
-                  checkSuites(first: 100) {
+                  checkSuites(first: 10) {
                     nodes {
                       app {
                         name


### PR DESCRIPTION
GitHub is telling us we're touching too many nodes with this query as it stands - it hits 100 PRs x 100 check suites x 100 jobs per suite, which is 1m nodes.

We only have two check suites.  I'm reducing it to 10, which keeps us under the limits.  A bigger solution would be to actually do paging.