### PR TITLE
Enable web_engine presubmit.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -247,11 +247,19 @@ class Config {
           'repo': 'engine',
         },
         <String, String>{
+          'name': 'Linux Web Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
           'name': 'Windows Host Engine',
           'repo': 'engine',
         },
         <String, String>{
           'name': 'Windows Android AOT Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Windows Web Engine',
           'repo': 'engine',
         }
       ];


### PR DESCRIPTION
First version of web_engine recipes are ready running Linux and Windows
tests. We are enabling their execution and we'll work later on a second
iteration of the recipes to provide more flexibility and scalbility.

https://github.com/flutter/flutter/issues/46782