### PR TITLE
Adding gold status check to framework PRs

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -33,6 +33,8 @@ Future<void> main() async {
       '/api/luci-status-handler': LuciStatusHandler(config, buildBucketClient),
       '/api/push-build-status-to-github':
           PushBuildStatusToGithub(config, authProvider),
+      '/api/push-gold-status-to-github':
+          PushGoldStatusToGithub(config, authProvider),
       '/api/push-engine-build-status-to-github':
           PushEngineStatusToGithub(config, authProvider),
       '/api/refresh-chromebot-status':

--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -13,7 +13,7 @@ cron:
 - description: sends build status to GitHub to annotate PRs and commits
   url: /api/push-build-status-to-github
   schedule: every 1 minutes
-- description: sends gold status to GitHub to annotate PRs and commits
+- description: sends pr-specific gold status to GitHub to annotate PRs and commits
   url: /api/push-gold-status-to-github
   schedule: every 3 minutes
 - description: sends build status to GitHub to annotate engine PRs and commits

--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -13,6 +13,9 @@ cron:
 - description: sends build status to GitHub to annotate PRs and commits
   url: /api/push-build-status-to-github
   schedule: every 1 minutes
+- description: sends gold status to GitHub to annotate PRs and commits
+  url: /api/push-gold-status-to-github
+  schedule: every 3 minutes
 - description: sends build status to GitHub to annotate engine PRs and commits
   url: /api/push-engine-build-status-to-github
   schedule: every 2 minutes

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -17,6 +17,7 @@ export 'src/request_handlers/github_webhook.dart';
 export 'src/request_handlers/luci_status.dart';
 export 'src/request_handlers/push_build_status_to_github.dart';
 export 'src/request_handlers/push_engine_status_to_github.dart';
+export 'src/request_handlers/push_gold_status_to_github.dart';
 export 'src/request_handlers/refresh_chromebot_status.dart';
 export 'src/request_handlers/refresh_cirrus_status.dart';
 export 'src/request_handlers/refresh_github_commits.dart';

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -89,8 +89,7 @@ class Config {
       '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
       'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get goldenBreakingChangeMessage => 'It looks like this pull request '
-      'includes a golden file change. Please make sure to follow '
+  String get goldenBreakingChangeMessage => 'Check '
       '[Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes). '
       'While there are exceptions to this rule, if this patch modifies an existing '
       'golden file, it is probably not an exception. Only new golden files are not '

--- a/app_dart/lib/src/model/appengine/github_gold_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_gold_status_update.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/app_dart/lib/src/model/appengine/github_gold_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_gold_status_update.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
-import 'package:github/server.dart';
 
 /// Class that represents an update having been posted to a GitHub
 /// flutter/flutter PR on the status of tryjobs generated on Flutter Gold.

--- a/app_dart/lib/src/model/appengine/github_gold_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_gold_status_update.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
+import 'package:github/server.dart';
 
 /// Class that represents an update having been posted to a GitHub
 /// flutter/flutter PR on the status of tryjobs generated on Flutter Gold.
@@ -13,6 +14,7 @@ class GithubGoldStatusUpdate extends Model {
     this.pr,
     this.head,
     this.status,
+    this.description,
     this.updates,
   }) {
     parentKey = key?.parent;
@@ -32,6 +34,9 @@ class GithubGoldStatusUpdate extends Model {
   @StringProperty(propertyName: 'Status', required: true)
   String status;
 
+  @StringProperty(propertyName: 'Description', required: true)
+  String description;
+
   @IntProperty(propertyName: 'Updates', required: true)
   int updates;
 
@@ -45,6 +50,7 @@ class GithubGoldStatusUpdate extends Model {
       ..write(', pr: $pr')
       ..write(', head: $head')
       ..write(', lastStatus: $status')
+      ..write(', description $description')
       ..write(', updates: $updates')
       ..write(')');
     return buf.toString();

--- a/app_dart/lib/src/model/appengine/github_gold_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_gold_status_update.dart
@@ -1,0 +1,52 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:gcloud/db.dart';
+
+/// Class that represents an update having been posted to a GitHub
+/// flutter/flutter PR on the status of tryjobs generated on Flutter Gold.
+@Kind(name: 'GithubGoldStatusUpdate')
+class GithubGoldStatusUpdate extends Model {
+  GithubGoldStatusUpdate({
+    Key key,
+    this.pr,
+    this.head,
+    this.status,
+    this.updates,
+  }) {
+    parentKey = key?.parent;
+    id = key?.id;
+  }
+
+  static const String statusCompleted = 'success';
+
+  static const String statusRunning = 'in_progress';
+
+  @IntProperty(propertyName: 'PR', required: true)
+  int pr;
+
+  @StringProperty(propertyName: 'Head')
+  String head;
+
+  @StringProperty(propertyName: 'Status', required: true)
+  String status;
+
+  @IntProperty(propertyName: 'Updates', required: true)
+  int updates;
+
+  @override
+  String toString() {
+    final StringBuffer buf = StringBuffer()
+      ..write('$runtimeType(')
+      ..write('id: $id')
+      ..write(', parentKey: ${parentKey?.id}')
+      ..write(', key: ${parentKey == null ? null : key.id}')
+      ..write(', pr: $pr')
+      ..write(', head: $head')
+      ..write(', lastStatus: $status')
+      ..write(', updates: $updates')
+      ..write(')');
+    return buf.toString();
+  }
+}

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -95,11 +95,11 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         // Get Gold status.
         final String goldStatus = await _getGoldStatus(pr, log);
         log.debug('Checks are completed, Gold reports $goldStatus status for '
-          '${pr.number} sha ${pr.head.sha}.');
+            '${pr.number} sha ${pr.head.sha}.');
         statusRequest =
-          _createStatus(goldStatus, _getStatusDescription(goldStatus));
+            _createStatus(goldStatus, _getStatusDescription(goldStatus));
         if (goldStatus == GithubGoldStatusUpdate.statusRunning &&
-          !await _alreadyCommented(gitHubClient, pr, slug)) {
+            !await _alreadyCommented(gitHubClient, pr, slug)) {
           log.debug('Notifying for triage.');
           await _commentAndApplyGoldLabel(gitHubClient, pr, slug);
         }

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -1,0 +1,236 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:gcloud/db.dart';
+import 'package:github/server.dart';
+import 'package:graphql/client.dart';
+import 'package:meta/meta.dart';
+
+import '../datastore/cocoon_config.dart';
+import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
+import '../model/appengine/github_gold_status_update.dart';
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/authentication.dart';
+import '../request_handling/body.dart';
+import '../service/datastore.dart';
+
+@immutable
+class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
+  const PushGoldStatusToGithub(Config config,
+    AuthenticationProvider authenticationProvider, {
+    @visibleForTesting DatastoreServiceProvider datastoreProvider,
+    @visibleForTesting LoggingProvider loggingProvider,
+  }) : datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
+       loggingProvider = loggingProvider ?? Providers.serviceScopeLogger,
+       super(config: config, authenticationProvider: authenticationProvider);
+
+  final DatastoreServiceProvider datastoreProvider;
+  final LoggingProvider loggingProvider;
+
+  @override
+  Future<Body> get() async {
+    final Logging log = loggingProvider();
+    final DatastoreService datastore = datastoreProvider();
+
+    if (authContext.clientContext.isDevelopmentEnvironment) {
+      // Don't push gold status from the local dev server.
+      return Body.empty;
+    }
+
+    const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
+    final GitHub github = await config.createGitHubClient();
+    final GraphQLClient client = await config.createCirrusGraphQLClient();
+    final List<GithubGoldStatusUpdate> updates = <GithubGoldStatusUpdate>[];
+    final List<String> checkStatuses = <String>[];
+    const List<String> cirrusInProgressStates = <String>[
+      'EXECUTING',
+      'CREATED',
+      'TRIGGERED',
+      'NEEDS_APPROVAL'
+    ];
+
+
+    await for (PullRequest pr in github.pullRequests.list(slug)) {
+      // Check run statuses for this pr
+      for (dynamic runStatus in await _queryGraphQL(
+        pr.id.toString(),
+        pr.head.sha,
+        client,
+      )) {
+        final String status = runStatus['status'];
+        final String taskName = runStatus['name'];
+
+        log.debug('Found Cirrus build status for pull request ${pr.id}, commit '
+          '${pr.head.sha}: $taskName ($status)');
+
+        if (taskName.contains('framework'))
+          checkStatuses.add(status);
+      }
+
+      if (checkStatuses.isEmpty)
+        return Body.empty;
+
+      // This PR needs a Gold Status
+      // Get last known Gold status from datastore
+      final GithubGoldStatusUpdate lastUpdate =
+        await datastore.queryLastGoldUpdate(slug, pr);
+      CreateStatus statusRequest;
+
+      log.debug('Last known Gold status for ${pr.id} was with sha '
+        '${lastUpdate.head}, status: ${lastUpdate.status ?? 'initial'}');
+
+      // Checks have not completed uploading to Gold
+      if (checkStatuses.any(cirrusInProgressStates.contains)) {
+
+        log.debug('Checks for ${pr.id} at ${pr.head.sha} are still running.');
+
+        if (lastUpdate.status == GithubGoldStatusUpdate.statusRunning)
+          return Body.empty;
+        
+        else {
+          // Set up running status for github.
+          statusRequest = CreateStatus(GithubGoldStatusUpdate.statusRunning);
+          statusRequest.targetUrl = 'https://flutter-gold.skia.org/changelists';
+          statusRequest.context = 'flutter-gold';
+          statusRequest.description = 'This check is waiting for framework '
+            'checks to be completed';
+        }
+      } else {
+        
+        // Checks have completed
+        final String status = await _getGoldStatus(pr, log);
+        if (lastUpdate.head != pr.head.sha || lastUpdate.status != status) {
+          // Set up status for github.
+          statusRequest = CreateStatus(status);
+          statusRequest.targetUrl = 'https://flutter-gold.skia.org/changelists';
+          statusRequest.context = 'flutter-gold';
+
+          switch (status) {
+            case GithubGoldStatusUpdate.statusRunning:
+              statusRequest.description = 'Image changes have been found for '
+                'this pr. Visit https://flutter-gold.skia.org/changelists to '
+                'view and triage (e.g. because this is an intentional change).';
+              break;
+            case GithubGoldStatusUpdate.statusCompleted:
+              statusRequest.description = 'All golden file tests have passed.';
+              break;
+          }
+        }
+      }
+
+      if (statusRequest != null) {
+        try {
+          await github.repositories.createStatus(slug, pr.head.sha, statusRequest);
+          lastUpdate.status = statusRequest.state;
+          lastUpdate.updates += 1;
+          updates.add(lastUpdate);
+        } catch (error) {
+          log.error(
+            'Failed to post status update to ${slug.fullName}#${pr.number}: $error');
+        }
+      }
+    }
+
+    final int maxEntityGroups = config.maxEntityGroups;
+    for (int i = 0; i < updates.length; i += maxEntityGroups) {
+      await datastore.db.withTransaction<void>((Transaction transaction) async {
+        transaction.queueMutations(
+          inserts: updates.skip(i).take(maxEntityGroups).toList());
+        await transaction.commit();
+      });
+    }
+    log.debug('Committed all updates');
+    return Body.empty;
+  }
+
+  /// Queries the Cirrus GraphQL for build information for the given pr and sha.
+  Future<List<dynamic>> _queryGraphQL(
+    String pr,
+    String sha,
+    GraphQLClient client,
+  ) async {
+    const String owner = 'flutter';
+    const String name = 'flutter';
+    const String cirrusStatusQuery = r'''
+    query BuildBySHAQuery($owner: String!, $name: String!, $SHA: String) { 
+      searchBuilds(repositoryOwner: $owner, repositoryName: $name, SHA: $SHA) {
+        pullRequest(first: 1, query: $PR) { 
+          id latestGroupTasks { 
+            id name status 
+          }
+        } 
+      } 
+    }''';
+    final QueryResult result = await client.query(
+      QueryOptions(
+        document: cirrusStatusQuery,
+        fetchPolicy: FetchPolicy.noCache,
+        variables: <String, dynamic>{
+          'owner': owner,
+          'name': name,
+          'SHA': sha,
+          'PR': pr,
+        },
+      ),
+    );
+
+    if (result.hasErrors) {
+      for (GraphQLError error in result.errors) {
+        log.error(error.toString());
+      }
+      throw const BadRequestException('GraphQL query failed');
+    }
+
+    final List<dynamic> tasks = <dynamic>[];
+    final Map<String, dynamic> searchBuilds = result.data['searchBuilds'].first;
+    tasks.addAll(searchBuilds['latestGroupTasks']);
+    return tasks;
+  }
+
+  /// Used to check for any tryjob results from Flutter Gold associated with a PR.
+  Future<String> _getGoldStatus(PullRequest pr, Logging log) async {
+      final Uri requestForTryjobStatus = Uri.parse(
+        'http://flutter-gold.skia.org/json/changelist/github/${pr.id}/${pr.head.sha}/untriaged'
+    );
+    String rawResponse;
+    try {
+      final io.HttpClient httpClient = io.HttpClient();
+      final io.HttpClientRequest request = await httpClient.getUrl(requestForTryjobStatus);
+      final io.HttpClientResponse response = await request.close();
+
+      rawResponse = await utf8.decodeStream(response);
+      final Map<String, dynamic> decodedResponse = json.decode(rawResponse);
+
+      if (decodedResponse['digests'] == null) {
+
+        log.debug('There are no unexpected image results for ${pr.id} at sha '
+          '${pr.head.sha}, returning status ${GithubGoldStatusUpdate.statusCompleted}');
+
+        return GithubGoldStatusUpdate.statusCompleted;
+      } else {
+
+        log.debug('Tryjob for ${pr.id} at sha ${pr.head.sha} generated new '
+          'images, returning status ${GithubGoldStatusUpdate.statusRunning}');
+
+        return GithubGoldStatusUpdate.statusRunning;
+      }
+    } on FormatException catch (_) {
+      throw BadRequestException('Formatting error detected requesting '
+        'tryjob status for pr ${pr.id} from Flutter Gold.\n'
+        'rawResponse: $rawResponse');
+    } catch (e) {
+      throw BadRequestException('Error detected requesting tryjob status for pr '
+        '${pr.id} from Flutter Gold.\n'
+        'error: $e');
+    }
+  }
+}
+

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -91,18 +91,18 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         // Checks are still running, we have to wait.
         statusRequest = _createStatus(GithubGoldStatusUpdate.statusRunning,
             'This check is waiting for all other checks to be completed.');
-      }
-
-      // Get Gold status.
-      final String goldStatus = await _getGoldStatus(pr, log);
-      log.debug('Checks are completed, Gold reports $goldStatus status for '
+      } else {
+        // Get Gold status.
+        final String goldStatus = await _getGoldStatus(pr, log);
+        log.debug('Checks are completed, Gold reports $goldStatus status for '
           '${pr.number} sha ${pr.head.sha}.');
-      statusRequest =
+        statusRequest =
           _createStatus(goldStatus, _getStatusDescription(goldStatus));
-      if (goldStatus == GithubGoldStatusUpdate.statusRunning &&
+        if (goldStatus == GithubGoldStatusUpdate.statusRunning &&
           !await _alreadyCommented(gitHubClient, pr, slug)) {
-        log.debug('Notifying for triage.');
-        await _commentAndApplyGoldLabel(gitHubClient, pr, slug);
+          log.debug('Notifying for triage.');
+          await _commentAndApplyGoldLabel(gitHubClient, pr, slug);
+        }
       }
 
       // Push updates if there is a status change (detected by unique description)

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -210,8 +210,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   String _getStatusDescription(String status) {
     if (status == GithubGoldStatusUpdate.statusRunning) {
       return 'Image changes have been found for '
-        'this pr. Visit https://flutter-gold.skia.org/changelists to '
-        'view and triage (e.g. because this is an intentional change).';
+          'this pr. Visit https://flutter-gold.skia.org/changelists to '
+          'view and triage (e.g. because this is an intentional change).';
     }
     return 'All golden file tests have passed.';
   }

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -80,11 +80,13 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             'Found Cirrus build status for pull request ${pr.number}, commit '
             '${pr.head.sha}: $taskName ($status)');
 
-        if (taskName.contains('framework')) cirrusCheckStatuses.add(status);
+        if (taskName.contains('framework'))
+          cirrusCheckStatuses.add(status);
       }
 
       // Is there a framework test? (Generates gold tryjobs)
-      if (cirrusCheckStatuses.isEmpty) return Body.empty;
+      if (cirrusCheckStatuses.isEmpty)
+        return Body.empty;
 
       // This PR needs a Gold Status
       // Get last known Gold status from datastore

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -80,13 +80,17 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             'Found Cirrus build status for pull request ${pr.number}, commit '
             '${pr.head.sha}: $taskName ($status)');
 
-        if (taskName.contains('framework'))
+        if (taskName.contains('framework')) {
+          // Analyzer requires curly braces here.
           cirrusCheckStatuses.add(status);
+        }
       }
 
       // Is there a framework test? (Generates gold tryjobs)
-      if (cirrusCheckStatuses.isEmpty)
+      if (cirrusCheckStatuses.isEmpty) {
+        // Analyzer requires curly braces here.
         return Body.empty;
+      }
 
       // This PR needs a Gold Status
       // Get last known Gold status from datastore

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -70,7 +70,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     await for (PullRequest pr in gitHubClient.pullRequests.list(slug)) {
       // Check run statuses for this pr
       final List<dynamic> cirrusStatuses =
-        await queryCirrusGraphQL(pr.head.sha, cirrusClient, log, 'flutter');
+          await queryCirrusGraphQL(pr.head.sha, cirrusClient, log, 'flutter');
       for (dynamic runStatus in cirrusStatuses) {
         final String status = runStatus['status'];
         final String taskName = runStatus['name'];

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -19,11 +19,11 @@ import '../service/datastore.dart';
 import 'refresh_cirrus_status_queries.dart';
 
 /// Refer all cirrus build statuses at: https://github.com/cirruslabs/cirrus-ci-web/blob/master/schema.graphql#L120
-const List<String> _failedStates = <String>[
+const List<String> kCirrusFailedStates = <String>[
   'ABORTED',
   'FAILED',
 ];
-const List<String> _inProgressStates = <String>[
+const List<String> kCirrusInProgressStates = <String>[
   'CREATED',
   'TRIGGERED',
   'SCHEDULED',

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -68,10 +68,10 @@ class RefreshCirrusStatus extends ApiRequestHandler<Body> {
       String newTaskStatus;
       if (statuses.isEmpty) {
         newTaskStatus = Task.statusNew;
-      } else if (statuses.any(_failedStates.contains)) {
+      } else if (statuses.any(kCirrusFailedStates.contains)) {
         newTaskStatus = Task.statusFailed;
         task.task.endTimestamp = DateTime.now().millisecondsSinceEpoch;
-      } else if (statuses.any(_inProgressStates.contains)) {
+      } else if (statuses.any(kCirrusInProgressStates.contains)) {
         newTaskStatus = Task.statusInProgress;
       } else {
         newTaskStatus = Task.statusSucceeded;

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -167,8 +167,8 @@ class DatastoreService {
     if (previousStatusUpdates.isEmpty) {
       return GithubGoldStatusUpdate(
         pr: pr.number,
-        head: null,
-        status: null,
+        head: '',
+        status: '',
         updates: 0,
       );
     } else {

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -164,13 +164,13 @@ class DatastoreService {
   Future<GithubGoldStatusUpdate> queryLastGoldUpdate(
     RepositorySlug slug,
     PullRequest pr,
-    ) async {
+  ) async {
     final Query<GithubGoldStatusUpdate> query = db
-      .query<GithubGoldStatusUpdate>()
-      ..filter('repository =', slug.fullName)
-      ..filter('pr =', pr.number);
+        .query<GithubGoldStatusUpdate>()
+          ..filter('repository =', slug.fullName)
+          ..filter('pr =', pr.number);
     final List<GithubGoldStatusUpdate> previousStatusUpdates =
-      await query.run().toList();
+        await query.run().toList();
 
     if (previousStatusUpdates.isEmpty) {
       return GithubGoldStatusUpdate(
@@ -182,7 +182,7 @@ class DatastoreService {
     } else {
       if (previousStatusUpdates.length > 1) {
         throw StateError(
-          'GithubGoldStatusUpdate should have no more than one entry on '
+            'GithubGoldStatusUpdate should have no more than one entry on '
             'repository ${slug.fullName}, pr ${pr.number}.');
       }
       return previousStatusUpdates.single;

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -170,6 +170,7 @@ class DatastoreService {
         head: '',
         status: '',
         updates: 0,
+        description: '',
       );
     } else {
       if (previousStatusUpdates.length > 1) {

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
 import '../model/appengine/github_build_status_update.dart';
+import '../model/appengine/github_gold_status_update.dart';
 import '../model/appengine/stage.dart';
 import '../model/appengine/task.dart';
 import '../model/appengine/time_series.dart';
@@ -155,6 +156,34 @@ class DatastoreService {
         throw StateError(
             'GithubBuildStatusUpdate should have no more than one entries on '
             'repository ${slug.fullName}, pr ${pr.number}, head ${pr.head.sha}');
+      }
+      return previousStatusUpdates.single;
+    }
+  }
+
+  Future<GithubGoldStatusUpdate> queryLastGoldUpdate(
+    RepositorySlug slug,
+    PullRequest pr,
+    ) async {
+    final Query<GithubGoldStatusUpdate> query = db
+      .query<GithubGoldStatusUpdate>()
+      ..filter('repository =', slug.fullName)
+      ..filter('pr =', pr.number);
+    final List<GithubGoldStatusUpdate> previousStatusUpdates =
+      await query.run().toList();
+
+    if (previousStatusUpdates.isEmpty) {
+      return GithubGoldStatusUpdate(
+        pr: pr.number,
+        head: null,
+        status: null,
+        updates: 0,
+      );
+    } else {
+      if (previousStatusUpdates.length > 1) {
+        throw StateError(
+          'GithubGoldStatusUpdate should have no more than one entry on '
+            'repository ${slug.fullName}, pr ${pr.number}.');
       }
       return previousStatusUpdates.single;
     }

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -43,6 +43,7 @@ void main() {
       clientContext = FakeClientContext();
       authContext = FakeAuthenticatedContext(clientContext: clientContext);
       auth = FakeAuthenticationProvider(clientContext: clientContext);
+      cirrusGraphQLClient = FakeGraphQLClient();
       config = FakeConfig(cirrusGraphQLClient: cirrusGraphQLClient);
       db = FakeDatastoreDB();
       log = FakeLogging();

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -158,20 +158,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not apply labels or make comments
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
 
         test('same commit, checks running, last status running', () async {
@@ -195,20 +195,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not apply labels or make comments
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
 
         test('same commit, checks complete, last status complete', () async {
@@ -232,20 +232,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not apply labels or make comments
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
 
         test(
@@ -348,20 +348,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not apply labels or make comments
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
       });
 
@@ -387,20 +387,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not apply labels or make comments
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
 
         test('new commit, checks complete, no changes detected', () async {
@@ -435,20 +435,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not label or comment
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
 
         test('new commit, checks complete, change detected, should comment',
@@ -541,20 +541,20 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
           // Should not label or comment
-          verify(issuesService.addLabelsToIssue(
+          verifyNever(issuesService.addLabelsToIssue(
             slug,
             pr.number,
             <String>[
               'will affect goldens',
               'severe: API break',
             ],
-          )).called(0);
+          ));
 
-          verify(issuesService.createComment(
+          verifyNever(issuesService.createComment(
             slug,
             pr.number,
             argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(0);
+          ));
         });
       });
     });

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -1,0 +1,360 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart';
+import 'package:cocoon_service/src/request_handlers/push_gold_status_to_github.dart';
+import 'package:cocoon_service/src/request_handling/body.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:gcloud/db.dart' as gcloud_db;
+import 'package:github/server.dart';
+import 'package:graphql/client.dart';
+import 'package:meta/meta.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_logging.dart';
+import '../src/service/fake_graphql_client.dart';
+
+// TODO(Piinks): Add checks for comments and labels, finish mocks
+
+void main() {
+  group('PushGoldStatusToGithub', () {
+    FakeConfig config;
+    FakeClientContext clientContext;
+    FakeAuthenticatedContext authContext;
+    FakeAuthenticationProvider auth;
+    FakeDatastoreDB db;
+    FakeLogging log;
+    ApiRequestHandlerTester tester;
+    PushGoldStatusToGithub handler;
+    FakeGraphQLClient cirrusGraphQLClient;
+    List<dynamic> statuses = <dynamic>[];
+
+    setUp(() {
+      clientContext = FakeClientContext();
+      authContext = FakeAuthenticatedContext(clientContext: clientContext);
+      auth = FakeAuthenticationProvider(clientContext: clientContext);
+      config = FakeConfig(cirrusGraphQLClient: cirrusGraphQLClient);
+      db = FakeDatastoreDB();
+      log = FakeLogging();
+      tester = ApiRequestHandlerTester(context: authContext);
+      handler = PushGoldStatusToGithub(
+        config,
+        auth,
+        datastoreProvider: () => DatastoreService(db: db),
+        loggingProvider: () => log,
+      );
+
+      cirrusGraphQLClient.mutateResultForOptions =
+        (MutationOptions options) => QueryResult();
+
+      cirrusGraphQLClient.queryResultForOptions = (QueryOptions options) {
+        return createCirrusQueryResult(statuses);
+      };
+    });
+
+    group('in development environment', () {
+      setUp(() {
+        clientContext.isDevelopmentEnvironment = true;
+      });
+
+      test('Does nothing', () async {
+        config.githubClient = ThrowingGitHub();
+        db.onCommit =
+          (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+        throw AssertionError();
+        db.addOnQuery<GithubGoldStatusUpdate>(
+            (Iterable<GithubGoldStatusUpdate> results) {
+            throw AssertionError();
+          });
+        final Body body = await tester.get<Body>(handler);
+        expect(body, same(Body.empty));
+      });
+    });
+
+    group('in non-development environment', () {
+      MockGitHub github;
+      MockPullRequestsService pullRequestsService;
+      MockRepositoriesService repositoriesService;
+      List<PullRequest> prsFromGitHub;
+
+      setUp(() {
+        github = MockGitHub();
+        pullRequestsService = MockPullRequestsService();
+        repositoriesService = MockRepositoriesService();
+        when(github.pullRequests).thenReturn(pullRequestsService);
+        when(github.repositories).thenReturn(repositoriesService);
+        when(pullRequestsService.list(any)).thenAnswer((Invocation _) {
+          return Stream<PullRequest>.fromIterable(prsFromGitHub);
+        });
+        config.githubClient = github;
+        clientContext.isDevelopmentEnvironment = false;
+      });
+
+      GithubGoldStatusUpdate newStatusUpdate(
+        PullRequest pr, String statusUpdate, String sha) {
+        return GithubGoldStatusUpdate(
+          key: db.emptyKey.append(GithubGoldStatusUpdate),
+          status: statusUpdate,
+          pr: pr.number,
+          head: sha,
+          updates: 0,
+        );
+      }
+
+      PullRequest newPullRequest({@required int id, @required String sha}) {
+        return PullRequest()
+          ..number = 123
+          ..head = (PullRequestHead()..sha = 'abc');
+      }
+
+      group('does not update anything', () {
+        setUp(() {
+          db.onCommit =
+            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+          throw AssertionError();
+          when(repositoriesService.createStatus(any, any, any))
+            .thenThrow(AssertionError());
+        });
+
+        test('if there are no PRs', () async {
+          prsFromGitHub = <PullRequest>[];
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('if there are no framework tests for this PR', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'EXECUTING', 'name': 'tool-test-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'tool-test-2'}
+          ];
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, null, null);
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('same commit, last status running, checks still running', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'EXECUTING', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('same commit, last status complete, checks complete', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, GithubGoldStatusUpdate.statusCompleted, 'abc');
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('same commit, last status same as gold status, checks complete', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+          // TODO(Piinks): mock gold request
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, GithubGoldStatusUpdate.statusCompleted, 'abc');
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+      });
+
+      group('updates GitHub and datastore', () {
+        test('new commit, checks running', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'EXECUTING', 'name': 'framework-1'},
+            <String, String>{'status': 'EXECUTING', 'name': 'framework-2'}
+          ];
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, null, null);
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusRunning);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('new commit, no last status, checks completed', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+          // TODO(Piinks): mock gold request
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, null, null);
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusRunning);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('same commit, new status, checks completed', () async {
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+          // TODO(Piinks): mock gold request
+          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status =
+            newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          db.values[status.key] = status;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+      });
+
+      test('Generates a comment and applies label on PR with golden changes', () async {
+
+      });
+    });
+  });
+}
+
+class ThrowingGitHub implements GitHub {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw AssertionError();
+}
+
+class MockGitHub extends Mock implements GitHub {}
+
+class MockPullRequestsService extends Mock implements PullRequestsService {}
+
+class MockRepositoriesService extends Mock implements RepositoriesService {}
+
+class MockHttpClient extends Mock implements HttpClient {}
+
+class MockHttpClientRequest extends Mock implements HttpClientRequest {}
+
+class MockHttpClientResponse extends Mock implements HttpClientResponse {
+  MockHttpClientResponse(this.response);
+
+  final List<int> response;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void onData(List<int> event), {
+      Function onError,
+      void onDone(),
+      bool cancelOnError,
+    }) {
+    return Stream<List<int>>.fromFuture(Future<List<int>>.value(response))
+      .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  }
+}
+
+class MockHttpImageResponse extends Mock implements HttpClientResponse {
+  MockHttpImageResponse(this.response);
+
+  final List<List<int>> response;
+
+  @override
+  Future<void> forEach(void action(List<int> element)) async {
+    response.forEach(action);
+  }
+}
+
+QueryResult createCirrusQueryResult(List<dynamic> statuses) {
+  assert(statuses != null);
+
+  return QueryResult(
+    data: <String, dynamic>{
+      'searchBuilds': <dynamic>[
+        <String, dynamic>{
+          'id': '1',
+          'latestGroupTasks': <dynamic>[
+            <String, dynamic>{
+              'id': '1',
+              'name': statuses.first['name'],
+              'status': statuses.first['status']
+            },
+            <String, dynamic>{
+              'id': '2',
+              'name': statuses.last['name'],
+              'status': statuses.last['status']
+            }
+          ],
+        }
+      ],
+    },
+  );
+}
+
+/// JSON response template for Skia Gold empty tryjob status request.
+String tryjobEmpty() {
+  return '''
+    {
+      "digests": null
+    }
+  ''';
+}
+
+/// JSON response template for Skia Gold empty tryjob status request.
+String tryjobDigests() {
+  return '''
+    {
+      "digests": [
+        "abcd",
+        "efgh",
+        "ijkl"
+      ]
+    }
+  ''';
+}

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -236,8 +236,8 @@ void main() {
               GithubGoldStatusUpdate.statusRunning,
               'abc',
               'Image changes have been found for '
-          'this pull request. Visit https://flutter-gold.skia.org/changelists '
-          'to view and triage (e.g. because this is an intentional change).');
+                  'this pull request. Visit https://flutter-gold.skia.org/changelists '
+                  'to view and triage (e.g. because this is an intentional change).');
           db.values[status.key] = status;
 
           // Checks complete
@@ -403,7 +403,7 @@ void main() {
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
+            (_) => Stream<IssueComment>.value(
               IssueComment()..body = 'some other comment',
             ),
           );
@@ -433,61 +433,64 @@ void main() {
         });
 
         test(
-          'same commit, checks complete, last status was waiting & gold status is needing triage, should comment',
+            'same commit, checks complete, last status was waiting & gold status is needing triage, should comment',
             () async {
-            // Same commit
-            final PullRequest pr = newPullRequest(123, 'abc');
-            prsFromGitHub = <PullRequest>[pr];
-            final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr, GithubGoldStatusUpdate.statusRunning, 'abc', 'This check is waiting for all other checks to be completed.');
-            db.values[status.key] = status;
+          // Same commit
+          final PullRequest pr = newPullRequest(123, 'abc');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr,
+              GithubGoldStatusUpdate.statusRunning,
+              'abc',
+              'This check is waiting for all other checks to be completed.');
+          db.values[status.key] = status;
 
-            // Checks complete
-            statuses = <dynamic>[
-              <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
-              <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
-            ];
+          // Checks complete
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
 
-            // Gold status is running
-            final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-            final MockHttpClientResponse mockHttpResponse =
-            MockHttpClientResponse(utf8.encode(tryjobDigests()));
-            when(mockHttpClient.getUrl(Uri.parse(
-              'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+          // Gold status is running
+          final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
+          final MockHttpClientResponse mockHttpResponse =
+              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer(
-                (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-            when(mockHttpRequest.close()).thenAnswer(
-                (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer(
+              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
-            // Have not already commented for this commit.
-            when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-                (_) => Stream<IssueComment>.value(
-                IssueComment()..body = 'some other comment',
-              ),
-            );
+          // Have not already commented for this commit.
+          when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
+            (_) => Stream<IssueComment>.value(
+              IssueComment()..body = 'some other comment',
+            ),
+          );
 
-            final Body body = await tester.get<Body>(handler);
-            expect(body, same(Body.empty));
-            expect(status.updates, 1);
-            expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
-            expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
 
-            // Should apply labels and make comment
-            verify(issuesService.addLabelsToIssue(
-              slug,
-              pr.number,
-              <String>[
-                'will affect goldens',
-                'severe: API break',
-              ],
-            )).called(1);
+          // Should apply labels and make comment
+          verify(issuesService.addLabelsToIssue(
+            slug,
+            pr.number,
+            <String>[
+              'will affect goldens',
+              'severe: API break',
+            ],
+          )).called(1);
 
-            verify(issuesService.createComment(
-              slug,
-              pr.number,
-              argThat(contains(config.goldenBreakingChangeMessageValue)),
-            )).called(1);
-          });
+          verify(issuesService.createComment(
+            slug,
+            pr.number,
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
+          )).called(1);
+        });
 
         test('same commit, checks complete, new status, should not comment',
             () async {

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -169,7 +169,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(any(String))),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
 
@@ -206,7 +206,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(any(String))),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
 
@@ -243,7 +243,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(any(String))),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
 
@@ -359,7 +359,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(any(String))),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
       });
@@ -398,7 +398,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(any(String))),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
 
@@ -446,7 +446,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.missingTestsPullRequestMessageValue)),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
 
@@ -495,7 +495,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.missingTestsPullRequestMessageValue)),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(1);
         });
 
@@ -552,7 +552,7 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.missingTestsPullRequestMessageValue)),
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(0);
         });
       });

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -57,7 +57,7 @@ void main() {
       );
 
       cirrusGraphQLClient.mutateResultForOptions =
-        (MutationOptions options) => QueryResult();
+          (MutationOptions options) => QueryResult();
 
       cirrusGraphQLClient.queryResultForOptions = (QueryOptions options) {
         return createCirrusQueryResult(statuses);
@@ -74,12 +74,12 @@ void main() {
       test('Does nothing', () async {
         config.githubClient = ThrowingGitHub();
         db.onCommit =
-          (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
-        throw AssertionError();
+            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+                throw AssertionError();
         db.addOnQuery<GithubGoldStatusUpdate>(
             (Iterable<GithubGoldStatusUpdate> results) {
-            throw AssertionError();
-          });
+          throw AssertionError();
+        });
         final Body body = await tester.get<Body>(handler);
         expect(body, same(Body.empty));
       });
@@ -109,7 +109,7 @@ void main() {
       });
 
       GithubGoldStatusUpdate newStatusUpdate(
-        PullRequest pr, String statusUpdate, String sha) {
+          PullRequest pr, String statusUpdate, String sha) {
         return GithubGoldStatusUpdate(
           key: db.emptyKey.append(GithubGoldStatusUpdate),
           status: statusUpdate,
@@ -128,10 +128,10 @@ void main() {
       group('does not update GitHub or Datastore', () {
         setUp(() {
           db.onCommit =
-            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
-          throw AssertionError();
+              (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
+                  throw AssertionError();
           when(repositoriesService.createStatus(any, any, any))
-            .thenThrow(AssertionError());
+              .thenThrow(AssertionError());
         });
 
         test('if there are no PRs', () async {
@@ -178,7 +178,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-          newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
           db.values[status.key] = status;
 
           // Checks still running
@@ -214,8 +214,8 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status =
-            newStatusUpdate(pr, GithubGoldStatusUpdate.statusCompleted, 'abc');
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr, GithubGoldStatusUpdate.statusCompleted, 'abc');
           db.values[status.key] = status;
 
           // Checks complete
@@ -247,12 +247,14 @@ void main() {
           )).called(0);
         });
 
-        test('same commit, checks complete, last status & gold status is running, should comment', () async {
+        test(
+            'same commit, checks complete, last status & gold status is running, should comment',
+            () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-          newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
           db.values[status.key] = status;
 
           // Checks complete
@@ -264,19 +266,17 @@ void main() {
           // Gold status is running
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(tryjobDigests()));
-          when(mockHttpClient
-            .getUrl(Uri.parse(
-              'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged'
-            )))
-            .thenAnswer(
-              (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
+            (_) => Stream<IssueComment>.value(
               IssueComment()..body = 'some other comment',
             ),
           );
@@ -304,12 +304,14 @@ void main() {
           )).called(1);
         });
 
-        test('same commit, checks complete, last status & gold status is running, should not comment', () async {
+        test(
+            'same commit, checks complete, last status & gold status is running, should not comment',
+            () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-          newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
           db.values[status.key] = status;
 
           // Checks complete
@@ -321,21 +323,20 @@ void main() {
           // Gold status is running
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse =
-            MockHttpClientResponse(utf8.encode(tryjobDigests()));
-          when(mockHttpClient
-            .getUrl(Uri.parse(
-              'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged'
-            )))
-            .thenAnswer(
-              (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
-              IssueComment()..body = 'Changes reported for pull request '
-                '${pr.number} at sha ${pr.head.sha}',
+            (_) => Stream<IssueComment>.value(
+              IssueComment()
+                ..body = 'Changes reported for pull request '
+                    '${pr.number} at sha ${pr.head.sha}',
             ),
           );
 
@@ -417,13 +418,11 @@ void main() {
           // Change detected by Gold
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(tryjobEmpty()));
-          when(mockHttpClient
-            .getUrl(Uri.parse(
-            'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged'
-          )))
-            .thenAnswer(
-              (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+              MockHttpClientResponse(utf8.encode(tryjobEmpty()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -451,7 +450,8 @@ void main() {
           )).called(0);
         });
 
-        test('new commit, checks complete, change detected, should comment', () async {
+        test('new commit, checks complete, change detected, should comment',
+            () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
@@ -467,13 +467,11 @@ void main() {
           // Change detected by Gold
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(tryjobDigests()));
-          when(mockHttpClient
-            .getUrl(Uri.parse(
-            'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged'
-          )))
-            .thenAnswer(
-              (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -501,12 +499,13 @@ void main() {
           )).called(1);
         });
 
-        test('same commit, checks complete, new status, should not comment', () async {
+        test('same commit, checks complete, new status, should not comment',
+            () async {
           // Same commit: abc
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-          newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
           db.values[status.key] = status;
 
           // Checks completed
@@ -518,19 +517,17 @@ void main() {
           // New status: completed/triaged/no changes
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse =
-            MockHttpClientResponse(utf8.encode(tryjobEmpty()));
-          when(mockHttpClient
-            .getUrl(Uri.parse(
-              'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged'
-            )))
-            .thenAnswer(
-              (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+              MockHttpClientResponse(utf8.encode(tryjobEmpty()));
+          when(mockHttpClient.getUrl(Uri.parse(
+                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Previous comment was for a separate commit: def
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
+            (_) => Stream<IssueComment>.value(
               IssueComment()..body = 'some other comment',
             ),
           );
@@ -588,12 +585,13 @@ class MockHttpClientResponse extends Mock implements HttpClientResponse {
   @override
   StreamSubscription<List<int>> listen(
     void onData(List<int> event), {
-      Function onError,
-      void onDone(),
-      bool cancelOnError,
-    }) {
+    Function onError,
+    void onDone(),
+    bool cancelOnError,
+  }) {
     return Stream<List<int>>.fromFuture(Future<List<int>>.value(response))
-      .listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+        .listen(onData,
+            onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 }
 

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -110,13 +110,14 @@ void main() {
       });
 
       GithubGoldStatusUpdate newStatusUpdate(
-          PullRequest pr, String statusUpdate, String sha) {
+          PullRequest pr, String statusUpdate, String sha, String description) {
         return GithubGoldStatusUpdate(
           key: db.emptyKey.append(GithubGoldStatusUpdate),
           status: statusUpdate,
           pr: pr.number,
           head: sha,
           updates: 0,
+          description: description,
         );
       }
 
@@ -147,8 +148,12 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            'This check is waiting for all other checks to be completed.',
+          );
           db.values[status.key] = status;
 
           // Checks still running
@@ -185,7 +190,10 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr, GithubGoldStatusUpdate.statusCompleted, 'abc');
+              pr,
+              GithubGoldStatusUpdate.statusCompleted,
+              'abc',
+              'All golden file tests have passed.');
           db.values[status.key] = status;
 
           // Checks complete
@@ -223,8 +231,8 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr, GithubGoldStatusUpdate.statusRunning, 'abc', '');
           db.values[status.key] = status;
 
           // Checks complete
@@ -280,8 +288,11 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr,
+              GithubGoldStatusUpdate.statusRunning,
+              'abc',
+              'This check is waiting for all other checks to be completed.');
           db.values[status.key] = status;
 
           // Checks complete
@@ -339,7 +350,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, null, null);
+          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks running
@@ -376,7 +387,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, null, null);
+          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -425,7 +436,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, null, null);
+          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -474,8 +485,11 @@ void main() {
           // Same commit: abc
           final PullRequest pr = newPullRequest(123, 'abc');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc');
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr,
+              GithubGoldStatusUpdate.statusRunning,
+              'abc',
+              'This check is waiting for all other checks to be completed.');
           db.values[status.key] = status;
 
           // Checks completed

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -226,64 +226,7 @@ void main() {
         });
 
         test(
-            'same commit, checks complete, last status & gold status is running, should comment',
-            () async {
-          // Same commit
-          final PullRequest pr = newPullRequest(123, 'abc');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr, GithubGoldStatusUpdate.statusRunning, 'abc', '');
-          db.values[status.key] = status;
-
-          // Checks complete
-          statuses = <dynamic>[
-            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
-            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
-          ];
-
-          // Gold status is running
-          final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobDigests()));
-          when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-
-          // Have not already commented for this commit.
-          when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-            (_) => Stream<IssueComment>.value(
-              IssueComment()..body = 'some other comment',
-            ),
-          );
-
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(status.updates, 0);
-          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
-          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
-
-          // Should apply labels and make comment
-          verify(issuesService.addLabelsToIssue(
-            slug,
-            pr.number,
-            <String>[
-              'will affect goldens',
-              'severe: API break',
-            ],
-          )).called(1);
-
-          verify(issuesService.createComment(
-            slug,
-            pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
-          )).called(1);
-        });
-
-        test(
-            'same commit, checks complete, last status & gold status is running, should not comment',
+            'same commit, checks complete, last status & gold status is running/awaiting triage, should not comment',
             () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');
@@ -292,7 +235,9 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusRunning,
               'abc',
-              'This check is waiting for all other checks to be completed.');
+              'Image changes have been found for '
+          'this pull request. Visit https://flutter-gold.skia.org/changelists '
+          'to view and triage (e.g. because this is an intentional change).');
           db.values[status.key] = status;
 
           // Checks complete
@@ -456,6 +401,13 @@ void main() {
           when(mockHttpRequest.close()).thenAnswer(
               (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
+          // Have not already commented for this commit.
+          when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
+              (_) => Stream<IssueComment>.value(
+              IssueComment()..body = 'some other comment',
+            ),
+          );
+
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(status.updates, 1);
@@ -479,6 +431,63 @@ void main() {
             argThat(contains(config.goldenBreakingChangeMessageValue)),
           )).called(1);
         });
+
+        test(
+          'same commit, checks complete, last status was waiting & gold status is needing triage, should comment',
+            () async {
+            // Same commit
+            final PullRequest pr = newPullRequest(123, 'abc');
+            prsFromGitHub = <PullRequest>[pr];
+            final GithubGoldStatusUpdate status = newStatusUpdate(
+              pr, GithubGoldStatusUpdate.statusRunning, 'abc', 'This check is waiting for all other checks to be completed.');
+            db.values[status.key] = status;
+
+            // Checks complete
+            statuses = <dynamic>[
+              <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+              <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+            ];
+
+            // Gold status is running
+            final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
+            final MockHttpClientResponse mockHttpResponse =
+            MockHttpClientResponse(utf8.encode(tryjobDigests()));
+            when(mockHttpClient.getUrl(Uri.parse(
+              'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+              .thenAnswer(
+                (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+            when(mockHttpRequest.close()).thenAnswer(
+                (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+
+            // Have not already commented for this commit.
+            when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
+                (_) => Stream<IssueComment>.value(
+                IssueComment()..body = 'some other comment',
+              ),
+            );
+
+            final Body body = await tester.get<Body>(handler);
+            expect(body, same(Body.empty));
+            expect(status.updates, 1);
+            expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+            expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+
+            // Should apply labels and make comment
+            verify(issuesService.addLabelsToIssue(
+              slug,
+              pr.number,
+              <String>[
+                'will affect goldens',
+                'severe: API break',
+              ],
+            )).called(1);
+
+            verify(issuesService.createComment(
+              slug,
+              pr.number,
+              argThat(contains(config.goldenBreakingChangeMessageValue)),
+            )).called(1);
+          });
 
         test('same commit, checks complete, new status, should not comment',
             () async {

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -143,37 +143,6 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
         });
 
-        test('if there are no framework tests for this PR', () async {
-          statuses = <dynamic>[
-            <String, String>{'status': 'EXECUTING', 'name': 'tool-test-1'},
-            <String, String>{'status': 'COMPLETED', 'name': 'tool-test-2'}
-          ];
-          final PullRequest pr = newPullRequest(123, 'abc');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, null, null);
-          db.values[status.key] = status;
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
-          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
-
-          // Should not apply labels or make comments
-          verifyNever(issuesService.addLabelsToIssue(
-            slug,
-            pr.number,
-            <String>[
-              'will affect goldens',
-              'severe: API break',
-            ],
-          ));
-
-          verifyNever(issuesService.createComment(
-            slug,
-            pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
-          ));
-        });
-
         test('same commit, checks running, last status running', () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc');


### PR DESCRIPTION
This change will add a Gold status check to all framework PRs that reflects the state of the current tryjobs run through Flutter Gold for the pr and commit.

This was originally attempted in https://github.com/flutter/flutter/pull/49370 as a Cirrus check. That implementation was subject to timeouts from Cirrus, so it will be implemented here instead.

Adding this check will do a couple of things for improved workflow and productivity.
- This will streamline framework changes.
  - Currently, framework tests fail when a golden file change is detected. After triaging on the Flutter Gold dashboard, the affected test shards need to be re-executed, which in some cases could take over an hour. A follow-up to this change in the framework would remove the failure case on individual test shards, making this check the gatekeeper. It will notify when a golden file change is detected, and once triaged, will update in 3 minutes or less.
- This will help the engine roll go more smoothly when golden files are affected.
  - Currently, the engine auto-roller will repeatedly close attempts to roll into the framework since golden file shards fail. Without a notification or delay for images to be triaged and shards to be re-triggered, this often results in the need for a manual engine roll to check in golden file changes. This will stop the auto-roller from closing the pull request, leaving this check in a running state and notifying the engine sheriff to triage images on the dashboard. Once the images have been triaged, the auto-roller will proceed. Related issue: https://github.com/flutter/flutter/issues/48744