### PR TITLE
WhitelistedAccount field name fix - authentication

### DIFF
--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -225,7 +225,7 @@ class AuthenticationProvider {
   Future<bool> _isWhitelisted(String email) async {
     final Query<WhitelistedAccount> query =
         _config.db.query<WhitelistedAccount>()
-          ..filter('Email =', email)
+          ..filter('email =', email)
           ..limit(20);
 
     return !(await query.run().isEmpty);


### PR DESCRIPTION
This fixes the typo for WhitelistedAccount filed: `Email` to `email`.