### PR TITLE
Slow vacuum clean cron to run hourly

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -9,7 +9,7 @@ cron:
   schedule: every 3 minutes
 - description: clean up stale datastore records
   url: /api/vacuum-clean
-  schedule: every 10 minutes
+  schedule: every 1 hours
 - description: sends build status to GitHub to annotate PRs and commits
   url: /api/push-build-status-to-github
   schedule: every 1 minutes


### PR DESCRIPTION
The vacuum clean handler looks for tasks that are running for more than an hour.

Currently it checks every 10 minutes, which seems excessive with the current usage.