### PR TITLE
Fixed the roll widget to report when a roll has failed.

### DIFF
--- a/app/lib/repository/details/roll.dart
+++ b/app/lib/repository/details/roll.dart
@@ -152,22 +152,21 @@ class AutoRollWidget extends StatelessWidget {
     final SkiaAutoRoll autoRoll = ModelBinding.of<SkiaAutoRoll>(context);
     IconData icon;
     Color backgroundColor;
-    switch (autoRoll.mode) {
-      case 'running':
+    if (autoRoll.mode == 'running') {
+      if (autoRoll.lastRollResult == 'succeeded') {
         icon = Icons.check;
         backgroundColor = Colors.green;
-        break;
-      case 'dry run':
-        icon = Icons.warning;
-        backgroundColor = Colors.amberAccent;
-        break;
-      case 'stopped':
+      } else if (autoRoll.lastRollResult == 'failed') {
         icon = Icons.error;
         backgroundColor = Colors.redAccent;
-        break;
-      default:
-        icon = Icons.help_outline;
-        backgroundColor = Colors.grey;
+      }
+    } else if (autoRoll.mode == 'stopped') {
+      icon = Icons.pause_circle_filled;
+      backgroundColor = Colors.amberAccent;
+    }
+    if (icon == null || backgroundColor == null) {
+      icon = Icons.report_problem;
+      backgroundColor = Colors.grey;
     }
     return ListTile(
         title: Text(name),


### PR DESCRIPTION
Previously the roll dashboard would display green if the last roll failed, but the roller was still running.  That isn't very useful.  I switched it to display red if there was a failure.  This is slightly more useful and consistent with our other reporting.