### PR TITLE
Make health checks resilient to flutter failures.

### DIFF
--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -66,6 +66,7 @@ Future<AgentHealth> performHealthChecks(Agent agent) async {
             } else {
               results['able-to-build-and-sign'] = HealthCheckResult.failure(
                   'Failed to build and sign iOS app.');
+              await getFlutterAt('master');
             }
           });
         } finally {


### PR DESCRIPTION
One health check is creating a flutter app and compiling it. If there is
and error with flutter then the agent will quarantine until we manually
checkout a new version of flutter.

https://github.com/flutter/flutter/issues/51085