### PR TITLE
Enable Mac Web Engine presubmit.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -264,6 +264,10 @@ class Config {
         <String, String>{
           'name': 'Windows Web Engine',
           'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Web Engine',
+          'repo': 'engine',
         }
       ];
 


### PR DESCRIPTION
This PR enables Mac web engine presubmit test.

Related:
https://github.com/flutter/cocoon/pull/645
https://github.com/flutter/flutter/issues/46782