### PR TITLE
Consider SKIPPED status for cirrus graphql API

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -256,7 +256,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       }
     }
 
-    const List<String> _failedStates = <String>['FAILED', 'ERRORED', 'ABORTED'];
+    const List<String> _failedStates = <String>['FAILED', 'ABORTED'];
     const List<String> _succeededStates = <String>['COMPLETED', 'SKIPPED'];
     final GraphQLClient cirrusClient = await config.createCirrusGraphQLClient();
     final List<dynamic> cirrusStatuses =

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -257,6 +257,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     }
 
     const List<String> _failedStates = <String>['FAILED', 'ERRORED', 'ABORTED'];
+    const List<String> _succeededStates = <String>['COMPLETED', 'SKIPPED'];
     final GraphQLClient cirrusClient = await config.createCirrusGraphQLClient();
     final List<dynamic> cirrusStatuses =
         await queryCirrusGraphQL(sha, cirrusClient, log, name);
@@ -266,7 +267,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     for (dynamic runStatus in cirrusStatuses) {
       final String status = runStatus['status'];
       final String name = runStatus['name'];
-      if (status != 'COMPLETED') {
+      if (!_succeededStates.contains(status)) {
         allSuccess = false;
       }
       if (_failedStates.contains(status)) {

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -19,12 +19,16 @@ import '../service/datastore.dart';
 import 'refresh_cirrus_status_queries.dart';
 
 /// Refer all cirrus build statuses at: https://github.com/cirruslabs/cirrus-ci-web/blob/master/schema.graphql#L120
-const List<String> _failedStates = <String>['FAILED', 'ERRORED', 'ABORTED'];
+const List<String> _failedStates = <String>[
+  'ABORTED',
+  'FAILED',
+];
 const List<String> _inProgressStates = <String>[
-  'EXECUTING',
   'CREATED',
   'TRIGGERED',
-  'NEEDS_APPROVAL'
+  'SCHEDULED',
+  'EXECUTING',
+  'PAUSED'
 ];
 
 @immutable

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -178,7 +178,7 @@ void main() {
 
     test('Merge PR with complated tests', () async {
       statuses = <dynamic>[
-        <String, String>{'id': '1', 'status': 'COMPLETED', 'name': 'test1'},
+        <String, String>{'id': '1', 'status': 'SKIPPED', 'name': 'test1'},
         <String, String>{'id': '2', 'status': 'COMPLETED', 'name': 'test2'}
       ];
 


### PR DESCRIPTION
Existing cirrus status logic misses `SKIPPED` status, which causes hang when one task is `SKIPPED`. This will cause PRs not merging forever.

This PR puts `SKIPPED` as a success flag for tasks in cirrus.