### PR TITLE
Added curly braces to analyzer

### DIFF
--- a/app_dart/analysis_options.yaml
+++ b/app_dart/analysis_options.yaml
@@ -88,7 +88,7 @@ linter:
     # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
-    # - curly_braces_in_flow_control_structures # not yet tested
+    - curly_braces_in_flow_control_structures
     # - diagnostic_describe_all_properties # not yet tested
     - directives_ordering
     - empty_catches


### PR DESCRIPTION
Per comment here: https://github.com/flutter/cocoon/pull/651#discussion_r385561485
The current configuration of the analyzer has a contradiction in it.

dartfmt demands this
```dart
if (this) do that;
```

but the analyzer demands
```dart
if (this)
  do that;
```

The **only** way to pass analysis is to include curly braces. 
```dart
if (this) {
  do that;
}
```


Adding this to the analyzer will help alleviate confusion and back & forth when this case presents itself. :)