### PR TITLE
Make task name selectable

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -335,7 +335,7 @@ class TaskOverlayContents extends StatelessWidget {
           ListTile(
             leading:
                 Tooltip(message: taskStatus, child: statusIcon[taskStatus]),
-            title: Text(task.name),
+            title: SelectableText(task.name),
             subtitle: isDevicelab(task)
                 ? Text('Attempts: ${task.attempts}\n'
                     'Run time: ${runDuration.inMinutes} minutes\n'


### PR DESCRIPTION
Currently the git commit SHA is a SelectableText, but task name is not.
That said, when tasks fail, developers frequently want to search the
source for the task in question in order to debug.