### PR TITLE
Support branch parameter for API get-status

### DIFF
--- a/app_dart/index.yaml
+++ b/app_dart/index.yaml
@@ -8,6 +8,11 @@ indexes:
   properties:
   - name: CreateTimestamp
     direction: desc
+- kind: Checklist
+  properties:
+  - name: Branch
+  - name: CreateTimestamp
+    direction: desc
 - kind: Task
   ancestor: yes
   properties:

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -20,7 +20,7 @@ class Commit extends Model {
     this.author,
     this.authorAvatarUrl,
     this.repository,
-    this.branch,
+    this.branch = 'master',
   }) {
     parentKey = key?.parent;
     id = key?.id;

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -32,11 +32,13 @@ class GetStatus extends RequestHandler<Body> {
   final BuildStatusProvider buildStatusProvider;
 
   static const String lastCommitKeyParam = 'lastCommitKey';
+  static const String branchParam = 'branch';
 
   @override
   Future<Body> get() async {
     final String encodedLastCommitKey =
         request.uri.queryParameters[lastCommitKeyParam];
+    final String branch = request.uri.queryParameters[branchParam] ?? 'master';
     final DatastoreService datastore = datastoreProvider();
     final KeyHelper keyHelper = config.keyHelper;
     final int commitNumber = config.commitNumber;
@@ -45,7 +47,7 @@ class GetStatus extends RequestHandler<Body> {
 
     final List<SerializableCommitStatus> statuses = await buildStatusProvider
         .retrieveCommitStatus(
-            limit: commitNumber, timestamp: lastCommitTimestamp)
+            limit: commitNumber, timestamp: lastCommitTimestamp, branch: branch)
         .map<SerializableCommitStatus>((CommitStatus status) =>
             SerializableCommitStatus(
                 status, keyHelper.encode(status.commit.key)))

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -107,10 +107,11 @@ class BuildStatusProvider {
   ///
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
-  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp, String branch}) async* {
+  Stream<CommitStatus> retrieveCommitStatus(
+      {int limit, int timestamp, String branch}) async* {
     final DatastoreService datastore = datastoreProvider();
-    await for (Commit commit
-        in datastore.queryRecentCommits(limit: limit, timestamp: timestamp, branch: branch)) {
+    await for (Commit commit in datastore.queryRecentCommits(
+        limit: limit, timestamp: timestamp, branch: branch)) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -107,10 +107,10 @@ class BuildStatusProvider {
   ///
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
-  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp}) async* {
+  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp, String branch}) async* {
     final DatastoreService datastore = datastoreProvider();
     await for (Commit commit
-        in datastore.queryRecentCommits(limit: limit, timestamp: timestamp)) {
+        in datastore.queryRecentCommits(limit: limit, timestamp: timestamp, branch: branch)) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -43,10 +43,13 @@ class DatastoreService {
   /// The [limit] argument specifies the maximum number of commits to retrieve.
   ///
   /// The returned commits will be ordered by most recent [Commit.timestamp].
-  Stream<Commit> queryRecentCommits({int limit = 100, int timestamp}) {
+  Stream<Commit> queryRecentCommits(
+      {int limit = 100, int timestamp, String branch}) {
     timestamp ??= DateTime.now().millisecondsSinceEpoch;
+    branch ??= 'master';
     final Query<Commit> query = db.query<Commit>()
       ..limit(limit)
+      ..filter('branch =', branch)
       ..order('-timestamp')
       ..filter('timestamp <', timestamp);
     return query.run();

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   googleapis_auth: ^0.2.10
   googleapis: ^0.54.0
   graphql: ^2.1.0
-  http: ^0.12.0
+  http: ^0.12.0+4
   json_annotation: ^3.0.0
   meta: ^1.1.7
   mime: ^0.9.0

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   googleapis_auth: ^0.2.10
   googleapis: ^0.54.0
   graphql: ^2.1.0
-  http: ^0.12.0+4
+  http: ^0.12.0
   json_annotation: ^3.0.0
   meta: ^1.1.7
   mime: ^0.9.0

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -192,7 +192,6 @@ void main() {
       expect(config.db.values.length, 2);
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
-        //GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
         GetStatus.branchParam: branch,
       });
       final Map<String, dynamic> result = await decodeHandlerBody();

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -88,11 +88,13 @@ void main() {
       final Commit commit1 = Commit(
           key: config.db.emptyKey.append(Commit,
               id: 'flutter/flutter/ea28a9c34dc701de891eaf74503ca4717019f829'),
-          timestamp: 3);
+          timestamp: 3,
+          branch: 'master');
       final Commit commit2 = Commit(
           key: config.db.emptyKey.append(Commit,
               id: 'flutter/flutter/d5b0b3c8d1c5fd89302089077ccabbcfaae045e4'),
-          timestamp: 1);
+          timestamp: 1,
+          branch: 'master');
       config.db.values[commit1.key] = commit1;
       config.db.values[commit2.key] = commit2;
       buildStatusProvider = FakeBuildStatusProvider(
@@ -115,11 +117,13 @@ void main() {
       final Commit commit1 = Commit(
           key: config.db.emptyKey.append(Commit,
               id: 'flutter/flutter/ea28a9c34dc701de891eaf74503ca4717019f829'),
-          timestamp: 3);
+          timestamp: 3,
+          branch: 'master');
       final Commit commit2 = Commit(
           key: config.db.emptyKey.append(Commit,
               id: 'flutter/flutter/d5b0b3c8d1c5fd89302089077ccabbcfaae045e4'),
-          timestamp: 1);
+          timestamp: 1,
+          branch: 'master');
       config.db.values[commit1.key] = commit1;
       config.db.values[commit2.key] = commit2;
       buildStatusProvider = FakeBuildStatusProvider(
@@ -152,13 +156,12 @@ void main() {
               'Sha': null,
               'Author': <String, dynamic>{'Login': null, 'avatar_url': null}
             },
-            'Branch': null
+            'Branch': 'master'
           }
         },
         'Stages': <String>[]
       });
     });
-
 
     test('reports statuses with input branch', () async {
       final Commit commit1 = Commit(
@@ -184,12 +187,12 @@ void main() {
         buildStatusProvider: buildStatusProvider,
       );
 
-      const String expectedLastCommitKeyEncoded =
-          'ahNzfmZsdXR0ZXItZGFzaGJvYXJkckcLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci9lYTI4YTljMzRkYzcwMWRlODkxZWFmNzQ1MDNjYTQ3MTcwMTlmODI5DA';
       const String branch = 'v0.0.0';
 
+      expect(config.db.values.length, 2);
+
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
-        GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
+        //GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
         GetStatus.branchParam: branch,
       });
       final Map<String, dynamic> result = await decodeHandlerBody();

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -27,7 +27,8 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
   }
 
   @override
-  Stream<CommitStatus> retrieveCommitStatus({int limit = 100, int timestamp}) {
+  Stream<CommitStatus> retrieveCommitStatus(
+      {int limit = 100, int timestamp, String branch}) {
     if (commitStatuses == null) {
       throw AssertionError();
     }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -36,7 +36,8 @@ class FakeBuildStatusProvider implements BuildStatusProvider {
         a.commit.timestamp.compareTo(b.commit.timestamp));
 
     return Stream<CommitStatus>.fromIterable(commitStatuses.where(
-        (CommitStatus commitStatuse) =>
-            commitStatuse.commit.timestamp < timestamp));
+        (CommitStatus commitStatus) =>
+            commitStatus.commit.timestamp < timestamp &&
+            commitStatus.commit.branch == branch));
   }
 }


### PR DESCRIPTION
This PR prepares for frontend support to list commits w.r.t. different branches. Default lists are for `master`, otherwise it shows corresponding lists when `branch` parameter is specified.

Related issue: https://github.com/flutter/flutter/issues/51807