### PR TITLE
dartfmt only on src directories

### DIFF
--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -14,7 +14,7 @@ pushd $1 > /dev/null
 pub get
 
 echo "############# files that require formatting ###########"
-dartfmt -n --set-exit-if-changed .
+dartfmt -n --set-exit-if-changed lib/ test/ dev/ bin/
 echo "#######################################################"
 
 # agent doesn't use build_runner as of this writing.


### PR DESCRIPTION
```
############# files that require formatting ###########
#######################################################
Failed to precompile build_runner:build_runner:
../../../cache/.pub-cache/hosted/pub.dartlang.org/http_multi_server-2.1.0/lib/src/multi_headers.dart:129:8: Error: The method 'MultiHeaders.set' has fewer named arguments than those of overridden method 'HttpHeaders.set'.
  void set(String name, Object value) {
       ^
org-dartlang-sdk:///sdk/lib/_http/http.dart:703:8: Context: This is the overridden method ('set').
  void set(String name, Object value,
       ^
../../../cache/.pub-cache/hosted/pub.dartlang.org/http_multi_server-2.1.0/lib/src/multi_headers.dart:97:8: Error: The method 'MultiHeaders.add' has fewer named arguments than those of overridden method 'HttpHeaders.add'.
  void add(String name, Object value) {
       ^
org-dartlang-sdk:///sdk/lib/_http/http.dart:694:8: Context: This is the overridden method ('add').
  void add(String name, Object value,
       ^
```

app_dart tests are currently throwing a formatter issue on LUCI. I believe this is due to it running dartfmt on all the files in app_dart when it should just do it to the src directories.