### PR TITLE
Update app_dart readme with how to run the tests

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -4,6 +4,10 @@ This folder contains a Dart based backend for Cocoon.
 
 ## Building and running
 
+### Running the tests
+
+`pub run test`
+
 ### Running codegen
 
 #### JSON


### PR DESCRIPTION
This was done in GitHub. A trailing white space was removed on another line :tada: 