### PR TITLE
Fix Flutter app tests that rely on BoxDecoration for color checks

### DIFF
--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -24,7 +24,8 @@ class TaskBox extends StatefulWidget {
       {Key key,
       @required this.buildState,
       @required this.task,
-      @required this.commit})
+      @required this.commit,
+      @visibleForTesting this.insertColorKeys = false})
       : assert(task != null),
         assert(buildState != null),
         assert(commit != null),
@@ -38,6 +39,9 @@ class TaskBox extends StatefulWidget {
 
   /// [Commit] for cirrus tasks to show log.
   final Commit commit;
+
+  /// Test variable for storing the color in the key.
+  final bool insertColorKeys;
 
   /// Status messages that map to TaskStatus enums.
   // TODO(chillers): Remove these and use TaskStatus enum when available. https://github.com/flutter/cocoon/issues/441
@@ -94,16 +98,19 @@ class _TaskBoxState extends State<TaskBox> {
       }
     }
 
+    final Color taskColor = TaskBox.statusColor.containsKey(status)
+        ? TaskBox.statusColor[status]
+        : Colors.black;
+
     return SizedBox(
+      key: widget.insertColorKeys ? Key(taskColor.toString()) : null,
       width: StatusGrid.cellSize,
       height: StatusGrid.cellSize,
       child: GestureDetector(
         onTap: _handleTap,
         child: Container(
           margin: const EdgeInsets.all(1.0),
-          color: TaskBox.statusColor.containsKey(status)
-              ? TaskBox.statusColor[status]
-              : Colors.black,
+          color: taskColor,
           child: taskIndicators(widget.task, status),
         ),
       ),

--- a/app_flutter/lib/task_box.dart
+++ b/app_flutter/lib/task_box.dart
@@ -20,13 +20,13 @@ import 'task_helper.dart';
 /// with a [CircularProgressIndicator] in the box.
 /// Shows a black box for unknown statuses.
 class TaskBox extends StatefulWidget {
-  const TaskBox(
-      {Key key,
-      @required this.buildState,
-      @required this.task,
-      @required this.commit,
-      @visibleForTesting this.insertColorKeys = false})
-      : assert(task != null),
+  const TaskBox({
+    Key key,
+    @required this.buildState,
+    @required this.task,
+    @required this.commit,
+    @visibleForTesting this.insertColorKeys = false,
+  })  : assert(task != null),
         assert(buildState != null),
         assert(commit != null),
         super(key: key);

--- a/app_flutter/test/task_box_test.dart
+++ b/app_flutter/test/task_box_test.dart
@@ -71,14 +71,14 @@ void main() {
             buildState: buildState,
             task: repeatTask,
             commit: Commit(),
+            insertColorKeys: true,
           ),
         ),
       );
 
-      final Container taskBoxWidget =
-          find.byType(Container).evaluate().first.widget;
-      final BoxDecoration decoration = taskBoxWidget.decoration;
-      expect(decoration.color, Colors.orange);
+      final SizedBox taskBoxWidget =
+          find.byKey(Key(Colors.orange.toString())).evaluate().first.widget;
+      expect(taskBoxWidget, isNotNull);
     });
 
     testWidgets(
@@ -94,14 +94,14 @@ void main() {
             buildState: buildState,
             task: repeatTask,
             commit: Commit(),
+            insertColorKeys: true,
           ),
         ),
       );
 
-      final Container taskBoxWidget =
-          find.byType(Container).evaluate().first.widget;
-      final BoxDecoration decoration = taskBoxWidget.decoration;
-      expect(decoration.color, Colors.orange);
+      final SizedBox taskBoxWidget =
+          find.byKey(Key(Colors.orange.toString())).evaluate().first.widget;
+      expect(taskBoxWidget, isNotNull);
       expect(find.byIcon(Icons.timelapse), findsOneWidget);
     });
 
@@ -153,14 +153,14 @@ void main() {
             buildState: buildState,
             task: repeatTask,
             commit: Commit(),
+            insertColorKeys: true,
           ),
         ),
       );
 
-      final Container taskBoxWidget =
-          find.byType(Container).evaluate().first.widget;
-      final BoxDecoration decoration = taskBoxWidget.decoration;
-      expect(decoration.color, Colors.yellow);
+      final SizedBox taskBoxWidget =
+          find.byKey(Key(Colors.yellow.toString())).evaluate().first.widget;
+      expect(taskBoxWidget, isNotNull);
     });
 
     testWidgets('is the color black when given an unknown message',
@@ -627,14 +627,14 @@ Future<void> expectTaskBoxColorWithMessage(
         buildState: FlutterBuildState(),
         task: Task()..status = message,
         commit: Commit(),
+        insertColorKeys: true,
       ),
     ),
   );
 
-  final Container taskBoxWidget =
-      find.byType(Container).evaluate().first.widget;
-  final BoxDecoration decoration = taskBoxWidget.decoration;
-  expect(decoration.color, expectedColor);
+  final SizedBox taskBoxWidget =
+      find.byKey(Key(expectedColor.toString())).evaluate().first.widget;
+  expect(taskBoxWidget, isNotNull);
 }
 
 class MockFlutterBuildState extends Mock implements FlutterBuildState {}


### PR DESCRIPTION
Update the tests to use `Key` instead of `BoxDecoration` for how they verify `TaskBox` is behaving how it should.

## Issues

https://github.com/flutter/flutter/issues/52147