### PR TITLE
Remove signing helloworld app check.

### DIFF
--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -47,34 +47,6 @@ Future<AgentHealth> performHealthChecks(Agent agent) async {
         results['cocoon-authentication'] = HealthCheckResult.success();
       }
     });
-    if (Platform.isMacOS &&
-        config.deviceOperatingSystem == DeviceOperatingSystem.ios) {
-      results['ios'] = await _captureErrors(() async {
-        final Directory tempDir =
-            Directory.systemTemp.createTempSync('health_tmp');
-        final Directory projectDir =
-            Directory(path.join(tempDir.path, 'hello'));
-        try {
-          await inDirectory(tempDir, () async {
-            await flutter('create', options: <String>['hello']);
-          });
-
-          await inDirectory(projectDir, () async {
-            int exitCode = await flutter('build', options: <String>['ios']);
-            if (exitCode == 0) {
-              results['able-to-build-and-sign'] = HealthCheckResult.success();
-            } else {
-              results['able-to-build-and-sign'] = HealthCheckResult.failure(
-                  'Failed to build and sign iOS app.');
-              await getFlutterAt('master');
-            }
-          });
-        } finally {
-          rrm(tempDir);
-        }
-      });
-    }
-
     results['remove-xcode-derived-data'] =
         await _captureErrors(removeXcodeDerivedData);
   });


### PR DESCRIPTION
When devicelab was having signing issues we added a health check that
created and app, build it and sign it. Later on we had some issues
where a problem with flutter sdk cause all the test beds to get
quarantined as soon as it was running test.

App signing has been very stable recently and we don't need this health
check anymore. We are removing it to get a couple of minutes of
execution time back.

Bug:
https://github.com/flutter/flutter/issues/52286