### PR TITLE
Lock version of build_web_compilers.

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   # Enables the `pub run build_runner` command
   build_runner: ^1.1.2
   # Includes the JavaScript compilers
-  build_web_compilers: ^1.0.0
+  build_web_compilers: 1.2.3
   flutter_web_test: any
 
 dependency_overrides:


### PR DESCRIPTION
New versions of build_web_compilers are failing and we need to lock it
to the latest good known version.

Bug:

https://github.com/flutter/flutter/issues/52362