### PR TITLE
Add transaction retries.

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -4,15 +4,20 @@
 
 import 'package:gcloud/datastore.dart';
 import 'package:retry/retry.dart';
+import 'package:grpc/grpc.dart';
 
 typedef RetryHandler = Function();
 
 // Runs a db transaction with retries.
 //
 // It uses quadratic backoff starting with 50ms and 3 max attempts.
-Future<void> runTransactionWithRetries(RetryHandler retryHandler) {
-  const RetryOptions r =
-      RetryOptions(delayFactor: Duration(milliseconds: 50), maxAttempts: 3);
-  return r.retry(retryHandler,
-      retryIf: (Exception e) => e is TransactionAbortedError);
+Future<void> runTransactionWithRetries(RetryHandler retryHandler,
+    {int delayMilliseconds = 50, int maxAttempts = 3}) {
+  final RetryOptions r = RetryOptions(
+      delayFactor: Duration(milliseconds: delayMilliseconds),
+      maxAttempts: maxAttempts);
+  return r.retry(
+    retryHandler,
+    retryIf: (Exception e) => e is TransactionAbortedError || e is GrpcError,
+  );
 }

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -1,0 +1,18 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:gcloud/datastore.dart';
+import 'package:retry/retry.dart';
+
+typedef RetryHandler = Function();
+
+// Runs a db transaction with retries.
+//
+// It uses quadratic backoff starting with 50ms and 3 max attempts.
+Future<void> runTransactionWithRetries(RetryHandler retryHandler) {
+  const RetryOptions r =
+      RetryOptions(delayFactor: Duration(milliseconds: 50), maxAttempts: 3);
+  return r.retry(retryHandler,
+      retryIf: (Exception e) => e is TransactionAbortedError);
+}

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:gcloud/datastore.dart';
+import 'package:grpc/grpc.dart';
+
+import 'package:cocoon_service/src/foundation/utils.dart';
+
+class Counter {
+  int count = 0;
+  void increase() {
+    count = count + 1;
+  }
+
+  int value() {
+    return count;
+  }
+}
+
+void main() {
+  group('RunTransactionWithRetry', () {
+    test('retriesOnGrpcError', () async {
+      final Counter counter = Counter();
+      try {
+        await runTransactionWithRetries(() async {
+          counter.increase();
+          throw GrpcError.aborted();
+        });
+      } catch (e) {
+        expect(e, isA<GrpcError>());
+      }
+      expect(counter.value(), greaterThan(1));
+    });
+    test('retriesTransactionAbortedError', () async {
+      final Counter counter = Counter();
+      try {
+        await runTransactionWithRetries(() async {
+          counter.increase();
+          throw TransactionAbortedError();
+        });
+      } catch (e) {
+        expect(e, isA<TransactionAbortedError>());
+      }
+      expect(counter.value(), greaterThan(1));
+    });
+    test('DoesNotRetryOnSuccess', () async {
+      final Counter counter = Counter();
+      await runTransactionWithRetries(() async {
+        counter.increase();
+      });
+      expect(counter.value(), equals(1));
+    });
+  });
+}


### PR DESCRIPTION
Most of the 500 errors in the backend are related to failing
transactions. This change adds retries with quadratic backoffs to remove
the flakiness.

Bugs:

https://github.com/flutter/flutter/issues/42524
https://github.com/flutter/flutter/issues/43112
https://github.com/flutter/flutter/issues/49673
https://github.com/flutter/flutter/issues/49672