### PR TITLE
Cocoon getFlutterBranches()

### DIFF
--- a/app_flutter/lib/build_dashboard_page.dart
+++ b/app_flutter/lib/build_dashboard_page.dart
@@ -37,7 +37,7 @@ class _BuildDashboardPageState extends State<BuildDashboardPage> {
   void initState() {
     super.initState();
 
-    widget.buildState.startFetchingBuildStateUpdates();
+    widget.buildState.startFetchingUpdates();
 
     widget.buildState.errors.addListener(_showErrorSnackbar);
   }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -116,6 +116,28 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   @override
+  Future<CocoonResponse<List<String>>> fetchFlutterBranches() async {
+    final String getBranchesUrl = _apiEndpoint('/api/public/get-branches');
+
+    /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
+    final http.Response response = await _client.get(getBranchesUrl);
+
+    if (response.statusCode != HttpStatus.ok) {
+      print(response.body);
+      return CocoonResponse<List<String>>()
+        ..error = '/api/public/get-branches returned ${response.statusCode}';
+    }
+
+    try {
+      final List<String> jsonResponse = jsonDecode(response.body);
+      return CocoonResponse<List<String>>()
+        ..data = jsonResponse;
+    } catch (error) {
+      return CocoonResponse<List<String>>()..error = error.toString();
+    }
+  }
+
+  @override
   Future<bool> rerunTask(Task task, String idToken) async {
     assert(idToken != null);
     final String postResetTaskUrl = _apiEndpoint('/api/reset-devicelab-task');

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -119,7 +119,7 @@ class AppEngineCocoonService implements CocoonService {
   Future<CocoonResponse<List<String>>> fetchFlutterBranches() async {
     final String getBranchesUrl = _apiEndpoint('/api/public/get-branches');
 
-    /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
+    /// This endpoint returns JSON {"Branches": List<String>}
     final http.Response response = await _client.get(getBranchesUrl);
 
     if (response.statusCode != HttpStatus.ok) {
@@ -129,9 +129,9 @@ class AppEngineCocoonService implements CocoonService {
     }
 
     try {
-      final List<String> jsonResponse = jsonDecode(response.body);
-      return CocoonResponse<List<String>>()
-        ..data = jsonResponse;
+      final Map<String, dynamic> jsonResponse = jsonDecode(response.body);
+      final List<String> branches = jsonResponse['Branches'].cast<String>();
+      return CocoonResponse<List<String>>()..data = branches;
     } catch (error) {
       return CocoonResponse<List<String>>()..error = error.toString();
     }

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -39,6 +39,9 @@ abstract class CocoonService {
   /// Get the current Flutter infra agent statuses.
   Future<CocoonResponse<List<Agent>>> fetchAgentStatuses();
 
+  /// Get the current list of version branches in flutter/flutter.
+  Future<CocoonResponse<List<String>>> fetchFlutterBranches();
+
   /// Send rerun [Task] command to devicelab.
   ///
   /// Will not rerun tasks that are outside of devicelab.

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -37,6 +37,12 @@ class FakeCocoonService implements CocoonService {
   }
 
   @override
+  Future<CocoonResponse<List<String>>> fetchFlutterBranches() async {
+    return CocoonResponse<List<String>>()
+      ..data = <String>['master', 'dev', 'beta', 'stable'];
+  }
+
+  @override
   Future<bool> rerunTask(Task task, String accessToken) async {
     return false;
   }

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -114,7 +114,7 @@ class FlutterBuildState extends ChangeNotifier {
   }
 
   Future<List<String>> _fetchFlutterBranches() async {
-    _cocoonService
+    return _cocoonService
         .fetchFlutterBranches()
         .then((CocoonResponse<List<String>> response) {
       if (response.error != null) {

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -67,7 +67,7 @@ class FlutterBuildState extends ChangeNotifier {
       'An error occured fetching branches from flutter/flutter on Cocoon.';
 
   /// Start a fixed interval loop that fetches build state updates based on [refreshRate].
-  Future<void> startFetchingBuildStateUpdates() async {
+  Future<void> startFetchingUpdates() async {
     if (refreshTimer != null) {
       // There's already an update loop, no need to make another.
       return;

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -486,7 +486,10 @@ void main() {
       final CocoonResponse<List<String>> branches =
           await service.fetchFlutterBranches();
 
-      expect(branches.data, <String>['master', 'flutter-0.0-candidate.1',]);
+      expect(branches.data, <String>[
+        'master',
+        'flutter-0.0-candidate.1',
+      ]);
     });
 
     /// This requires a separate test run on the web platform.

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -36,13 +36,12 @@ void main() {
       when(mockService.fetchTreeBuildStatus()).thenAnswer((_) =>
           Future<CocoonResponse<bool>>.value(
               CocoonResponse<bool>()..data = true));
-      when(mockService.fetchFlutterBranches()).thenAnswer((_) => 
+      when(mockService.fetchFlutterBranches()).thenAnswer((_) =>
           Future<CocoonResponse<List<String>>>.value(
               CocoonResponse<List<String>>()..data = <String>['master']));
     });
 
-    testWidgets('start calls fetch branches',
-        (WidgetTester tester) async {
+    testWidgets('start calls fetch branches', (WidgetTester tester) async {
       buildState.startFetchingBuildStateUpdates();
 
       // startFetching immediately starts fetching results

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -36,6 +36,21 @@ void main() {
       when(mockService.fetchTreeBuildStatus()).thenAnswer((_) =>
           Future<CocoonResponse<bool>>.value(
               CocoonResponse<bool>()..data = true));
+      when(mockService.fetchFlutterBranches()).thenAnswer((_) => 
+          Future<CocoonResponse<List<String>>>.value(
+              CocoonResponse<List<String>>()..data = <String>['master']));
+    });
+
+    testWidgets('start calls fetch branches',
+        (WidgetTester tester) async {
+      buildState.startFetchingBuildStateUpdates();
+
+      // startFetching immediately starts fetching results
+      verify(mockService.fetchFlutterBranches()).called(1);
+
+      // Tear down fails to cancel the timer
+      await tester.pump(buildState.refreshRate * 2);
+      buildState.dispose();
     });
 
     testWidgets('timer should periodically fetch updates',

--- a/app_flutter/test/state/flutter_build_test.dart
+++ b/app_flutter/test/state/flutter_build_test.dart
@@ -42,7 +42,7 @@ void main() {
     });
 
     testWidgets('start calls fetch branches', (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       // startFetching immediately starts fetching results
       verify(mockService.fetchFlutterBranches()).called(1);
@@ -54,7 +54,7 @@ void main() {
 
     testWidgets('timer should periodically fetch updates',
         (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       // startFetching immediately starts fetching results
       verify(mockService.fetchCommitStatuses()).called(1);
@@ -70,11 +70,11 @@ void main() {
 
     testWidgets('multiple start updates should not change the timer',
         (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
       final Timer refreshTimer = buildState.refreshTimer;
 
       // This second run should not change the refresh timer
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       expect(refreshTimer, equals(buildState.refreshTimer));
 
@@ -88,7 +88,7 @@ void main() {
 
     testWidgets('statuses error should not delete previous statuses data',
         (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       // Periodic timers don't necessarily run at the same time in each interval.
       // We double the refreshRate to gurantee a call would have been made.
@@ -113,7 +113,7 @@ void main() {
     testWidgets(
         'build status error should not delete previous build status data',
         (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       // Periodic timers don't necessarily run at the same time in each interval.
       // We double the refreshRate to gurantee a call would have been made.
@@ -137,7 +137,7 @@ void main() {
 
     testWidgets('fetch more commit statuses appends',
         (WidgetTester tester) async {
-      buildState.startFetchingBuildStateUpdates();
+      buildState.startFetchingUpdates();
 
       await untilCalled(mockService.fetchCommitStatuses());
 

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -48,4 +48,7 @@ class FakeFlutterBuildState extends ChangeNotifier
 
   @override
   Future<void> fetchMoreCommitStatuses() => null;
+
+  @override
+  List<String> get branches => <String>['master'];
 }

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -38,7 +38,7 @@ class FakeFlutterBuildState extends ChangeNotifier
   Future<void> signOut() => null;
 
   @override
-  Future<void> startFetchingBuildStateUpdates() => null;
+  Future<void> startFetchingUpdates() => null;
 
   @override
   List<CommitStatus> statuses = <CommitStatus>[];


### PR DESCRIPTION
This adds the necessary backend in the Flutter app to get the list of branches from Cocoon. It defaults to showing just the `master` branch until data is loaded. The branch list is not refreshed after the initial load of the app.

# Tests

Tested all possible points of error like the other cocoon service functions are.

Tested that on start of the Flutter build state this `getFlutterBranches()` is called.

# Issues 

https://github.com/flutter/flutter/issues/51807 - Flutter branching for releases

# Future Work

Enable UI in the Flutter app to switch the current branch