### PR TITLE
Add force-deploy and help flags to deploy script

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -106,6 +106,12 @@ $ dart dev/deploy.dart --project PROJECT_ID --version VERSION
 The deploy script will build the Flutter project and copy it over for deployment.
 Then it will use the Google Cloud CLI to deploy the project to AppEngine.
 
+For more options run:
+
+```sh
+$ dart dev/deploy.dart --help
+```
+
 ### Branching support for flutter repo
 
 Define branch regular expressions in `dev/branch_regexps.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).

--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -17,7 +17,7 @@ const String gcloudProjectVersionFlag = 'version';
 const String gcloudProjectVersionAbbrFlag = 'v';
 
 const String flutterProfileModeFlag = 'profile';
-const String ignoreVersionFlag = 'force-deploy';
+const String ignoreVersionFlag = 'ignore-version-check';
 const String helpFlag = 'help';
 
 String _gcloudProjectId;


### PR DESCRIPTION
There was an issue this past week in deploying where the latest Flutter dev channel broke Cocoon. To prevent these breakages is WIP and being tracked in https://github.com/flutter/flutter/issues/52147

This allows us to pass --force-deploy to ignore Flutter not being a recent version from the past 3 weeks.

Added help dialog to have the deploy script document itself.