### PR TITLE
Fix agent lint issue

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -633,7 +633,7 @@ List<String> runningProcessesOnWindows(String processName) {
       .runSync(<String>['powershell', 'Get-CimInstance', 'Win32_Process']);
   List<String> pids = <String>[];
   if (result.exitCode == 0) {
-    String stdoutResult = result.stdout as String;
+    final String stdoutResult = result.stdout as String;
     for (String rawProcess in stdoutResult.split('\n')) {
       final String process = rawProcess.trim();
       if (!process.contains(processName)) {

--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -633,7 +633,8 @@ List<String> runningProcessesOnWindows(String processName) {
       .runSync(<String>['powershell', 'Get-CimInstance', 'Win32_Process']);
   List<String> pids = <String>[];
   if (result.exitCode == 0) {
-    for (String rawProcess in result.stdout.split('\n')) {
+    String stdoutResult = result.stdout as String;
+    for (String rawProcess in stdoutResult.split('\n')) {
       final String process = rawProcess.trim();
       if (!process.contains(processName)) {
         continue;


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/691 and https://github.com/flutter/cocoon/pull/690 (and any new PRs to Cocoon) are blocked due to some lint issue with the agent:

```
  error - The type 'Iterable<dynamic>' used in the 'for' loop must implement Iterable with a type argument that can be assigned to 'String' at lib/src/utils.dart:636:31 - (for_in_of_invalid_element_type)
```

I believe this is due to the Dart tests using the latest dev channel, and this issue is now rolled into Cocoon.