### PR TITLE
Explicitly use the master branch in build dashboard

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -310,7 +310,7 @@ class AppEngineCocoonService implements CocoonService {
   /// production endpoint.
   ///
   /// The urlSuffix begins with a slash, e.g. "/api/public/get-status".
-  /// 
+  ///
   /// [queryParameters] are appended to the url and are url encoded.
   @visibleForTesting
   String apiEndpoint(

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -310,6 +310,8 @@ class AppEngineCocoonService implements CocoonService {
   /// production endpoint.
   ///
   /// The urlSuffix begins with a slash, e.g. "/api/public/get-status".
+  /// 
+  /// [queryParameters] are appended to the url and are url encoded.
   @visibleForTesting
   String apiEndpoint(
     String urlSuffix, {

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -31,10 +31,13 @@ abstract class CocoonService {
   /// [List<CommitStatus>] after [lastCommitStatus], not including it.
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
+    String branch,
   });
 
   /// Gets the current build status of flutter/flutter.
-  Future<CocoonResponse<bool>> fetchTreeBuildStatus();
+  Future<CocoonResponse<bool>> fetchTreeBuildStatus({
+    String branch,
+  });
 
   /// Get the current Flutter infra agent statuses.
   Future<CocoonResponse<List<Agent>>> fetchAgentStatuses();

--- a/app_flutter/lib/service/fake_cocoon.dart
+++ b/app_flutter/lib/service/fake_cocoon.dart
@@ -21,13 +21,16 @@ class FakeCocoonService implements CocoonService {
   @override
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
+    String branch,
   }) async {
     return CocoonResponse<List<CommitStatus>>()
       ..data = _createFakeCommitStatuses();
   }
 
   @override
-  Future<CocoonResponse<bool>> fetchTreeBuildStatus() async {
+  Future<CocoonResponse<bool>> fetchTreeBuildStatus({
+    String branch,
+  }) async {
     return CocoonResponse<bool>()..data = random.nextBool();
   }
 

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -51,7 +51,7 @@ class FlutterBuildState extends ChangeNotifier {
   List<String> _branches = <String>['master'];
   List<String> get branches => _branches;
 
-  String _currentBranch = 'master';
+  final String _currentBranch = 'master';
   String get currentBranch => _currentBranch;
 
   /// A [ChangeNotifer] for knowing when errors occur that relate to this [FlutterBuildState].
@@ -84,11 +84,6 @@ class FlutterBuildState extends ChangeNotifier {
 
     refreshTimer =
         Timer.periodic(refreshRate, (_) => _fetchBuildStatusUpdate());
-  }
-
-  /// Switch the current branch being displayed on the build dashboard.
-  Future<void> updateBranch(String branch) {
-    _currentBranch = branch;
   }
 
   /// Request the latest [statuses] and [isTreeBuilding] from [CocoonService].

--- a/app_flutter/lib/state/flutter_build.dart
+++ b/app_flutter/lib/state/flutter_build.dart
@@ -51,6 +51,9 @@ class FlutterBuildState extends ChangeNotifier {
   List<String> _branches = <String>['master'];
   List<String> get branches => _branches;
 
+  String _currentBranch = 'master';
+  String get currentBranch => _currentBranch;
+
   /// A [ChangeNotifer] for knowing when errors occur that relate to this [FlutterBuildState].
   FlutterBuildStateErrors errors = FlutterBuildStateErrors();
 
@@ -83,11 +86,18 @@ class FlutterBuildState extends ChangeNotifier {
         Timer.periodic(refreshRate, (_) => _fetchBuildStatusUpdate());
   }
 
+  /// Switch the current branch being displayed on the build dashboard.
+  Future<void> updateBranch(String branch) {
+    _currentBranch = branch;
+  }
+
   /// Request the latest [statuses] and [isTreeBuilding] from [CocoonService].
   Future<void> _fetchBuildStatusUpdate() async {
     await Future.wait(<Future<void>>[
       _cocoonService
-          .fetchCommitStatuses()
+          .fetchCommitStatuses(
+        branch: _currentBranch,
+      )
           .then((CocoonResponse<List<CommitStatus>> response) {
         if (response.error != null) {
           print(response.error);
@@ -99,7 +109,9 @@ class FlutterBuildState extends ChangeNotifier {
         notifyListeners();
       }),
       _cocoonService
-          .fetchTreeBuildStatus()
+          .fetchTreeBuildStatus(
+        branch: _currentBranch,
+      )
           .then((CocoonResponse<bool> response) {
         if (response.error != null) {
           print(response.error);

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -111,7 +111,7 @@ const String jsonBuildStatusFalseResponse = '''
 ''';
 
 void main() {
-  group('AppEngine CocoonService fetchCommitStatus ', () {
+  group('AppEngine CocoonService fetchCommitStatus', () {
     AppEngineCocoonService service;
 
     setUp(() async {
@@ -170,10 +170,10 @@ void main() {
       await service.fetchCommitStatuses();
 
       if (kIsWeb) {
-        verify(mockClient.get('/api/public/get-status'));
+        verify(mockClient.get('/api/public/get-status?branch=master'));
       } else {
         verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-status'));
+            'https://flutter-dashboard.appspot.com/api/public/get-status?branch=master'));
       }
     });
 
@@ -191,11 +191,11 @@ void main() {
       await service.fetchCommitStatuses(lastCommitStatus: status);
 
       if (kIsWeb) {
-        verify(
-            mockClient.get('/api/public/get-status?lastCommitKey=iamatestkey'));
+        verify(mockClient.get(
+            '/api/public/get-status?lastCommitKey=iamatestkey&branch=master'));
       } else {
         verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-status?lastCommitKey=iamatestkey'));
+            'https://flutter-dashboard.appspot.com/api/public/get-status?lastCommitKey=iamatestkey&branch=master'));
       }
     });
 
@@ -218,7 +218,7 @@ void main() {
     });
   });
 
-  group('AppEngine CocoonService fetchTreeBuildStatus ', () {
+  group('AppEngine CocoonService fetchTreeBuildStatus', () {
     AppEngineCocoonService service;
 
     setUp(() async {
@@ -262,10 +262,10 @@ void main() {
       await service.fetchTreeBuildStatus();
 
       if (kIsWeb) {
-        verify(mockClient.get('/api/public/build-status'));
+        verify(mockClient.get('/api/public/build-status?branch=master'));
       } else {
         verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/build-status'));
+            'https://flutter-dashboard.appspot.com/api/public/build-status?branch=master'));
       }
     });
 
@@ -368,8 +368,7 @@ void main() {
 
       test('should send correct request to downloader service', () async {
         final Downloader mockDownloader = MockDownloader();
-        when(mockDownloader.download(
-                argThat(contains('/api/get-log?ownerKey=')),
+        when(mockDownloader.download(argThat(contains('/api/get-log?ownerKey')),
                 'test_task_shashan_1.log',
                 idToken: 'abc123'))
             .thenAnswer((_) => Future<bool>.value(true));

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -179,6 +179,24 @@ void main() {
       }
     });
 
+    /// This requires a separate test run on the web platform.
+    test('should query correct endpoint when given a specific branch',
+        () async {
+      final Client mockClient = MockHttpClient();
+      when(mockClient.get(any))
+          .thenAnswer((_) => Future<Response>.value(Response('', 200)));
+      service = AppEngineCocoonService(client: mockClient);
+
+      await service.fetchCommitStatuses(branch: 'stable');
+
+      if (kIsWeb) {
+        verify(mockClient.get('/api/public/get-status?branch=stable'));
+      } else {
+        verify(
+            mockClient.get('$_baseApiUrl/api/public/get-status?branch=stable'));
+      }
+    });
+
     test(
         'given last commit status should query correct endpoint whether web or mobile',
         () async {
@@ -271,6 +289,24 @@ void main() {
       }
     });
 
+    /// This requires a separate test run on the web platform.
+    test('should query correct endpoint when given a specific branch',
+        () async {
+      final Client mockClient = MockHttpClient();
+      when(mockClient.get(any))
+          .thenAnswer((_) => Future<Response>.value(Response('', 200)));
+      service = AppEngineCocoonService(client: mockClient);
+
+      await service.fetchTreeBuildStatus(branch: 'stable');
+
+      if (kIsWeb) {
+        verify(mockClient.get('/api/public/build-status?branch=stable'));
+      } else {
+        verify(mockClient
+            .get('$_baseApiUrl/api/public/build-status?branch=stable'));
+      }
+    });
+
     test('should have error if given non-200 response', () async {
       service = AppEngineCocoonService(
           client: MockClient((Request request) async => Response('', 404)));
@@ -288,107 +324,107 @@ void main() {
           await service.fetchTreeBuildStatus();
       expect(response.error, isNotNull);
     });
+  });
 
-    group('AppEngine CocoonService rerun task', () {
-      AppEngineCocoonService service;
+  group('AppEngine CocoonService rerun task', () {
+    AppEngineCocoonService service;
 
-      setUp(() {
-        service =
-            AppEngineCocoonService(client: MockClient((Request request) async {
-          return Response('', 200);
-        }));
-      });
-
-      test('should return true if request succeeds', () async {
-        expect(
-            await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
-            true);
-      });
-
-      test('should return false if request failed', () async {
-        service =
-            AppEngineCocoonService(client: MockClient((Request request) async {
-          return Response('', 500);
-        }));
-
-        expect(
-            await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
-            false);
-      });
-
-      test('should return false if task key is null', () async {
-        expect(service.rerunTask(Task(), null),
-            throwsA(const TypeMatcher<AssertionError>()));
-      });
-
-      /// This requires a separate test run on the web platform.
-      test('should query correct endpoint whether web or mobile', () async {
-        final Client mockClient = MockHttpClient();
-        when(mockClient.post(argThat(endsWith('/api/reset-devicelab-task')),
-                headers: captureAnyNamed('headers'),
-                body: captureAnyNamed('body')))
-            .thenAnswer((_) => Future<Response>.value(Response('', 200)));
-        service = AppEngineCocoonService(client: mockClient);
-
-        await service.rerunTask(Task(), '');
-
-        if (kIsWeb) {
-          verify(mockClient.post(
-            '/api/reset-devicelab-task',
-            headers: captureAnyNamed('headers'),
-            body: captureAnyNamed('body'),
-          ));
-        } else {
-          verify(mockClient.post(
-            '$_baseApiUrl/api/reset-devicelab-task',
-            headers: captureAnyNamed('headers'),
-            body: captureAnyNamed('body'),
-          ));
-        }
-      });
+    setUp(() {
+      service =
+          AppEngineCocoonService(client: MockClient((Request request) async {
+        return Response('', 200);
+      }));
     });
 
-    group('AppEngine CocoonService download log', () {
-      AppEngineCocoonService service;
+    test('should return true if request succeeds', () async {
+      expect(
+          await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
+          true);
+    });
 
-      setUp(() {
-        service =
-            AppEngineCocoonService(client: MockClient((Request request) async {
-          return Response('', 200);
-        }));
-      });
+    test('should return false if request failed', () async {
+      service =
+          AppEngineCocoonService(client: MockClient((Request request) async {
+        return Response('', 500);
+      }));
 
-      test('should throw assertion error if task is null', () async {
-        expect(service.downloadLog(null, 'abc123', 'shashank'),
-            throwsA(const TypeMatcher<AssertionError>()));
-      });
+      expect(
+          await service.rerunTask(Task()..key = RootKey(), 'fakeAccessToken'),
+          false);
+    });
 
-      test('should throw assertion error if id token is null', () async {
-        expect(service.downloadLog(Task()..key = RootKey(), null, 'shashank'),
-            throwsA(const TypeMatcher<AssertionError>()));
-      });
+    test('should return false if task key is null', () async {
+      expect(service.rerunTask(Task(), null),
+          throwsA(const TypeMatcher<AssertionError>()));
+    });
 
-      test('should send correct request to downloader service', () async {
-        final Downloader mockDownloader = MockDownloader();
-        when(mockDownloader.download(argThat(contains('/api/get-log?ownerKey')),
-                'test_task_shashan_1.log',
-                idToken: 'abc123'))
-            .thenAnswer((_) => Future<bool>.value(true));
-        service = AppEngineCocoonService(
-            client: MockClient((Request request) async {
-              return Response('', 200);
-            }),
-            downloader: mockDownloader);
+    /// This requires a separate test run on the web platform.
+    test('should query correct endpoint whether web or mobile', () async {
+      final Client mockClient = MockHttpClient();
+      when(mockClient.post(argThat(endsWith('/api/reset-devicelab-task')),
+              headers: captureAnyNamed('headers'),
+              body: captureAnyNamed('body')))
+          .thenAnswer((_) => Future<Response>.value(Response('', 200)));
+      service = AppEngineCocoonService(client: mockClient);
 
-        expect(
-            await service.downloadLog(
-                Task()
-                  ..name = 'test_task'
-                  ..attempts = 1,
-                'abc123',
-                'shashankabcdefghijklmno'),
-            isTrue);
-      });
+      await service.rerunTask(Task(), '');
+
+      if (kIsWeb) {
+        verify(mockClient.post(
+          '/api/reset-devicelab-task',
+          headers: captureAnyNamed('headers'),
+          body: captureAnyNamed('body'),
+        ));
+      } else {
+        verify(mockClient.post(
+          '$_baseApiUrl/api/reset-devicelab-task',
+          headers: captureAnyNamed('headers'),
+          body: captureAnyNamed('body'),
+        ));
+      }
+    });
+  });
+
+  group('AppEngine CocoonService download log', () {
+    AppEngineCocoonService service;
+
+    setUp(() {
+      service =
+          AppEngineCocoonService(client: MockClient((Request request) async {
+        return Response('', 200);
+      }));
+    });
+
+    test('should throw assertion error if task is null', () async {
+      expect(service.downloadLog(null, 'abc123', 'shashank'),
+          throwsA(const TypeMatcher<AssertionError>()));
+    });
+
+    test('should throw assertion error if id token is null', () async {
+      expect(service.downloadLog(Task()..key = RootKey(), null, 'shashank'),
+          throwsA(const TypeMatcher<AssertionError>()));
+    });
+
+    test('should send correct request to downloader service', () async {
+      final Downloader mockDownloader = MockDownloader();
+      when(mockDownloader.download(argThat(contains('/api/get-log?ownerKey')),
+              'test_task_shashan_1.log',
+              idToken: 'abc123'))
+          .thenAnswer((_) => Future<bool>.value(true));
+      service = AppEngineCocoonService(
+          client: MockClient((Request request) async {
+            return Response('', 200);
+          }),
+          downloader: mockDownloader);
+
+      expect(
+          await service.downloadLog(
+              Task()
+                ..name = 'test_task'
+                ..attempts = 1,
+              'abc123',
+              'shashankabcdefghijklmno'),
+          isTrue);
     });
   });
 

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -110,6 +110,8 @@ const String jsonBuildStatusFalseResponse = '''
   }
 ''';
 
+const String _baseApiUrl = 'https://flutter-dashboard.appspot.com';
+
 void main() {
   group('AppEngine CocoonService fetchCommitStatus', () {
     AppEngineCocoonService service;
@@ -172,8 +174,8 @@ void main() {
       if (kIsWeb) {
         verify(mockClient.get('/api/public/get-status?branch=master'));
       } else {
-        verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-status?branch=master'));
+        verify(
+            mockClient.get('$_baseApiUrl/api/public/get-status?branch=master'));
       }
     });
 
@@ -195,7 +197,7 @@ void main() {
             '/api/public/get-status?lastCommitKey=iamatestkey&branch=master'));
       } else {
         verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-status?lastCommitKey=iamatestkey&branch=master'));
+            '$_baseApiUrl/api/public/get-status?lastCommitKey=iamatestkey&branch=master'));
       }
     });
 
@@ -264,8 +266,8 @@ void main() {
       if (kIsWeb) {
         verify(mockClient.get('/api/public/build-status?branch=master'));
       } else {
-        verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/build-status?branch=master'));
+        verify(mockClient
+            .get('$_baseApiUrl/api/public/build-status?branch=master'));
       }
     });
 
@@ -287,7 +289,7 @@ void main() {
       expect(response.error, isNotNull);
     });
 
-    group('AppEngine Cocoon Service rerun task', () {
+    group('AppEngine CocoonService rerun task', () {
       AppEngineCocoonService service;
 
       setUp(() {
@@ -338,7 +340,7 @@ void main() {
           ));
         } else {
           verify(mockClient.post(
-            'https://flutter-dashboard.appspot.com/api/reset-devicelab-task',
+            '$_baseApiUrl/api/reset-devicelab-task',
             headers: captureAnyNamed('headers'),
             body: captureAnyNamed('body'),
           ));
@@ -346,7 +348,7 @@ void main() {
       });
     });
 
-    group('AppEngine Cocoon Service download log', () {
+    group('AppEngine CocoonService download log', () {
       AppEngineCocoonService service;
 
       setUp(() {
@@ -442,8 +444,7 @@ void main() {
       if (kIsWeb) {
         verify(mockClient.get('/api/public/get-status'));
       } else {
-        verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-status'));
+        verify(mockClient.get('$_baseApiUrl/api/public/get-status'));
       }
     });
 
@@ -503,8 +504,7 @@ void main() {
       if (kIsWeb) {
         verify(mockClient.get('/api/public/get-branches'));
       } else {
-        verify(mockClient.get(
-            'https://flutter-dashboard.appspot.com/api/public/get-branches'));
+        verify(mockClient.get('$_baseApiUrl/api/public/get-branches'));
       }
     });
 
@@ -527,7 +527,7 @@ void main() {
     });
   });
 
-  group('AppEngine Cocoon Service create agent', () {
+  group('AppEngine CocoonService create agent', () {
     AppEngineCocoonService service;
 
     setUp(() {
@@ -588,7 +588,7 @@ void main() {
         ));
       } else {
         verify(mockClient.post(
-          'https://flutter-dashboard.appspot.com/api/create-agent',
+          '$_baseApiUrl/api/create-agent',
           headers: captureAnyNamed('headers'),
           body: captureAnyNamed('body'),
         ));
@@ -596,7 +596,7 @@ void main() {
     });
   });
 
-  group('AppEngine Cocoon Service authorize agent', () {
+  group('AppEngine CocoonService authorize agent', () {
     AppEngineCocoonService service;
 
     setUp(() {
@@ -658,7 +658,7 @@ void main() {
         ));
       } else {
         verify(mockClient.post(
-          'https://flutter-dashboard.appspot.com/api/authorize-agent',
+          '$_baseApiUrl/api/authorize-agent',
           headers: captureAnyNamed('headers'),
           body: captureAnyNamed('body'),
         ));
@@ -666,7 +666,7 @@ void main() {
     });
   });
 
-  group('AppEngine Cocoon Service reserve task', () {
+  group('AppEngine CocoonService reserve task', () {
     AppEngineCocoonService service;
 
     setUp(() {
@@ -719,11 +719,48 @@ void main() {
         ));
       } else {
         verify(mockClient.post(
-          'https://flutter-dashboard.appspot.com/api/reserve-task',
+          '$_baseApiUrl/api/reserve-task',
           headers: captureAnyNamed('headers'),
           body: captureAnyNamed('body'),
         ));
       }
+    });
+  });
+
+  group('AppEngine CocoonService apiEndpoint', () {
+    AppEngineCocoonService service;
+
+    setUp(() {
+      service =
+          AppEngineCocoonService(client: MockClient((Request request) async {
+        return Response('{"Token": "abc123"}', 200);
+      }));
+    });
+    test('handles url suffix', () {
+      expect(service.apiEndpoint('/test'), '$_baseApiUrl/test');
+    });
+
+    test('single query parameter', () {
+      expect(
+          service.apiEndpoint('/test',
+              queryParameters: <String, String>{'key': 'value'}),
+          '$_baseApiUrl/test?key=value');
+    });
+
+    test('multiple query parameters', () {
+      expect(
+          service.apiEndpoint('/test', queryParameters: <String, String>{
+            'key': 'value',
+            'another': 'test'
+          }),
+          '$_baseApiUrl/test?key=value&another=test');
+    });
+
+    test('query parameter with null value', () {
+      expect(
+          service.apiEndpoint('/test',
+              queryParameters: <String, String>{'key': null}),
+          '$_baseApiUrl/test?key');
     });
   });
 }

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -51,4 +51,10 @@ class FakeFlutterBuildState extends ChangeNotifier
 
   @override
   List<String> get branches => <String>['master'];
+
+  @override
+  String get currentBranch => 'master';
+
+  @override
+  Future<void> updateBranch(String branch) => throw UnimplementedError();
 }

--- a/app_flutter/test/utils/fake_flutter_build.dart
+++ b/app_flutter/test/utils/fake_flutter_build.dart
@@ -54,7 +54,4 @@ class FakeFlutterBuildState extends ChangeNotifier
 
   @override
   String get currentBranch => 'master';
-
-  @override
-  Future<void> updateBranch(String branch) => throw UnimplementedError();
 }


### PR DESCRIPTION
Create `currentBranch` in `FlutterBuildState` and plumbed it through everywhere that uses it.

Refactored some of the test code to remove some of the duplication spread throughout it and fixed some spacing issues.

# Tests

Added tests for `apiEndpoint` refactor to handle query parameters.

Updated tests to check for defaulting to the `master` branch.

# Issues 

https://github.com/flutter/flutter/issues/51807 - Flutter branching for releases

# Future work

Create an `updateBranch` method in `FlutterBuildState` to change `currentBranch` to update the UI.