### PR TITLE
Reserve task regardless of branches

### DIFF
--- a/app_dart/lib/src/request_handlers/reserve_task.dart
+++ b/app_dart/lib/src/request_handlers/reserve_task.dart
@@ -194,7 +194,7 @@ class TaskProvider {
   final DatastoreService datastore;
 
   Future<FullTask> findNextTask(Agent agent) async {
-    await for (Commit commit in datastore.queryRecentCommits()) {
+    await for (Commit commit in datastore.queryRecentCommitsNoBranch()) {
       final List<Stage> stages =
           await datastore.queryTasksGroupedByStage(commit);
       for (Stage stage in stages) {


### PR DESCRIPTION
As we are implementing support for branching, `reserve-task` API reserves tasks for the default `master` branch only before this PR.

This PR fixes that by reserving tasks regardless of branches. It will reserve tasks for latest commits first, no matter what branch it is.

In the future, we may need to adjust priority to run tasks for different branches.