### PR TITLE
Update CommitStatus to have branch field

### DIFF
--- a/app_dart/lib/src/model/proto/internal/commit_status.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/commit_status.pb.dart
@@ -9,14 +9,15 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'commit.pb.dart' as $1;
-import 'stage.pb.dart' as $3;
+import 'commit.pb.dart' as $0;
+import 'stage.pb.dart' as $1;
 
 class CommitStatus extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo('CommitStatus',
       createEmptyInstance: create)
-    ..aOM<$1.Commit>(1, 'commit', subBuilder: $1.Commit.create)
-    ..pc<$3.Stage>(2, 'stages', $pb.PbFieldType.PM, subBuilder: $3.Stage.create)
+    ..aOM<$0.Commit>(1, 'commit', subBuilder: $0.Commit.create)
+    ..pc<$1.Stage>(2, 'stages', $pb.PbFieldType.PM, subBuilder: $1.Stage.create)
+    ..aOS(3, 'branch')
     ..hasRequiredFields = false;
 
   CommitStatus._() : super();
@@ -42,9 +43,9 @@ class CommitStatus extends $pb.GeneratedMessage {
   static CommitStatus _defaultInstance;
 
   @$pb.TagNumber(1)
-  $1.Commit get commit => $_getN(0);
+  $0.Commit get commit => $_getN(0);
   @$pb.TagNumber(1)
-  set commit($1.Commit v) {
+  set commit($0.Commit v) {
     setField(1, v);
   }
 
@@ -53,8 +54,20 @@ class CommitStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearCommit() => clearField(1);
   @$pb.TagNumber(1)
-  $1.Commit ensureCommit() => $_ensure(0);
+  $0.Commit ensureCommit() => $_ensure(0);
 
   @$pb.TagNumber(2)
-  $core.List<$3.Stage> get stages => $_getList(1);
+  $core.List<$1.Stage> get stages => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.String get branch => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set branch($core.String v) {
+    $_setString(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasBranch() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBranch() => clearField(3);
 }

--- a/app_dart/lib/src/model/proto/internal/commit_status.proto
+++ b/app_dart/lib/src/model/proto/internal/commit_status.proto
@@ -10,4 +10,5 @@ import "lib/src/model/proto/internal/stage.proto";
 message CommitStatus {
     optional Commit commit = 1;
     repeated Stage stages = 2;
+    optional string branch = 3;
 }

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -375,10 +375,18 @@ class AppEngineCocoonService implements CocoonService {
       final Map<String, Object> checklist = jsonCommitStatus['Checklist'];
       statuses.add(CommitStatus()
         ..commit = _commitFromJson(checklist)
+        ..branch = _branchFromJson(checklist)
         ..stages.addAll(_stagesFromJson(jsonCommitStatus['Stages'])));
     }
 
     return statuses;
+  }
+
+  String _branchFromJson(Map<String, Object> jsonChecklist) {
+    assert(jsonChecklist != null);
+
+    final Map<String, Object> checklist = jsonChecklist['Checklist'];
+    return checklist['Branch'];
   }
 
   Commit _commitFromJson(Map<String, Object> jsonChecklist) {

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -26,6 +26,7 @@ const String jsonGetStatsResponse = '''
           "Checklist": {
             "Key": "iamatestkey", 
             "Checklist": {
+              "Branch": "master",
               "FlutterRepositoryPath": "flutter/cocoon", 
               "CreateTimestamp": 123456789, 
               "Commit": {
@@ -133,6 +134,7 @@ void main() {
           await service.fetchCommitStatuses();
 
       final CommitStatus expectedStatus = CommitStatus()
+        ..branch = 'master'
         ..commit = (Commit()
           ..timestamp = Int64(123456789)
           ..key = (RootKey()..child = (Key()..name = 'iamatestkey'))


### PR DESCRIPTION
This lets the frontend track data based on branch.

# Issues

flutter/flutter#51807 - Flutter branching for releases

# Tests

app_dart tests pass

app_flutter appengine json updated to match latest which includes the branch field

# Future work

Use this to invalidate previous branch data to show the currently selected branch.