### PR TITLE
Support branching for push build status to github

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -126,7 +126,10 @@ class Config {
 
   String get cqLabelName => 'CQ+1';
 
+  // Repository status context for github status.
   String get flutterBuild => 'flutter-build';
+
+  // Repository status description for github status.
   String get flutterBuildDescription =>
       'Flutter build is currently broken. Please do not merge this '
       'PR unless it contains a fix to the broken build.';

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -126,6 +126,11 @@ class Config {
 
   String get cqLabelName => 'CQ+1';
 
+  String get flutterBuild => 'flutter-build';
+  String get flutterBuildDescription =>
+      'Flutter build is currently broken. Please do not merge this '
+      'PR unless it contains a fix to the broken build.';
+
   RepositorySlug get flutterSlug => const RepositorySlug('flutter', 'flutter');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:gcloud/datastore.dart';
 import 'package:github/server.dart';
 import 'package:grpc/grpc.dart';
@@ -91,7 +92,8 @@ Future<List<Branch>> getBranches(
     HttpClientProvider branchHttpClientProvider,
     Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator) async {
-  final GitHub github = await config.createGitHubClient();
+  final GithubService githubService = await config.createGithubService();
+  final GitHub github = githubService.github;
   const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
   final Stream<Branch> branchList = github.repositories.listBranches(slug);
   final List<String> regExps = await loadBranchRegExps(

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -83,8 +83,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
           log.debug(
               'Updating status of ${slug.fullName}#${pr.number} from ${update.status}');
           final CreateStatus request = CreateStatus(buildStatus.githubStatus);
-          request.targetUrl =
-              'https://flutter-dashboard.appspot.com/#/build';
+          request.targetUrl = 'https://flutter-dashboard.appspot.com/#/build';
           request.context = config.flutterBuild;
           if (buildStatus != BuildStatus.succeeded) {
             request.description = config.flutterBuildDescription;
@@ -102,6 +101,8 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
         }
       }
 
+      /// Whenever github status is updated, [update.updates] will be synchronized in
+      /// datastore [GithubBuildStatusUpdate].
       final int maxEntityGroups = config.maxEntityGroups;
       for (int i = 0; i < updates.length; i += maxEntityGroups) {
         await datastore.db

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -16,6 +16,7 @@ import 'package:cocoon_service/src/foundation/utils.dart';
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/fake_logging.dart';
+import '../src/service/fake_github_service.dart';
 
 const String branchRegExp = '''
       master
@@ -137,15 +138,17 @@ void main() {
       }
 
       setUp(() {
-        final MockGitHub github = MockGitHub();
-        final MockRepositoriesService repositories = MockRepositoriesService();
+        final FakeGithubService githubService = FakeGithubService();
+        //final MockGitHub github = MockGitHub();
+        final MockRepositoriesService repositoriesService =
+            MockRepositoriesService();
         branchHttpClient = FakeHttpClient();
-        config = FakeConfig(githubClient: github);
+        config = FakeConfig(githubService: githubService);
         log = FakeLogging();
 
+        when(githubService.github.repositories).thenReturn(repositoriesService);
         const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-        when(github.repositories).thenReturn(repositories);
-        when(repositories.listBranches(slug)).thenAnswer((Invocation _) {
+        when(repositoriesService.listBranches(slug)).thenAnswer((_) {
           return branchStream();
         });
       });

--- a/app_dart/test/request_handlers/get_branches_test.dart
+++ b/app_dart/test/request_handlers/get_branches_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/request_handler_tester.dart';
+import '../src/service/fake_github_service.dart';
 
 const String branchRegExp = '''
       master
@@ -39,11 +40,11 @@ void main() {
     }
 
     setUp(() {
-      final MockGitHub github = MockGitHub();
+      final FakeGithubService githubService = FakeGithubService();
       final MockRepositoriesService repositories = MockRepositoriesService();
 
       const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-      config = FakeConfig(githubClient: github, flutterSlugValue: slug);
+      config = FakeConfig(githubService: githubService, flutterSlugValue: slug);
       branchHttpClient = FakeHttpClient();
       tester = RequestHandlerTester();
       handler = GetBranches(
@@ -52,7 +53,7 @@ void main() {
         gitHubBackoffCalculator: (int attempt) => Duration.zero,
       );
 
-      when(github.repositories).thenReturn(repositories);
+      when(githubService.github.repositories).thenReturn(repositories);
       when(repositories.listBranches(slug)).thenAnswer((Invocation _) {
         return branchStream();
       });

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -129,7 +129,6 @@ void main() {
     });
 
     group('in non-development environment', () {
-
       setUp(() {
         clientContext.isDevelopmentEnvironment = false;
       });
@@ -226,8 +225,9 @@ void main() {
           expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
         });
-        
-        test('if status has changed since last update - multiple branches', () async {
+
+        test('if status has changed since last update - multiple branches',
+            () async {
           githubPullRequestsMaster = <int>[0];
           githubPullRequestsOther = <int>[1];
           final PullRequest prMaster = newPullRequest(id: 0, sha: '0');

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -20,8 +20,15 @@ import '../src/datastore/fake_cocoon_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/fake_logging.dart';
 import '../src/service/fake_build_status_provider.dart';
+import '../src/service/fake_github_service.dart';
+
+const String branchRegExp = '''
+      master
+      ^flutter-[0-9]+\.[0-9]+-candidate\.[0-9]+
+      ''';
 
 void main() {
   group('PushBuildStatusToGithub', () {
@@ -35,6 +42,33 @@ void main() {
     ApiRequestHandlerTester tester;
     PushBuildStatusToGithub handler;
     FakeTabledataResourceApi tabledataResourceApi;
+    FakeHttpClient branchHttpClient;
+    List<int> githubPullRequestsMaster;
+    List<int> githubPullRequestsOther;
+    List<String> githubBranches;
+
+    List<PullRequest> pullRequestList(String branch) {
+      final List<PullRequest> pullRequests = <PullRequest>[];
+      for (int pr in (branch == 'master')
+          ? githubPullRequestsMaster
+          : githubPullRequestsOther) {
+        pullRequests.add(PullRequest()
+          ..number = pr
+          ..head = (PullRequestHead()..sha = pr.toString()));
+      }
+      return pullRequests;
+    }
+
+    Stream<Branch> branchStream() async* {
+      for (String branchName in githubBranches) {
+        final CommitDataUser author = CommitDataUser('a', 1, 'b');
+        final GitCommit gitCommit = GitCommit();
+        final CommitData commitData = CommitData('sha', gitCommit, 'test',
+            'test', 'test', author, author, <Map<String, dynamic>>[]);
+        final Branch branch = Branch(branchName, commitData);
+        yield branch;
+      }
+    }
 
     setUp(() {
       clientContext = FakeClientContext();
@@ -42,7 +76,11 @@ void main() {
       auth = FakeAuthenticationProvider(clientContext: clientContext);
       buildStatusProvider = FakeBuildStatusProvider();
       tabledataResourceApi = FakeTabledataResourceApi();
-      config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
+      branchHttpClient = FakeHttpClient();
+      final FakeGithubService githubService = FakeGithubService();
+      config = FakeConfig(
+          tabledataResourceApi: tabledataResourceApi,
+          githubService: githubService);
       db = FakeDatastoreDB();
       log = FakeLogging();
       tester = ApiRequestHandlerTester(context: authContext);
@@ -52,7 +90,15 @@ void main() {
         datastoreProvider: () => DatastoreService(db: db),
         loggingProvider: () => log,
         buildStatusProvider: buildStatusProvider,
+        branchHttpClientProvider: () => branchHttpClient,
+        gitHubBackoffCalculator: (int attempt) => Duration.zero,
       );
+
+      githubPullRequestsMaster = <int>[];
+      githubPullRequestsOther = <int>[];
+      githubService.listPullRequestsBranch = (String branch) {
+        return pullRequestList(branch);
+      };
     });
 
     group('in development environment', () {
@@ -78,7 +124,6 @@ void main() {
       MockGitHub github;
       MockPullRequestsService pullRequestsService;
       MockRepositoriesService repositoriesService;
-      List<PullRequest> prsFromGitHub;
 
       setUp(() {
         github = MockGitHub();
@@ -86,8 +131,9 @@ void main() {
         repositoriesService = MockRepositoriesService();
         when(github.pullRequests).thenReturn(pullRequestsService);
         when(github.repositories).thenReturn(repositoriesService);
-        when(pullRequestsService.list(any)).thenAnswer((Invocation _) {
-          return Stream<PullRequest>.fromIterable(prsFromGitHub);
+        const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
+        when(repositoriesService.listBranches(slug)).thenAnswer((_) {
+          return branchStream();
         });
         config.githubClient = github;
         clientContext.isDevelopmentEnvironment = false;
@@ -120,8 +166,9 @@ void main() {
         });
 
         test('if there are no PRs', () async {
-          prsFromGitHub = <PullRequest>[];
+          githubBranches = <String>['master'];
           buildStatusProvider.cumulativeStatus = BuildStatus.succeeded;
+          branchHttpClient.request.response.body = branchRegExp;
           final Body body = await tester.get<Body>(handler);
           final TableDataList tableDataList =
               await tabledataResourceApi.list('test', 'test', 'test');
@@ -134,15 +181,34 @@ void main() {
         });
 
         test('if status has not changed since last update', () async {
-          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
-          prsFromGitHub = <PullRequest>[pr];
+          githubPullRequestsMaster = <int>[1];
+          final PullRequest pr = newPullRequest(id: 1, sha: '1');
+          githubBranches = <String>['master'];
           buildStatusProvider.cumulativeStatus = BuildStatus.succeeded;
           final GithubBuildStatusUpdate status =
               newStatusUpdate(pr, BuildStatus.succeeded);
           db.values[status.key] = status;
+          branchHttpClient.request.response.body = branchRegExp;
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+        });
+
+        test('if there is no pr found for a targeted branch', () async {
+          githubPullRequestsMaster = <int>[1];
+          final PullRequest pr = newPullRequest(id: 1, sha: '1');
+          githubBranches = <String>['flutter-0.0-candidate.0'];
+          buildStatusProvider.cumulativeStatus = BuildStatus.succeeded;
+          final GithubBuildStatusUpdate status =
+              newStatusUpdate(pr, BuildStatus.failed);
+          db.values[status.key] = status;
+          branchHttpClient.request.response.body = branchRegExp;
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(status.status, BuildStatus.failed.githubStatus);
           expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
           expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
         });
@@ -150,12 +216,14 @@ void main() {
 
       group('updates GitHub and datastore', () {
         test('if status has changed since last update', () async {
-          final PullRequest pr = newPullRequest(id: 123, sha: 'abc');
-          prsFromGitHub = <PullRequest>[pr];
+          githubPullRequestsOther = <int>[1];
+          final PullRequest pr = newPullRequest(id: 1, sha: '1');
+          githubBranches = <String>['flutter-0.0-candidate.0'];
           buildStatusProvider.cumulativeStatus = BuildStatus.succeeded;
           final GithubBuildStatusUpdate status =
               newStatusUpdate(pr, BuildStatus.failed);
           db.values[status.key] = status;
+          branchHttpClient.request.response.body = branchRegExp;
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(status.updates, 1);

--- a/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
@@ -18,6 +18,7 @@ import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
+import '../src/service/fake_github_service.dart';
 import '../src/service/fake_graphql_client.dart';
 
 void main() {
@@ -47,7 +48,7 @@ void main() {
     }
 
     setUp(() {
-      final MockGitHub github = MockGitHub();
+      final FakeGithubService githubService = FakeGithubService();
       final MockRepositoriesService repositories = MockRepositoriesService();
       datastoreDB = FakeDatastoreDB();
       branchHttpClient = FakeHttpClient();
@@ -56,7 +57,7 @@ void main() {
       config = FakeConfig(
           dbValue: datastoreDB,
           cirrusGraphQLClient: cirrusGraphQLClient,
-          githubClient: github);
+          githubService: githubService);
       handler = RefreshCirrusStatus(
         config,
         FakeAuthenticationProvider(),
@@ -75,7 +76,7 @@ void main() {
       };
 
       const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-      when(github.repositories).thenReturn(repositories);
+      when(githubService.github.repositories).thenReturn(repositories);
       when(repositories.listBranches(slug)).thenAnswer((Invocation _) {
         return branchStream();
       });

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -87,7 +87,6 @@ void main() {
     }
 
     setUp(() {
-      final MockGitHub github = MockGitHub();
       final MockRepositoriesService repositories = MockRepositoriesService();
       final FakeGithubService githubService = FakeGithubService();
       final MockTabledataResourceApi tabledataResourceApi =
@@ -98,7 +97,6 @@ void main() {
 
       yieldedCommitCount = 0;
       config = FakeConfig(
-          githubClient: github,
           tabledataResourceApi: tabledataResourceApi,
           githubService: githubService);
       auth = FakeAuthenticationProvider();
@@ -120,7 +118,7 @@ void main() {
       };
 
       const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-      when(github.repositories).thenReturn(repositories);
+      when(githubService.github.repositories).thenReturn(repositories);
       when(repositories.listBranches(slug)).thenAnswer((Invocation _) {
         return branchStream();
       });

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -43,6 +43,8 @@ class FakeConfig implements Config {
     this.rollerAccountsValue,
     this.luciTryInfraFailureRetriesValue,
     this.flutterSlugValue,
+    this.flutterBuildValue,
+    this.flutterBuildDescriptionValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -64,6 +66,8 @@ class FakeConfig implements Config {
   String goldenTriageMessageValue;
   String webhookKeyValue;
   String cqLabelNameValue;
+  String flutterBuildValue;
+  String flutterBuildDescriptionValue;
   List<Map<String, dynamic>> luciBuildersValue;
   List<Map<String, dynamic>> luciTryBuildersValue;
   Logging loggingServiceValue;
@@ -137,6 +141,12 @@ class FakeConfig implements Config {
 
   @override
   String get cqLabelName => cqLabelNameValue;
+
+  @override
+  String get flutterBuild => flutterBuildValue;
+
+  @override
+  String get flutterBuildDescription => flutterBuildDescriptionValue;
 
   @override
   List<Map<String, dynamic>> get luciBuilders => luciBuildersValue;

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -173,7 +173,7 @@ class FakeQuery<T extends Model> implements Query<T> {
     for (FakeFilterSpec filter in filters) {
       final String filterString = filter.filterString;
       final Object value = filter.comparisonObject;
-      if (filterString.contains('branch =')) {
+      if (filterString.contains('branch =') || filterString.contains('pr =')) {
         resultsView = resultsView
             .where((T result) => result.toString().contains(value.toString()));
       }

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -4,6 +4,7 @@
 
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/server.dart';
+import 'package:mockito/mockito.dart';
 
 /// A fake GithubService implementation.
 class FakeGithubService implements GithubService {
@@ -11,7 +12,7 @@ class FakeGithubService implements GithubService {
   List<PullRequest> Function(String) listPullRequestsBranch;
 
   @override
-  final GitHub github = null;
+  final GitHub github = MockGitHub();
 
   @override
   Future<List<RepositoryCommit>> listCommits(
@@ -25,3 +26,5 @@ class FakeGithubService implements GithubService {
     return listPullRequestsBranch(branch);
   }
 }
+
+class MockGitHub extends Mock implements GitHub {}

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -8,6 +8,7 @@ import 'package:github/server.dart';
 /// A fake GithubService implementation.
 class FakeGithubService implements GithubService {
   List<RepositoryCommit> Function(String) listCommitsBranch;
+  List<PullRequest> Function(String) listPullRequestsBranch;
 
   @override
   final GitHub github = null;
@@ -16,5 +17,11 @@ class FakeGithubService implements GithubService {
   Future<List<RepositoryCommit>> listCommits(
       RepositorySlug slug, String branch) async {
     return listCommitsBranch(branch);
+  }
+
+  @override
+  Future<List<PullRequest>> listPullRequests(
+      RepositorySlug slug, String branch) async {
+    return listPullRequestsBranch(branch);
   }
 }


### PR DESCRIPTION
This is part of https://github.com/flutter/flutter/issues/51807

We will support commits following different branches. Existing logic to push build status to github doesn't recognize branch difference. It will calculate build status based on latest commits of `master` (default), and push the status to all PRs in github.

The change here fixes above issue. It will update PRs of a specific branch based on the build status calculated according to that branch's commits.