### PR TITLE
Do not remove .pub-cache as it is required by the agent.

### DIFF
--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -147,7 +147,7 @@ Future<HealthCheckResult> removeCachedData(
   if (home == null) {
     return HealthCheckResult.failure('Missing \$HOME environment variable.');
   }
-  List<String> cacheFolders = ['.graddle', '.dartServer', '.pub-cache'];
+  List<String> cacheFolders = ['.graddle', '.dartServer'];
   for (String folder in cacheFolders) {
     String folderPath = path.join(home, folder);
     rrm(fs.directory(folderPath));

--- a/agent/test/src/health_test.dart
+++ b/agent/test/src/health_test.dart
@@ -71,11 +71,7 @@ void main() {
       platform.FakePlatform pf = platform.FakePlatform()
         ..operatingSystem = "macos"
         ..environment = <String, String>{"HOME": "/foo"};
-      List<String> folders = <String>[
-        '/foo/.graddle',
-        '/foo/.dartServer',
-        '/foo/.pub-cache'
-      ];
+      List<String> folders = <String>['/foo/.graddle', '/foo/.dartServer'];
       for (String dir in folders) {
         fs.directory(dir)..createSync(recursive: true);
       }


### PR DESCRIPTION
If we delete .pub-cache the agent execution is affected even if we
immediately run pub get. Pub-cache will need to be cleaned out as part
of the agent update.

https://github.com/flutter/flutter/issues/52957