### PR TITLE
Remove dependencies on DateTime.now

### DIFF
--- a/app_flutter/lib/agent_health_details_bar.dart
+++ b/app_flutter/lib/agent_health_details_bar.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'agent_health_details.dart';
+import 'now.dart';
 
 /// An icon bar to display information from [AgentHealthDetails].
 class AgentHealthDetailsBar extends StatelessWidget {
@@ -18,9 +19,10 @@ class AgentHealthDetailsBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final DateTime now = Now.of(context);
     return Row(
       children: <Widget>[
-        if (!healthDetails.pingedRecently)
+        if (!healthDetails.pingedRecently(now))
           Tooltip(
             message: 'Agent timed out',
             child: Icon(Icons.timer, color: theme.errorColor),

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'agent_dashboard_page.dart';
 import 'build_dashboard_page.dart';
 import 'index_page.dart';
+import 'now.dart';
 import 'service/cocoon.dart';
 import 'service/google_authentication.dart';
 import 'state/agent.dart';
@@ -23,7 +24,7 @@ void main() {
       indexState: IndexState(authService: authService),
       agentState: AgentState(authService: authService, cocoonService: cocoonService),
       buildState: FlutterBuildState(authService: authService, cocoonService: cocoonService),
-      child: const MyApp(),
+      child: Now(child: const MyApp()),
     ),
   );
 }

--- a/app_flutter/lib/now.dart
+++ b/app_flutter/lib/now.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+/// An inherited widget that reports the current time and
+/// ticks once per second.
+class Now extends InheritedNotifier<ValueNotifier<DateTime>> {
+  /// For production.
+  Now({
+    Key key,
+    Widget child,
+  }) : super(
+          key: key,
+          notifier: _Clock(),
+          child: child,
+        );
+
+  /// For tests.
+  Now.fixed({
+    Key key,
+    @required DateTime dateTime,
+    Widget child,
+  })  : assert(dateTime != null),
+        super(
+          key: key,
+          notifier: ValueNotifier<DateTime>(dateTime),
+          child: child,
+        );
+
+  static DateTime of(BuildContext context) {
+    final Now now = context.dependOnInheritedWidgetOfExactType<Now>();
+    assert(now != null);
+    return now.notifier.value;
+  }
+}
+
+class _Clock extends ValueNotifier<DateTime> {
+  _Clock() : super(null);
+
+  Timer _timer;
+
+  @override
+  void addListener(VoidCallback listener) {
+    if (!hasListeners) {
+      assert(_timer == null);
+      value = DateTime.now();
+      _scheduleTick();
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!hasListeners && _timer != null) {
+      _timer.cancel();
+      _timer = null;
+      value = null;
+    }
+  }
+
+  void _tick() {
+    value = DateTime.now();
+    _scheduleTick();
+    notifyListeners();
+  }
+
+  void _scheduleTick() {
+    // To make the application appear responsive, we try to tick at the start of each second
+    // (as opposed to just anywhere within a second, each second). To do that, each tick, we
+    // set up a new timer to fire just as the time on the device reaches a new second, right
+    // when the milliseconds component of the time is zero.
+    //
+    // To compute the time until the next second, we take the current time, ignore all parts
+    // except the milliseconds, and subtract that from one second. (We have to take care and
+    // never wait for zero milliseconds; if the milliseconds part is zero, then we must wait
+    // a full second.)
+    //
+    // By scheduling a new tick each time, we also ensure that we skip past any seconds that
+    // we were too busy to service without increasing the load on the device.
+    _timer = Timer(Duration(milliseconds: 1000 - (value.millisecondsSinceEpoch % 1000)), _tick);
+  }
+}

--- a/app_flutter/test/agent_dashboard_page_test.dart
+++ b/app_flutter/test/agent_dashboard_page_test.dart
@@ -12,6 +12,7 @@ import 'package:mockito/mockito.dart';
 import 'package:app_flutter/agent_dashboard_page.dart';
 import 'package:app_flutter/agent_tile.dart';
 import 'package:app_flutter/error_brook_watcher.dart';
+import 'package:app_flutter/now.dart';
 import 'package:app_flutter/service/cocoon.dart';
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/sign_in_button.dart';
@@ -99,12 +100,15 @@ void main() {
     agentState.errors.addListener((String message) => lastError = message);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: ValueProvider<AgentState>(
-          value: agentState,
-          child: ValueProvider<GoogleSignInService>(
-            value: agentState.authService,
-            child: const AgentDashboardPage(),
+      Now.fixed(
+        dateTime: DateTime(2000),
+        child: MaterialApp(
+          home: ValueProvider<AgentState>(
+            value: agentState,
+            child: ValueProvider<GoogleSignInService>(
+              value: agentState.authService,
+              child: const AgentDashboardPage(),
+            ),
           ),
         ),
       ),
@@ -166,13 +170,16 @@ void main() {
     );
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: ValueProvider<AgentState>(
-          value: agentState,
-          child: ValueProvider<GoogleSignInService>(
-            value: mockAuthService,
-            child: const AgentDashboardPage(
-              agentFilter: 'dash-test-3',
+      Now.fixed(
+        dateTime: DateTime(2000),
+        child: MaterialApp(
+          home: ValueProvider<AgentState>(
+            value: agentState,
+            child: ValueProvider<GoogleSignInService>(
+              value: mockAuthService,
+              child: const AgentDashboardPage(
+                agentFilter: 'dash-test-3',
+              ),
             ),
           ),
         ),

--- a/app_flutter/test/agent_health_details_bar_test.dart
+++ b/app_flutter/test/agent_health_details_bar_test.dart
@@ -10,11 +10,20 @@ import 'package:cocoon_service/protos.dart' show Agent;
 
 import 'package:app_flutter/agent_health_details.dart';
 import 'package:app_flutter/agent_health_details_bar.dart';
+import 'package:app_flutter/now.dart';
+
+final DateTime pingTime = DateTime(2010, 5, 6, 12, 30);
+final DateTime soonTime = pingTime.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive ~/ 2),
+);
+final DateTime laterTime = pingTime.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive * 2),
+);
 
 void main() {
   testWidgets('healthy bar', (WidgetTester tester) async {
     final Agent agent = Agent()
-      ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+      ..healthCheckTimestamp = Int64(pingTime.millisecondsSinceEpoch)
       ..isHealthy = true
       ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -31,8 +40,11 @@ able-to-perform-health-check: succeeded''';
     final AgentHealthDetails healthDetails = AgentHealthDetails(agent);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: AgentHealthDetailsBar(healthDetails),
+      Now.fixed(
+        dateTime: soonTime,
+        child: MaterialApp(
+          home: AgentHealthDetailsBar(healthDetails),
+        ),
       ),
     );
 
@@ -44,7 +56,7 @@ able-to-perform-health-check: succeeded''';
 
   testWidgets('timed out icon', (WidgetTester tester) async {
     final Agent agent = Agent()
-      ..healthCheckTimestamp = Int64.parseInt('100')
+      ..healthCheckTimestamp = Int64(100)
       ..isHealthy = true
       ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -61,8 +73,11 @@ able-to-perform-health-check: succeeded''';
     final AgentHealthDetails healthDetails = AgentHealthDetails(agent);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: AgentHealthDetailsBar(healthDetails),
+      Now.fixed(
+        dateTime: soonTime,
+        child: MaterialApp(
+          home: AgentHealthDetailsBar(healthDetails),
+        ),
       ),
     );
 
@@ -74,15 +89,18 @@ able-to-perform-health-check: succeeded''';
 
   testWidgets('unhealthy bar', (WidgetTester tester) async {
     final Agent agent = Agent()
-      ..healthCheckTimestamp = Int64.parseInt('100')
+      ..healthCheckTimestamp = Int64(100)
       ..isHealthy = false
       ..healthDetails = '';
 
     final AgentHealthDetails healthDetails = AgentHealthDetails(agent);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: AgentHealthDetailsBar(healthDetails),
+      Now.fixed(
+        dateTime: soonTime,
+        child: MaterialApp(
+          home: AgentHealthDetailsBar(healthDetails),
+        ),
       ),
     );
 

--- a/app_flutter/test/agent_health_details_test.dart
+++ b/app_flutter/test/agent_health_details_test.dart
@@ -9,10 +9,18 @@ import 'package:cocoon_service/protos.dart' show Agent;
 
 import 'package:app_flutter/agent_health_details.dart';
 
+final DateTime pingTime = DateTime(2010, 5, 6, 12, 30);
+final DateTime soonTime = pingTime.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive ~/ 2),
+);
+final DateTime laterTime = pingTime.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive * 2),
+);
+
 void main() {
   test('is healthy when everything is healthy', () {
     final Agent agent = Agent()
-      ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+      ..healthCheckTimestamp = Int64(pingTime.millisecondsSinceEpoch)
       ..isHealthy = true
       ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -33,13 +41,15 @@ able-to-perform-health-check: succeeded''';
     expect(healthDetails.cocoonConnection, isTrue);
     expect(healthDetails.hasHealthyDevices, isTrue);
     expect(healthDetails.hasSshConnectivity, isTrue);
-    expect(healthDetails.pingedRecently, isTrue);
-    expect(healthDetails.isHealthy, isTrue);
+    expect(healthDetails.pingedRecently(soonTime), isTrue);
+    expect(healthDetails.pingedRecently(laterTime), isFalse);
+    expect(healthDetails.isHealthy(soonTime), isTrue);
+    expect(healthDetails.isHealthy(laterTime), isFalse);
   });
 
   test('is not healthy when just one metric is unhealthy', () {
     final Agent agent = Agent()
-      ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+      ..healthCheckTimestamp = Int64(pingTime.millisecondsSinceEpoch)
       ..isHealthy = false
       ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -91,8 +101,10 @@ able-to-perform-health-check: succeeded''';
     expect(healthDetails.cocoonConnection, isTrue);
     expect(healthDetails.hasHealthyDevices, isFalse);
     expect(healthDetails.hasSshConnectivity, isTrue);
-    expect(healthDetails.pingedRecently, isTrue);
-    expect(healthDetails.isHealthy, isFalse);
+    expect(healthDetails.pingedRecently(soonTime), isTrue);
+    expect(healthDetails.isHealthy(soonTime), isFalse);
+    expect(healthDetails.pingedRecently(laterTime), isFalse);
+    expect(healthDetails.isHealthy(laterTime), isFalse);
   });
 
   test('is not healthy when all metrics are healthy but has timed out', () {
@@ -118,8 +130,10 @@ able-to-perform-health-check: succeeded''';
     expect(healthDetails.cocoonConnection, isTrue);
     expect(healthDetails.hasHealthyDevices, isTrue);
     expect(healthDetails.hasSshConnectivity, isTrue);
-    expect(healthDetails.pingedRecently, isFalse);
-    expect(healthDetails.isHealthy, isFalse);
+    expect(healthDetails.pingedRecently(soonTime), isFalse);
+    expect(healthDetails.isHealthy(soonTime), isFalse);
+    expect(healthDetails.pingedRecently(laterTime), isFalse);
+    expect(healthDetails.isHealthy(laterTime), isFalse);
   });
 
   test('is unhealthy when health details is null', () {
@@ -134,7 +148,9 @@ able-to-perform-health-check: succeeded''';
     expect(healthDetails.cocoonConnection, isFalse);
     expect(healthDetails.hasHealthyDevices, isFalse);
     expect(healthDetails.hasSshConnectivity, isFalse);
-    expect(healthDetails.pingedRecently, isFalse);
-    expect(healthDetails.isHealthy, isFalse);
+    expect(healthDetails.pingedRecently(soonTime), isFalse);
+    expect(healthDetails.isHealthy(soonTime), isFalse);
+    expect(healthDetails.pingedRecently(laterTime), isFalse);
+    expect(healthDetails.isHealthy(laterTime), isFalse);
   });
 }

--- a/app_flutter/test/agent_list_test.dart
+++ b/app_flutter/test/agent_list_test.dart
@@ -6,16 +6,33 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:cocoon_service/protos.dart' show Agent;
-
+import 'package:app_flutter/agent_health_details.dart';
 import 'package:app_flutter/agent_list.dart';
 import 'package:app_flutter/agent_tile.dart';
+import 'package:app_flutter/now.dart';
+import 'package:cocoon_service/protos.dart' show Agent;
+
+final DateTime pingTime1 = DateTime(2010, 5, 6, 12, 30);
+final DateTime pingTime2 = pingTime1.add(const Duration(minutes: 1));
+final DateTime pingTime3 = pingTime1.add(const Duration(minutes: 2));
+final DateTime soonTime = pingTime1.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive ~/ 2),
+);
+final DateTime laterTime = pingTime1.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive * 2),
+);
 
 void main() {
   group('AgentList', () {
     testWidgets('empty list of agents shows loading indicator', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AgentList(agents: <Agent>[])));
-
+      await tester.pumpWidget(
+        Now.fixed(
+          dateTime: soonTime,
+          child: const MaterialApp(
+            home: AgentList(agents: <Agent>[]),
+          ),
+        ),
+      );
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
@@ -23,7 +40,7 @@ void main() {
       final List<Agent> agents = <Agent>[
         Agent()
           ..agentId = 'healthy1'
-          ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+          ..healthCheckTimestamp = Int64(pingTime1.millisecondsSinceEpoch)
           ..isHealthy = true
           ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -38,11 +55,11 @@ cocoon-connection: succeeded
 able-to-perform-health-check: succeeded''',
         Agent()
           ..agentId = 'sick'
-          ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+          ..healthCheckTimestamp = Int64(pingTime2.millisecondsSinceEpoch)
           ..isHealthy = false,
         Agent()
           ..agentId = 'healthy2'
-          ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+          ..healthCheckTimestamp = Int64(pingTime3.millisecondsSinceEpoch)
           ..isHealthy = true
           ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -58,9 +75,12 @@ able-to-perform-health-check: succeeded''',
       ];
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: AgentList(agents: agents, insertKeys: true),
+        Now.fixed(
+          dateTime: soonTime,
+          child: MaterialApp(
+            home: Scaffold(
+              body: AgentList(agents: agents, insertKeys: true),
+            ),
           ),
         ),
       );
@@ -74,18 +94,21 @@ able-to-perform-health-check: succeeded''',
       final List<Agent> agents = <Agent>[
         Agent()
           ..agentId = 'secret agent'
-          ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+          ..healthCheckTimestamp = Int64(pingTime1.millisecondsSinceEpoch)
           ..isHealthy = true,
         Agent()
           ..agentId = 'pigeon'
-          ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+          ..healthCheckTimestamp = Int64(pingTime2.millisecondsSinceEpoch)
           ..isHealthy = false,
       ];
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: AgentList(agents: agents, agentFilter: 'pigeon', insertKeys: true),
+        Now.fixed(
+          dateTime: soonTime,
+          child: MaterialApp(
+            home: Scaffold(
+              body: AgentList(agents: agents, agentFilter: 'pigeon', insertKeys: true),
+            ),
           ),
         ),
       );

--- a/app_flutter/test/agent_tile_test.dart
+++ b/app_flutter/test/agent_tile_test.dart
@@ -11,17 +11,21 @@ import 'package:cocoon_service/protos.dart' show Agent;
 
 import 'package:app_flutter/agent_health_details.dart';
 import 'package:app_flutter/agent_health_details_bar.dart';
-import 'package:app_flutter/agent_list.dart';
 import 'package:app_flutter/agent_tile.dart';
+import 'package:app_flutter/now.dart';
 
 import 'utils/mocks.dart';
 import 'utils/output.dart';
 
+final DateTime healthyTime = DateTime(2010, 5, 6, 12, 30);
+final DateTime nowTime = healthyTime.add(
+  const Duration(minutes: AgentHealthDetails.minutesUntilAgentIsUnresponsive ~/ 2),
+);
+
 void main() {
   group('AgentTile', () {
     final Agent agent = Agent()
-      // TODO(ianh): here and in other files, remove dependency on DateTime.now since that can introduce flakes.
-      ..healthCheckTimestamp = Int64.parseInt(DateTime.now().millisecondsSinceEpoch.toString())
+      ..healthCheckTimestamp = Int64(healthyTime.millisecondsSinceEpoch)
       ..isHealthy = true
       ..healthDetails = '''
 ssh-connectivity: succeeded
@@ -35,7 +39,7 @@ cocoon-authentication: succeeded
 cocoon-connection: succeeded
 able-to-perform-health-check: succeeded''';
 
-    final FullAgent fullAgent = FullAgent(agent, AgentHealthDetails(agent));
+    final AgentHealthDetails agentHealthDetails = AgentHealthDetails(agent);
 
     MockAgentState mockAgentState;
 
@@ -49,10 +53,11 @@ able-to-perform-health-check: succeeded''';
 
     testWidgets('raw health details dialog', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: AgentTile(
-              fullAgent: fullAgent,
+        Now.fixed(
+          dateTime: nowTime,
+          child: MaterialApp(
+            home: AgentTile(
+              agentHealthDetails: agentHealthDetails,
             ),
           ),
         ),
@@ -92,10 +97,13 @@ able-to-perform-health-check: succeeded''';
 
     testWidgets('authorize agent calls api', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: AgentTile(
-            fullAgent: fullAgent,
-            agentState: mockAgentState,
+        Now.fixed(
+          dateTime: nowTime,
+          child: MaterialApp(
+            home: AgentTile(
+              agentHealthDetails: agentHealthDetails,
+              agentState: mockAgentState,
+            ),
           ),
         ),
       );
@@ -116,11 +124,14 @@ able-to-perform-health-check: succeeded''';
 
     testWidgets('reserve task calls api', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: AgentTile(
-              fullAgent: fullAgent,
-              agentState: mockAgentState,
+        Now.fixed(
+          dateTime: nowTime,
+          child: MaterialApp(
+            home: Scaffold(
+              body: AgentTile(
+                agentHealthDetails: agentHealthDetails,
+                agentState: mockAgentState,
+              ),
             ),
           ),
         ),
@@ -142,9 +153,12 @@ able-to-perform-health-check: succeeded''';
 
     testWidgets('agent info is shown', (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: AgentTile(
-            fullAgent: fullAgent,
+        Now.fixed(
+          dateTime: nowTime,
+          child: MaterialApp(
+            home: AgentTile(
+              agentHealthDetails: agentHealthDetails,
+            ),
           ),
         ),
       );

--- a/app_flutter/test/utils/wrapper.dart
+++ b/app_flutter/test/utils/wrapper.dart
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
+
+import 'package:app_flutter/now.dart';
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/state_provider.dart';
-import 'package:flutter/material.dart';
 
 import 'fake_agent_state.dart';
 import 'fake_flutter_build.dart';
@@ -25,7 +27,10 @@ class FakeInserter extends StatelessWidget {
       indexState: FakeIndexState(authService: authService),
       agentState: FakeAgentState(authService: authService),
       buildState: FakeFlutterBuildState(authService: authService),
-      child: child,
+      child: Now.fixed(
+        dateTime: DateTime(2000),
+        child: child,
+      ),
     );
   }
 }


### PR DESCRIPTION
Having DateTime.now dependencies in logic has two problems:

- It causes the view to become stale over time (because nothing
  changes when the time changes, so e.g. "10 minutes ago" stops being
  accurate).

- It increases the chance of flakes in tests (because any time you run
  the tests, you're running them with new previously untested data,
  and because if there's multiple places in the code checking the
  current time, they race each other).

Instead this provides the time as an inherited widget.