### PR TITLE
Remove web build test from test runner now that there are flutter web tests in CI

### DIFF
--- a/test_utilities/bin/flutter_test_runner.bat
+++ b/test_utilities/bin/flutter_test_runner.bat
@@ -20,8 +20,6 @@ PUSHD %1
 CALL flutter packages get
 CALL flutter analyze
 CALL flutter format --line-length=120 --set-exit-if-changed lib/ test/
-CALL flutter config --enable-web
-CALL flutter build web
 CALL flutter test --test-randomize-ordering-seed=random
 
 POPD

--- a/test_utilities/bin/flutter_test_runner.sh
+++ b/test_utilities/bin/flutter_test_runner.sh
@@ -24,8 +24,6 @@ pushd $1 > /dev/null
 flutter packages get
 flutter analyze
 flutter format --line-length=120 --set-exit-if-changed lib/ test/
-flutter config --enable-web
-flutter build web
 flutter test --test-randomize-ordering-seed=random
 
 popd > /dev/null


### PR DESCRIPTION
This is causing timeouts on flutter/tests. This was originally added before the web team had tests running in CI on the framework repo. This was to help detect issues before deploying. Now that there is tooling around this, we can remove it from Cocoon's CI.