### PR TITLE
Use latest build result instead for cirrus status check

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -273,7 +273,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       return allSuccess;
     }
     final List<Map<String, dynamic>> cirrusStatuses = cirrusResults
-        .singleWhere(
+        .firstWhere(
             (CirrusResult cirrusResult) => cirrusResult.branch == branch)
         .tasks;
     if (cirrusStatuses == null) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -89,7 +89,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         continue;
       }
       final List<dynamic> cirrusChecks = cirrusResults
-          .singleWhere((CirrusResult cirrusResult) =>
+          .firstWhere((CirrusResult cirrusResult) =>
               cirrusResult.branch == 'pull/${pr.number}')
           .tasks;
       for (dynamic check in cirrusChecks) {

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -126,7 +126,7 @@ class RefreshCirrusStatus extends ApiRequestHandler<Body> {
       return statuses;
     }
     for (Map<String, dynamic> runStatus in cirrusResults
-        .singleWhere(
+        .firstWhere(
             (CirrusResult cirrusResult) => cirrusResult.branch == branch)
         .tasks) {
       final String status = runStatus['status'] as String;


### PR DESCRIPTION
This fixes: https://github.com/flutter/engine/pull/17387#issuecomment-606133019

Per discussions in the above thread, multiple build cirrus results may exist for same SHA and branch. This pr uses the latest result instead, rather than assuming single result.