### PR TITLE
Update remaining handlers to use service/datastore.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -58,11 +58,6 @@ class Config {
     return Uint8List.fromList(result.value.codeUnits);
   }
 
-  /// Per the docs in [DatastoreDB.withTransaction], only 5 entity groups can
-  /// be touched in any given transaction, or the backing datastore will throw
-  /// an error.
-  int get maxEntityGroups => 5;
-
   DatastoreDB get db => _db;
 
   Future<String> get oauthClientId => _getSingleValue('OAuthClientId');

--- a/app_dart/lib/src/request_handlers/append_log.dart
+++ b/app_dart/lib/src/request_handlers/append_log.dart
@@ -43,8 +43,7 @@ class AppendLog extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> post() async {
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final String encodedOwnerKey = request.uri.queryParameters[ownerKeyParam];
     if (encodedOwnerKey == null) {
       throw const BadRequestException(

--- a/app_dart/lib/src/request_handlers/authorize_agent.dart
+++ b/app_dart/lib/src/request_handlers/authorize_agent.dart
@@ -36,8 +36,7 @@ class AuthorizeAgent extends ApiRequestHandler<AuthorizeAgentResponse> {
     checkRequiredParameters(<String>[agentIdParam]);
 
     final String agentId = requestData[agentIdParam] as String;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final AgentService agentService = agentServiceProvider();
     final Key key = datastore.db.emptyKey.append(Agent, id: agentId);
     final Agent agent = await datastore.db.lookupValue<Agent>(

--- a/app_dart/lib/src/request_handlers/create_agent.dart
+++ b/app_dart/lib/src/request_handlers/create_agent.dart
@@ -41,8 +41,7 @@ class CreateAgent extends ApiRequestHandler<CreateAgentResponse> {
         (requestData[capabilitiesParam] as List<dynamic>)
             .cast<String>()
             .toList();
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final AgentService agentService = agentServiceProvider();
     final Key key = datastore.db.emptyKey.append(Agent, id: agentId);
 

--- a/app_dart/lib/src/request_handlers/get_benchmarks.dart
+++ b/app_dart/lib/src/request_handlers/get_benchmarks.dart
@@ -28,8 +28,7 @@ class GetBenchmarks extends RequestHandler<Body> {
   @override
   Future<Body> get() async {
     const int maxRecords = 50;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final DatastoreDB db = datastore.db;
 
     final List<Map<String, dynamic>> benchmarks = <Map<String, dynamic>>[];

--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -37,8 +37,7 @@ class GetBuildStatus extends RequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService =
         buildStatusProvider(datastore);
     final String branch = request.uri.queryParameters[branchParam] ?? 'master';

--- a/app_dart/lib/src/request_handlers/get_log.dart
+++ b/app_dart/lib/src/request_handlers/get_log.dart
@@ -48,8 +48,7 @@ class GetLog extends ApiRequestHandler<Body> {
         KeyHelper(applicationContext: context.applicationContext);
     final Key ownerKey = keyHelper.decode(encodedOwnerKey);
 
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final Task task =
         await datastore.db.lookupValue<Task>(ownerKey, orElse: () => null);
     if (task == null) {

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -39,8 +39,7 @@ class GetStatus extends RequestHandler<Body> {
     final String encodedLastCommitKey =
         request.uri.queryParameters[lastCommitKeyParam];
     final String branch = request.uri.queryParameters[branchParam] ?? 'master';
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService =
         buildStatusProvider(datastore);
     final KeyHelper keyHelper = config.keyHelper;

--- a/app_dart/lib/src/request_handlers/get_timeseries_history.dart
+++ b/app_dart/lib/src/request_handlers/get_timeseries_history.dart
@@ -40,8 +40,7 @@ class GetTimeSeriesHistory
     checkRequiredParameters(<String>[timeSeriesKeyParam]);
     // This number inherites from earlier GO backend. Up to change if necessary.
     const int maxRecords = 6000;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final KeyHelper keyHelper = KeyHelper(
         applicationContext: AppEngineContext(false, '', '', '', '', '', Uri()));
     final Set<Commit> commits =

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -58,8 +58,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     }
 
     const RepositorySlug slug = RepositorySlug('flutter', 'engine');
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final GitHub github = await config.createGitHubClient();
     final List<GithubBuildStatusUpdate> updates = <GithubBuildStatusUpdate>[];
     await for (PullRequest pr in github.pullRequests.list(slug)) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -43,8 +43,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   @override
   Future<Body> get() async {
     final Logging log = loggingProvider();
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
 
     if (authContext.clientContext.isDevelopmentEnvironment) {
       // Don't push gold status from the local dev server.

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -56,8 +56,7 @@ class RefreshCirrusStatus extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final GraphQLClient client = await config.createCirrusGraphQLClient();
     final List<Branch> branches = await getBranches(
         config, branchHttpClientProvider, log, gitHubBackoffCalculator);

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -56,8 +56,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
   Future<Body> get() async {
     const RepositorySlug slug = RepositorySlug('flutter', 'flutter');
     final GithubService githubService = await config.createGithubService();
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final List<Branch> branches = await getBranches(
         config, branchHttpClientProvider, log, gitHubBackoffCalculator);
 

--- a/app_dart/lib/src/request_handlers/reserve_task.dart
+++ b/app_dart/lib/src/request_handlers/reserve_task.dart
@@ -46,8 +46,8 @@ class ReserveTask extends ApiRequestHandler<ReserveTaskResponse> {
 
   @override
   Future<ReserveTaskResponse> post() async {
-    final DatastoreService datastore = DatastoreService.defaultProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore =
+        DatastoreService.defaultProvider(config.db);
     final TaskService taskService = taskServiceProvider(datastore);
     final ReservationService reservationService =
         reservationServiceProvider(datastore);

--- a/app_dart/lib/src/request_handlers/reset_devicelab_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_devicelab_task.dart
@@ -34,8 +34,7 @@ class ResetDevicelabTask extends ApiRequestHandler<Body> {
   @override
   Future<Body> post() async {
     checkRequiredParameters(<String>[keyParam]);
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final String encodedKey = requestData[keyParam] as String;
     final ClientContext clientContext = authContext.clientContext;
     final KeyHelper keyHelper =

--- a/app_dart/lib/src/request_handlers/update_agent_health.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health.dart
@@ -38,8 +38,7 @@ class UpdateAgentHealth extends ApiRequestHandler<UpdateAgentHealthResponse> {
     final String agentId = requestData[agentIdParam] as String;
     final bool isHealthy = requestData[isHealthyParam] as bool;
     final String healthDetails = requestData[healthDetailsParam] as String;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final Key key = datastore.db.emptyKey.append(Agent, id: agentId);
     final Agent agent = await datastore.db.lookupValue<Agent>(
       key,

--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -45,8 +45,7 @@ class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {
     final Logging log = loggingProvider();
     final TabledataResourceApi tabledataResourceApi =
         await config.createTabledataResourceApi();
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final Query<Agent> agentQuery = datastore.db.query<Agent>()
       ..order('agentId');
     final List<Agent> agents =

--- a/app_dart/lib/src/request_handlers/update_benchmark_targets.dart
+++ b/app_dart/lib/src/request_handlers/update_benchmark_targets.dart
@@ -39,8 +39,7 @@ class UpdateBenchmarkTargets
         <String>[timeSeriesKeyParam, goalParam, baselineParam]);
 
     final ClientContext clientContext = authContext.clientContext;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final KeyHelper keyHelper =
         KeyHelper(applicationContext: clientContext.applicationContext);
     double goal = requestData[goalParam] as double;

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -46,8 +46,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
   Future<UpdateTaskStatusResponse> post() async {
     checkRequiredParameters(<String>[taskKeyParam, newStatusParam]);
 
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final ClientContext clientContext = authContext.clientContext;
     final KeyHelper keyHelper =
         KeyHelper(applicationContext: clientContext.applicationContext);

--- a/app_dart/lib/src/request_handlers/update_timeseries.dart
+++ b/app_dart/lib/src/request_handlers/update_timeseries.dart
@@ -48,8 +48,7 @@ class UpdateTimeSeries extends ApiRequestHandler<UpdateTimeSeriesResponse> {
       archivedParam
     ]);
 
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final ClientContext clientContext = authContext.clientContext;
     final KeyHelper keyHelper =
         KeyHelper(applicationContext: clientContext.applicationContext);

--- a/app_dart/lib/src/request_handlers/vacuum-clean.dart
+++ b/app_dart/lib/src/request_handlers/vacuum-clean.dart
@@ -39,8 +39,7 @@ class VacuumClean extends ApiRequestHandler<Body> {
   @override
   Future<Body> get() async {
     final int maxRetries = config.maxTaskRetries;
-    final DatastoreService datastore = datastoreProvider(
-        db: config.db, maxEntityGroups: config.maxEntityGroups);
+    final DatastoreService datastore = datastoreProvider(config.db);
     final List<Task> tasks = await datastore
         .queryRecentTasks(commitLimit: config.commitNumber)
         .map<Task>((FullTask fullTask) => fullTask.task)

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -20,9 +20,13 @@ import '../model/appengine/task.dart';
 import '../model/appengine/time_series.dart';
 import '../model/appengine/time_series_value.dart';
 
+/// Per the docs in [DatastoreDB.withTransaction], only 5 entity groups can
+/// be touched in any given transaction, or the backing datastore will throw
+/// an error.
+const int defaultMaxEntityGroups = 5;
+
 /// Function signature for a [DatastoreService] provider.
-typedef DatastoreServiceProvider = DatastoreService Function(
-    {DatastoreDB db, int maxEntityGroups});
+typedef DatastoreServiceProvider = DatastoreService Function(DatastoreDB db);
 
 /// Function signature that will be executed with retries.
 typedef RetryHandler = Function();
@@ -63,9 +67,8 @@ class DatastoreService {
   final DatastoreDB db;
 
   /// Creates and returns a [DatastoreService] using [db] and [maxEntityGroups].
-  static DatastoreService defaultProvider(
-      {DatastoreDB db, int maxEntityGroups}) {
-    return DatastoreService(db ?? dbService, maxEntityGroups ?? 5);
+  static DatastoreService defaultProvider(DatastoreDB db) {
+    return DatastoreService(db ?? dbService, defaultMaxEntityGroups);
   }
 
   /// Queries for recent commits.

--- a/app_dart/test/request_handlers/authorize_agent_test.dart
+++ b/app_dart/test/request_handlers/authorize_agent_test.dart
@@ -27,8 +27,7 @@ void main() {
       handler = AuthorizeAgent(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/create_agent_test.dart
+++ b/app_dart/test/request_handlers/create_agent_test.dart
@@ -31,8 +31,7 @@ void main() {
       handler = CreateAgent(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -47,8 +47,7 @@ void main() {
           FakeBuildStatusService(commitStatuses: <CommitStatus>[]);
       handler = GetStatus(
         config,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         buildStatusProvider: (_) => buildStatusService,
       );
     });
@@ -109,8 +108,7 @@ void main() {
           ]);
       handler = GetStatus(
         config,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         buildStatusProvider: (_) => buildStatusService,
       );
 
@@ -139,8 +137,7 @@ void main() {
           ]);
       handler = GetStatus(
         config,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         buildStatusProvider: (_) => buildStatusService,
       );
 
@@ -190,8 +187,7 @@ void main() {
           ]);
       handler = GetStatus(
         config,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         buildStatusProvider: (_) => buildStatusService,
       );
 

--- a/app_dart/test/request_handlers/get_timeseries_history_test.dart
+++ b/app_dart/test/request_handlers/get_timeseries_history_test.dart
@@ -31,8 +31,7 @@ void main() {
       };
       handler = GetTimeSeriesHistory(
         config,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -90,8 +90,7 @@ void main() {
       handler = PushBuildStatusToGithub(
         config,
         auth,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         loggingProvider: () => log,
         buildStatusServiceProvider: (_) => buildStatusService,
         branchHttpClientProvider: () => branchHttpClient,

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -55,8 +55,7 @@ void main() {
       handler = PushGoldStatusToGithub(
         config,
         auth,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         loggingProvider: () => log,
         goldClient: mockHttpClient,
       );

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -64,8 +64,7 @@ void main() {
         config,
         FakeAuthenticationProvider(),
         luciServiceProvider: (_) => mockLuciService,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         branchHttpClientProvider: () => branchHttpClient,
         gitHubBackoffCalculator: (int attempt) => Duration.zero,
       );

--- a/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
@@ -62,8 +62,7 @@ void main() {
       handler = RefreshCirrusStatus(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         branchHttpClientProvider: () => branchHttpClient,
       );
 

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -109,8 +109,7 @@ void main() {
       handler = RefreshGithubCommits(
         config,
         auth,
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         httpClientProvider: () => httpClient,
         branchHttpClientProvider: () => branchHttpClient,
         gitHubBackoffCalculator: (int attempt) => Duration.zero,

--- a/app_dart/test/request_handlers/reset_devicelab_task_test.dart
+++ b/app_dart/test/request_handlers/reset_devicelab_task_test.dart
@@ -31,8 +31,7 @@ void main() {
       handler = ResetDevicelabTask(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/update_agent_health_history_test.dart
+++ b/app_dart/test/request_handlers/update_agent_health_history_test.dart
@@ -42,8 +42,7 @@ void main() {
       handler = UpdateAgentHealthHistory(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         loggingProvider: () => log,
       );
     });

--- a/app_dart/test/request_handlers/update_agent_health_test.dart
+++ b/app_dart/test/request_handlers/update_agent_health_test.dart
@@ -29,8 +29,7 @@ void main() {
       handler = UpdateAgentHealth(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/update_benchmark_targets_test.dart
+++ b/app_dart/test/request_handlers/update_benchmark_targets_test.dart
@@ -30,7 +30,9 @@ void main() {
       handler = UpdateBenchmarkTargets(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
+        datastoreProvider: (
+          DatastoreDB db,
+        ) =>
             DatastoreService(config.db, 5),
       );
     });

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -44,8 +44,7 @@ void main() {
       handler = UpdateTaskStatus(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/request_handlers/update_timeseries_test.dart
+++ b/app_dart/test/request_handlers/update_timeseries_test.dart
@@ -34,8 +34,7 @@ void main() {
       handler = UpdateTimeSeries(
         config,
         FakeAuthenticationProvider(),
-        datastoreProvider: ({DatastoreDB db, int maxEntityGroups}) =>
-            DatastoreService(config.db, 5),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
     });
 

--- a/app_dart/test/service/datastore_test.dart
+++ b/app_dart/test/service/datastore_test.dart
@@ -44,9 +44,7 @@ void main() {
       setUp(() {});
 
       test('defaultProvider returns a DatasourceService object', () async {
-        expect(
-            DatastoreService.defaultProvider(
-                db: config.db, maxEntityGroups: config.maxEntityGroups),
+        expect(DatastoreService.defaultProvider(config.db),
             isA<DatastoreService>());
       });
 
@@ -94,8 +92,7 @@ void main() {
           await datastoreService.shard(<Commit>[Commit()]);
       expect(shards, hasLength(1));
       // maxEntityGroups = 1
-      config.maxEntityGroups = 1;
-      datastoreService = DatastoreService(config.db, config.maxEntityGroups);
+      datastoreService = DatastoreService(config.db, 1);
       shards =
           await datastoreService.shard(<Commit>[Commit(), Commit(), Commit()]);
       expect(shards, hasLength(3));

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -19,7 +19,6 @@ import 'fake_datastore.dart';
 // ignore: must_be_immutable
 class FakeConfig implements Config {
   FakeConfig({
-    this.maxEntityGroups = 5,
     this.githubClient,
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
@@ -81,9 +80,6 @@ class FakeConfig implements Config {
 
   @override
   int get luciTryInfraFailureRetries => luciTryInfraFailureRetriesValue;
-
-  @override
-  int maxEntityGroups;
 
   @override
   Future<GitHub> createGitHubClient() async => githubClient;


### PR DESCRIPTION
* Force to pass the db parameter when creating datastore.
* Move maxEntityGroups constant to service/datastore.
* Remove passing the maxEntityGroups in handlers and tests.

Bugs:

  flutter/flutter#42524
  flutter/flutter#43112
  flutter/flutter#49673
  flutter/flutter#49672