### PR TITLE
Fix too many entity groups error.

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -236,8 +236,8 @@ class DatastoreService {
   Future<List<List<Model>>> shard(List<Model> rows) async {
     final List<List<Model>> shards = <List<Model>>[];
     for (int i = 0; i < rows.length; i += maxEntityGroups) {
-      shards.add(
-          rows.sublist(i, i + min<int>(rows.length - i, i + maxEntityGroups)));
+      shards
+          .add(rows.sublist(i, i + min<int>(rows.length - i, maxEntityGroups)));
     }
     return shards;
   }

--- a/app_dart/test/service/datastore_test.dart
+++ b/app_dart/test/service/datastore_test.dart
@@ -88,19 +88,26 @@ void main() {
 
     test('Shard', () async {
       // default maxEntityGroups = 5
-      List<List<Model>> shards =
-          await datastoreService.shard(<Commit>[Commit()]);
-      expect(shards, hasLength(1));
-      // maxEntityGroups = 1
-      datastoreService = DatastoreService(config.db, 1);
-      shards =
-          await datastoreService.shard(<Commit>[Commit(), Commit(), Commit()]);
-      expect(shards, hasLength(3));
+      List<List<Model>> shards = await datastoreService.shard(
+          <Commit>[Commit(), Commit(), Commit(), Commit(), Commit(), Commit()]);
+      expect(shards, hasLength(2));
+      expect(shards[0], hasLength(5));
+      expect(shards[1], hasLength(1));
       // maxEntigroups = 2
       datastoreService = DatastoreService(config.db, 2);
       shards =
           await datastoreService.shard(<Commit>[Commit(), Commit(), Commit()]);
       expect(shards, hasLength(2));
+      expect(shards[0], hasLength(2));
+      expect(shards[1], hasLength(1));
+      // maxEntityGroups = 1
+      datastoreService = DatastoreService(config.db, 1);
+      shards =
+          await datastoreService.shard(<Commit>[Commit(), Commit(), Commit()]);
+      expect(shards, hasLength(3));
+      expect(shards[0], hasLength(1));
+      expect(shards[1], hasLength(1));
+      expect(shards[2], hasLength(1));
     });
 
     test('Insert', () async {


### PR DESCRIPTION
This was because we were trying to send too many groups >5 in a single
transaction.

https://github.com/flutter/flutter/issues/54376