### PR TITLE
Re-enable Engine try jobs.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -278,6 +278,30 @@ class Config {
           'repo': 'engine',
         },
         <String, String>{
+          'name': 'Mac Host Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Android AOT Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Android Debug Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Engine Drone',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac Host Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
+          'name': 'Mac iOS Engine',
+          'repo': 'engine',
+        },
+        <String, String>{
           'name': 'Windows Host Engine',
           'repo': 'engine',
         },


### PR DESCRIPTION
We have add 10 mac minis that can run these Engine try builds. Let's see if the capacity is enough.

A known issue: Mac iOS Engine is flaky due to https://github.com/flutter/flutter/issues/53455.

Bug: https://github.com/flutter/flutter/issues/49088