### PR TITLE
Add branch filter when querying TimeseriesValue for benchmark history

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -114,9 +114,10 @@ class DatastoreService {
   /// If startFrom is nil, starts from the latest available record.
   /// [startFrom] to be implemented...
   Stream<TimeSeriesValue> queryRecentTimeSeriesValues(TimeSeries timeSeries,
-      {int limit = 1500, String startFrom}) {
+      {int limit = 1500, String startFrom, String branch = 'master'}) {
     final Query<TimeSeriesValue> query =
         db.query<TimeSeriesValue>(ancestorKey: timeSeries.key)
+          ..filter('branch =', branch)
           ..limit(limit)
           ..order('-createTimestamp');
     return query.run();


### PR DESCRIPTION
Before this PR, it queries recent history data regardless of branches. 
With this PR, it uses default `master`.