### PR TITLE
Add cocoon API to save different repo commits and roll commits to bigquery tables

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -40,6 +40,7 @@ Future<void> main() async {
       '/api/refresh-chromebot-status':
           RefreshChromebotStatus(config, authProvider),
       '/api/refresh-github-commits': RefreshGithubCommits(config, authProvider),
+      '/api/refresh-gitiles-commits': RefreshGitilesCommits(config, authProvider),
       '/api/refresh-cirrus-status': RefreshCirrusStatus(config, authProvider),
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(config, authProvider),

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -40,7 +40,8 @@ Future<void> main() async {
       '/api/refresh-chromebot-status':
           RefreshChromebotStatus(config, authProvider),
       '/api/refresh-github-commits': RefreshGithubCommits(config, authProvider),
-      '/api/refresh-gitiles-commits': RefreshGitilesCommits(config, authProvider),
+      '/api/refresh-gitiles-commits':
+          RefreshGitilesCommits(config, authProvider),
       '/api/refresh-cirrus-status': RefreshCirrusStatus(config, authProvider),
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(config, authProvider),

--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -28,3 +28,6 @@ cron:
 - description: insert agent health status to bigquery
   url: /api/update-agent-health-history
   schedule: every 1 minutes
+- description: refresh commits from gitiles
+  url: /api/refresh-gitiles-commits
+  schedule: every 10 minutes

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -22,6 +22,7 @@ export 'src/request_handlers/push_gold_status_to_github.dart';
 export 'src/request_handlers/refresh_chromebot_status.dart';
 export 'src/request_handlers/refresh_cirrus_status.dart';
 export 'src/request_handlers/refresh_github_commits.dart';
+export 'src/request_handlers/refresh_gitiles_commits.dart';
 export 'src/request_handlers/reserve_task.dart';
 export 'src/request_handlers/reset_devicelab_task.dart';
 export 'src/request_handlers/update_agent_health.dart';

--- a/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
@@ -22,8 +22,7 @@ import '../request_handling/body.dart';
 /// For parent repo roll commits, obtains its sub-repo commits and inserts
 /// them to `BigQuery`.
 @immutable
-class RefreshGitilesCommits
-    extends ApiRequestHandler<Body> {
+class RefreshGitilesCommits extends ApiRequestHandler<Body> {
   const RefreshGitilesCommits(
     Config config,
     AuthenticationProvider authenticationProvider, {

--- a/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
@@ -18,7 +18,7 @@ import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
 
 /// Queries `gitiles` for the list of recent commits of different repos,
-/// and creates corresponding rows in the `BigQuery` for any new commits. 
+/// and creates corresponding rows in the `BigQuery` for any new commits.
 /// For parent repo roll commits, obtains its sub-repo commits and inserts
 /// them to `BigQuery`.
 @immutable
@@ -67,8 +67,8 @@ class RefreshGitilesCommits
     final List<Map<String, dynamic>> listResult = <Map<String, dynamic>>[];
     final HttpClient httpClient = httpClientProvider();
     for (String repo in repoMap.keys) {
-      final List<Map<String, dynamic>> list = await _getCommitList(httpClient,
-          repoMap[repo].address, '${repoMap[repo].path}$refs');
+      final List<Map<String, dynamic>> list = await _getCommitList(
+          httpClient, repoMap[repo].address, '${repoMap[repo].path}$refs');
       await _insertBigquery(list, repo);
       listResult.add(list[0]);
     }
@@ -84,8 +84,8 @@ class RefreshGitilesCommits
     return DateTime.parse(newCommitTime).millisecondsSinceEpoch;
   }
 
-  Future<List<Map<String, dynamic>>> _getCommitList(final HttpClient client, 
-      String address, String path) async {
+  Future<List<Map<String, dynamic>>> _getCommitList(
+      final HttpClient client, String address, String path) async {
     final Uri url =
         Uri.https(address, path, <String, String>{'format': 'JSON'});
     //final HttpClient client = httpClientProvider();
@@ -153,16 +153,16 @@ class RefreshGitilesCommits
 
     await _insertCommit(commitRequestRows, tabledataResourceApi, table);
     if (skiaRollCommitRequestRows.isNotEmpty) {
-      await _insertCommit(skiaRollCommitRequestRows, tabledataResourceApi,
-          'skiaRoller');
+      await _insertCommit(
+          skiaRollCommitRequestRows, tabledataResourceApi, 'skiaRoller');
     }
     if (dartRollCommitRequestRows.isNotEmpty) {
-      await _insertCommit(dartRollCommitRequestRows, tabledataResourceApi,
-          'dartRoller');
+      await _insertCommit(
+          dartRollCommitRequestRows, tabledataResourceApi, 'dartRoller');
     }
     if (engineRollCommitRequestRows.isNotEmpty) {
-      await _insertCommit(engineRollCommitRequestRows, tabledataResourceApi,
-          'engineRoller');
+      await _insertCommit(
+          engineRollCommitRequestRows, tabledataResourceApi, 'engineRoller');
     }
   }
 
@@ -259,7 +259,8 @@ class RefreshGitilesCommits
 
     final List<String> subjectSplit = subject.split(' ');
     final HttpClient rollHttpClient = rollHttpClientProvider();
-    final List<Map<String, dynamic>> rollCommitList = await _getCommitList(rollHttpClient, 
+    final List<Map<String, dynamic>> rollCommitList = await _getCommitList(
+        rollHttpClient,
         repoMap[priorRepo].address,
         '${repoMap[priorRepo].path}${subjectSplit[2]}');
     log.debug('$subject, ${rollCommitList.length}');
@@ -277,22 +278,10 @@ class RefreshGitilesCommits
 }
 
 class RefreshGitilesCommitsResponse extends JsonBody {
-  const RefreshGitilesCommitsResponse(this.commitList) : assert(commitList != null);
+  const RefreshGitilesCommitsResponse(this.commitList)
+      : assert(commitList != null);
 
   final List<Map<String, dynamic>> commitList;
-
-  @override
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'CommitList': commitList,
-    };
-  }
-}
-
-class RefreshGitilesCommitsResponse2 extends JsonBody {
-  const RefreshGitilesCommitsResponse2(this.commitList) : assert(commitList != null);
-
-  final String commitList;
 
   @override
   Map<String, dynamic> toJson() {

--- a/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
@@ -1,0 +1,312 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:meta/meta.dart';
+
+import '../datastore/cocoon_config.dart';
+import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/authentication.dart';
+import '../request_handling/body.dart';
+
+/// Queries `gitiles` for the list of recent commits of different repos,
+/// and creates corresponding rows in the `BigQuery` for any new commits. 
+/// For parent repo roll commits, obtains its sub-repo commits and inserts
+/// them to `BigQuery`.
+@immutable
+class RefreshGitilesCommits
+    extends ApiRequestHandler<RefreshGitilesCommitsResponse> {
+  const RefreshGitilesCommits(
+    Config config,
+    AuthenticationProvider authenticationProvider, {
+    @visibleForTesting this.httpClientProvider = Providers.freshHttpClient,
+    @visibleForTesting this.rollHttpClientProvider = Providers.freshHttpClient,
+  })  : assert(httpClientProvider != null),
+        super(config: config, authenticationProvider: authenticationProvider);
+
+  final HttpClientProvider httpClientProvider;
+  final HttpClientProvider rollHttpClientProvider;
+
+  static const String projectId = 'flutter-dashboard';
+  static const String dataset = 'roller';
+
+  static const Map<String, String> monthMap = <String, String>{
+    'Jan': '01',
+    'Feb': '02',
+    'Mar': '03',
+    'Apr': '04',
+    'May': '05',
+    'Jun': '06',
+    'Jul': '07',
+    'Aug': '08',
+    'Sep': '09',
+    'Oct': '10',
+    'Nov': '11',
+    'Dec': '12'
+  };
+  static const Map<String, RepoUrl> repoMap = <String, RepoUrl>{
+    'skia': RepoUrl('skia.googlesource.com', '/skia.git/+log/'),
+    'dart': RepoUrl('dart.googlesource.com', '/sdk.git/+log/'),
+    'engine': RepoUrl('chromium.googlesource.com',
+        '/external/github.com/flutter/engine/+log/'),
+    'flutter': RepoUrl('chromium.googlesource.com',
+        '/external/github.com/flutter/flutter/+log/'),
+  };
+  static const String refs = 'refs/heads/master';
+
+  @override
+  Future<RefreshGitilesCommitsResponse> get() async {
+    final List<Map<String, dynamic>> listResult = <Map<String, dynamic>>[];
+    final HttpClient httpClient = httpClientProvider();
+    for (String repo in repoMap.keys) {
+      final List<Map<String, dynamic>> list = await _getCommitList(httpClient,
+          repoMap[repo].address, '${repoMap[repo].path}$refs');
+      await _insertBigquery(list, repo);
+      listResult.add(list[0]);
+    }
+
+    return RefreshGitilesCommitsResponse(listResult);
+  }
+
+  int _getMilliseconds(String time) {
+    /// [time] is with format `Fri Apr 17 11:58:29 2020 -0500`.
+    final List<String> timeParts = time.split(' ');
+    final String newCommitTime =
+        '${timeParts[4]}-${monthMap[timeParts[1]]}-${timeParts[2]} ${timeParts[3]}';
+    return DateTime.parse(newCommitTime).millisecondsSinceEpoch;
+  }
+
+  Future<List<Map<String, dynamic>>> _getCommitList(final HttpClient client, 
+      String address, String path) async {
+    final Uri url =
+        Uri.https(address, path, <String, String>{'format': 'JSON'});
+    //final HttpClient client = httpClientProvider();
+    final HttpClientRequest clientRequest = await client.getUrl(url);
+    final HttpClientResponse clientResponse = await clientRequest.close();
+    final int status = clientResponse.statusCode;
+
+    String content;
+
+    if (status == HttpStatus.ok) {
+      content = await utf8.decoder.bind(clientResponse).join();
+    } else {
+      log.warning(
+          'Attempt to retrieve $address commit list failed (HTTP $status)');
+      return const <Map<String, dynamic>>[];
+    }
+    final Map<String, dynamic> map =
+        json.decode(content.substring(content.indexOf('{')))
+            as Map<String, dynamic>;
+    return (map['log'] as List<dynamic>).cast<Map<String, dynamic>>();
+  }
+
+  Future<void> _insertBigquery(
+      List<Map<String, dynamic>> list, String repo) async {
+    final String table = '${repo}Commit';
+    final TabledataResourceApi tabledataResourceApi =
+        await config.createTabledataResourceApi();
+    final List<Map<String, Object>> commitRequestRows = <Map<String, Object>>[];
+    final List<Map<String, Object>> skiaRollCommitRequestRows =
+        <Map<String, Object>>[];
+    final List<Map<String, Object>> dartRollCommitRequestRows =
+        <Map<String, Object>>[];
+    final List<Map<String, Object>> engineRollCommitRequestRows =
+        <Map<String, Object>>[];
+    final int lastCommitedTime =
+        await _getLastCommitedTime(tabledataResourceApi, table, 'CommitTime');
+
+    //log.debug('lastCommitedTime: $lastCommitedTime');
+    for (Map<String, dynamic> commit in list) {
+      final String message = commit['message'] as String;
+      final String subject = message.split('\n')[0];
+      final bool newCommitflag = await _appendNewCommit(
+          commit, commitRequestRows, lastCommitedTime, subject, repo);
+      if (!newCommitflag) {
+        break;
+      }
+
+      /// Insert roll commits if any.
+      final String priorRepo = _getPriorRepo(subject);
+      if (priorRepo.isNotEmpty) {
+        await _appendRollCommit(
+            skiaRollCommitRequestRows,
+            dartRollCommitRequestRows,
+            engineRollCommitRequestRows,
+            subject,
+            priorRepo,
+            commit);
+      }
+    }
+
+    if (commitRequestRows.isEmpty) {
+      log.debug('no new commits found for repo $repo');
+      return;
+    }
+
+    await _insertCommit(commitRequestRows, tabledataResourceApi, table);
+    if (skiaRollCommitRequestRows.isNotEmpty) {
+      await _insertCommit(skiaRollCommitRequestRows, tabledataResourceApi,
+          'skiaRoller');
+    }
+    if (dartRollCommitRequestRows.isNotEmpty) {
+      await _insertCommit(dartRollCommitRequestRows, tabledataResourceApi,
+          'dartRoller');
+    }
+    if (engineRollCommitRequestRows.isNotEmpty) {
+      await _insertCommit(engineRollCommitRequestRows, tabledataResourceApi,
+          'engineRoller');
+    }
+  }
+
+  Future<int> _getLastCommitedTime(TabledataResourceApi tabledataResourceApi,
+      String table, String selectedFields) async {
+    final TableDataList tableDataList = await tabledataResourceApi
+        .list(projectId, dataset, table, selectedFields: selectedFields);
+    int lastCommitedTime = 0;
+    if (tableDataList.rows != null) {
+      final List<int> commitTimeList =
+          (tableDataList.rows.map((TableRow e) => e.f).toList())
+              .map((List<TableCell> e) => int.parse(e[0].v as String))
+              .toList();
+      lastCommitedTime = commitTimeList.reduce(math.max);
+    }
+    return lastCommitedTime;
+  }
+
+  Future<void> _insertCommit(List<Map<String, Object>> requestRows,
+      TabledataResourceApi tabledataResourceApi, String table) async {
+    /// [rows] to be inserted to [BigQuery]
+    final TableDataInsertAllRequest request =
+        TableDataInsertAllRequest.fromJson(
+            <String, Object>{'rows': requestRows});
+
+    try {
+      await tabledataResourceApi.insertAll(request, projectId, dataset, table);
+      log.debug(
+          'successfully inserted ${requestRows.length} new commits to table $table');
+    } catch (ApiRequestError) {
+      log.warning('Failed to add data to $table in BigQuery: $ApiRequestError');
+    }
+  }
+
+  Future<bool> _appendNewCommit(
+    Map<String, dynamic> commit,
+    List<Map<String, Object>> requestRows,
+    int lastCommitedTime,
+    String subject,
+    String repo,
+  ) async {
+    final Map<String, dynamic> author =
+        commit['author'] as Map<String, dynamic>;
+    final Map<String, dynamic> committer =
+        commit['committer'] as Map<String, dynamic>;
+    final int commitTime = _getMilliseconds(committer['time'] as String);
+    //log.debug('Time for commit: ${commit['commit'] as String} is $commitTime (${committer['time'] as String})');
+    if (commitTime <= lastCommitedTime) {
+      log.debug('found ${requestRows.length} new commits for repo $repo');
+      return false;
+    }
+    requestRows.add(<String, Object>{
+      'json': <String, Object>{
+        'Sha': commit['commit'] as String,
+        'CommitTime': commitTime,
+        'Subject': subject,
+        'Author': author['name'] as String,
+      },
+    });
+    return true;
+  }
+
+  String _getPriorRepo(String subject) {
+    String priorRepo = '';
+    if (subject.startsWith('Roll src\/third_party\/dart')) {
+      priorRepo = 'dart';
+    } else if (subject.startsWith('Roll src\/third_party\/skia')) {
+      priorRepo = 'skia';
+    } else if (subject.startsWith('Roll engine')) {
+      priorRepo = 'engine';
+    }
+    return priorRepo;
+  }
+
+  Future<void> _appendRollCommit(
+      List<Map<String, Object>> skiaRollCommitRequestRows,
+      List<Map<String, Object>> dartRollCommitRequestRows,
+      List<Map<String, Object>> engineRollCommitRequestRows,
+      String subject,
+      String priorRepo,
+      Map<String, dynamic> rollCommit) async {
+    final Map<String, dynamic> committer =
+        rollCommit['committer'] as Map<String, dynamic>;
+    final int commitTime = _getMilliseconds(committer['time'] as String);
+
+    List<Map<String, Object>> rollCommitRequestRows;
+    if (priorRepo == 'skia') {
+      rollCommitRequestRows = skiaRollCommitRequestRows;
+    } else if (priorRepo == 'dart') {
+      rollCommitRequestRows = dartRollCommitRequestRows;
+    } else {
+      rollCommitRequestRows = engineRollCommitRequestRows;
+    }
+
+    final List<String> subjectSplit = subject.split(' ');
+    final HttpClient rollHttpClient = rollHttpClientProvider();
+    final List<Map<String, dynamic>> rollCommitList = await _getCommitList(rollHttpClient, 
+        repoMap[priorRepo].address,
+        '${repoMap[priorRepo].path}${subjectSplit[2]}');
+    log.debug('$subject, ${rollCommitList.length}');
+
+    for (Map<String, dynamic> commit in rollCommitList) {
+      rollCommitRequestRows.add(<String, Object>{
+        'json': <String, Object>{
+          'RollFromSha': commit['commit'] as String,
+          'RollToSha': rollCommit['commit'] as String,
+          'RollTime': commitTime,
+        },
+      });
+    }
+  }
+}
+
+class RefreshGitilesCommitsResponse extends JsonBody {
+  const RefreshGitilesCommitsResponse(this.commitList) : assert(commitList != null);
+
+  final List<Map<String, dynamic>> commitList;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'CommitList': commitList,
+    };
+  }
+}
+
+class RefreshGitilesCommitsResponse2 extends JsonBody {
+  const RefreshGitilesCommitsResponse2(this.commitList) : assert(commitList != null);
+
+  final String commitList;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'CommitList': commitList,
+    };
+  }
+}
+
+class RepoUrl {
+  const RepoUrl(this.address, this.path)
+      : assert(address != null),
+        assert(path != null);
+
+  final String address;
+  final String path;
+}

--- a/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_gitiles_commits.dart
@@ -23,7 +23,7 @@ import '../request_handling/body.dart';
 /// them to `BigQuery`.
 @immutable
 class RefreshGitilesCommits
-    extends ApiRequestHandler<RefreshGitilesCommitsResponse> {
+    extends ApiRequestHandler<Body> {
   const RefreshGitilesCommits(
     Config config,
     AuthenticationProvider authenticationProvider, {
@@ -63,17 +63,15 @@ class RefreshGitilesCommits
   static const String refs = 'refs/heads/master';
 
   @override
-  Future<RefreshGitilesCommitsResponse> get() async {
-    final List<Map<String, dynamic>> listResult = <Map<String, dynamic>>[];
+  Future<Body> get() async {
     final HttpClient httpClient = httpClientProvider();
     for (String repo in repoMap.keys) {
       final List<Map<String, dynamic>> list = await _getCommitList(
           httpClient, repoMap[repo].address, '${repoMap[repo].path}$refs');
       await _insertBigquery(list, repo);
-      listResult.add(list[0]);
     }
 
-    return RefreshGitilesCommitsResponse(listResult);
+    return Body.empty;
   }
 
   int _getMilliseconds(String time) {
@@ -274,20 +272,6 @@ class RefreshGitilesCommits
         },
       });
     }
-  }
-}
-
-class RefreshGitilesCommitsResponse extends JsonBody {
-  const RefreshGitilesCommitsResponse(this.commitList)
-      : assert(commitList != null);
-
-  final List<Map<String, dynamic>> commitList;
-
-  @override
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'CommitList': commitList,
-    };
   }
 }
 

--- a/app_dart/test/request_handlers/refresh_gitiles_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_gitiles_commits_test.dart
@@ -63,8 +63,9 @@ void main() {
 
     test('insert to bigquery for non-roller commit list', () async {
       httpClient.request.response.body = skiaCommits;
-      
+
       await tester.get(handler);
+
       /// Insert happens four times `skia, dart, engine, flutter`. Each time
       /// it inserts two commits in [skiaCommits].
       expect(tabledataResourceApi.rows.length, 8);
@@ -73,8 +74,9 @@ void main() {
     test('insert to bigquery for commit list with roll commit', () async {
       httpClient.request.response.body = commits;
       rollHttpClient.request.response.body = rollCommits;
-      
+
       await tester.get(handler);
+
       /// Insert happens four times `skia, dart, engine, flutter`. Each time
       /// it inserts one commit in [commits] and two commits in [rollCommits].
       expect(tabledataResourceApi.rows.length, 12);

--- a/app_dart/test/request_handlers/refresh_gitiles_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_gitiles_commits_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/request_handlers/refresh_gitiles_commits.dart';
+import 'package:test/test.dart';
+
+import '../src/bigquery/fake_tabledata_resource.dart';
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_http.dart';
+
+const String skiaCommits = ''')]}{
+      "log": [
+        {"commit": "c1", 
+        "author": {"name": "n1"},
+        "committer": {"time": "Wed Apr 22 17:58:07 2020 +0000"},
+        "message": "abc"},
+        {"commit": "c2", 
+        "author": {"name": "n2"},
+        "committer": {"time": "Wed Apr 21 17:58:07 2020 +0000"},
+        "message": "def"}]}''';
+const String commits = ''')]}{
+      "log": [
+        {"commit": "c2", 
+        "author": {"name": "n2"},
+        "committer": {"time": "Wed Apr 21 17:58:07 2020 +0000"},
+        "message": "Roll src/third_party/skia abc...def"}]}''';
+const String rollCommits = ''')]}{
+      "log": [
+        {"commit": "c3", 
+        "author": {"name": "n3"},
+        "committer": {"time": "Wed Apr 20 17:58:07 2020 +0000"},
+        "message": "ghi"},
+        {"commit": "c4", 
+        "author": {"name": "n4"},
+        "committer": {"time": "Wed Apr 19 17:58:07 2020 +0000"},
+        "message": "jkl"}]}''';
+
+void main() {
+  group('RefreshGitilesCommits', () {
+    FakeConfig config;
+    ApiRequestHandlerTester tester;
+    RefreshGitilesCommits handler;
+    FakeHttpClient httpClient;
+    FakeHttpClient rollHttpClient;
+    FakeTabledataResourceApi tabledataResourceApi;
+
+    setUp(() {
+      tester = ApiRequestHandlerTester();
+      httpClient = FakeHttpClient();
+      rollHttpClient = FakeHttpClient();
+      tabledataResourceApi = FakeTabledataResourceApi();
+      config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
+      handler = RefreshGitilesCommits(
+        config,
+        FakeAuthenticationProvider(),
+        httpClientProvider: () => httpClient,
+        rollHttpClientProvider: () => rollHttpClient,
+      );
+    });
+
+    test('insert to bigquery for non-roller commit list', () async {
+      httpClient.request.response.body = skiaCommits;
+      
+      await tester.get(handler);
+      /// Insert happens four times `skia, dart, engine, flutter`. Each time
+      /// it inserts two commits in [skiaCommits].
+      expect(tabledataResourceApi.rows.length, 8);
+    });
+
+    test('insert to bigquery for commit list with roll commit', () async {
+      httpClient.request.response.body = commits;
+      rollHttpClient.request.response.body = rollCommits;
+      
+      await tester.get(handler);
+      /// Insert happens four times `skia, dart, engine, flutter`. Each time
+      /// it inserts one commit in [commits] and two commits in [rollCommits].
+      expect(tabledataResourceApi.rows.length, 12);
+    });
+  });
+}

--- a/app_dart/test/src/bigquery/fake_tabledata_resource.dart
+++ b/app_dart/test/src/bigquery/fake_tabledata_resource.dart
@@ -18,7 +18,11 @@ class FakeTabledataResourceApi implements TabledataResourceApi {
       String datasetId,
       String tableId,
       {String $fields}) async {
-    rows = request.rows;
+    if (rows == null) {
+      rows = request.rows;
+    } else {
+      rows.addAll(request.rows);
+    }
     return TableDataInsertAllResponse.fromJson(<String, String>{});
   }
 
@@ -29,11 +33,18 @@ class FakeTabledataResourceApi implements TabledataResourceApi {
       String startIndex,
       String pageToken,
       String $fields}) async {
+    if (rows == null) {
+      return TableDataList();
+    }
     final List<Map<String, Object>> tableRowList = <Map<String, Object>>[];
     for (TableDataInsertAllRequestRows tableDataInsertAllRequestRows in rows) {
       final Map<String, Object> value = tableDataInsertAllRequestRows.json;
       final List<Map<String, Object>> tableCellList = <Map<String, Object>>[];
-      tableCellList.add(<String, Object>{'v': value});
+      if (selectedFields == 'CommitTime') {
+        tableCellList.add(<String, Object>{'v': '0'});
+      }else {
+        tableCellList.add(<String, Object>{'v': value});
+      }
       tableRowList.add(<String, Object>{'f': tableCellList});
     }
 

--- a/app_dart/test/src/bigquery/fake_tabledata_resource.dart
+++ b/app_dart/test/src/bigquery/fake_tabledata_resource.dart
@@ -42,7 +42,7 @@ class FakeTabledataResourceApi implements TabledataResourceApi {
       final List<Map<String, Object>> tableCellList = <Map<String, Object>>[];
       if (selectedFields == 'CommitTime') {
         tableCellList.add(<String, Object>{'v': '0'});
-      }else {
+      } else {
         tableCellList.add(<String, Object>{'v': value});
       }
       tableRowList.add(<String, Object>{'f': tableCellList});


### PR DESCRIPTION
This PR keeps refreshing commits of four repos: skia, dart, engine, and flutter, to bigquery.

It focuses on two parts: one inserts all new commits of those repos to bigquery; the other queries roller-related commits and save parent-child pair to roller tables in bigquery.

These saved data will be used for flutter infra roller metrics analysis.
