### PR TITLE
Add Luci builds to Gold status check

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -111,10 +111,14 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
 
       if (runsGoldenFileTests) {
         // Make sure we account for any running Luci builds
-        final List<String> luciIncompleteStates = <String>['failure', 'unreachable', 'pending'];
+        final List<String> luciIncompleteStates = <String>[
+          'failure',
+          'unreachable',
+          'pending'
+        ];
         final List<String> luciStatuses = <String>[];
         final Stream<RepositoryStatus> statusStream =
-          gitHubClient.repositories.listStatuses(slug, pr.head.sha);
+            gitHubClient.repositories.listStatuses(slug, pr.head.sha);
         await for (RepositoryStatus status in statusStream) {
           if (status.description.contains('LUCI')) {
             luciStatuses.add(status.state);

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -121,6 +121,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             gitHubClient.repositories.listStatuses(slug, pr.head.sha);
         await for (RepositoryStatus status in statusStream) {
           if (status.description.contains('LUCI')) {
+            log.debug('Found Luci build status for pull request #${pr.number}, '
+                'commit ${pr.head.sha}: ${status.description} (${status.state})');
             luciStatuses.add(status.state);
           }
         }

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -211,6 +211,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks still running
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'pending'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'EXECUTING', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -252,6 +259,53 @@ void main() {
           db.values[status.key] = status;
 
           // Checks complete
+          statuses = <dynamic>[
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
+            <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
+          ];
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+
+          // Should not apply labels or make comments
+          verifyNever(issuesService.addLabelsToIssue(
+            slug,
+            pr.number,
+            <String>[
+              'will affect goldens',
+              'severe: API break',
+            ],
+          ));
+
+          verifyNever(issuesService.createComment(
+            slug,
+            pr.number,
+            argThat(contains(config.goldenBreakingChangeMessageValue)),
+          ));
+        });
+
+        test('same commit, cirrus checks complete, luci still running, last status running', () async {
+          // Same commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            'This check is waiting for the all clear from Gold.',);
+          db.values[status.key] = status;
+
+          // Luci running, Cirrus checks complete
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'pending'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -354,6 +408,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks running
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'pending'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'EXECUTING', 'name': 'framework-1'},
             <String, String>{'status': 'EXECUTING', 'name': 'framework-2'}
@@ -394,6 +455,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -452,6 +520,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -509,6 +584,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -559,6 +641,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -621,6 +710,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks complete
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -681,6 +777,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks complete
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -744,6 +847,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -801,6 +911,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks completed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'success'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
@@ -840,6 +957,13 @@ void main() {
           db.values[status.key] = status;
 
           // Checks failed
+          when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
+              (_) => Stream<RepositoryStatus>.value(
+              RepositoryStatus()
+                ..state = 'failed'
+                ..description = 'Flutter LUCI Build: Linux',
+            ),
+          );
           statuses = <dynamic>[
             <String, String>{'status': 'FAILED', 'name': 'framework-1'},
             <String, String>{'status': 'ABORTED', 'name': 'framework-2'}
@@ -891,6 +1015,13 @@ void main() {
         db.values[followUpStatus.key] = followUpStatus;
 
         // Checks completed
+        when(repositoriesService.listStatuses(slug, any)).thenAnswer(
+            (_) => Stream<RepositoryStatus>.value(
+            RepositoryStatus()
+              ..state = 'success'
+              ..description = 'Flutter LUCI Build: Linux',
+          ),
+        );
         statuses = <dynamic>[
           <String, String>{'status': 'COMPLETED', 'name': 'framework-1'},
           <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -212,7 +212,7 @@ void main() {
 
           // Checks still running
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'pending'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -287,7 +287,9 @@ void main() {
           ));
         });
 
-        test('same commit, cirrus checks complete, luci still running, last status running', () async {
+        test(
+            'same commit, cirrus checks complete, luci still running, last status running',
+            () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
@@ -295,12 +297,13 @@ void main() {
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
-            'This check is waiting for the all clear from Gold.',);
+            'This check is waiting for the all clear from Gold.',
+          );
           db.values[status.key] = status;
 
           // Luci running, Cirrus checks complete
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'pending'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -409,7 +412,7 @@ void main() {
 
           // Checks running
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'pending'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -456,7 +459,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -521,7 +524,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -585,7 +588,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -642,7 +645,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -711,7 +714,7 @@ void main() {
 
           // Checks complete
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -778,7 +781,7 @@ void main() {
 
           // Checks complete
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -848,7 +851,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -912,7 +915,7 @@ void main() {
 
           // Checks completed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'success'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -958,7 +961,7 @@ void main() {
 
           // Checks failed
           when(repositoriesService.listStatuses(slug, pr.head.sha)).thenAnswer(
-              (_) => Stream<RepositoryStatus>.value(
+            (_) => Stream<RepositoryStatus>.value(
               RepositoryStatus()
                 ..state = 'failed'
                 ..description = 'Flutter LUCI Build: Linux',
@@ -1016,7 +1019,7 @@ void main() {
 
         // Checks completed
         when(repositoriesService.listStatuses(slug, any)).thenAnswer(
-            (_) => Stream<RepositoryStatus>.value(
+          (_) => Stream<RepositoryStatus>.value(
             RepositoryStatus()
               ..state = 'success'
               ..description = 'Flutter LUCI Build: Linux',


### PR DESCRIPTION
Closing out a TODO I noticed while making another change yesterday.
Now that we are running Luci pre-submit checks, we should include them in determining the Gold status. The flutter-gold check waits on all checks to finish successfully before checking in with the Flutter Gold service for image changes.