### PR TITLE
[Gold Status] Account for null status descriptions when parsing luci builds 

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -120,7 +120,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         final Stream<RepositoryStatus> statusStream =
             gitHubClient.repositories.listStatuses(slug, pr.head.sha);
         await for (RepositoryStatus status in statusStream) {
-          if (status.description.contains('LUCI')) {
+          if (status.description != null &&
+              status.description.contains('LUCI')) {
             log.debug('Found Luci build status for pull request #${pr.number}, '
                 'commit ${pr.head.sha}: ${status.description} (${status.state})');
             luciStatuses.add(status.state);


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/56682 which was introduced in https://github.com/flutter/cocoon/pull/762 as we as parsing statuses now looking for Luci builds.