### PR TITLE
Mark linux_bot as flaky

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -218,7 +218,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       newTask(
           'mac_bot', 'chromebot', <String>['can-update-chromebots'], false, 0),
       newTask('linux_bot', 'chromebot', <String>['can-update-chromebots'],
-          false, 0),
+          true, 0),
       newTask('windows_bot', 'chromebot', <String>['can-update-chromebots'],
           false, 0),
     ];

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -217,8 +217,8 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       newTask('cirrus', 'cirrus', <String>['can-update-github'], false, 0),
       newTask(
           'mac_bot', 'chromebot', <String>['can-update-chromebots'], false, 0),
-      newTask('linux_bot', 'chromebot', <String>['can-update-chromebots'],
-          true, 0),
+      newTask(
+          'linux_bot', 'chromebot', <String>['can-update-chromebots'], true, 0),
       newTask('windows_bot', 'chromebot', <String>['can-update-chromebots'],
           false, 0),
     ];


### PR DESCRIPTION
Linux bots are experiencing infra failures downloading and installing tiles_ctl dependencies for the fuchsia test.

Temporarily mark as flaky.