### PR TITLE
Revert "Mark linux_bot as flaky"

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -217,8 +217,8 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       newTask('cirrus', 'cirrus', <String>['can-update-github'], false, 0),
       newTask(
           'mac_bot', 'chromebot', <String>['can-update-chromebots'], false, 0),
-      newTask(
-          'linux_bot', 'chromebot', <String>['can-update-chromebots'], true, 0),
+      newTask('linux_bot', 'chromebot', <String>['can-update-chromebots'],
+          false, 0),
       newTask('windows_bot', 'chromebot', <String>['can-update-chromebots'],
           false, 0),
     ];


### PR DESCRIPTION
Reverts flutter/cocoon#766

@godofredoc removed the fuchsia tests and will land them on a separate builder.
Fixes https://github.com/flutter/flutter/issues/57042.