### PR TITLE
Update task ID in bigquery to be consistent with commit ID

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -126,7 +126,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
     requestRows.add(<String, Object>{
       'json': <String, Object>{
-        'ID': 'flutter/flutter/${commit.sha}',
+        'ID': 'flutter/flutter/${commit.branch}/${commit.sha}',
         'CreateTimestamp': task.createTimestamp,
         'StartTimestamp': task.startTimestamp,
         'EndTimestamp': task.endTimestamp,


### PR DESCRIPTION
Old `task` ID follows format: `/flutter/flutter/<SHA>`, whereas `commit` ID follows: `/flutter/flutter/<branch>/<SHA>`. This make it difficult to join these tables in bigquery.

This PR changes `task` ID to have the same format as `commit`.