### PR TITLE
Fix benchmark malformed issue

### DIFF
--- a/app/lib/benchmark/benchmark_card.html
+++ b/app/lib/benchmark/benchmark_card.html
@@ -1,4 +1,3 @@
-<!DOCTYPE HTML>
 <!-- Copyright 2018 The Flutter Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->

--- a/app/lib/benchmark/benchmark_grid.html
+++ b/app/lib/benchmark/benchmark_grid.html
@@ -1,4 +1,3 @@
-<!DOCTYPE HTML>
 <!-- Copyright 2018 The Flutter Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->


### PR DESCRIPTION
This PR solves the malformed <!DOCTYPE HTML> issue on flutter benchmark page.

(The above issue happens in both benchmark_grid and benchmark_card).