### PR TITLE
Move configs to detect if a repo supports presubmit to config.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -29,6 +29,13 @@ class Config {
 
   final CacheService _cache;
 
+  /// List of Github presubmit supported repos.
+  static const Set<String> supportedRepos = <String>{
+    'engine',
+    'flutter',
+    'cocoon'
+  };
+
   @visibleForTesting
   static const String configCacheName = 'config';
 
@@ -384,6 +391,10 @@ class Config {
   Future<GithubService> createGithubService() async {
     final GitHub github = await createGitHubClient();
     return GithubService(github);
+  }
+
+  bool githubPresubmitSupportedRepo(String repositoryName) {
+    return supportedRepos.contains(repositoryName);
   }
 }
 

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -19,14 +19,6 @@ import '../request_handling/exceptions.dart';
 import '../request_handling/request_handler.dart';
 import '../service/buildbucket.dart';
 
-/// List of Github supported repos.
-const Set<String> kSupportedRepos = <String>{
-  'cocoon',
-  'engine',
-  'flutter',
-  'packages',
-};
-
 /// List of repos that require CQ+1 label.
 const Set<String> kNeedsCQLabelList = <String>{'flutter/flutter'};
 
@@ -242,7 +234,7 @@ class GithubWebhook extends RequestHandler<Body> {
     assert(number != null);
     assert(sha != null);
     assert(repositoryName != null);
-    if (!kSupportedRepos.contains(repositoryName)) {
+    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
       log.error('Unsupported repo on webhook: $repositoryName');
       throw BadRequestException(
           'Repository $repositoryName is not supported by this service.');
@@ -320,7 +312,7 @@ class GithubWebhook extends RequestHandler<Body> {
 
   Future<void> _cancelLuci(
       String repositoryName, int number, String sha, String reason) async {
-    if (!kSupportedRepos.contains(repositoryName)) {
+    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
       throw BadRequestException(
           'This service does not support repository $repositoryName.');
     }

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -196,4 +196,9 @@ class FakeConfig implements Config {
 
   @override
   Set<String> get rollerAccounts => rollerAccountsValue;
+
+  @override
+  bool githubPresubmitSupportedRepo(String repositoryName) {
+    return <String>['flutter', 'cocoon'].contains(repositoryName);
+  }
 }


### PR DESCRIPTION
Previously this list was on webhook but they will need to get shared
with different utilities needed to enable checks apis.

Bug:
  flutter/flutter#56422