### PR TITLE
re-enable mac web engine

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -335,12 +335,10 @@ class Config {
           'name': 'Windows Web Engine',
           'repo': 'engine',
         },
-        // TODO(fujino): Re-enable after
-        // https://github.com/flutter/flutter/issues/58012 is fixed.
-        //<String, String>{
-        //  'name': 'Mac Web Engine',
-        //  'repo': 'engine',
-        //},
+        <String, String>{
+          'name': 'Mac Web Engine',
+          'repo': 'engine',
+        },
         <String, String>{
           'name': 'fuchsia_ctl',
           'repo': 'packages',


### PR DESCRIPTION
Reverses https://github.com/flutter/cocoon/pull/782 because the flaking tests have been disabled in the recipe: https://flutter-review.googlesource.com/c/recipes/+/3162 and the builder re-enabled in https://github.com/flutter/infra/pull/130.

Related to https://github.com/flutter/flutter/issues/58012