### PR TITLE
Add a luci build service.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -396,6 +396,14 @@ class Config {
   bool githubPresubmitSupportedRepo(String repositoryName) {
     return supportedRepos.contains(repositoryName);
   }
+
+  Future<RepositorySlug> repoNameForBuilder(String builderName) async {
+    final List<Map<String, dynamic>> builders = luciTryBuilders;
+    final String repoName = builders.firstWhere(
+        (Map<String, dynamic> builder) =>
+            builder['name'] == builderName)['repo'] as String;
+    return RepositorySlug('flutter', repoName);
+  }
 }
 
 @Kind(name: 'CocoonConfig', idType: IdType.String)

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -191,14 +191,6 @@ class LuciStatusHandler extends RequestHandler<Body> {
     return info.email == devicelabServiceAccount.email;
   }
 
-  Future<RepositorySlug> _getRepoNameForBuilder(String builderName) async {
-    final List<Map<String, dynamic>> builders = config.luciTryBuilders;
-    final String repoName = builders.firstWhere(
-        (Map<String, dynamic> builder) =>
-            builder['name'] == builderName)['repo'] as String;
-    return RepositorySlug('flutter', repoName);
-  }
-
   CreateStatus _statusForResult(Result result) {
     switch (result) {
       case Result.canceled:
@@ -218,7 +210,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
     @required String buildUrl,
     @required Result result,
   }) async {
-    final RepositorySlug slug = await _getRepoNameForBuilder(builderName);
+    final RepositorySlug slug = await config.repoNameForBuilder(builderName);
     final GitHub gitHubClient = await config.createGitHubClient();
     final CreateStatus status = _statusForResult(result)
       ..context = builderName
@@ -232,7 +224,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
     @required String builderName,
     @required String buildUrl,
   }) async {
-    final RepositorySlug slug = await _getRepoNameForBuilder(builderName);
+    final RepositorySlug slug = await config.repoNameForBuilder(builderName);
     final GitHub gitHubClient = await config.createGitHubClient();
     // GitHub "only" allows setting a status for a context/ref pair 1000 times.
     // We should avoid unnecessarily setting a pending status, e.g. if we get

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -12,7 +12,7 @@ import '../model/appengine/service_account_info.dart';
 import '../model/luci/buildbucket.dart';
 import 'buildbucket.dart';
 
-/// Class with utilities to interact with LUCI buildbucket to get, trigger
+/// Class to interact with LUCI buildbucket to get, trigger
 /// and cancel builds for github repos. It uses [config.luciTryBuilders] to
 /// get the list of available builders.
 class LuciBuildService {
@@ -21,7 +21,7 @@ class LuciBuildService {
   BuildBucketClient buildBucketClient;
   Config config;
   ServiceAccountInfo serviceAccount;
-  List<Status> failStatusList = <Status>[
+  static const List<Status> failStatusList = <Status>[
     Status.canceled,
     Status.failure,
     Status.infraFailure

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -21,11 +21,11 @@ class LuciBuildService {
   BuildBucketClient buildBucketClient;
   Config config;
   ServiceAccountInfo serviceAccount;
-  static const List<Status> failStatusList = <Status>[
+  static const Set<Status> failStatusList = <Status>{
     Status.canceled,
     Status.failure,
     Status.infraFailure
-  ];
+  };
 
   /// Returns a map of the BuildBucket builds for a given [repositoryName]
   /// [prNumber] and [commitSha] using the [builderName] as key and [Build]

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -1,0 +1,244 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:github/github.dart';
+import 'package:meta/meta.dart';
+
+import '../../cocoon_service.dart';
+import '../model/appengine/service_account_info.dart';
+import '../model/luci/buildbucket.dart';
+import 'buildbucket.dart';
+
+/// Class with utilities to interact with LUCI buildbucket to get, trigger
+/// and cancel builds for github repos. It uses [config.luciTryBuilders] to
+/// get the list of available builders.
+class LuciBuildService {
+  LuciBuildService(this.config, this.buildBucketClient, this.serviceAccount);
+
+  BuildBucketClient buildBucketClient;
+  Config config;
+  ServiceAccountInfo serviceAccount;
+  List<Status> failStatusList = <Status>[
+    Status.canceled,
+    Status.failure,
+    Status.infraFailure
+  ];
+
+  /// Returns a map of the BuildBucket builds for a given [repositoryName]
+  /// [prNumber] and [commitSha] using the [builderName] as key and [Build]
+  /// as value.
+  Future<Map<String, Build>> buildsForRepositoryAndPr(
+    String repositoryName,
+    int prNumber,
+    String commitSha,
+  ) async {
+    final BatchResponse batch =
+        await buildBucketClient.batch(BatchRequest(requests: <Request>[
+      Request(
+        searchBuilds: SearchBuildsRequest(
+          predicate: BuildPredicate(
+            builderId: const BuilderId(
+              project: 'flutter',
+              bucket: 'try',
+            ),
+            createdBy: serviceAccount.email,
+            tags: <String, List<String>>{
+              'buildset': <String>['pr/git/$prNumber'],
+              'github_link': <String>[
+                'https://github.com/flutter/$repositoryName/pull/$prNumber'
+              ],
+              'user_agent': const <String>['flutter-cocoon'],
+            },
+          ),
+        ),
+      ),
+      Request(
+        searchBuilds: SearchBuildsRequest(
+          predicate: BuildPredicate(
+            builderId: const BuilderId(
+              project: 'flutter',
+              bucket: 'try',
+            ),
+            tags: <String, List<String>>{
+              'buildset': <String>['pr/git/$prNumber'],
+              'user_agent': const <String>['recipe'],
+            },
+          ),
+        ),
+      ),
+    ]));
+    final Iterable<Build> builds = batch.responses
+        .map((Response response) => response.searchBuilds)
+        .expand(
+            (SearchBuildsResponse response) => response.builds ?? <Build>[]);
+    return Map<String, Build>.fromIterable(builds,
+        key: (dynamic b) => b.builderId.builder as String,
+        value: (dynamic b) => b as Build);
+  }
+
+  /// Schedules BuildBucket builds for a given [prNumber], [commitSha]
+  /// and repositoryName. It returns [true] if it was able to schedule
+  /// build or [false] otherwise.
+  Future<bool> scheduleBuilds({
+    @required int prNumber,
+    @required String commitSha,
+    @required String repositoryName,
+  }) async {
+    assert(prNumber != null);
+    assert(commitSha != null);
+    assert(repositoryName != null);
+    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
+      throw BadRequestException(
+          'Repository $repositoryName is not supported by this service.');
+    }
+
+    final Map<String, Build> builds = await buildsForRepositoryAndPr(
+      repositoryName,
+      prNumber,
+      commitSha,
+    );
+
+    if (builds != null &&
+        builds.values.any((Build build) {
+          return build.status == Status.scheduled ||
+              build.status == Status.started;
+        })) {
+      return false;
+    }
+
+    final List<Map<String, dynamic>> builders = config.luciTryBuilders;
+    final List<String> builderNames = builders
+        .where(
+            (Map<String, dynamic> builder) => builder['repo'] == repositoryName)
+        .map<String>(
+            (Map<String, dynamic> builder) => builder['name'] as String)
+        .toList();
+    if (builderNames.isEmpty) {
+      throw InternalServerError('$repositoryName does not have any builders');
+    }
+
+    final List<Request> requests = <Request>[];
+    for (String builder in builderNames) {
+      final BuilderId builderId = BuilderId(
+        project: 'flutter',
+        bucket: 'try',
+        builder: builder,
+      );
+      requests.add(
+        Request(
+          scheduleBuild: ScheduleBuildRequest(
+            builderId: builderId,
+            tags: <String, List<String>>{
+              'buildset': <String>['pr/git/$prNumber', 'sha/git/$commitSha'],
+              'user_agent': const <String>['flutter-cocoon'],
+              'github_link': <String>[
+                'https://github.com/flutter/$repositoryName/pull/$prNumber'
+              ],
+            },
+            properties: <String, String>{
+              'git_url': 'https://github.com/flutter/$repositoryName',
+              'git_ref': 'refs/pull/$prNumber/head',
+            },
+            notify: NotificationConfig(
+              pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
+              userData: json.encode(const <String, dynamic>{
+                'retries': 0,
+              }),
+            ),
+          ),
+        ),
+      );
+    }
+    await buildBucketClient.batch(BatchRequest(requests: requests));
+    return true;
+  }
+
+  /// Cancels all the current builds for a given [repositoryName], [prNumber]
+  /// and [commitSha] adding a message for the cancelation reason.
+  Future<void> cancelBuilds(String repositoryName, int prNumber,
+      String commitSha, String reason) async {
+    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
+      throw BadRequestException(
+          'This service does not support repository $repositoryName.');
+    }
+    final Map<String, Build> builds = await buildsForRepositoryAndPr(
+      repositoryName,
+      prNumber,
+      commitSha,
+    );
+    if (builds == null ||
+        !builds.values.any((Build build) {
+          return build.status == Status.scheduled ||
+              build.status == Status.started;
+        })) {
+      return;
+    }
+    final List<Request> requests = <Request>[];
+    for (Build build in builds.values) {
+      requests.add(
+        Request(
+          cancelBuild:
+              CancelBuildRequest(id: build.id, summaryMarkdown: reason),
+        ),
+      );
+    }
+    await buildBucketClient.batch(BatchRequest(requests: requests));
+  }
+
+  /// Gets a list of failed builds for a given [repositoryName], [prNumber] and
+  /// [commitSha].
+  Future<List<Build>> failedBuilds(
+    String repositoryName,
+    int prNumber,
+    String commitSha,
+  ) async {
+    final Map<String, Build> builds =
+        await buildsForRepositoryAndPr(repositoryName, prNumber, commitSha);
+    return builds.values
+        .where((Build build) => failStatusList.contains(build.status))
+        .toList();
+  }
+
+  /// Sends a [BuildBucket.scheduleBuild] request as long as the `retries`
+  /// parameter has not exceeded [CocoonConfig.luciTryInfraFailureRetries].
+  ///
+  /// If the retries have been exhausted, it sets the GitHub status to failure.
+  ///
+  /// The buildset, user_agent, and github_link tags are applied to match the
+  /// original build. The build properties from the original build are also
+  /// preserved.
+  Future<void> rescheduleBuild({
+    @required String commitSha,
+    @required String builderName,
+    @required Build build,
+    @required int retries,
+  }) async {
+    if (retries >= config.luciTryInfraFailureRetries) {
+      // Too many retries.
+      return;
+    }
+    await buildBucketClient.scheduleBuild(ScheduleBuildRequest(
+      builderId: BuilderId(
+        project: build.builderId.project,
+        bucket: build.builderId.bucket,
+        builder: build.builderId.builder,
+      ),
+      tags: <String, List<String>>{
+        'buildset': build.tags['buildset'],
+        'user_agent': build.tags['user_agent'],
+        'github_link': build.tags['github_link'],
+      },
+      properties: build.input.properties,
+      notify: NotificationConfig(
+        pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
+        userData: json.encode(<String, dynamic>{
+          'retries': retries + 1,
+        }),
+      ),
+    ));
+  }
+}

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -21,7 +21,7 @@ class LuciBuildService {
   BuildBucketClient buildBucketClient;
   Config config;
   ServiceAccountInfo serviceAccount;
-  static const Set<Status> failStatusList = <Status>{
+  static const Set<Status> failStatusSet = <Status>{
     Status.canceled,
     Status.failure,
     Status.infraFailure
@@ -198,7 +198,7 @@ class LuciBuildService {
     final Map<String, Build> builds =
         await buildsForRepositoryAndPr(repositoryName, prNumber, commitSha);
     return builds.values
-        .where((Build build) => failStatusList.contains(build.status))
+        .where((Build build) => failStatusSet.contains(build.status))
         .toList();
   }
 

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1,0 +1,316 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:core';
+
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
+import 'package:cocoon_service/src/model/luci/buildbucket.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/luci_build_service.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+
+void main() {
+  ServiceAccountInfo serviceAccountInfo;
+  FakeConfig config;
+  MockBuildBucketClient mockBuildBucketClient;
+  group('buildsForRepositoryAndPr', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+    });
+    test('emptyResponse', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[],
+              ),
+            ),
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final Map<String, Build> builders =
+          await service.buildsForRepositoryAndPr('cocoon', 1, 'abcd');
+      expect(builders.keys, isEmpty);
+    });
+
+    test('someBuilders', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  Build(
+                    id: 999,
+                    builderId: BuilderId(
+                      project: 'flutter',
+                      bucket: 'prod',
+                      builder: 'Mac',
+                    ),
+                    status: Status.started,
+                  )
+                ],
+              ),
+            ),
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  Build(
+                    id: 998,
+                    builderId: BuilderId(
+                      project: 'flutter',
+                      bucket: 'prod',
+                      builder: 'Linux',
+                    ),
+                    status: Status.started,
+                  )
+                ],
+              ),
+            ),
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final Map<String, Build> builders =
+          await service.buildsForRepositoryAndPr('cocoon', 1, 'abcd');
+      expect(builders.keys.toList(), equals(<String>['Mac', 'Linux']));
+    });
+  });
+  group('scheduleBuilds', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+    });
+    test('alreadyStarted', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  Build(
+                    id: 998,
+                    builderId: BuilderId(
+                      project: 'flutter',
+                      bucket: 'prod',
+                      builder: 'Linux',
+                    ),
+                    status: Status.started,
+                  )
+                ],
+              ),
+            ),
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final bool result = await service.scheduleBuilds(
+        prNumber: 1,
+        commitSha: 'abc',
+        repositoryName: 'cocoon',
+      );
+      expect(result, isFalse);
+    });
+    test('alreadyScheduled', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  Build(
+                    id: 998,
+                    builderId: BuilderId(
+                      project: 'flutter',
+                      bucket: 'prod',
+                      builder: 'Linux',
+                    ),
+                    status: Status.scheduled,
+                  )
+                ],
+              ),
+            ),
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final bool result = await service.scheduleBuilds(
+        prNumber: 1,
+        commitSha: 'abc',
+        repositoryName: 'cocoon',
+      );
+      expect(result, isFalse);
+    });
+    test('emptyListBuild', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[],
+        );
+      });
+      config.luciTryBuildersValue =
+          (json.decode('[{"name": "Cocoon", "repo": "cocoon"}]')
+                  as List<dynamic>)
+              .cast<Map<String, dynamic>>();
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final bool result = await service.scheduleBuilds(
+        prNumber: 1,
+        commitSha: 'abc',
+        repositoryName: 'cocoon',
+      );
+      expect(result, isTrue);
+    });
+    test('unsupportedRepo', () async {
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      expect(
+          () async => await service.scheduleBuilds(
+                prNumber: 1,
+                commitSha: 'abc',
+                repositoryName: 'notsupported',
+              ),
+          throwsA(const TypeMatcher<BadRequestException>()));
+    });
+  });
+
+  group('cancelBuilds', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+    });
+    test('emptyList', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      await service.cancelBuilds('cocoon', 1, 'abc', 'new builds');
+      verify(mockBuildBucketClient.batch(any)).called(1);
+    });
+    test('withScheduledBuild', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+                searchBuilds: SearchBuildsResponse(builds: <Build>[
+              Build(
+                id: 998,
+                builderId: BuilderId(
+                  project: 'flutter',
+                  bucket: 'prod',
+                  builder: 'Linux',
+                ),
+                status: Status.started,
+              )
+            ]))
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      await service.cancelBuilds('cocoon', 1, 'abc', 'new builds');
+      verify(mockBuildBucketClient.batch(any)).called(2);
+    });
+    test('unsupportedRepo', () async {
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      expect(
+          () async => await service.cancelBuilds(
+                'notsupported',
+                1,
+                'abc',
+                'new builds',
+              ),
+          throwsA(const TypeMatcher<BadRequestException>()));
+    });
+  });
+
+  group('failedBuilds', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+    });
+    test('emptyList', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final List<Build> result = await service.failedBuilds('cocoon', 1, 'abc');
+      expect(result, isEmpty);
+    });
+    test('withFailures', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+                searchBuilds: SearchBuildsResponse(builds: <Build>[
+              Build(
+                id: 998,
+                builderId: BuilderId(
+                  project: 'flutter',
+                  bucket: 'prod',
+                  builder: 'Linux',
+                ),
+                status: Status.failure,
+              )
+            ]))
+          ],
+        );
+      });
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final List<Build> result = await service.failedBuilds('cocoon', 1, 'abc');
+      expect(result, hasLength(1));
+    });
+  });
+  group('rescheduleBuild', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+    });
+    test('worksProperly', () async {
+      config.luciTryInfraFailureRetriesValue = 3;
+      final LuciBuildService service =
+          LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      final Map<String, List<String>> tags = <String, List<String>>{
+        'buildset': <String>['123'],
+        'user_agent': <String>['cocoon'],
+        'github_link': <String>['the_link']
+      };
+      final Build build = Build(
+          id: 123,
+          builderId: const BuilderId(),
+          tags: tags,
+          input: const Input());
+      await service.rescheduleBuild(
+          commitSha: 'abc', builderName: 'mybuild', build: build, retries: 1);
+      verify(mockBuildBucketClient.scheduleBuild(any)).called(1);
+    });
+  });
+}
+
+// ignore: must_be_immutable
+class MockBuildBucketClient extends Mock implements BuildBucketClient {}

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -201,4 +201,11 @@ class FakeConfig implements Config {
   bool githubPresubmitSupportedRepo(String repositoryName) {
     return <String>['flutter', 'engine', 'cocoon'].contains(repositoryName);
   }
+
+  @override
+  Future<RepositorySlug> repoNameForBuilder(String builderName) async {
+    final String name =
+        (builderName == 'Linux Host Engine') ? 'engine' : 'flutter';
+    return RepositorySlug('flutter', name);
+  }
 }


### PR DESCRIPTION
This is part of the refactoring to add checks api. We are moving generic
functionality used in luci_status and github_webhook.

Bug:
  https://github.com/flutter/flutter/issues/56422