### PR TITLE
Use timestmap of last commit rather than a fixed time period to query github commits API

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -143,12 +143,6 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 30;
 
-  /// The default hours to look back for github commits refresh - existing branch.
-  int get existingBranchHours => 1;
-
-  /// The default hours to look back for github commits refresh - new branch.
-  int get newBranchHours => 168;
-
   // TODO(keyonghan): update all existing APIs to use this reference, https://github.com/flutter/flutter/issues/48987.
   KeyHelper get keyHelper =>
       KeyHelper(applicationContext: context.applicationContext);

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -61,13 +61,13 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     for (String branch in await config.flutterBranches) {
       final List<Commit> lastCommit =
           await datastore.queryRecentCommits(limit: 1, branch: branch).toList();
-      int lastCommitTimestamp = 0;
+      int lastCommitTimestampMills = 0;
       if (lastCommit.isNotEmpty) {
-        lastCommitTimestamp = lastCommit[0].timestamp;
+        lastCommitTimestampMills = lastCommit[0].timestamp;
       }
 
       final List<RepositoryCommit> commits = await githubService.listCommits(
-          slug, branch, lastCommitTimestamp, config);
+          slug, branch, lastCommitTimestampMills, config);
 
       final List<Commit> newCommits =
           await _getNewCommits(commits, datastore, branch);

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -59,15 +59,15 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     final DatastoreService datastore = datastoreProvider(config.db);
 
     for (String branch in await config.flutterBranches) {
-      final List<Commit> lastCommit =
+      final List<Commit> lastProcessedCommit =
           await datastore.queryRecentCommits(limit: 1, branch: branch).toList();
       int lastCommitTimestampMills = 0;
-      if (lastCommit.isNotEmpty) {
-        lastCommitTimestampMills = lastCommit[0].timestamp;
+      if (lastProcessedCommit.isNotEmpty) {
+        lastCommitTimestampMills = lastProcessedCommit[0].timestamp;
       }
 
       final List<RepositoryCommit> commits = await githubService.listCommits(
-          slug, branch, lastCommitTimestampMills, config);
+          slug, branch, lastCommitTimestampMills);
 
       final List<Commit> newCommits =
           await _getNewCommits(commits, datastore, branch);

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -61,6 +61,8 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     for (String branch in await config.flutterBranches) {
       final List<Commit> lastProcessedCommit =
           await datastore.queryRecentCommits(limit: 1, branch: branch).toList();
+
+      /// That [lastCommitTimestampMills] equals 0 means a new release branch is detected.
       int lastCommitTimestampMills = 0;
       if (lastProcessedCommit.isNotEmpty) {
         lastCommitTimestampMills = lastProcessedCommit[0].timestamp;

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -14,8 +14,9 @@ class GithubService {
 
   /// Lists commits of the provided repository [slug] and [branch]. When
   /// [lastCommitTimestampMills] equals 0, it means a new release branch is
-  /// found and only the branched commit will be returned. Otherwise, it returns
-  /// all newer commits since [lastCommitTimestampMills].
+  /// found and only the branched commit will be returned for now, though the
+  /// rare case that multiple commits exist. For other cases, it returns all
+  /// newer commits since [lastCommitTimestampMills].
   Future<List<RepositoryCommit>> listCommits(
       RepositorySlug slug, String branch, int lastCommitTimestampMills) async {
     ArgumentError.checkNotNull(slug);

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -51,6 +51,10 @@ class GithubService {
     }
 
     /// When a release branch is first detected only the most recent commit would be needed.
+    ///
+    /// If for the worst case, a new release branch consists of a useful cherry pick commit
+    /// which should be considered as well, here is the todo.
+    // TODO(keyonghan): https://github.com/flutter/flutter/issues/59275
     if (lastCommitTimestampMills == 0) {
       commits = commits.take(1).toList();
     }

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -33,6 +33,7 @@ class GithubService {
     List<Map<String, dynamic>> commits = <Map<String, dynamic>>[];
 
     /// [lastCommitTimestamp+1] excludes last commit itself.
+    /// Github api url: https://developer.github.com/v3/repos/commits/#list-commits
     await for (Response response in paginationHelper.fetchStreamed(
       'GET',
       '/repos/${slug.fullName}/commits',
@@ -49,7 +50,7 @@ class GithubService {
           .cast<Map<String, dynamic>>());
     }
 
-    /// Take the latest single commit for a new release branch.
+    /// When a release branch is first detected only the most recent commit would be needed.
     if (lastCommitTimestampMills == 0) {
       commits = commits.take(1).toList();
     }

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -7,22 +7,24 @@ import 'dart:convert' show json;
 import 'package:github/github.dart';
 import 'package:http/http.dart';
 
-import '../datastore/cocoon_config.dart';
-
 class GithubService {
   const GithubService(this.github);
 
   final GitHub github;
 
-  /// Lists the commits of the provided repository [slug] and [branch].
-  Future<List<RepositoryCommit>> listCommits(RepositorySlug slug, String branch,
-      int lastCommitTimestampMills, Config config) async {
+  /// Lists commits of the provided repository [slug] and [branch]. When
+  /// [lastCommitTimestampMills] equals 0, it means a new release branch is
+  /// found and only the branched commit will be returned. Otherwise, it returns
+  /// all newer commits since [lastCommitTimestampMills].
+  Future<List<RepositoryCommit>> listCommits(
+      RepositorySlug slug, String branch, int lastCommitTimestampMills) async {
     ArgumentError.checkNotNull(slug);
     final PaginationHelper paginationHelper = PaginationHelper(github);
 
-    /// Return only one page when this is a new branch. Otherwise it will
-    /// return all commits prior to this release branch commit, leading to
-    /// heavy workload.
+    /// The [pages] defines the number of pages of returned http request
+    /// results. Return only one page when this is a new branch. Otherwise
+    ///  it will return all commits prior to this release branch commit,
+    /// leading to heavy workload.
     int pages;
     if (lastCommitTimestampMills == 0) {
       pages = 1;

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -16,7 +16,7 @@ class GithubService {
 
   /// Lists the commits of the provided repository [slug] and [branch].
   Future<List<RepositoryCommit>> listCommits(RepositorySlug slug, String branch,
-      int lastCommitTimestamp, Config config) async {
+      int lastCommitTimestampMills, Config config) async {
     ArgumentError.checkNotNull(slug);
     final PaginationHelper paginationHelper = PaginationHelper(github);
 
@@ -24,7 +24,7 @@ class GithubService {
     /// return all commits prior to this release branch commit, leading to
     /// heavy workload.
     int pages;
-    if (lastCommitTimestamp == 0) {
+    if (lastCommitTimestampMills == 0) {
       pages = 1;
     }
 
@@ -36,9 +36,10 @@ class GithubService {
       '/repos/${slug.fullName}/commits',
       params: <String, dynamic>{
         'sha': branch,
-        'since': DateTime.fromMillisecondsSinceEpoch(lastCommitTimestamp + 1)
-            .toUtc()
-            .toIso8601String(),
+        'since':
+            DateTime.fromMillisecondsSinceEpoch(lastCommitTimestampMills + 1)
+                .toUtc()
+                .toIso8601String(),
       },
       pages: pages,
     )) {
@@ -47,7 +48,7 @@ class GithubService {
     }
 
     /// Take the latest single commit for a new release branch.
-    if (lastCommitTimestamp == 0) {
+    if (lastCommitTimestampMills == 0) {
       commits = commits.take(1).toList();
     }
 

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -161,7 +161,6 @@ void main() {
     test('inserts the latest single commit if a new branch is found', () async {
       githubCommits = <String>['1', '2', '3', '4', '5', '6', '7', '8', '9'];
       config.flutterBranchesValue = <String>['flutter-0.0-candidate.0'];
-      config.newBranchHoursValue = 168;
 
       expect(db.values.values.whereType<Commit>().length, 0);
       httpClient.request.response.body = singleTaskManifestYaml;

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -71,7 +71,9 @@ void main() {
     Commit shaToCommit(String sha, String branch) {
       return Commit(
           key: db.emptyKey.append(Commit, id: 'flutter/flutter/$branch/$sha'),
-          sha: sha);
+          sha: sha,
+          branch: branch,
+          timestamp: int.parse(sha));
     }
 
     setUp(() {
@@ -172,7 +174,7 @@ void main() {
 
       /// Pre-insert one commit first, otherwise it will insert only one
       /// commit for a new branch.
-      const List<String> dbCommits = <String>['0'];
+      const List<String> dbCommits = <String>['4'];
       for (String sha in dbCommits) {
         final Commit commit = shaToCommit(sha, 'master');
         db.values[commit.key] = commit;
@@ -192,7 +194,9 @@ void main() {
       expect(db.values.values.whereType<Commit>().length, 3);
       expect(db.values.values.whereType<Task>().length, 10);
       expect(db.values.values.whereType<Commit>().map<String>(toSha),
-          <String>['0', '1', '3']);
+          <String>['4', '1', '3']);
+      expect(db.values.values.whereType<Commit>().map<int>(toTimestamp),
+          <int>[4, 1, 3]);
       expect(await body.serialize().toList(), isEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.WARNING)), isNotEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -46,7 +46,7 @@ void main() {
     List<String> githubCommits;
     int yieldedCommitCount;
 
-    List<RepositoryCommit> commitList(int lastCommitTimestamp) {
+    List<RepositoryCommit> commitList(int lastCommitTimestampMills) {
       List<RepositoryCommit> commits = <RepositoryCommit>[];
       for (String sha in githubCommits) {
         final User author = User()
@@ -62,7 +62,7 @@ void main() {
           ..author = author
           ..commit = gitCommit);
       }
-      if (lastCommitTimestamp == 0) {
+      if (lastCommitTimestampMills == 0) {
         commits = commits.take(1).toList();
       }
       return commits;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -23,8 +23,6 @@ class FakeConfig implements Config {
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
     this.commitNumberValue,
-    this.existingBranchHoursValue,
-    this.newBranchHoursValue,
     this.keyHelperValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
@@ -62,8 +60,6 @@ class FakeConfig implements Config {
   ServiceAccountInfo deviceLabServiceAccountValue;
   int maxTaskRetriesValue;
   int commitNumberValue;
-  int existingBranchHoursValue;
-  int newBranchHoursValue;
   FakeKeyHelper keyHelperValue;
   String oauthClientIdValue;
   String githubOAuthTokenValue;
@@ -127,12 +123,6 @@ class FakeConfig implements Config {
 
   @override
   int get commitNumber => commitNumberValue;
-
-  @override
-  int get existingBranchHours => existingBranchHoursValue;
-
-  @override
-  int get newBranchHours => newBranchHoursValue;
 
   @override
   Future<List<String>> get flutterBranches async => flutterBranchesValue;

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -16,8 +16,8 @@ class FakeGithubService implements GithubService {
   final GitHub github = MockGitHub();
 
   @override
-  Future<List<RepositoryCommit>> listCommits(RepositorySlug slug, String branch,
-      int lastCommitTimestampMills, Config config) async {
+  Future<List<RepositoryCommit>> listCommits(
+      RepositorySlug slug, String branch, int lastCommitTimestampMills) async {
     return listCommitsBranch(branch, lastCommitTimestampMills);
   }
 

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -16,9 +16,9 @@ class FakeGithubService implements GithubService {
   final GitHub github = MockGitHub();
 
   @override
-  Future<List<RepositoryCommit>> listCommits(
-      RepositorySlug slug, String branch, int hours, Config config) async {
-    return listCommitsBranch(branch, hours);
+  Future<List<RepositoryCommit>> listCommits(RepositorySlug slug, String branch,
+      int lastCommitTimestamp, Config config) async {
+    return listCommitsBranch(branch, lastCommitTimestamp);
   }
 
   @override

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -17,8 +17,8 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<List<RepositoryCommit>> listCommits(RepositorySlug slug, String branch,
-      int lastCommitTimestamp, Config config) async {
-    return listCommitsBranch(branch, lastCommitTimestamp);
+      int lastCommitTimestampMills, Config config) async {
+    return listCommitsBranch(branch, lastCommitTimestampMills);
   }
 
   @override

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
This PR fixes: https://github.com/flutter/flutter/issues/54284

It uses `timestamp` of last commit in datastore as the criteria to query Github api. This makes the query more accurate than the case using a fixed time period.