### PR TITLE
Remove old key check when refreshing github commits

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -159,14 +159,8 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       final String id = 'flutter/flutter/$branch/${commit.sha}';
       final Key key = datastore.db.emptyKey.append(Commit, id: id);
 
-      // TODO(keyonghan): remove old Key check, https://github.com/flutter/flutter/issues/52503
-      final String oldId = 'flutter/flutter/${commit.sha}';
-      final Key oldKey = datastore.db.emptyKey.append(Commit, id: oldId);
-
       if (await datastore.db.lookupValue<Commit>(key, orElse: () => null) ==
-              null &&
-          await datastore.db.lookupValue<Commit>(oldKey, orElse: () => null) ==
-              null) {
+          null) {
         newCommits.add(Commit(
           key: key,
           timestamp: commit.commit.committer.date.millisecondsSinceEpoch,


### PR DESCRIPTION
This fixes issue: https://github.com/flutter/flutter/issues/52503

Cocoon has been using new key pair <sha, branch> for commits, and the old key <sha> is no longer needed to check.