### PR TITLE
Update local dev doc to remove requirement of creating a service account in GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ these values should be.
 
 If you see `Serving requests at 0.0.0.0:8080` the dev server is working.
 
-To develop and test some features, you need to have a local `key.json` 
-copy of a service account ([dart-cocoon](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/110857733037195084916?project=flutter-dashboard)) in the GCP dashboard. Please refer to the 
-[internal team doc](https://g3doc.corp.google.com/company/teams/flutter/cocoon/local_run.md?cl=head) for how to get a local copy; these cannot be tested if 
-you do not work for Google currently.
+To develop and test some features, you need to have a local service 
+account(key.json) with access to the project you will be connecting to.
+
+If you work for Google you can use the key with flutter-dashboard project
+via [internal doc](https://g3doc.corp.google.com/company/teams/flutter/cocoon/local_run.md?cl=head).
 
 ### Building the server for deployment
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ these values should be.
 
 If you see `Serving requests at 0.0.0.0:8080` the dev server is working.
 
-You may need to [create a service account in the GCP
-dashboard](https://pantheon.corp.google.com/iam-admin/serviceaccounts?project=flutter-dashboard&supportedpurview=project)
-to develop and test some features; these cannot be tested if you do
-not work for Google currently.
+To develop and test some features, you need to have a local `key.json` 
+copy of a service account in the GCP dashboard. Please refer to the 
+internal team doc for how to get a local copy; these cannot be tested if 
+you do not work for Google currently.
 
 ### Building the server for deployment
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ these values should be.
 If you see `Serving requests at 0.0.0.0:8080` the dev server is working.
 
 To develop and test some features, you need to have a local `key.json` 
-copy of a service account in the GCP dashboard. Please refer to the 
+copy of a service account ([dart-cocoon](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/110857733037195084916?project=flutter-dashboard)) in the GCP dashboard. Please refer to the 
 internal team doc for how to get a local copy; these cannot be tested if 
 you do not work for Google currently.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you see `Serving requests at 0.0.0.0:8080` the dev server is working.
 
 To develop and test some features, you need to have a local `key.json` 
 copy of a service account ([dart-cocoon](https://pantheon.corp.google.com/iam-admin/serviceaccounts/details/110857733037195084916?project=flutter-dashboard)) in the GCP dashboard. Please refer to the 
-internal team doc for how to get a local copy; these cannot be tested if 
+[internal team doc](https://g3doc.corp.google.com/company/teams/flutter/cocoon/local_run.md?cl=head) for how to get a local copy; these cannot be tested if 
 you do not work for Google currently.
 
 ### Building the server for deployment


### PR DESCRIPTION
This is part of https://github.com/flutter/flutter/issues/58619