### PR TITLE
[app_dart] Re-enable presubmit trigger for the packages repo

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -33,7 +33,8 @@ class Config {
   static const Set<String> supportedRepos = <String>{
     'engine',
     'flutter',
-    'cocoon'
+    'cocoon',
+    'packages',
   };
 
   @visibleForTesting


### PR DESCRIPTION
So that it will trigger fuchsia_ctl presubmit builders.

Bug: https://github.com/flutter/flutter/issues/56138