### PR TITLE
Add an env var that supports using inmemory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ server will serve them.
 
 Set the environment variables `GCLOUD_PROJECT` and `GCLOUD_KEY`.
 Running `dart bin/server.dart` will give more explanation on what
-these values should be.
+these values should be. You should also set `COCOON_USE_IN_MEMORY_CACHE`
+to `true` as you typically don't have access to the remote redis
+instance during local development.
 
 If you see `Serving requests at 0.0.0.0:8080` the dev server is working.
 

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -8,9 +8,14 @@ import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:gcloud/db.dart';
 
+/// For local development, you might want to set this to true.
+const String _kCocoonUseInMemoryCache = 'COCOON_USE_IN_MEMORY_CACHE';
+
 Future<void> main() async {
   await withAppEngineServices(() async {
-    final CacheService cache = CacheService();
+    final bool inMemoryCache =
+        Platform.environment[_kCocoonUseInMemoryCache] == 'true';
+    final CacheService cache = CacheService(inMemory: inMemoryCache);
 
     final Config config = Config(dbService, cache);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);


### PR DESCRIPTION
When `COCOON_USE_IN_MEMORY_CACHE` is set to `true`
we use in memory cache as opposed to the remote redis
instance.

fixes: https://github.com/flutter/flutter/issues/43743