### PR TITLE
Avoid unwanted branches scan

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -114,4 +114,4 @@ $ dart dev/deploy.dart --help
 
 ### Branching support for flutter repo
 
-Define branch regular expressions in `dev/branch_regexps.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).
+Add targeted branches in `dev/branch_regexps.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).

--- a/app_dart/dev/branch_regexps.txt
+++ b/app_dart/dev/branch_regexps.txt
@@ -1,2 +1,4 @@
-^flutter-[0-9]+\.[0-9]+-candidate\.[0-9]+$
+^flutter-1+\.17+-candidate\.3+$
+^flutter-1+\.18+-candidate\.11+$
+^flutter-1+\.19+-candidate\.4+$
 master


### PR DESCRIPTION
This PR skips unwanted branches scan by changing the general branch regexp to more detailed format.

Related issue:
https://github.com/flutter/flutter/issues/58627
https://github.com/flutter/flutter/issues/55579
