### PR TITLE
Removing Gold checks on non-master branches

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -129,12 +129,6 @@ class Config {
       'For more information about working with golden files, see the wiki page '
       '[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).';
 
-  String get goldenBranchMessage => 'Golden file changes have been found '
-      'for this pull request, however this pull request is not staged to land on '
-      'the master branch.\n\n'
-      'This can happen when images have changes on the master branch and have not '
-      'been updated for this branch. If this is the case, you can disregard.';
-
   int get maxTaskRetries => 2;
 
   /// The number of times to retry a LUCI job on infra failures.

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -32,7 +32,6 @@ class FakeConfig implements Config {
     this.nonMasterPullRequestMessageValue,
     this.goldenBreakingChangeMessageValue,
     this.goldenTriageMessageValue,
-    this.goldenBranchMessageValue,
     this.webhookKeyValue,
     this.cqLabelNameValue,
     this.luciBuildersValue,
@@ -71,7 +70,6 @@ class FakeConfig implements Config {
   String nonMasterPullRequestMessageValue;
   String goldenBreakingChangeMessageValue;
   String goldenTriageMessageValue;
-  String goldenBranchMessageValue;
   String webhookKeyValue;
   String cqLabelNameValue;
   String flutterBuildValue;
@@ -158,9 +156,6 @@ class FakeConfig implements Config {
 
   @override
   String get goldenTriageMessage => goldenTriageMessageValue;
-
-  @override
-  String get goldenBranchMessage => goldenBranchMessageValue;
 
   @override
   Future<String> get webhookKey async => webhookKeyValue;


### PR DESCRIPTION
Related issues: https://github.com/flutter/flutter/issues/58627 https://github.com/flutter/flutter/issues/58814

This removes the gold check from branches that are not staged to land on master (i.e. release branches) We've been hitting Github API rate limits, so this should help cut back on those requests.