### PR TITLE
[cocoon] Avoid GitHub API call after changing branch regexps to branches

### DIFF
--- a/app_dart/dev/branch_regexps.txt
+++ b/app_dart/dev/branch_regexps.txt
@@ -1,4 +1,0 @@
-^flutter-1+\.17+-candidate\.3+$
-^flutter-1+\.18+-candidate\.11+$
-^flutter-1+\.19+-candidate\.4+$
-master

--- a/app_dart/dev/branches.txt
+++ b/app_dart/dev/branches.txt
@@ -1,0 +1,4 @@
+flutter-1.17-candidate.3
+flutter-1.18-candidate.11
+flutter-1.19-candidate.4
+master

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -48,8 +48,8 @@ class Config {
     final Uint8List cacheValue = await _cache.getOrCreate(
       configCacheName,
       'flutterBranches',
-      createFn: () => getBranches(this, Providers.freshHttpClient,
-          loggingService, twoSecondLinearBackoff),
+      createFn: () => getBranches(
+          Providers.freshHttpClient, loggingService, twoSecondLinearBackoff),
       ttl: configCacheTtl,
     );
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -67,10 +67,8 @@ Future<List<String>> loadBranches(HttpClientProvider branchHttpClientProvider,
   return <String>['master'];
 }
 
-Future<Uint8List> getBranches(
-    HttpClientProvider branchHttpClientProvider,
-    Logging log,
-    GitHubBackoffCalculator gitHubBackoffCalculator) async {
+Future<Uint8List> getBranches(HttpClientProvider branchHttpClientProvider,
+    Logging log, GitHubBackoffCalculator gitHubBackoffCalculator) async {
   final List<String> branches = await loadBranches(
       branchHttpClientProvider, log, gitHubBackoffCalculator);
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -8,10 +8,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/src/service/github_service.dart';
-import 'package:github/github.dart';
 
-import '../datastore/cocoon_config.dart';
 import '../foundation/typedefs.dart';
 
 /// Signature for a function that calculates the backoff duration to wait in

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -27,11 +27,9 @@ Duration twoSecondLinearBackoff(int attempt) {
   return const Duration(seconds: 2) * (attempt + 1);
 }
 
-Future<List<String>> loadBranchRegExps(
-    HttpClientProvider branchHttpClientProvider,
-    Logging log,
-    GitHubBackoffCalculator gitHubBackoffCalculator) async {
-  const String path = '/flutter/cocoon/master/app_dart/dev/branch_regexps.txt';
+Future<List<String>> loadBranches(HttpClientProvider branchHttpClientProvider,
+    Logging log, GitHubBackoffCalculator gitHubBackoffCalculator) async {
+  const String path = '/flutter/cocoon/master/app_dart/dev/branches.txt';
   final Uri url = Uri.https('raw.githubusercontent.com', path);
 
   final HttpClient client = branchHttpClientProvider();
@@ -70,27 +68,11 @@ Future<List<String>> loadBranchRegExps(
 }
 
 Future<Uint8List> getBranches(
-    Config config,
     HttpClientProvider branchHttpClientProvider,
     Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator) async {
-  final GithubService githubService = await config.createGithubService();
-  final GitHub github = githubService.github;
-  final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-  final Stream<Branch> branchList = github.repositories.listBranches(slug);
-  final List<String> regExps = await loadBranchRegExps(
+  final List<String> branches = await loadBranches(
       branchHttpClientProvider, log, gitHubBackoffCalculator);
-  final List<Branch> branches = <Branch>[];
 
-  await for (Branch branch in branchList) {
-    if (!regExps.any((String regExp) => RegExp(regExp).hasMatch(branch.name))) {
-      continue;
-    }
-    branches.add(branch);
-  }
-  return Uint8List.fromList(branches
-      .map((Branch branch) => branch.name)
-      .toList()
-      .join(',')
-      .codeUnits);
+  return Uint8List.fromList(branches.join(',').codeUnits);
 }

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -77,7 +77,7 @@ void main() {
         branchHttpClient = FakeHttpClient();
         log = FakeLogging();
       });
-      test('returns matched branches', () async {
+      test('returns branches', () async {
         branchHttpClient.request.response.body = branchRegExp;
         final Uint8List branches = await getBranches(
             () => branchHttpClient, log, (int attempt) => Duration.zero);

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -81,7 +81,8 @@ void main() {
         branchHttpClient.request.response.body = branchRegExp;
         final Uint8List branches = await getBranches(
             () => branchHttpClient, log, (int attempt) => Duration.zero);
-        expect(String.fromCharCodes(branches), 'master,flutter-1.1-candidate.1');
+        expect(
+            String.fromCharCodes(branches), 'master,flutter-1.1-candidate.1');
       });
     });
 


### PR DESCRIPTION
This PR addressed comment: https://github.com/flutter/cocoon/pull/799#discussion_r436174916

Cocoon is using fixed branch name list to iterate wanted branches after PR: https://github.com/flutter/cocoon/pull/799. However it still keeps querying GitHub API to unnecessarily screen through all available branches. This helps nothing but wasting API calls.

This PR removes the above GitHub api call, and uses branches directly.