### PR TITLE
Remove duplicated code from web_hook and luci_status.

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -6,14 +6,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
+import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:crypto/crypto.dart';
 import 'package:github/github.dart';
 import 'package:github/hooks.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
-import '../model/appengine/service_account_info.dart';
-import '../model/luci/buildbucket.dart';
+
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
 import '../request_handling/request_handler.dart';
@@ -49,6 +50,10 @@ class GithubWebhook extends RequestHandler<Body> {
   @override
   Future<Body> post() async {
     final String gitHubEvent = request.headers.value('X-GitHub-Event');
+    final ServiceAccountInfo serviceAccountInfo =
+        await config.deviceLabServiceAccount;
+    final LuciBuildService luciBuilderService =
+        LuciBuildService(config, buildBucketClient, serviceAccountInfo);
     if (gitHubEvent == null ||
         request.headers.value('X-Hub-Signature') == null) {
       throw const BadRequestException('Missing required headers.');
@@ -64,7 +69,7 @@ class GithubWebhook extends RequestHandler<Body> {
       final String stringRequest = utf8.decode(requestBytes);
       switch (gitHubEvent) {
         case 'pull_request':
-          await _handlePullRequest(stringRequest);
+          await _handlePullRequest(stringRequest, luciBuilderService);
           break;
       }
 
@@ -76,7 +81,9 @@ class GithubWebhook extends RequestHandler<Body> {
     }
   }
 
-  Future<void> _handlePullRequest(String rawRequest) async {
+  Future<void> _handlePullRequest(
+      String rawRequest, LuciBuildService luciBuilderService) async {
+    // ignore: undefined_class
     final PullRequestEvent pullRequestEvent =
         await _getPullRequestEvent(rawRequest);
     if (pullRequestEvent == null) {
@@ -97,7 +104,7 @@ class GithubWebhook extends RequestHandler<Body> {
         if (pr.merged) {
           await _checkForGoldenTriage(eventAction, pr, pr.labels);
         } else {
-          await _cancelLuci(
+          await luciBuilderService.cancelBuilds(
             pr.head.repo.name,
             pr.number,
             pr.head.sha,
@@ -115,19 +122,19 @@ class GithubWebhook extends RequestHandler<Body> {
       case 'reopened':
         // These cases should trigger LUCI jobs.
         await _checkForLabelsAndTests(eventAction, pr);
-        await _scheduleIfMergeable(pr);
+        await _scheduleIfMergeable(pr, luciBuilderService);
         break;
       case 'labeled':
         // This should only trigger a LUCI job for flutter/flutter right now,
         // since it is in the needsCQLabelList.
         if (kNeedsCQLabelList.contains(pr.base.repo.fullName.toLowerCase())) {
-          await _scheduleIfMergeable(pr);
+          await _scheduleIfMergeable(pr, luciBuilderService);
         }
         break;
       case 'synchronize':
         // This indicates the PR has new commits. We need to cancel old jobs
         // and schedule new ones.
-        await _scheduleIfMergeable(pr);
+        await _scheduleIfMergeable(pr, luciBuilderService);
         break;
       case 'unlabeled':
         // Cancel the jobs if someone removed the label on a repo that needs
@@ -136,7 +143,7 @@ class GithubWebhook extends RequestHandler<Body> {
           break;
         }
         if (!await _checkForCqLabel(pr.labels)) {
-          await _cancelLuci(
+          await luciBuilderService.cancelBuilds(
             pr.head.repo.name,
             pr.number,
             pr.head.sha,
@@ -157,7 +164,8 @@ class GithubWebhook extends RequestHandler<Body> {
 
   /// This method assumes that jobs should be cancelled if they are already
   /// runnning.
-  Future<void> _scheduleIfMergeable(PullRequest pr) async {
+  Future<void> _scheduleIfMergeable(
+      PullRequest pr, LuciBuildService luciBuilderService) async {
     // The mergeable flag may be null. False indicates there's a merge conflict,
     // null indicates unknown. Err on the side of allowing the job to run.
 
@@ -169,184 +177,23 @@ class GithubWebhook extends RequestHandler<Body> {
     }
 
     // Always cancel running builds so we don't ever schedule duplicates.
-    await _cancelLuci(
+    await luciBuilderService.cancelBuilds(
       pr.head.repo.name,
       pr.number,
       pr.head.sha,
       'Newer commit available',
     );
-    await _scheduleLuci(
-      number: pr.number,
-      sha: pr.head.sha,
+    await luciBuilderService.scheduleBuilds(
+      prNumber: pr.number,
+      commitSha: pr.head.sha,
       repositoryName: pr.head.repo.name,
     );
-  }
-
-  /// This method checks if there are running builds for this PR
-  Future<List<Build>> _buildsForRepositoryAndPr(
-    String repositoryName,
-    int number,
-    String sha,
-    BuildBucketClient buildBucketClient,
-    ServiceAccountInfo serviceAccount,
-  ) async {
-    final BatchResponse batch =
-        await buildBucketClient.batch(BatchRequest(requests: <Request>[
-      Request(
-        searchBuilds: SearchBuildsRequest(
-          predicate: BuildPredicate(
-            builderId: const BuilderId(
-              project: 'flutter',
-              bucket: 'try',
-            ),
-            createdBy: serviceAccount.email,
-            tags: <String, List<String>>{
-              'buildset': <String>['pr/git/$number'],
-              'github_link': <String>[
-                'https://github.com/flutter/$repositoryName/pull/$number'
-              ],
-              'user_agent': const <String>['flutter-cocoon'],
-            },
-          ),
-        ),
-      ),
-      Request(
-        searchBuilds: SearchBuildsRequest(
-          predicate: BuildPredicate(
-            builderId: const BuilderId(
-              project: 'flutter',
-              bucket: 'try',
-            ),
-            tags: <String, List<String>>{
-              'buildset': <String>['pr/git/$number'],
-              'user_agent': const <String>['recipe'],
-            },
-          ),
-        ),
-      ),
-    ]));
-    return batch.responses
-        .map((Response response) => response.searchBuilds)
-        .expand((SearchBuildsResponse response) => response.builds ?? <Build>[])
-        .toList();
-  }
-
-  Future<bool> _scheduleLuci({
-    @required int number,
-    @required String sha,
-    @required String repositoryName,
-  }) async {
-    assert(number != null);
-    assert(sha != null);
-    assert(repositoryName != null);
-    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
-      log.error('Unsupported repo on webhook: $repositoryName');
-      throw BadRequestException(
-          'Repository $repositoryName is not supported by this service.');
-    }
-    final ServiceAccountInfo serviceAccount =
-        await config.deviceLabServiceAccount;
-
-    final List<Build> builds = await _buildsForRepositoryAndPr(
-      repositoryName,
-      number,
-      sha,
-      buildBucketClient,
-      serviceAccount,
-    );
-    if (builds != null &&
-        builds.any((Build build) {
-          return build.status == Status.scheduled ||
-              build.status == Status.started;
-        })) {
-      return false;
-    }
-
-    final List<Map<String, dynamic>> builders = config.luciTryBuilders;
-    final List<String> builderNames = builders
-        .where(
-            (Map<String, dynamic> builder) => builder['repo'] == repositoryName)
-        .map<String>(
-            (Map<String, dynamic> builder) => builder['name'] as String)
-        .toList();
-    if (builderNames.isEmpty) {
-      throw InternalServerError('$repositoryName does not have any builders');
-    }
-
-    final List<Request> requests = <Request>[];
-    for (String builder in builderNames) {
-      final BuilderId builderId = BuilderId(
-        project: 'flutter',
-        bucket: 'try',
-        builder: builder,
-      );
-      requests.add(
-        Request(
-          scheduleBuild: ScheduleBuildRequest(
-            builderId: builderId,
-            tags: <String, List<String>>{
-              'buildset': <String>['pr/git/$number', 'sha/git/$sha'],
-              'user_agent': const <String>['flutter-cocoon'],
-              'github_link': <String>[
-                'https://github.com/flutter/$repositoryName/pull/$number'
-              ],
-            },
-            properties: <String, String>{
-              'git_url': 'https://github.com/flutter/$repositoryName',
-              'git_ref': 'refs/pull/$number/head',
-            },
-            notify: NotificationConfig(
-              pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
-              userData: json.encode(const <String, dynamic>{
-                'retries': 0,
-              }),
-            ),
-          ),
-        ),
-      );
-    }
-    await buildBucketClient.batch(BatchRequest(requests: requests));
-    return true;
   }
 
   /// Checks the issue in the given repository for `config.cqLabelName`.
   Future<bool> _checkForCqLabel(List<IssueLabel> labels) async {
     final String cqLabelName = config.cqLabelName;
     return labels.any((IssueLabel label) => label.name == cqLabelName);
-  }
-
-  Future<void> _cancelLuci(
-      String repositoryName, int number, String sha, String reason) async {
-    if (!config.githubPresubmitSupportedRepo(repositoryName)) {
-      throw BadRequestException(
-          'This service does not support repository $repositoryName.');
-    }
-    final ServiceAccountInfo serviceAccount =
-        await config.deviceLabServiceAccount;
-    final List<Build> builds = await _buildsForRepositoryAndPr(
-      repositoryName,
-      number,
-      sha,
-      buildBucketClient,
-      serviceAccount,
-    );
-    if (builds == null ||
-        !builds.any((Build build) {
-          return build.status == Status.scheduled ||
-              build.status == Status.started;
-        })) {
-      return;
-    }
-    final List<Request> requests = <Request>[];
-    for (Build build in builds) {
-      requests.add(
-        Request(
-          cancelBuild:
-              CancelBuildRequest(id: build.id, summaryMarkdown: reason),
-        ),
-      );
-    }
-    await buildBucketClient.batch(BatchRequest(requests: requests));
   }
 
   Future<bool> _isIgnoredForGold(String eventAction, PullRequest pr) async {

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -52,7 +52,7 @@ class GithubWebhook extends RequestHandler<Body> {
     final String gitHubEvent = request.headers.value('X-GitHub-Event');
     final ServiceAccountInfo serviceAccountInfo =
         await config.deviceLabServiceAccount;
-    final LuciBuildService luciBuilderService =
+    final LuciBuildService luciBuildService =
         LuciBuildService(config, buildBucketClient, serviceAccountInfo);
     if (gitHubEvent == null ||
         request.headers.value('X-Hub-Signature') == null) {
@@ -69,7 +69,7 @@ class GithubWebhook extends RequestHandler<Body> {
       final String stringRequest = utf8.decode(requestBytes);
       switch (gitHubEvent) {
         case 'pull_request':
-          await _handlePullRequest(stringRequest, luciBuilderService);
+          await _handlePullRequest(stringRequest, luciBuildService);
           break;
       }
 
@@ -83,7 +83,6 @@ class GithubWebhook extends RequestHandler<Body> {
 
   Future<void> _handlePullRequest(
       String rawRequest, LuciBuildService luciBuilderService) async {
-    // ignore: undefined_class
     final PullRequestEvent pullRequestEvent =
         await _getPullRequestEvent(rawRequest);
     if (pullRequestEvent == null) {

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -5,6 +5,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cocoon_service/src/service/buildbucket.dart';
+import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/oauth2/v2.dart';
 import 'package:http/http.dart' as http;
@@ -12,12 +14,10 @@ import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../model/appengine/service_account_info.dart';
-import '../model/luci/buildbucket.dart' as bb;
 import '../model/luci/push_message.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
 import '../request_handling/request_handler.dart';
-import '../service/buildbucket.dart';
 
 /// An endpoint for listening to LUCI status updates for scheduled builds.
 ///
@@ -48,6 +48,11 @@ class LuciStatusHandler extends RequestHandler<Body> {
 
   @override
   Future<Body> post() async {
+    final ServiceAccountInfo serviceAccountInfo =
+        await config.deviceLabServiceAccount;
+    final LuciBuildService luciBuildService =
+        LuciBuildService(config, buildBucketClient, serviceAccountInfo);
+
     if (!await _authenticateRequest(request.headers)) {
       throw const Unauthorized();
     }
@@ -75,6 +80,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
           builderName: builderName,
           build: build,
           retries: userData['retries'] as int,
+          luciBuildService: luciBuildService,
         );
         break;
       case Status.scheduled:
@@ -97,6 +103,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
     @required String builderName,
     @required Build build,
     @required int retries,
+    @required LuciBuildService luciBuildService,
   }) async {
     assert(sha != null);
     assert(builderName != null);
@@ -105,14 +112,13 @@ class LuciStatusHandler extends RequestHandler<Body> {
       switch (build.failureReason) {
         case FailureReason.buildbucketFailure:
         case FailureReason.infraFailure:
-          // infra failed
-          await _rescheduleBuild(
-            sha: sha,
+          await luciBuildService.rescheduleBuild(
+            commitSha: sha,
             builderName: builderName,
             build: build,
             retries: retries,
           );
-          return;
+          break;
         case FailureReason.invalidBuildDefinition:
         case FailureReason.buildFailure:
           // the commit failed
@@ -125,52 +131,6 @@ class LuciStatusHandler extends RequestHandler<Body> {
       buildUrl: build.url,
       result: build.result,
     );
-  }
-
-  /// Sends a [BuildBucket.scheduleBuild] request as long as the `retries`
-  /// parameter has not exceeded [CocoonConfig.luciTryInfraFailureRetries].
-  ///
-  /// If the retries have been exhausted, it sets the GitHub status to failure.
-  ///
-  /// The buildset, user_agent, and github_link tags are applied to match the
-  /// original build. The build properties from the original build are also
-  /// preserved.
-  Future<void> _rescheduleBuild({
-    @required String sha,
-    @required String builderName,
-    @required Build build,
-    @required int retries,
-  }) async {
-    if (retries >= config.luciTryInfraFailureRetries) {
-      // Too many retries.
-      await _setCompletedStatus(
-        ref: sha,
-        builderName: builderName,
-        buildUrl: build.url,
-        result: build.result,
-      );
-      return;
-    }
-    await buildBucketClient.scheduleBuild(bb.ScheduleBuildRequest(
-      builderId: bb.BuilderId(
-        project: build.project,
-        bucket: 'try',
-        builder: builderName,
-      ),
-      tags: <String, List<String>>{
-        'buildset': build.tagsByName('buildset'),
-        'user_agent': build.tagsByName('user_agent'),
-        'github_link': build.tagsByName('github_link'),
-      },
-      properties: (build.buildParameters['properties'] as Map<String, dynamic>)
-          .cast<String, String>(),
-      notify: bb.NotificationConfig(
-        pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
-        userData: json.encode(<String, dynamic>{
-          'retries': retries + 1,
-        }),
-      ),
-    ));
   }
 
   Future<bool> _authenticateRequest(HttpHeaders headers) async {

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -112,13 +112,13 @@ class LuciStatusHandler extends RequestHandler<Body> {
       switch (build.failureReason) {
         case FailureReason.buildbucketFailure:
         case FailureReason.infraFailure:
-          final bool result = await luciBuildService.rescheduleBuild(
+          final bool rescheduled = await luciBuildService.rescheduleBuild(
             commitSha: sha,
             builderName: builderName,
             build: build,
             retries: retries,
           );
-          if (result) {
+          if (rescheduled) {
             await _setPendingStatus(
               ref: sha,
               builderName: builderName,
@@ -211,6 +211,9 @@ class LuciStatusHandler extends RequestHandler<Body> {
 
     String updatedBuildUrl = '';
     if (buildUrl.isNotEmpty) {
+      // If buildUrl is not empty then append a query parameter to refresh the page
+      // content every 30 seconds. A resulting updatedBuild url will look like:
+      // https://ci.chromium.org/p/flutter/builders/try/Linux%20Web%20Engine/5275?reload=30
       updatedBuildUrl =
           '$buildUrl${buildUrl.contains('?') ? '&' : '?'}reload=30';
     }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -211,7 +211,7 @@ class LuciBuildService {
   /// The buildset, user_agent, and github_link tags are applied to match the
   /// original build. The build properties from the original build are also
   /// preserved.
-  Future<void> rescheduleBuild({
+  Future<bool> rescheduleBuild({
     @required String commitSha,
     @required String builderName,
     @required push_message.Build build,
@@ -219,7 +219,7 @@ class LuciBuildService {
   }) async {
     if (retries >= config.luciTryInfraFailureRetries) {
       // Too many retries.
-      return;
+      return false;
     }
     await buildBucketClient.scheduleBuild(ScheduleBuildRequest(
       builderId: BuilderId(
@@ -241,5 +241,6 @@ class LuciBuildService {
         }),
       ),
     ));
+    return true;
   }
 }

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -1162,7 +1162,7 @@ void main() {
                       builderId: BuilderId(
                         project: 'flutter',
                         bucket: 'prod',
-                        builder: 'Linux',
+                        builder: 'Linux Host',
                       ),
                       status: Status.started,
                     )

--- a/app_dart/test/request_handlers/luci_status_test.dart
+++ b/app_dart/test/request_handlers/luci_status_test.dart
@@ -21,6 +21,7 @@ import '../src/datastore/fake_cocoon_config.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/request_handler_tester.dart';
 import '../src/utilities/mocks.dart';
+import '../src/utilities/push_message.dart';
 
 const String ref = 'deadbeef';
 
@@ -265,7 +266,7 @@ void main() {
         ScheduleBuildRequest(
           builderId: const BuilderId(
             project: 'flutter',
-            bucket: 'try',
+            bucket: 'luci.flutter.prod',
             builder: 'Linux',
           ),
           tags: const <String, List<String>>{
@@ -288,14 +289,18 @@ void main() {
         ).toJson(),
       ),
     );
-    verifyNever(mockRepositoriesService.createStatus(
-      RepositorySlug('flutter', 'flutter'),
-      ref,
-      captureAny,
-    ));
+    expect(
+      verify(mockRepositoriesService.createStatus(
+        RepositorySlug('flutter', 'flutter'),
+        ref,
+        captureAny,
+      )).captured.single.toJson(),
+      jsonDecode(
+          '{"state":"failure","target_url":"https://ci.chromium.org/b/8905920700440101120","description":"Flutter LUCI Build: Linux","context":"Linux"}'),
+    );
   });
 
-  test('Does not an infra failure after too many retries', () async {
+  test('Does not schedule after infra failure and too many retries', () async {
     request.bodyBytes = utf8.encode(pushMessageJson('COMPLETED',
         builderName: 'Linux',
         result: 'FAILURE',
@@ -371,70 +376,3 @@ void main() {
     );
   });
 }
-
-String pushMessageJson(
-  String status, {
-  String result,
-  String builderName = 'Linux Coverage',
-  String urlParam = '',
-  int retries = 0,
-  String failureReason,
-}) {
-  return '''{
-     "message": {
-       "attributes": {},
-       "data": "${buildPushMessageJson(status, result: result, builderName: builderName, urlParam: urlParam, retries: retries, failureReason: failureReason)}",
-       "messageId": "123"
-     },
-     "subscription": "projects/myproject/subscriptions/mysubscription"
-   }''';
-}
-
-String buildPushMessageJson(String status,
-        {String result,
-        String builderName = 'Linux Coverage',
-        String urlParam = '',
-        int retries = 0,
-        String failureReason}) =>
-    base64.encode(
-      utf8.encode('''{
-  "build": {
-    "bucket": "luci.flutter.prod",
-    "canary": false,
-    "canary_preference": "PROD",
-    "created_by": "user:dnfield@google.com",
-    "created_ts": "1565049186247524",
-    "experimental": false,
-    ${failureReason != null ? '"failure_reason": "$failureReason",' : ''}
-    "id": "8905920700440101120",
-    "parameters_json": "{\\"builder_name\\": \\"$builderName\\", \\"properties\\": {\\"git_ref\\": \\"refs/pull/37647/head\\", \\"git_url\\": \\"https://github.com/flutter/flutter\\"}}",
-    "project": "flutter",
-    ${result != null ? '"result": "$result",' : ''}
-    "result_details_json": "{\\"properties\\": {}, \\"swarming\\": {\\"bot_dimensions\\": {\\"caches\\": [\\"flutter_openjdk_install\\", \\"git\\", \\"goma_v2\\", \\"vpython\\"], \\"cores\\": [\\"8\\"], \\"cpu\\": [\\"x86\\", \\"x86-64\\", \\"x86-64-Broadwell_GCE\\", \\"x86-64-avx2\\"], \\"gce\\": [\\"1\\"], \\"gpu\\": [\\"none\\"], \\"id\\": [\\"luci-flutter-prod-xenial-2-bnrz\\"], \\"image\\": [\\"chrome-xenial-19052201-9cb74617499\\"], \\"inside_docker\\": [\\"0\\"], \\"kvm\\": [\\"1\\"], \\"locale\\": [\\"en_US.UTF-8\\"], \\"machine_type\\": [\\"n1-standard-8\\"], \\"os\\": [\\"Linux\\", \\"Ubuntu\\", \\"Ubuntu-16.04\\"], \\"pool\\": [\\"luci.flutter.prod\\"], \\"python\\": [\\"2.7.12\\"], \\"server_version\\": [\\"4382-5929880\\"], \\"ssd\\": [\\"0\\"], \\"zone\\": [\\"us\\", \\"us-central\\", \\"us-central1\\", \\"us-central1-c\\"]}}}",
-    "service_account": "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com",
-    "started_ts": "1565049193786080",
-    "status": "$status",
-    "status_changed_ts": "1565049194386647",
-    "tags": [
-      "build_address:luci.flutter.prod/$builderName/1698",
-      "builder:$builderName",
-      "buildset:pr/git/37647",
-      "buildset:sha/git/$ref",
-      "github_link:https://github.com/flutter/flutter/pull/37647",
-      "swarming_hostname:chromium-swarm.appspot.com",
-      "swarming_tag:log_location:logdog://logs.chromium.org/flutter/buildbucket/cr-buildbucket.appspot.com/8905920700440101120/+/annotations",
-      "swarming_tag:luci_project:flutter",
-      "swarming_tag:os:Linux",
-      "swarming_tag:recipe_name:flutter/flutter",
-      "swarming_tag:recipe_package:infra/recipe_bundles/chromium.googlesource.com/chromium/tools/build",
-      "swarming_task_id:467d04f2f022d510",
-      "user_agent:flutter-cocoon"
-    ],
-    "updated_ts": "1565049194391321",
-    "url": "https://ci.chromium.org/b/8905920700440101120$urlParam",
-    "utcnow_ts": "1565049194653640"
-  },
-  "hostname": "cr-buildbucket.appspot.com",
-  "user_data": "{\\"retries\\": $retries}"
-}'''),
-    );

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -7,6 +7,8 @@ import 'dart:core';
 
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
+import 'package:cocoon_service/src/model/luci/push_message.dart'
+    as push_message;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:mockito/mockito.dart';
@@ -14,6 +16,7 @@ import 'package:test/test.dart';
 
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/utilities/mocks.dart';
+import '../src/utilities/push_message.dart';
 
 void main() {
   ServiceAccountInfo serviceAccountInfo;
@@ -289,17 +292,12 @@ void main() {
     });
     test('Reschedule an existing build', () async {
       config.luciTryInfraFailureRetriesValue = 3;
-
-      final Map<String, List<String>> tags = <String, List<String>>{
-        'buildset': <String>['123'],
-        'user_agent': <String>['cocoon'],
-        'github_link': <String>['the_link']
-      };
-      final Build build = Build(
-          id: 123,
-          builderId: const BuilderId(),
-          tags: tags,
-          input: const Input());
+      final Map<String, dynamic> json = jsonDecode(buildPushMessageString(
+        'COMPLETED',
+        result: 'FAILURE',
+        builderName: 'Linux Host Engine',
+      ))['build'] as Map<String, dynamic>;
+      final push_message.Build build = push_message.Build.fromJson(json);
       await service.rescheduleBuild(
           commitSha: 'abc', builderName: 'mybuild', build: build, retries: 1);
       verify(mockBuildBucketClient.scheduleBuild(any)).called(1);

--- a/app_dart/test/src/utilities/push_message.dart
+++ b/app_dart/test/src/utilities/push_message.dart
@@ -1,0 +1,90 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Utilities to create PushMessages for testing.
+
+import 'dart:convert';
+
+const String ref = 'deadbeef';
+
+String pushMessageJson(
+  String status, {
+  String result,
+  String builderName = 'Linux Coverage',
+  String urlParam = '',
+  int retries = 0,
+  String failureReason,
+}) {
+  return '''{
+     "message": {
+       "attributes": {},
+       "data": "${buildPushMessageJson(status, result: result, builderName: builderName, urlParam: urlParam, retries: retries, failureReason: failureReason)}",
+       "messageId": "123"
+     },
+     "subscription": "projects/myproject/subscriptions/mysubscription"
+   }''';
+}
+
+String buildPushMessageJson(String status,
+        {String result,
+        String builderName = 'Linux Coverage',
+        String urlParam = '',
+        int retries = 0,
+        String failureReason}) =>
+    base64.encode(utf8.encode(buildPushMessageString(
+      status,
+      result: result,
+      builderName: builderName,
+      urlParam: urlParam,
+      retries: retries,
+      failureReason: failureReason,
+    )));
+
+String buildPushMessageString(String status,
+    {String result,
+    String builderName = 'Linux Coverage',
+    String urlParam = '',
+    int retries = 0,
+    String failureReason}) {
+  return '''{
+  "build": {
+    "bucket": "luci.flutter.prod",
+    "canary": false,
+    "canary_preference": "PROD",
+    "created_by": "user:dnfield@google.com",
+    "created_ts": "1565049186247524",
+    "experimental": false,
+    ${failureReason != null ? '"failure_reason": "$failureReason",' : ''}
+    "id": "8905920700440101120",
+    "parameters_json": "{\\"builder_name\\": \\"$builderName\\", \\"properties\\": {\\"git_ref\\": \\"refs/pull/37647/head\\", \\"git_url\\": \\"https://github.com/flutter/flutter\\"}}",
+    "project": "flutter",
+    ${result != null ? '"result": "$result",' : ''}
+    "result_details_json": "{\\"properties\\": {}, \\"swarming\\": {\\"bot_dimensions\\": {\\"caches\\": [\\"flutter_openjdk_install\\", \\"git\\", \\"goma_v2\\", \\"vpython\\"], \\"cores\\": [\\"8\\"], \\"cpu\\": [\\"x86\\", \\"x86-64\\", \\"x86-64-Broadwell_GCE\\", \\"x86-64-avx2\\"], \\"gce\\": [\\"1\\"], \\"gpu\\": [\\"none\\"], \\"id\\": [\\"luci-flutter-prod-xenial-2-bnrz\\"], \\"image\\": [\\"chrome-xenial-19052201-9cb74617499\\"], \\"inside_docker\\": [\\"0\\"], \\"kvm\\": [\\"1\\"], \\"locale\\": [\\"en_US.UTF-8\\"], \\"machine_type\\": [\\"n1-standard-8\\"], \\"os\\": [\\"Linux\\", \\"Ubuntu\\", \\"Ubuntu-16.04\\"], \\"pool\\": [\\"luci.flutter.prod\\"], \\"python\\": [\\"2.7.12\\"], \\"server_version\\": [\\"4382-5929880\\"], \\"ssd\\": [\\"0\\"], \\"zone\\": [\\"us\\", \\"us-central\\", \\"us-central1\\", \\"us-central1-c\\"]}}}",
+    "service_account": "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com",
+    "started_ts": "1565049193786080",
+    "status": "$status",
+    "status_changed_ts": "1565049194386647",
+    "tags": [
+      "build_address:luci.flutter.prod/$builderName/1698",
+      "builder:$builderName",
+      "buildset:pr/git/37647",
+      "buildset:sha/git/$ref",
+      "github_link:https://github.com/flutter/flutter/pull/37647",
+      "swarming_hostname:chromium-swarm.appspot.com",
+      "swarming_tag:log_location:logdog://logs.chromium.org/flutter/buildbucket/cr-buildbucket.appspot.com/8905920700440101120/+/annotations",
+      "swarming_tag:luci_project:flutter",
+      "swarming_tag:os:Linux",
+      "swarming_tag:recipe_name:flutter/flutter",
+      "swarming_tag:recipe_package:infra/recipe_bundles/chromium.googlesource.com/chromium/tools/build",
+      "swarming_task_id:467d04f2f022d510",
+      "user_agent:flutter-cocoon"
+    ],
+    "updated_ts": "1565049194391321",
+    "url": "https://ci.chromium.org/b/8905920700440101120$urlParam",
+    "utcnow_ts": "1565049194653640"
+  },
+  "hostname": "cr-buildbucket.appspot.com",
+  "user_data": "{\\"retries\\": $retries}"
+}''';
+}


### PR DESCRIPTION
This is part of the refactoring required to enable checks api on the
cocoon application.

This also fixes a problem when failed builds were not resetting the
build state back to pending for a retry.

Bugs:
  https://github.com/flutter/flutter/issues/56421
  https://github.com/flutter/flutter/issues/56422