### PR TITLE
Remove Mac Engine Drone build.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -306,10 +306,6 @@ class Config {
           'repo': 'engine',
         },
         <String, String>{
-          'name': 'Mac Engine Drone',
-          'repo': 'engine',
-        },
-        <String, String>{
           'name': 'Mac Host Engine',
           'repo': 'engine',
         },


### PR DESCRIPTION
This builder will be used for subbuilds of mac and is not intended to
run directly.

Bug:
  https://github.com/flutter/flutter/issues/59169