### PR TITLE
Discard state pubsub message for builders that were deleted.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -394,6 +394,9 @@ class Config {
       orElse: () => <String, dynamic>{'repo': ''},
     );
     final String repoName = builderConfig['repo'] as String;
+    // If there is no builder config for the builderName then we
+    // return null. This is to allow the code calling this method
+    // to skip changes that depend on a builder configuration.
     if (repoName.isEmpty) {
       return null;
     }

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -389,9 +389,14 @@ class Config {
 
   Future<RepositorySlug> repoNameForBuilder(String builderName) async {
     final List<Map<String, dynamic>> builders = luciTryBuilders;
-    final String repoName = builders.firstWhere(
-        (Map<String, dynamic> builder) =>
-            builder['name'] == builderName)['repo'] as String;
+    final Map<String, dynamic> builderConfig = builders.firstWhere(
+      (Map<String, dynamic> builder) => builder['name'] == builderName,
+      orElse: () => <String, dynamic>{'repo': ''},
+    );
+    final String repoName = builderConfig['repo'] as String;
+    if (repoName.isEmpty) {
+      return null;
+    }
     return RepositorySlug('flutter', repoName);
   }
 }

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -396,7 +396,7 @@ class Config {
     final String repoName = builderConfig['repo'] as String;
     // If there is no builder config for the builderName then we
     // return null. This is to allow the code calling this method
-    // to skip changes that depend on a builder configuration.
+    // to skip changes that depend on builder configurations.
     if (repoName.isEmpty) {
       return null;
     }

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -178,6 +178,11 @@ class LuciStatusHandler extends RequestHandler<Body> {
     @required Result result,
   }) async {
     final RepositorySlug slug = await config.repoNameForBuilder(builderName);
+    if (slug == null) {
+      log.warning(
+          'Attempting to set state for non existent builder: $builderName');
+      return;
+    }
     final GitHub gitHubClient = await config.createGitHubClient();
     final CreateStatus status = _statusForResult(result)
       ..context = builderName
@@ -192,6 +197,11 @@ class LuciStatusHandler extends RequestHandler<Body> {
     @required String buildUrl,
   }) async {
     final RepositorySlug slug = await config.repoNameForBuilder(builderName);
+    if (slug == null) {
+      log.warning(
+          'Attempting to set state for non existent builder: $builderName');
+      return;
+    }
     final GitHub gitHubClient = await config.createGitHubClient();
     // GitHub "only" allows setting a status for a context/ref pair 1000 times.
     // We should avoid unnecessarily setting a pending status, e.g. if we get


### PR DESCRIPTION
When a builder is deleted there may be still pending or running tasks
that will try to update state. GCP pubsub will try to deliver the
message several times potentially generating several 500 http status.

Bug:
  https://github.com/flutter/flutter/issues/59270