### PR TITLE
Apply vacuum clean to branch tasks

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -166,6 +166,20 @@ class DatastoreService {
     }
   }
 
+  // Queries for recent tasks without considering branches.
+  Stream<FullTask> queryRecentTasksNoBranch(
+      {int commitLimit = 20, int taskLimit = 20}) async* {
+    assert(commitLimit != null);
+    assert(taskLimit != null);
+    await for (Commit commit
+        in queryRecentCommitsNoBranch(limit: commitLimit)) {
+      final Query<Task> query = db.query<Task>(ancestorKey: commit.key)
+        ..limit(taskLimit)
+        ..order('-createTimestamp');
+      yield* query.run().map<FullTask>((Task task) => FullTask(task, commit));
+    }
+  }
+
   /// Finds all tasks owned by the specified [commit] and partitions them into
   /// stages.
   ///

--- a/app_dart/test/request_handlers/vacuum_clean_test.dart
+++ b/app_dart/test/request_handlers/vacuum_clean_test.dart
@@ -1,0 +1,113 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/request_handlers/vacuum-clean.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:gcloud/db.dart';
+import 'package:test/test.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_authentication.dart';
+
+void main() {
+  group('VacuumClean', () {
+    FakeConfig config;
+    ApiRequestHandlerTester tester;
+    VacuumClean handler;
+    FakeDatastoreDB db;
+
+    setUp(() {
+      db = FakeDatastoreDB();
+      config = FakeConfig(
+          dbValue: db, commitNumberValue: 10, maxTaskRetriesValue: 2);
+      tester = ApiRequestHandlerTester();
+      handler = VacuumClean(
+        config,
+        FakeAuthenticationProvider(),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
+      );
+    });
+
+    test('does not update task status when task started less than one hour ago',
+        () async {
+      final Commit commit =
+          Commit(key: db.emptyKey.append(Commit, id: 'flutter/flutter/abc'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 123),
+          commitKey: commit.key,
+          attempts: 1,
+          status: Task.statusInProgress,
+          startTimestamp: DateTime.now().millisecondsSinceEpoch);
+      db.values[commit.key] = commit;
+      db.values[task.key] = task;
+
+      expect(task.status, Task.statusInProgress);
+      await tester.get(handler);
+      expect(task.status, Task.statusInProgress);
+    });
+
+    test('updates task status to new when task started one hour ago', () async {
+      final int now = DateTime.now().millisecondsSinceEpoch;
+      const Duration twoHour = Duration(hours: 2);
+      final Commit commit =
+          Commit(key: db.emptyKey.append(Commit, id: 'flutter/flutter/abc'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 123),
+          commitKey: commit.key,
+          attempts: 1,
+          status: Task.statusInProgress,
+          startTimestamp: now - twoHour.inMilliseconds);
+      db.values[commit.key] = commit;
+      db.values[task.key] = task;
+
+      expect(task.status, Task.statusInProgress);
+      await tester.get(handler);
+      expect(task.status, Task.statusNew);
+    });
+
+    test('updates task status to failed when task retries exceed limit',
+        () async {
+      final int now = DateTime.now().millisecondsSinceEpoch;
+      const Duration twoHour = Duration(hours: 2);
+      final Commit commit =
+          Commit(key: db.emptyKey.append(Commit, id: 'flutter/flutter/abc'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 123),
+          commitKey: commit.key,
+          attempts: 3,
+          status: Task.statusInProgress,
+          startTimestamp: now - twoHour.inMilliseconds);
+      db.values[commit.key] = commit;
+      db.values[task.key] = task;
+
+      expect(task.status, Task.statusInProgress);
+      await tester.get(handler);
+      expect(task.status, Task.statusFailed);
+    });
+
+    test('updates task status for non-master branch', () async {
+      final int now = DateTime.now().millisecondsSinceEpoch;
+      const Duration twoHour = Duration(hours: 2);
+      final Commit commit = Commit(
+          key: db.emptyKey.append(Commit, id: 'flutter/flutter/abc'),
+          branch: 'nonMaster');
+      final Task task = Task(
+          key: commit.key.append(Task, id: 123),
+          commitKey: commit.key,
+          attempts: 3,
+          status: Task.statusInProgress,
+          startTimestamp: now - twoHour.inMilliseconds);
+      db.values[commit.key] = commit;
+      db.values[task.key] = task;
+
+      expect(task.status, Task.statusInProgress);
+      await tester.get(handler);
+      expect(task.status, Task.statusFailed);
+    });
+  });
+}

--- a/app_dart/test/request_handlers/vacuum_clean_test.dart
+++ b/app_dart/test/request_handlers/vacuum_clean_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2020 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
Existing `vacuum-clean` api runs on `master` tasks only. This causes unhealthy status for tasks of release branches.

This PR updates `vacuum-clean` api to consider release branches as well.

Related issue: https://github.com/flutter/flutter/issues/60056