### PR TITLE
Update luci build number list

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -141,7 +141,12 @@ class Task extends Model {
   @JsonKey(name: 'BuildNumber')
   int buildNumber;
 
-  /// The build number list (reruns) of luci build.
+  /// The build number list of luci builds: comma joined string of
+  /// different build numbers. 
+  /// 
+  /// For the case with single run 123, [buildNumberList] = '123';
+  /// For the case with multiple reruns 123, 456, 789, 
+  /// [buildNumberList] = '123,456,789'.
   @StringProperty(propertyName: 'BuildNumberList')
   @JsonKey(name: 'BuildNumberList')
   String buildNumberList;

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -33,6 +33,7 @@ class Task extends Model {
     this.reservedForAgentId = '',
     this.stageName,
     this.buildNumber,
+    this.buildNumberList,
     this.builderName,
     this.luciPoolName,
     String status,
@@ -140,6 +141,11 @@ class Task extends Model {
   @JsonKey(name: 'BuildNumber')
   int buildNumber;
 
+  /// The build number list (reruns) of luci build.
+  @StringProperty(propertyName: 'BuildNumber')
+  @JsonKey(name: 'BuildNumberList')
+  String buildNumberList;
+
   /// The builder name of luci build.
   @StringProperty(propertyName: 'BuilderName')
   @JsonKey(name: 'BuilderName')
@@ -214,6 +220,7 @@ class Task extends Model {
       ..write(', stageName: $stageName')
       ..write(', status: $status')
       ..write(', buildNumber: $buildNumber')
+      ..write(', buildNumberList: $buildNumberList')
       ..write(', builderName: $builderName')
       ..write(', luciPoolName: $luciPoolName')
       ..write(')');

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -142,7 +142,7 @@ class Task extends Model {
   int buildNumber;
 
   /// The build number list (reruns) of luci build.
-  @StringProperty(propertyName: 'BuildNumber')
+  @StringProperty(propertyName: 'BuildNumberList')
   @JsonKey(name: 'BuildNumberList')
   String buildNumberList;
 

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -142,10 +142,10 @@ class Task extends Model {
   int buildNumber;
 
   /// The build number list of luci builds: comma joined string of
-  /// different build numbers. 
-  /// 
+  /// different build numbers.
+  ///
   /// For the case with single run 123, [buildNumberList] = '123';
-  /// For the case with multiple reruns 123, 456, 789, 
+  /// For the case with multiple reruns 123, 456, 789,
   /// [buildNumberList] = '123,456,789'.
   @StringProperty(propertyName: 'BuildNumberList')
   @JsonKey(name: 'BuildNumberList')

--- a/app_dart/lib/src/model/appengine/task.g.dart
+++ b/app_dart/lib/src/model/appengine/task.g.dart
@@ -19,6 +19,7 @@ Map<String, dynamic> _$TaskToJson(Task instance) => <String, dynamic>{
       'TimeoutInMinutes': instance.timeoutInMinutes,
       'Reason': instance.reason,
       'BuildNumber': instance.buildNumber,
+      'BuildNumberList': instance.buildNumberList,
       'BuilderName': instance.builderName,
       'LuciPoolName': instance.luciPoolName,
       'RequiredCapabilities': instance.requiredCapabilities,

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -131,7 +131,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
               'Committed ${tasks.length} new tasks for commit ${commit.sha}');
         });
       } catch (error) {
-        log.error('Failed to add commit ${commit.sha}: $error');
+        log.warning('Failed to add commit ${commit.sha}: $error');
       }
     }
 

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -131,7 +131,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
               'Committed ${tasks.length} new tasks for commit ${commit.sha}');
         });
       } catch (error) {
-        log.warning('Failed to add commit ${commit.sha}: $error');
+        log.error('Failed to add commit ${commit.sha}: $error');
       }
     }
 


### PR DESCRIPTION
This PR simplifies luci number support for luci reruns.

Existing strategy keeps track of different luci rerun builds by maintaining multiple task records in datastore.

With this PR, only one task record is needed: buildNumberList keeps track of all different builds. This will also make frontend change easiler.