### PR TITLE
Add packages repository.

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -33,7 +33,8 @@ class Config {
   static const Set<String> supportedRepos = <String>{
     'engine',
     'flutter',
-    'cocoon'
+    'cocoon',
+    'packages',
   };
 
   @visibleForTesting


### PR DESCRIPTION
LUCI support for packages repository was removed in one of the many
refactorings. This PR is adding it back.