### PR TITLE
Only process check updates if messages come from a supported repo.

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -65,7 +65,13 @@ Future<void> main() async {
         githubStatusService,
         githubChecksService,
       ),
-      '/api/luci-status-handler': LuciStatusHandler(config, buildBucketClient),
+      '/api/luci-status-handler': LuciStatusHandler(
+        config,
+        buildBucketClient,
+        luciBuildService,
+        githubStatusService,
+        githubChecksService,
+      ),
       '/api/push-build-status-to-github':
           PushBuildStatusToGithub(config, authProvider),
       '/api/push-gold-status-to-github':

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -97,7 +97,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
         jsonDecode(buildPushMessage.userData) as Map<String, dynamic>;
     if (userData != null &&
         userData.containsKey('repo_owner') &&
-        userData.containsKey('repo_owner')) {
+        userData.containsKey('repo_name')) {
       // Message is coming from a github checks api enabled repo. We need to
       // create the slug from the data in the message and send the check status
       // update.

--- a/app_dart/test/src/utilities/push_message.dart
+++ b/app_dart/test/src/utilities/push_message.dart
@@ -8,18 +8,17 @@ import 'dart:convert';
 
 const String ref = 'deadbeef';
 
-String pushMessageJson(
-  String status, {
-  String result,
-  String builderName = 'Linux Coverage',
-  String urlParam = '',
-  int retries = 0,
-  String failureReason,
-}) {
+String pushMessageJson(String status,
+    {String result,
+    String builderName = 'Linux Coverage',
+    String urlParam = '',
+    int retries = 0,
+    String failureReason,
+    String userData = '{}'}) {
   return '''{
      "message": {
        "attributes": {},
-       "data": "${buildPushMessageJson(status, result: result, builderName: builderName, urlParam: urlParam, retries: retries, failureReason: failureReason)}",
+       "data": "${buildPushMessageJson(status, result: result, builderName: builderName, urlParam: urlParam, retries: retries, failureReason: failureReason, userData: userData)}",
        "messageId": "123"
      },
      "subscription": "projects/myproject/subscriptions/mysubscription"
@@ -49,7 +48,8 @@ String buildPushMessageJson(String status,
         String builderName = 'Linux Coverage',
         String urlParam = '',
         int retries = 0,
-        String failureReason}) =>
+        String failureReason,
+        String userData}) =>
     base64.encode(utf8.encode(buildPushMessageString(
       status,
       result: result,
@@ -57,14 +57,17 @@ String buildPushMessageJson(String status,
       urlParam: urlParam,
       retries: retries,
       failureReason: failureReason,
+      userData: userData,
     )));
 
-String buildPushMessageJsonNoBuildset(String status,
-        {String result,
-        String builderName = 'Linux Coverage',
-        String urlParam = '',
-        int retries = 0,
-        String failureReason}) =>
+String buildPushMessageJsonNoBuildset(
+  String status, {
+  String result,
+  String builderName = 'Linux Coverage',
+  String urlParam = '',
+  int retries = 0,
+  String failureReason,
+}) =>
     base64.encode(utf8.encode(buildPushMessageNoBuildsetString(
       status,
       result: result,
@@ -79,7 +82,8 @@ String buildPushMessageString(String status,
     String builderName = 'Linux Coverage',
     String urlParam = '',
     int retries = 0,
-    String failureReason}) {
+    String failureReason,
+    String userData = '{}'}) {
   return '''{
   "build": {
     "bucket": "luci.flutter.prod",
@@ -118,7 +122,7 @@ String buildPushMessageString(String status,
     "utcnow_ts": "1565049194653640"
   },
   "hostname": "cr-buildbucket.appspot.com",
-  "user_data": "{\\"retries\\": $retries}"
+  "user_data": "$userData"
 }''';
 }
 


### PR DESCRIPTION
The implementation of the checks api will be one repo at a time and we
need to support repos with checks api support and the ones no yet
migrated. This PR checks is the status message comes with all the
expected fields to decide whether to process checks api updates or not.

Bug:
    https://github.com/flutter/flutter/issues/56422