### PR TITLE
Remove "whitelist" terminology in Cocoon

### DIFF
--- a/app_dart/lib/src/model/appengine/allowed_account.dart
+++ b/app_dart/lib/src/model/appengine/allowed_account.dart
@@ -11,10 +11,10 @@ import 'package:gcloud/db.dart';
 /// authenticated as "@google.com" accounts are allowed to make API requests
 /// to the Cocooon backend. This class represents instances where non-Google
 /// users have been explicitly allowlisted to make such requests.
-@Kind(name: 'AllowlistedAccount')
-class AllowlistedAccount extends Model {
-  /// Creates a new [AllowlistedAccount].
-  AllowlistedAccount({
+@Kind(name: 'AllowedAccount')
+class AllowedAccount extends Model {
+  /// Creates a new [AllowedAccount].
+  AllowedAccount({
     Key key,
     this.email,
   }) {

--- a/app_dart/lib/src/model/appengine/allowlisted_account.dart
+++ b/app_dart/lib/src/model/appengine/allowlisted_account.dart
@@ -4,17 +4,17 @@
 
 import 'package:gcloud/db.dart';
 
-/// Class that represents a non-Google account that has been whitelisted to
+/// Class that represents a non-Google account that has been allowlisted to
 /// make API requests to the Flutter dashboard.
 ///
 /// By default, only registered agents, App Engine cronjobs, and users
 /// authenticated as "@google.com" accounts are allowed to make API requests
 /// to the Cocooon backend. This class represents instances where non-Google
-/// users have been explicitly whitelisted to make such requests.
-@Kind(name: 'WhitelistedAccount')
-class WhitelistedAccount extends Model {
-  /// Creates a new [WhitelistedAccount].
-  WhitelistedAccount({
+/// users have been explicitly allowlisted to make such requests.
+@Kind(name: 'AllowlistedAccount')
+class AllowlistedAccount extends Model {
+  /// Creates a new [AllowlistedAccount].
+  AllowlistedAccount({
     Key key,
     this.email,
   }) {
@@ -22,7 +22,7 @@ class WhitelistedAccount extends Model {
     id = key?.id;
   }
 
-  /// The email address of the account that has been whitelisted.
+  /// The email address of the account that has been allowlisted.
   @StringProperty(propertyName: 'Email', required: true)
   String email;
 

--- a/app_dart/lib/src/model/appengine/key_helper.dart
+++ b/app_dart/lib/src/model/appengine/key_helper.dart
@@ -13,6 +13,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
 
 import 'agent.dart';
+import 'allowlisted_account.dart';
 import 'commit.dart';
 import 'github_build_status_update.dart';
 import 'key_helper.pb.dart';
@@ -20,7 +21,6 @@ import 'log_chunk.dart';
 import 'task.dart';
 import 'time_series.dart';
 import 'time_series_value.dart';
-import 'whitelisted_account.dart';
 
 const Set<Type> _defaultTypes = <Type>{
   Agent,
@@ -30,7 +30,7 @@ const Set<Type> _defaultTypes = <Type>{
   Task,
   TimeSeries,
   TimeSeriesValue,
-  WhitelistedAccount,
+  AllowlistedAccount,
 };
 
 /// Class used to encode and decode [Key] objects.

--- a/app_dart/lib/src/model/appengine/key_helper.dart
+++ b/app_dart/lib/src/model/appengine/key_helper.dart
@@ -13,7 +13,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
 
 import 'agent.dart';
-import 'allowlisted_account.dart';
+import 'allowed_account.dart';
 import 'commit.dart';
 import 'github_build_status_update.dart';
 import 'key_helper.pb.dart';
@@ -30,7 +30,7 @@ const Set<Type> _defaultTypes = <Type>{
   Task,
   TimeSeries,
   TimeSeriesValue,
-  AllowlistedAccount,
+  AllowedAccount,
 };
 
 /// Class used to encode and decode [Key] objects.

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -15,7 +15,7 @@ import 'package:meta/meta.dart';
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../model/appengine/agent.dart';
-import '../model/appengine/allowlisted_account.dart';
+import '../model/appengine/allowed_account.dart';
 import '../model/google/token_info.dart';
 
 import 'exceptions.dart';
@@ -51,7 +51,7 @@ import 'exceptions.dart';
 ///     (unless the request _also_ contained the aforementioned headers).
 ///
 ///     User accounts are only authorized if the user is either a "@google.com"
-///     account or is an allowlisted account in Cocoon's Datastore.
+///     account or is an [AllowedAccount] in Cocoon's Datastore.
 ///
 /// If none of the above authentication methods yield an authenticated
 /// request, then the request is unauthenticated, and any call to
@@ -210,8 +210,8 @@ class AuthenticationProvider {
       }
 
       if (token.hostedDomain != 'google.com') {
-        final bool isAllowlisted = await _isAllowlisted(token.email);
-        if (!isAllowlisted) {
+        final bool isAllowed = await _isAllowed(token.email);
+        if (!isAllowed) {
           throw Unauthenticated(
               '${token.email} is not authorized to access the dashboard');
         }
@@ -223,11 +223,10 @@ class AuthenticationProvider {
     }
   }
 
-  Future<bool> _isAllowlisted(String email) async {
-    final Query<AllowlistedAccount> query =
-        _config.db.query<AllowlistedAccount>()
-          ..filter('email =', email)
-          ..limit(20);
+  Future<bool> _isAllowed(String email) async {
+    final Query<AllowedAccount> query = _config.db.query<AllowedAccount>()
+      ..filter('email =', email)
+      ..limit(20);
 
     return !(await query.run().isEmpty);
   }

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -15,7 +15,7 @@ import 'package:meta/meta.dart';
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../model/appengine/agent.dart';
-import '../model/appengine/whitelisted_account.dart';
+import '../model/appengine/allowlisted_account.dart';
 import '../model/google/token_info.dart';
 
 import 'exceptions.dart';
@@ -51,7 +51,7 @@ import 'exceptions.dart';
 ///     (unless the request _also_ contained the aforementioned headers).
 ///
 ///     User accounts are only authorized if the user is either a "@google.com"
-///     account or is a whitelisted account in the Cocoon backend.
+///     account or is an allowlisted account in Cocoon's Datastore.
 ///
 /// If none of the above authentication methods yield an authenticated
 /// request, then the request is unauthenticated, and any call to
@@ -210,8 +210,8 @@ class AuthenticationProvider {
       }
 
       if (token.hostedDomain != 'google.com') {
-        final bool isWhitelisted = await _isWhitelisted(token.email);
-        if (!isWhitelisted) {
+        final bool isAllowlisted = await _isAllowlisted(token.email);
+        if (!isAllowlisted) {
           throw Unauthenticated(
               '${token.email} is not authorized to access the dashboard');
         }
@@ -223,9 +223,9 @@ class AuthenticationProvider {
     }
   }
 
-  Future<bool> _isWhitelisted(String email) async {
-    final Query<WhitelistedAccount> query =
-        _config.db.query<WhitelistedAccount>()
+  Future<bool> _isAllowlisted(String email) async {
+    final Query<AllowlistedAccount> query =
+        _config.db.query<AllowlistedAccount>()
           ..filter('email =', email)
           ..limit(20);
 

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/model/appengine/agent.dart';
-import 'package:cocoon_service/src/model/appengine/whitelisted_account.dart';
+import 'package:cocoon_service/src/model/appengine/allowlisted_account.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:test/test.dart';
@@ -242,7 +242,7 @@ void main() {
         expect(result.clientContext, same(clientContext));
       });
 
-      test('fails for non-whitelisted non-Google auth users', () async {
+      test('fails for non-allowlisted non-Google auth users', () async {
         verifyTokenResponse.body = '{"aud": "client-id", "hd": "gmail.com"}';
         config.oauthClientIdValue = 'client-id';
         await expectLater(
@@ -252,9 +252,9 @@ void main() {
         expect(httpClient.requestCount, 1);
       });
 
-      test('succeeds for whitelisted non-Google auth users', () async {
-        final WhitelistedAccount account = WhitelistedAccount(
-          key: config.db.emptyKey.append(WhitelistedAccount, id: 123),
+      test('succeeds for allowlisted non-Google auth users', () async {
+        final AllowlistedAccount account = AllowlistedAccount(
+          key: config.db.emptyKey.append(AllowlistedAccount, id: 123),
           email: 'test@gmail.com',
         );
         config.db.values[account.key] = account;

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/model/appengine/agent.dart';
-import 'package:cocoon_service/src/model/appengine/allowlisted_account.dart';
+import 'package:cocoon_service/src/model/appengine/allowed_account.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:test/test.dart';
@@ -242,7 +242,7 @@ void main() {
         expect(result.clientContext, same(clientContext));
       });
 
-      test('fails for non-allowlisted non-Google auth users', () async {
+      test('fails for non-allowed non-Google auth users', () async {
         verifyTokenResponse.body = '{"aud": "client-id", "hd": "gmail.com"}';
         config.oauthClientIdValue = 'client-id';
         await expectLater(
@@ -252,9 +252,9 @@ void main() {
         expect(httpClient.requestCount, 1);
       });
 
-      test('succeeds for allowlisted non-Google auth users', () async {
-        final AllowlistedAccount account = AllowlistedAccount(
-          key: config.db.emptyKey.append(AllowlistedAccount, id: 123),
+      test('succeeds for allowed non-Google auth users', () async {
+        final AllowedAccount account = AllowedAccount(
+          key: config.db.emptyKey.append(AllowedAccount, id: 123),
           email: 'test@gmail.com',
         );
         config.db.values[account.key] = account;


### PR DESCRIPTION
Switch `WhitelistedAccount` to `AllowedAccount` based off recommended practices. I originally had it as `AllowlistedAccount`, but dropped it as I don't think "listed" gave much value.

Public documentation available at https://developers.google.com/style/inclusive-documentation#features-and-users (googlers see go/avoid-whitelist)

If this looks good, I can duplicate the existing entities over to the new table before submitting. After deployed and verified, I can remove the `WhitelistedAccount` entities.

There's only a few accounts, so this change is relatively low risk.