### PR TITLE
GitHub Bot Improvements

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -107,14 +107,25 @@ class Config {
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
   String get wrongBaseBranchPullRequestMessage =>
-      'This pull request was opened against a branch other than _master_. '
-      'Since Flutter pull requests should not normally be opened against '
-      'branches other than master, I have changed the base to master. If this '
-      'was intended, you may modify the base back to {{branch}}. See the '
-      '[Release Process](https://github.com/flutter/flutter/wiki/Release-process) '
-      'for information about how other branches get updated.\n\n'
+      'This pull request was opened against a branch other than '
+      '_${kDefaultBranchName}_. Since Flutter pull requests should not '
+      'normally be opened against branches other than master, I have changed '
+      'the base to master. If this was intended, you may modify the base back '
+      'to {{branch}}. See the [Release Process]'
+      '(https://github.com/flutter/flutter/wiki/Release-process) for '
+      'information about how other branches get updated.\n\n'
       '__Reviewers__: Use caution before merging pull requests to branches other '
       'than master, unless this is an intentional hotfix/cherrypick.';
+
+  String wrongHeadBranchPullRequestMessage(String branch) =>
+      'This pull request is trying merge the branch $branch, which is the name '
+      'of a release branch. This is usually a mistake. See '
+      '[Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) '
+      'for detailed instructions on how to contribute to the Flutter project. '
+      'In particular, ensure that before you start coding, you create your '
+      'feature branch off of _${kDefaultBranchName}_.\n\n'
+      'This PR has been closed. If you are sure you want to merge $branch, you '
+      'may re-open this issue.';
 
   Future<String> get webhookKey => _getSingleValue('WebhookKey');
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -25,6 +25,9 @@ import '../service/access_client_provider.dart';
 import '../service/bigquery.dart';
 import '../service/github_service.dart';
 
+/// Name of the default git branch.
+const String kDefaultBranchName = 'master';
+
 class Config {
   Config(this._db, this._cache) : assert(_db != null);
 
@@ -109,13 +112,13 @@ class Config {
   String get wrongBaseBranchPullRequestMessage =>
       'This pull request was opened against a branch other than '
       '_${kDefaultBranchName}_. Since Flutter pull requests should not '
-      'normally be opened against branches other than master, I have changed '
-      'the base to master. If this was intended, you may modify the base back '
-      'to {{branch}}. See the [Release Process]'
-      '(https://github.com/flutter/flutter/wiki/Release-process) for '
-      'information about how other branches get updated.\n\n'
+      'normally be opened against branches other than $kDefaultBranchName, I '
+      'have changed the base to $kDefaultBranchName. If this was intended, you '
+      'may modify the base back to {{branch}}. See the [Release Process]'
+      '(https://github.com/flutter/flutter/wiki/Release-process) for information '
+      'about how other branches get updated.\n\n'
       '__Reviewers__: Use caution before merging pull requests to branches other '
-      'than master, unless this is an intentional hotfix/cherrypick.';
+      'than $kDefaultBranchName, unless this is an intentional hotfix/cherrypick.';
 
   String wrongHeadBranchPullRequestMessage(String branch) =>
       'This pull request is trying merge the branch $branch, which is the name '
@@ -175,7 +178,7 @@ class Config {
 
   String get cqLabelName => 'CQ+1';
 
-  String get defaultBranch => 'master';
+  String get defaultBranch => kDefaultBranchName;
 
   // Default number of commits to return for benchmark dashboard.
   int get maxRecords => 50;

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -106,13 +106,13 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  String get nonMasterPullRequestMessage => 'This pull request was opened '
-      'against a branch other than _master_. Since Flutter pull requests should '
-      'not normally be opened against branches other than master, I have changed '
-      'the base to master. If this was intended, you may modify the base back to '
-      '{{branch}}. See the [Release Process]'
-      '(https://github.com/flutter/flutter/wiki/Release-process) for information '
-      'about how other branches get updated.\n\n'
+  String get wrongBaseBranchPullRequestMessage =>
+      'This pull request was opened against a branch other than _master_. '
+      'Since Flutter pull requests should not normally be opened against '
+      'branches other than master, I have changed the base to master. If this '
+      'was intended, you may modify the base back to {{branch}}. See the '
+      '[Release Process](https://github.com/flutter/flutter/wiki/Release-process) '
+      'for information about how other branches get updated.\n\n'
       '__Reviewers__: Use caution before merging pull requests to branches other '
       'than master, unless this is an intentional hotfix/cherrypick.';
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -130,6 +130,17 @@ class Config {
       'This PR has been closed. If you are sure you want to merge $branch, you '
       'may re-open this issue.';
 
+  String get releaseBranchPullRequestMessage => 'This pull request was opened '
+      'from and to a release candidate branch. This should only be done as part '
+      'of the official [Flutter release process]'
+      '(https://github.com/flutter/flutter/wiki/Release-process). If you are '
+      'attempting to make a regular contribution to the Flutter project, please '
+      'close this PR and follow the instructions at [Tree Hygiene]'
+      '(https://github.com/flutter/flutter/wiki/Tree-hygiene) for detailed '
+      'instructions on contributing to Flutter.\n\n'
+      '__Reviewers__: Use caution before merging pull requests to release '
+      'branches. Ensure the proper procedure has been followed.';
+
   Future<String> get webhookKey => _getSingleValue('WebhookKey');
 
   String get missingTestsPullRequestMessage => 'It looks like this pull '

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -24,6 +24,9 @@ Duration twoSecondLinearBackoff(int attempt) {
   return const Duration(seconds: 2) * (attempt + 1);
 }
 
+/// Name of the default git branch.
+const String kDefaultBranchName = 'master';
+
 Future<List<String>> loadBranches(HttpClientProvider branchHttpClientProvider,
     Logging log, GitHubBackoffCalculator gitHubBackoffCalculator) async {
   const String path = '/flutter/cocoon/master/app_dart/dev/branches.txt';

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -24,9 +24,6 @@ Duration twoSecondLinearBackoff(int attempt) {
   return const Duration(seconds: 2) * (attempt + 1);
 }
 
-/// Name of the default git branch.
-const String kDefaultBranchName = 'master';
-
 Future<List<String>> loadBranches(HttpClientProvider branchHttpClientProvider,
     Logging log, GitHubBackoffCalculator gitHubBackoffCalculator) async {
   const String path = '/flutter/cocoon/master/app_dart/dev/branches.txt';

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -449,10 +449,10 @@ class GithubWebhook extends RequestHandler<Body> {
     if (pr.base.ref == kDefaultBranchName) {
       return;
     }
-    final RegExp regExp = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
+    final RegExp releaseRef = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
     if (pr.base.ref == pr.head.ref &&
-        regExp.hasMatch(pr.base.ref) &&
-        regExp.hasMatch(pr.head.ref)) {
+        releaseRef.hasMatch(pr.base.ref) &&
+        releaseRef.hasMatch(pr.head.ref)) {
       // This is most likely a release branch
       return;
     }
@@ -487,7 +487,7 @@ class GithubWebhook extends RequestHandler<Body> {
   }
 
   Future<String> _getWrongBaseComment(String base) async {
-    final String messageTemplate = config.nonMasterPullRequestMessage;
+    final String messageTemplate = config.wrongBaseBranchPullRequestMessage;
     return messageTemplate.replaceAll('{{branch}}', base);
   }
 

--- a/app_dart/test/request_handlers/get_benchmarks_test.dart
+++ b/app_dart/test/request_handlers/get_benchmarks_test.dart
@@ -40,7 +40,7 @@ void main() {
           FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
       config =
-          FakeConfig(keyHelperValue: keyHelper, defaultBranchValue: 'master');
+          FakeConfig(keyHelperValue: keyHelper);
       handler = GetBenchmarks(
         config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),

--- a/app_dart/test/request_handlers/get_benchmarks_test.dart
+++ b/app_dart/test/request_handlers/get_benchmarks_test.dart
@@ -39,8 +39,7 @@ void main() {
       keyHelper =
           FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
-      config =
-          FakeConfig(keyHelperValue: keyHelper);
+      config = FakeConfig(keyHelperValue: keyHelper);
       handler = GetBenchmarks(
         config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/foundation/utils.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/foundation/utils.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -90,6 +90,8 @@ void main() {
           'wrongHeadBranchPullRequestMessage';
       config.wrongBaseBranchPullRequestMessageValue =
           'wrongBaseBranchPullRequestMessage';
+      config.releaseBranchPullRequestMessageValue =
+          'releaseBranchPullRequestMessage';
       config.missingTestsPullRequestMessageValue =
           'missingTestPullRequestMessage';
       config.goldenBreakingChangeMessageValue = 'goldenBreakingChangeMessage';

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -158,10 +158,10 @@ void main() {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
       request.body = jsonTemplate(
-          'opened',
-          issueNumber,
-          kDefaultBranchName,
-          headRef: 'dev',
+        'opened',
+        issueNumber,
+        kDefaultBranchName,
+        headRef: 'dev',
       );
       final Uint8List body = utf8.encode(request.body) as Uint8List;
       final Uint8List key = utf8.encode(keyString) as Uint8List;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -28,6 +28,7 @@ class FakeConfig implements Config {
     this.githubOAuthTokenValue,
     this.missingTestsPullRequestMessageValue,
     this.wrongBaseBranchPullRequestMessageValue,
+    this.wrongHeadBranchPullRequestMessageValue,
     this.goldenBreakingChangeMessageValue,
     this.goldenTriageMessageValue,
     this.webhookKeyValue,
@@ -64,6 +65,7 @@ class FakeConfig implements Config {
   String githubOAuthTokenValue;
   String missingTestsPullRequestMessageValue;
   String wrongBaseBranchPullRequestMessageValue;
+  String wrongHeadBranchPullRequestMessageValue;
   String goldenBreakingChangeMessageValue;
   String goldenTriageMessageValue;
   String webhookKeyValue;
@@ -144,6 +146,10 @@ class FakeConfig implements Config {
   @override
   String get wrongBaseBranchPullRequestMessage =>
       wrongBaseBranchPullRequestMessageValue;
+
+  @override
+  String wrongHeadBranchPullRequestMessage(String branch) =>
+      wrongHeadBranchPullRequestMessageValue;
 
   @override
   String get goldenBreakingChangeMessage => goldenBreakingChangeMessageValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -47,7 +47,6 @@ class FakeConfig implements Config {
     this.flutterBuildDescriptionValue,
     this.flutterBranchesValue,
     this.maxRecordsValue,
-    this.defaultBranchValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -82,7 +81,6 @@ class FakeConfig implements Config {
   RepositorySlug flutterSlugValue;
   List<String> flutterBranchesValue;
   int maxRecordsValue;
-  String defaultBranchValue;
 
   @override
   int get luciTryInfraFailureRetries => luciTryInfraFailureRetriesValue;
@@ -112,7 +110,7 @@ class FakeConfig implements Config {
   FakeDatastoreDB get db => dbValue;
 
   @override
-  String get defaultBranch => defaultBranchValue;
+  String get defaultBranch => kDefaultBranchName;
 
   @override
   Future<ServiceAccountInfo> get deviceLabServiceAccount async =>

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -29,6 +29,7 @@ class FakeConfig implements Config {
     this.missingTestsPullRequestMessageValue,
     this.wrongBaseBranchPullRequestMessageValue,
     this.wrongHeadBranchPullRequestMessageValue,
+    this.releaseBranchPullRequestMessageValue,
     this.goldenBreakingChangeMessageValue,
     this.goldenTriageMessageValue,
     this.webhookKeyValue,
@@ -65,6 +66,7 @@ class FakeConfig implements Config {
   String missingTestsPullRequestMessageValue;
   String wrongBaseBranchPullRequestMessageValue;
   String wrongHeadBranchPullRequestMessageValue;
+  String releaseBranchPullRequestMessageValue;
   String goldenBreakingChangeMessageValue;
   String goldenTriageMessageValue;
   String webhookKeyValue;
@@ -148,6 +150,10 @@ class FakeConfig implements Config {
   @override
   String wrongHeadBranchPullRequestMessage(String branch) =>
       wrongHeadBranchPullRequestMessageValue;
+
+  @override
+  String get releaseBranchPullRequestMessage =>
+      releaseBranchPullRequestMessageValue;
 
   @override
   String get goldenBreakingChangeMessage => goldenBreakingChangeMessageValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -27,7 +27,7 @@ class FakeConfig implements Config {
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
     this.missingTestsPullRequestMessageValue,
-    this.nonMasterPullRequestMessageValue,
+    this.wrongBaseBranchPullRequestMessageValue,
     this.goldenBreakingChangeMessageValue,
     this.goldenTriageMessageValue,
     this.webhookKeyValue,
@@ -63,7 +63,7 @@ class FakeConfig implements Config {
   String oauthClientIdValue;
   String githubOAuthTokenValue;
   String missingTestsPullRequestMessageValue;
-  String nonMasterPullRequestMessageValue;
+  String wrongBaseBranchPullRequestMessageValue;
   String goldenBreakingChangeMessageValue;
   String goldenTriageMessageValue;
   String webhookKeyValue;
@@ -142,7 +142,8 @@ class FakeConfig implements Config {
       missingTestsPullRequestMessageValue;
 
   @override
-  String get nonMasterPullRequestMessage => nonMasterPullRequestMessageValue;
+  String get wrongBaseBranchPullRequestMessage =>
+      wrongBaseBranchPullRequestMessageValue;
 
   @override
   String get goldenBreakingChangeMessage => goldenBreakingChangeMessageValue;


### PR DESCRIPTION
This PR makes the following bot improvements:

1. Does **not** reset release candidate PRs to target master branch; fixes https://github.com/flutter/flutter/issues/55900
1. Auto-closes PRs that try to merge from {stable,beta,dev} with a comment pointing the user toward "Tree Hygiene" link in wiki; fixes https://github.com/flutter/flutter/issues/60386
1. Replaces a lot of hard-coded uses of the string `'master'` in the codebase to use a constant variable.