### PR TITLE
Fix TaskOverlay golden test flakes

### DIFF
--- a/app_flutter/test/widgets/task_overlay_test.dart
+++ b/app_flutter/test/widgets/task_overlay_test.dart
@@ -84,8 +84,7 @@ void main() {
     expect(find.text(expectedTaskInfoString), findsNothing);
     expect(find.text(expectedTask.reservedForAgentId), findsNothing);
 
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_closed.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_closed.png'));
 
     await tester.tapAt(const Offset(TaskBox.cellSize * 1.5, TaskBox.cellSize * 1.5));
     await tester.pump();
@@ -94,8 +93,7 @@ void main() {
     expect(find.text(expectedTaskInfoString), findsOneWidget);
     expect(find.text('SHOW ${expectedTask.reservedForAgentId}'), findsOneWidget);
 
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_open.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_open.png'));
 
     // Since the overlay positions itself below the middle of the widget,
     // it is safe to click the widget to close it again.
@@ -106,8 +104,7 @@ void main() {
     expect(find.text(expectedTaskInfoString), findsNothing);
     expect(find.text(expectedTask.reservedForAgentId), findsNothing);
 
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_closed.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.normal_overlay_closed.png'));
   });
 
   testWidgets('TaskOverlay shows when flaky is true', (WidgetTester tester) async {
@@ -134,13 +131,13 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     expect(find.text(flakyTask.name), findsNothing);
     expect(find.text(flakyTaskInfoString), findsNothing);
     expect(find.text(flakyTask.reservedForAgentId), findsNothing);
 
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.flaky_overlay_closed.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.flaky_overlay_closed.png'));
 
     await tester.tapAt(const Offset(TaskBox.cellSize * 1.5, TaskBox.cellSize * 1.5));
     await tester.pump();
@@ -149,8 +146,7 @@ void main() {
     expect(find.text(flakyTaskInfoString), findsOneWidget);
     expect(find.text('SHOW ${flakyTask.reservedForAgentId}'), findsOneWidget);
 
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.flaky_overlay_open.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.flaky_overlay_open.png'));
   });
 
   testWidgets('TaskOverlay computes durations correctly', (WidgetTester tester) async {
@@ -253,17 +249,16 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
 
     expect(find.text(expectedTaskInfoString), findsNothing);
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.nondevicelab_closed.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.nondevicelab_closed.png'));
 
     await tester.tapAt(const Offset(TaskBox.cellSize * 1.5, TaskBox.cellSize * 1.5));
     await tester.pump();
 
     expect(find.text(expectedTaskInfoString), findsOneWidget);
-    // TODO(chillers): Fix flakiness of precacheTaskIcons. https://github.com/flutter/flutter/issues/58833
-    // await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.nondevicelab_open.png'));
+    await expectLater(find.byType(MaterialApp), matchesGoldenFile('task_overlay_test.nondevicelab_open.png'));
   });
 
   testWidgets('TaskOverlay shows TaskAttemptSummary for devicelab tasks', (WidgetTester tester) async {


### PR DESCRIPTION
Two of the tests needed a `tester.pump()` after pumping the widget to allow for the precache to populate. When those tests were run first, they were not loading the asset in time.

# Issues
Fixes https://github.com/flutter/flutter/issues/58833