### PR TITLE
Receive local skip feedback for goldens

### DIFF
--- a/app_flutter/test/utils/golden.dart
+++ b/app_flutter/test/utils/golden.dart
@@ -14,12 +14,8 @@ Future<void> expectGoldenMatches(
   dynamic actual,
   String goldenFileKey, {
   String reason,
-  dynamic skip, // true or a String
+  dynamic skip = false, // true or a String
 }) {
-  if (!Platform.isLinux) {
-    // No-op as all golden tests for Cocoon only run on Linux.
-    return null;
-  }
   final String goldenPath = 'goldens/' + goldenFileKey;
-  return expectLater(actual, matchesGoldenFile(goldenPath), reason: reason, skip: skip);
+  return expectLater(actual, matchesGoldenFile(goldenPath), reason: reason, skip: skip || !Platform.isLinux);
 }


### PR DESCRIPTION
While working on https://github.com/flutter/cocoon/pull/847, I did not realize that I might be affecting golden files, as I was working on a Mac. 
A skipped test provides output at execution for better awareness than a silent no-op. :)

Now local test output will reflect a test being skipped:
![Screen Shot 2020-07-17 at 11 30 59 AM](https://user-images.githubusercontent.com/16964204/87819410-07e2c700-c821-11ea-867d-f6667b07e764.png)
