### PR TITLE
[app_flutter] Disable silent sign in

### DIFF
--- a/app_flutter/flake_catcher.sh
+++ b/app_flutter/flake_catcher.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+for i in {1..100}; do flutter test --test-randomize-ordering-seed=random test/widgets/task_overlay_test.dart || break; done

--- a/app_flutter/flake_catcher.sh
+++ b/app_flutter/flake_catcher.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-for i in {1..100}; do flutter test --test-randomize-ordering-seed=random test/widgets/task_overlay_test.dart || break; done

--- a/app_flutter/lib/service/google_authentication.dart
+++ b/app_flutter/lib/service/google_authentication.dart
@@ -18,7 +18,8 @@ class GoogleSignInService extends ChangeNotifier {
       notifyListeners();
     });
 
-    _googleSignIn.signInSilently();
+    // TODO(chillers): Re-enable when flakiness is fixed. https://github.com/flutter/flutter/issues/52338
+    // _googleSignIn.signInSilently();
   }
 
   /// A list of Google API OAuth Scopes this project needs access to.

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -37,7 +37,7 @@ void main() {
 
     test('sign in silently called', () async {
       verify(mockSignIn.signInSilently()).called(1);
-    });
+    }, skip: 'https://github.com/flutter/flutter/issues/52338');
 
     test('id token will prompt sign in', () async {
       final GoogleSignInAccount testAccountWithAuthentication = FakeGoogleSignInAccount()


### PR DESCRIPTION
The app is having google sign in silently crash when executing silent sign in. For now, disabling this should allow for the manual sign in process to work.

By default, a quick window will be opened by google sign in to log the user in. If the user isn't signed in, it will stay open for them to sign in.

Users that are not signed in and that try to perform an authenticated action will be prompted this sign in flow automatically. This is part of the apps built in error handling.

# Issues

https://github.com/flutter/flutter/issues/59086

https://github.com/flutter/flutter/issues/52338