### PR TITLE
Fix app theming and tests

### DIFF
--- a/app_flutter/lib/build_dashboard_page.dart
+++ b/app_flutter/lib/build_dashboard_page.dart
@@ -24,13 +24,13 @@ class BuildDashboardPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
 
     /// Color of [AppBar] based on [buildState.isTreeBuilding].
     final Map<bool, Color> colorTable = <bool, Color>{
       null: Colors.grey[850],
-      false: Colors.red,
-      true: Colors.green,
+      false: isDark ? Colors.red[800] : Colors.red,
+      true: isDark ? Colors.green[800] : Colors.green,
     };
 
     /// Message to show on [AppBar] based on [buildState.isTreeBuilding].

--- a/app_flutter/lib/build_dashboard_page.dart
+++ b/app_flutter/lib/build_dashboard_page.dart
@@ -28,9 +28,9 @@ class BuildDashboardPage extends StatelessWidget {
 
     /// Color of [AppBar] based on [buildState.isTreeBuilding].
     final Map<bool, Color> colorTable = <bool, Color>{
-      null: Colors.grey,
-      false: theme.errorColor,
-      true: theme.appBarTheme.color,
+      null: Colors.grey[850],
+      false: Colors.red,
+      true: Colors.green,
     };
 
     /// Message to show on [AppBar] based on [buildState.isTreeBuilding].
@@ -68,12 +68,7 @@ class BuildDashboardPage extends StatelessWidget {
                 (String value) {
                   return DropdownMenuItem<String>(
                     value: value,
-                    child: Text(
-                      value,
-                      style: TextStyle(
-                        color: theme.brightness == Brightness.light ? Colors.black : Colors.white,
-                      ),
-                    ),
+                    child: Text(value),
                   );
                 },
               ).toList(),

--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -29,21 +29,6 @@ void main() {
   );
 }
 
-final ThemeData lightTheme = ThemeData.from(
-  colorScheme: const ColorScheme.light(
-    primary: Colors.green,
-    secondary: Colors.blueAccent,
-  ),
-);
-
-final ThemeData darkTheme = ThemeData.from(
-  colorScheme: const ColorScheme.dark(
-    primary: Colors.green,
-    secondary: Colors.blueAccent,
-    background: Color(0xBB000000),
-  ),
-);
-
 class MyApp extends StatelessWidget {
   const MyApp({Key key}) : super(key: key);
 
@@ -51,8 +36,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Dashboard',
-      theme: lightTheme,
-      darkTheme: darkTheme,
+      theme: ThemeData(),
+      darkTheme: ThemeData.dark(),
       initialRoute: '/',
       routes: <String, WidgetBuilder>{
         IndexPage.routeName: (BuildContext context) => const IndexPage(),

--- a/app_flutter/test/build_dashboard_page_test.dart
+++ b/app_flutter/test/build_dashboard_page_test.dart
@@ -11,7 +11,6 @@ import 'package:mockito/mockito.dart';
 import 'package:cocoon_service/protos.dart';
 
 import 'package:app_flutter/build_dashboard_page.dart';
-import 'package:app_flutter/main.dart' as app show lightTheme;
 import 'package:app_flutter/service/cocoon.dart';
 import 'package:app_flutter/service/google_authentication.dart';
 import 'package:app_flutter/state/build.dart';

--- a/app_flutter/test/build_dashboard_page_test.dart
+++ b/app_flutter/test/build_dashboard_page_test.dart
@@ -78,11 +78,9 @@ void main() {
 
   testWidgets('shows loading when fetch tree status is null', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = null;
-    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -96,16 +94,38 @@ void main() {
     expect(find.text('Loading...'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
-    expect(appbarWidget.backgroundColor, Colors.grey);
+    expect(appbarWidget.backgroundColor, Colors.grey[850]);
+    expect(tester, meetsGuideline(textContrastGuideline));
+  });
+
+  testWidgets('shows loading when fetch tree status is null, dark mode', (WidgetTester tester) async {
+    final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = null;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: ValueProvider<BuildState>(
+          value: fakeBuildState,
+          child: ValueProvider<GoogleSignInService>(
+            value: fakeBuildState.authService,
+            child: const BuildDashboardPage(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Loading...'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
+    expect(appbarWidget.backgroundColor, Colors.grey[850]);
+    expect(tester, meetsGuideline(textContrastGuideline));
   });
 
   testWidgets('shows tree closed when fetch tree status is false', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = false;
-    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -119,16 +139,38 @@ void main() {
     expect(find.text('Tree is Closed'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
-    expect(appbarWidget.backgroundColor, lightTheme.errorColor);
+    expect(appbarWidget.backgroundColor, Colors.red);
+    expect(tester, meetsGuideline(textContrastGuideline));
+  });
+
+  testWidgets('shows tree closed when fetch tree status is false, dark mode', (WidgetTester tester) async {
+    final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: ValueProvider<BuildState>(
+          value: fakeBuildState,
+          child: ValueProvider<GoogleSignInService>(
+            value: fakeBuildState.authService,
+            child: const BuildDashboardPage(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Tree is Closed'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
+    expect(appbarWidget.backgroundColor, Colors.red[800]);
+    expect(tester, meetsGuideline(textContrastGuideline));
   });
 
   testWidgets('shows tree open when fetch tree status is true', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = true;
-    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -142,7 +184,31 @@ void main() {
     expect(find.text('Tree is Open'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
-    expect(appbarWidget.backgroundColor, lightTheme.appBarTheme.color);
+    expect(appbarWidget.backgroundColor, Colors.green);
+    expect(tester, meetsGuideline(textContrastGuideline));
+  });
+
+  testWidgets('shows tree open when fetch tree status is true, dark mode', (WidgetTester tester) async {
+    final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: ValueProvider<BuildState>(
+          value: fakeBuildState,
+          child: ValueProvider<GoogleSignInService>(
+            value: fakeBuildState.authService,
+            child: const BuildDashboardPage(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Tree is Open'), findsOneWidget);
+
+    final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
+    expect(appbarWidget.backgroundColor, Colors.green[800]);
+    expect(tester, meetsGuideline(textContrastGuideline));
   });
 
   testWidgets('show error snackbar when error occurs', (WidgetTester tester) async {

--- a/app_flutter/test/build_dashboard_page_test.dart
+++ b/app_flutter/test/build_dashboard_page_test.dart
@@ -79,10 +79,11 @@ void main() {
 
   testWidgets('shows loading when fetch tree status is null', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = null;
+    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: app.lightTheme,
+        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -101,10 +102,11 @@ void main() {
 
   testWidgets('shows tree closed when fetch tree status is false', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = false;
+    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: app.lightTheme,
+        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -118,15 +120,16 @@ void main() {
     expect(find.text('Tree is Closed'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
-    expect(appbarWidget.backgroundColor, app.lightTheme.errorColor);
+    expect(appbarWidget.backgroundColor, lightTheme.errorColor);
   });
 
   testWidgets('shows tree open when fetch tree status is true', (WidgetTester tester) async {
     final BuildState fakeBuildState = FakeBuildState()..isTreeBuilding = true;
+    final ThemeData lightTheme = ThemeData();
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: app.lightTheme,
+        theme: lightTheme,
         home: ValueProvider<BuildState>(
           value: fakeBuildState,
           child: ValueProvider<GoogleSignInService>(
@@ -140,7 +143,7 @@ void main() {
     expect(find.text('Tree is Open'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
-    expect(appbarWidget.backgroundColor, app.lightTheme.appBarTheme.color);
+    expect(appbarWidget.backgroundColor, lightTheme.appBarTheme.color);
   });
 
   testWidgets('show error snackbar when error occurs', (WidgetTester tester) async {


### PR DESCRIPTION
After recent deployment, noticed the changes from #847 did not match the goldens we checked in.
The tests appear to be using a different Theme than is actually used in the app (default dark and light themes instead of the custom themes in main.dart). 
To avoid updating all of the goldens, I've changed the app to match the tests. Happy to go the other way, will defer to reviewer. :)

Also added a11y tests for the affected conditional app bar color on the build page so it meets text contrast guidelines for light and dark themes for each tree status.

#### light:
![Screen Shot 2020-07-17 at 4 56 23 PM](https://user-images.githubusercontent.com/16964204/87839631-8c990980-c850-11ea-9626-62b16143fbdf.png)
![Screen Shot 2020-07-17 at 4 56 11 PM](https://user-images.githubusercontent.com/16964204/87839635-8e62cd00-c850-11ea-964e-3a394d7b09b0.png)
#### dark:
![Screen Shot 2020-07-17 at 4 55 41 PM](https://user-images.githubusercontent.com/16964204/87839633-8dca3680-c850-11ea-8661-f7853a60979c.png)
![Screen Shot 2020-07-17 at 4 55 52 PM](https://user-images.githubusercontent.com/16964204/87839634-8e62cd00-c850-11ea-8bc8-f06f8c597c33.png)
