### PR TITLE
Remove task number limit when vacuum clean tasks in bad state

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -155,13 +155,10 @@ class DatastoreService {
   }
 
   // Queries for recent tasks without considering branches.
-  Stream<FullTask> queryRecentTasksNoBranch({int commitLimit = 20, int taskLimit = 20}) async* {
+  Stream<FullTask> queryRecentTasksNoBranch({int commitLimit = 20}) async* {
     assert(commitLimit != null);
-    assert(taskLimit != null);
     await for (Commit commit in queryRecentCommitsNoBranch(limit: commitLimit)) {
-      final Query<Task> query = db.query<Task>(ancestorKey: commit.key)
-        ..limit(taskLimit)
-        ..order('-createTimestamp');
+      final Query<Task> query = db.query<Task>(ancestorKey: commit.key)..order('-createTimestamp');
       yield* query.run().map<FullTask>((Task task) => FullTask(task, commit));
     }
   }


### PR DESCRIPTION
Vacuum-clean API cleans datastore tasks in bad state every one hour. Existing task query has a limit on the returned number of tasks. With this limit, some tasks that do need to be cleaned up may be skipped.

We need to remove the limit and return all tasks.

\cc @pcsosinski 