### PR TITLE
Make the printed URL clickable in command terminals

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -136,7 +136,7 @@ Future<void> main() async {
       }
     }, onAcceptingConnections: (InternetAddress address, int port) {
       final String host = address.isLoopback ? 'localhost' : address.host;
-      print('Serving requests at $host:$port');
+      print('Serving requests at http://$host:$port/');
     });
   });
 }


### PR DESCRIPTION
A simple QoL change to make it easier to launch the web page from the printout in the terminal.