### PR TITLE
Update rota-ng endpoint.

### DIFF
--- a/app/lib/repository/services/sheriff_rotation_service.dart
+++ b/app/lib/repository/services/sheriff_rotation_service.dart
@@ -14,36 +14,17 @@ import '../models/roll_sheriff.dart';
 /// See go/rotations-ng
 Future<RollSheriff> fetchSheriff({http.Client client}) async {
   client ??= http.Client();
-  final Map<String, dynamic> fetchedRotations = await _getStatusBody(client);
-  if (fetchedRotations == null) {
+  final Map<String, dynamic> rotation = await _getStatusBody(client);
+  if (rotation == null) {
     return null;
   }
 
-  // Index of "flutter_engine" indicates the index of "participants" to check per calendar day.
-  final List<dynamic> rotations = fetchedRotations['rotations'];
-  if (rotations == null) {
-    return null;
-  }
-  int flutterIndex = rotations.indexOf('flutter_engine');
-  if (flutterIndex == -1) {
-    return null;
-  }
-
-  final List<dynamic> calendars = fetchedRotations['calendar'];
-  for (Map<String, dynamic> calendar in calendars.reversed) {
-    List<dynamic> participants = calendar['participants'];
-    List<dynamic> flutterSheriff = participants[flutterIndex];
-    if (flutterSheriff != null && flutterSheriff.isNotEmpty) {
-      return RollSheriff(currentSheriff: flutterSheriff.first);
-    }
-  }
-
-  return null;
+  return RollSheriff(currentSheriff: rotation['emails'].first);
 }
 
 Future<dynamic> _getStatusBody(http.Client client) async {
   try {
-    final http.Response response = await client.get('https://rota-ng.appspot.com/legacy/all_rotations.js');
+    final http.Response response = await client.get('https://rota-ng.appspot.com/legacy/sheriff_flutter_engine.json');
     final String body = response?.body;
     return (body != null && body.isNotEmpty) ? jsonDecode(body) : null;
   } catch (error) {


### PR DESCRIPTION
The rota-ng endpoint we were using to get the engine-oncall is being
deprecated and we are updating it to use the replacement.