### PR TITLE
Move function 'repoNameForBuilder' to utils from cocoon_config

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -452,22 +452,6 @@ class Config {
     return supportedRepos.contains(repositoryName);
   }
 
-  Future<RepositorySlug> repoNameForBuilder(String builderName) async {
-    final List<Map<String, dynamic>> builders = luciTryBuilders;
-    final Map<String, dynamic> builderConfig = builders.firstWhere(
-      (Map<String, dynamic> builder) => builder['name'] == builderName,
-      orElse: () => <String, String>{'repo': ''},
-    );
-    final String repoName = builderConfig['repo'] as String;
-    // If there is no builder config for the builderName then we
-    // return null. This is to allow the code calling this method
-    // to skip changes that depend on builder configurations.
-    if (repoName.isEmpty) {
-      return null;
-    }
-    return RepositorySlug('flutter', repoName);
-  }
-
   bool isChecksSupportedRepo(RepositorySlug slug) {
     return checksSupportedRepos.contains('${slug.owner}/${slug.name}');
   }

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -67,7 +67,7 @@ Future<Uint8List> getBranches(
   return Uint8List.fromList(branches.join(',').codeUnits);
 }
 
-RepositorySlug repoNameForBuilder(List<Map<String, dynamic>> builders, String builderName) {
+Future<RepositorySlug> repoNameForBuilder(List<Map<String, dynamic>> builders, String builderName) async {
   final Map<String, dynamic> builderConfig = builders.firstWhere(
     (Map<String, dynamic> builder) => builder['name'] == builderName,
     orElse: () => <String, String>{'repo': ''},

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
+import 'package:github/github.dart';
 
 import '../foundation/typedefs.dart';
 
@@ -64,4 +65,19 @@ Future<Uint8List> getBranches(
   final List<String> branches = await loadBranches(branchHttpClientProvider, log, gitHubBackoffCalculator);
 
   return Uint8List.fromList(branches.join(',').codeUnits);
+}
+
+RepositorySlug repoNameForBuilder(List<Map<String, dynamic>> builders, String builderName) {
+  final Map<String, dynamic> builderConfig = builders.firstWhere(
+    (Map<String, dynamic> builder) => builder['name'] == builderName,
+    orElse: () => <String, String>{'repo': ''},
+  );
+  final String repoName = builderConfig['repo'] as String;
+  // If there is no builder config for the builderName then we
+  // return null. This is to allow the code calling this method
+  // to skip changes that depend on builder configurations.
+  if (repoName.isEmpty) {
+    return null;
+  }
+  return RepositorySlug('flutter', repoName);
 }

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -17,6 +17,7 @@ import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../foundation/typedefs.dart';
+import '../foundation/utils.dart';
 import '../model/appengine/service_account_info.dart';
 import '../model/luci/push_message.dart';
 import '../request_handling/body.dart';
@@ -108,7 +109,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
     } else {
       // This message is coming from a repo that doesn't support checks api and
       // we need to create the slug from the builder configuration files.
-      slug = await config.repoNameForBuilder(builderName);
+      slug = repoNameForBuilder(config.luciTryBuilders, builderName);
     }
     switch (buildPushMessage.build.status) {
       case Status.completed:

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -109,7 +109,7 @@ class LuciStatusHandler extends RequestHandler<Body> {
     } else {
       // This message is coming from a repo that doesn't support checks api and
       // we need to create the slug from the builder configuration files.
-      slug = repoNameForBuilder(config.luciTryBuilders, builderName);
+      slug = await repoNameForBuilder(config.luciTryBuilders, builderName);
     }
     switch (buildPushMessage.build.status) {
       case Status.completed:

--- a/app_dart/lib/src/service/github_status_service.dart
+++ b/app_dart/lib/src/service/github_status_service.dart
@@ -52,7 +52,7 @@ class GithubStatusService {
     @required RepositorySlug slug,
   }) async {
     // No builderName configuration, nothing to do here.
-    if (repoNameForBuilder(config.luciTryBuilders, builderName) == null) {
+    if (await repoNameForBuilder(config.luciTryBuilders, builderName) == null) {
       return false;
     }
     final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
@@ -93,7 +93,7 @@ class GithubStatusService {
     @required Result result,
     @required RepositorySlug slug,
   }) async {
-    final RepositorySlug slug = repoNameForBuilder(config.luciTryBuilders, builderName);
+    final RepositorySlug slug = await repoNameForBuilder(config.luciTryBuilders, builderName);
     // No builderName configuration, nothing to do here.
     if (slug == null) {
       return;

--- a/app_dart/lib/src/service/github_status_service.dart
+++ b/app_dart/lib/src/service/github_status_service.dart
@@ -6,6 +6,7 @@ import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
+import '../foundation/utils.dart';
 import '../model/luci/buildbucket.dart' as bb;
 import '../model/luci/push_message.dart';
 import 'luci_build_service.dart';
@@ -51,7 +52,7 @@ class GithubStatusService {
     @required RepositorySlug slug,
   }) async {
     // No builderName configuration, nothing to do here.
-    if (await config.repoNameForBuilder(builderName) == null) {
+    if (repoNameForBuilder(config.luciTryBuilders, builderName) == null) {
       return false;
     }
     final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
@@ -92,7 +93,7 @@ class GithubStatusService {
     @required Result result,
     @required RepositorySlug slug,
   }) async {
-    final RepositorySlug slug = await config.repoNameForBuilder(builderName);
+    final RepositorySlug slug = repoNameForBuilder(config.luciTryBuilders, builderName);
     // No builderName configuration, nothing to do here.
     if (slug == null) {
       return;

--- a/app_dart/test/datastore/cocoon_config_test.dart
+++ b/app_dart/test/datastore/cocoon_config_test.dart
@@ -5,30 +5,11 @@
 import 'dart:typed_data';
 
 import 'package:cocoon_service/cocoon_service.dart';
-import 'package:github/github.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_datastore.dart';
 
 void main() {
-  group('repoNameForBuilder', () {
-    FakeDatastoreDB datastore;
-    Config config;
-    setUp(() {
-      datastore = FakeDatastoreDB();
-      config = Config(datastore, CacheService(inMemory: true));
-    });
-    test('Builder config does not exist', () async {
-      final RepositorySlug result = await config.repoNameForBuilder('DoesNotExist');
-      expect(result, isNull);
-    });
-
-    test('Builder exists', () async {
-      final RepositorySlug result = await config.repoNameForBuilder('Cocoon');
-      expect(result, isNotNull);
-      expect(result.fullName, equals('flutter/cocoon'));
-    });
-  });
   group('githubAppInstallations', () {
     FakeDatastoreDB datastore;
     CacheService cacheService;

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -90,7 +90,7 @@ void main() {
     group('repoNameForBuilder', () {
       test('Builder config does not exist', () async {
         final List<Map<String, dynamic>> builders = <Map<String, dynamic>>[];
-        final RepositorySlug result = repoNameForBuilder(builders, 'DoesNotExist');
+        final RepositorySlug result = await repoNameForBuilder(builders, 'DoesNotExist');
         expect(result, isNull);
       });
 
@@ -98,7 +98,7 @@ void main() {
         final List<Map<String, dynamic>> builders = <Map<String, dynamic>>[
           <String, String>{'name': 'Cocoon', 'repo': 'cocoon'}
         ];
-        final RepositorySlug result = repoNameForBuilder(builders, 'Cocoon');
+        final RepositorySlug result = await repoNameForBuilder(builders, 'Cocoon');
         expect(result, isNotNull);
         expect(result.fullName, equals('flutter/cocoon'));
       });

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -6,8 +6,8 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
+import 'package:github/github.dart';
 import 'package:test/test.dart';
-
 import 'package:cocoon_service/src/foundation/utils.dart';
 
 import '../src/request_handling/fake_http.dart';
@@ -84,6 +84,23 @@ void main() {
         expect(twoSecondLinearBackoff(1), const Duration(seconds: 4));
         expect(twoSecondLinearBackoff(2), const Duration(seconds: 6));
         expect(twoSecondLinearBackoff(3), const Duration(seconds: 8));
+      });
+    });
+
+    group('repoNameForBuilder', () {
+      test('Builder config does not exist', () async {
+        final List<Map<String, dynamic>> builders = <Map<String, dynamic>>[];
+        final RepositorySlug result = repoNameForBuilder(builders, 'DoesNotExist');
+        expect(result, isNull);
+      });
+
+      test('Builder exists', () async {
+        final List<Map<String, dynamic>> builders = <Map<String, dynamic>>[
+          <String, String>{'name': 'Cocoon', 'repo': 'cocoon'}
+        ];
+        final RepositorySlug result = repoNameForBuilder(builders, 'Cocoon');
+        expect(result, isNotNull);
+        expect(result.fullName, equals('flutter/cocoon'));
       });
     });
   });

--- a/app_dart/test/service/github_status_service_test.dart
+++ b/app_dart/test/service/github_status_service_test.dart
@@ -171,6 +171,9 @@ void main() {
     });
 
     test('Status updated when not pending or url is different', () async {
+      config.luciTryBuildersValue = <Map<String, dynamic>>[
+        <String, String>{'name': 'Mac', 'repo': 'flutter', 'TaskName': 'mac_bot'}
+      ];
       List<RepositoryStatus> repositoryStatuses = <RepositoryStatus>[
         RepositoryStatus()
           ..context = 'Mac'
@@ -223,6 +226,9 @@ void main() {
     });
 
     test('Status updated to cancelled', () async {
+      config.luciTryBuildersValue = <Map<String, dynamic>>[
+        <String, String>{'name': 'Mac', 'repo': 'flutter', 'TaskName': 'mac_bot'}
+      ];
       final List<RepositoryStatus> repositoryStatuses = <RepositoryStatus>[
         RepositoryStatus()
           ..context = 'Mac'
@@ -238,6 +244,9 @@ void main() {
           jsonDecode('{"state":"failure","target_url":"url","description":"Flutter LUCI Build: Mac","context":"Mac"}'));
     });
     test('Status updated to success', () async {
+      config.luciTryBuildersValue = <Map<String, dynamic>>[
+        <String, String>{'name': 'Mac', 'repo': 'flutter', 'TaskName': 'mac_bot'}
+      ];
       final List<RepositoryStatus> repositoryStatuses = <RepositoryStatus>[
         RepositoryStatus()
           ..context = 'Mac'

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -189,21 +189,6 @@ class FakeConfig implements Config {
   }
 
   @override
-  Future<RepositorySlug> repoNameForBuilder(String builderName) async {
-    String name;
-    switch (builderName) {
-      case 'Linux Host Engine':
-        name = 'engine';
-        break;
-      case 'MacNoExists':
-        return null;
-      default:
-        name = 'flutter';
-    }
-    return RepositorySlug('flutter', name);
-  }
-
-  @override
   Future<String> generateGithubToken(String user, String repository) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
This PR moves function `repoNameForBuilder` from cocoon_config to utils for below reasons:

- We are changing access of `luciBuilders` from cocoon_config to http request. This change will make testing `repoNameForBuilder` in `cocoon_config_test` challenging. Instead, moving it to `utils` makes it easy for testing in `utils_test`.
- `repoNameForBuilder` will be more general for both `try` and `prod` builders, rather than hard-coded for `try`.