### PR TITLE
Update with correct builders

### DIFF
--- a/app_dart/dev/luci_prod_builders.json
+++ b/app_dart/dev/luci_prod_builders.json
@@ -1,18 +1,23 @@
 {
    "builders":[
       {
-         "name":"Cocoon",
-         "repo":"cocoon"
-      },
-      {
          "name":"Linux",
          "repo":"flutter",
          "taskName":"linux_bot"
       },
       {
+         "name":"Mac",
+         "repo":"flutter",
+         "taskName":"mac_bot"
+      },
+      {
          "name":"Windows",
          "repo":"flutter",
          "taskName":"windows_bot"
+      },
+      {
+         "name":"Linux Coverage",
+         "repo":"flutter"
       },
       {
          "name":"Linux Host Engine",
@@ -31,10 +36,6 @@
          "repo":"engine"
       },
       {
-         "name":"Linux Web Engine",
-         "repo":"engine"
-      },
-      {
          "name":"Mac Host Engine",
          "repo":"engine"
       },
@@ -47,11 +48,15 @@
          "repo":"engine"
       },
       {
-         "name":"Mac Host Engine",
+         "name":"Mac iOS Engine",
          "repo":"engine"
       },
       {
-         "name":"Mac iOS Engine",
+         "name":"Mac iOS Engine Profile",
+         "repo":"engine"
+      },
+      {
+         "name":"Mac iOS Engine Release",
          "repo":"engine"
       },
       {
@@ -61,18 +66,6 @@
       {
          "name":"Windows Android AOT Engine",
          "repo":"engine"
-      },
-      {
-         "name":"Windows Web Engine",
-         "repo":"engine"
-      },
-      {
-         "name":"Mac Web Engine",
-         "repo":"engine"
-      },
-      {
-         "name":"fuchsia_ctl",
-         "repo":"packages"
       }
    ]
 }

--- a/app_dart/dev/luci_try_builders.json
+++ b/app_dart/dev/luci_try_builders.json
@@ -1,23 +1,18 @@
 {
    "builders":[
       {
+         "name":"Cocoon",
+         "repo":"cocoon"
+      },
+      {
          "name":"Linux",
          "repo":"flutter",
          "taskName":"linux_bot"
       },
       {
-         "name":"Mac",
-         "repo":"flutter",
-         "taskName":"mac_bot"
-      },
-      {
          "name":"Windows",
          "repo":"flutter",
          "taskName":"windows_bot"
-      },
-      {
-         "name":"Linux Coverage",
-         "repo":"flutter"
       },
       {
          "name":"Linux Host Engine",
@@ -36,6 +31,10 @@
          "repo":"engine"
       },
       {
+         "name":"Linux Web Engine",
+         "repo":"engine"
+      },
+      {
          "name":"Mac Host Engine",
          "repo":"engine"
       },
@@ -48,15 +47,11 @@
          "repo":"engine"
       },
       {
+         "name":"Mac Host Engine",
+         "repo":"engine"
+      },
+      {
          "name":"Mac iOS Engine",
-         "repo":"engine"
-      },
-      {
-         "name":"Mac iOS Engine Profile",
-         "repo":"engine"
-      },
-      {
-         "name":"Mac iOS Engine Release",
          "repo":"engine"
       },
       {
@@ -66,6 +61,18 @@
       {
          "name":"Windows Android AOT Engine",
          "repo":"engine"
+      },
+      {
+         "name":"Windows Web Engine",
+         "repo":"engine"
+      },
+      {
+         "name":"Mac Web Engine",
+         "repo":"engine"
+      },
+      {
+         "name":"fuchsia_ctl",
+         "repo":"packages"
       }
    ]
 }


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/860 mis-switched the contents for `try` and `prod`. This pr updates the files with the correct list.