### PR TITLE
Update the handler url to retry prod bots.

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -144,7 +144,7 @@ class AppEngineCocoonService implements CocoonService {
     if (qualifiedTask.isDevicelab) {
       postResetTaskUrl = apiEndpoint('/api/reset-devicelab-task');
     } else if (qualifiedTask.isLuci) {
-      postResetTaskUrl = apiEndpoint('/api/reset-luci-task');
+      postResetTaskUrl = apiEndpoint('/api/reset-prod-task');
     } else {
       assert(false);
     }


### PR DESCRIPTION
The handler url was changed but the client code was not updated.

Bug:
  https://github.com/flutter/flutter/issues/54873