### PR TITLE
Refactor cocoon links to be easier to add

### DIFF
--- a/app_flutter/lib/index_page.dart
+++ b/app_flutter/lib/index_page.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
+import 'logic/links.dart';
 import 'navigation_drawer.dart';
 import 'state/index.dart';
 import 'widgets/app_bar.dart';
@@ -27,6 +27,7 @@ class IndexPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final IndexState indexState = Provider.of<IndexState>(context);
+    final List<CocoonLink> cocoonLinks = createCocoonLinks(context);
     return AnimatedBuilder(
       animation: indexState,
       builder: (BuildContext context, Widget child) => Scaffold(
@@ -36,47 +37,19 @@ class IndexPage extends StatelessWidget {
         body: ErrorBrookWatcher(
           errors: indexState.errors,
           child: Center(
-            child: IntrinsicWidth(
-              stepWidth: 80.0,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  separator,
-                  const HeaderText('Select a dashboard'),
-                  separator,
-                  RaisedButton.icon(
-                    icon: const Icon(Icons.build),
-                    label: const Text('BUILD'),
-                    onPressed: () => Navigator.pushReplacementNamed(context, '/build'),
-                  ),
-                  separator,
-                  RaisedButton.icon(
-                    icon: const Icon(Icons.show_chart),
-                    label: const Text('BENCHMARKS'),
-                    onPressed: () => launch('/benchmarks.html'),
-                  ),
-                  separator,
-                  RaisedButton.icon(
-                    icon: const Icon(Icons.show_chart),
-                    label: const Text('BENCHMARKS ON SKIA PERF'),
-                    onPressed: () => launch('https://flutter-perf.skia.org/'),
-                  ),
-                  separator,
-                  RaisedButton.icon(
-                    icon: const Icon(Icons.info_outline),
-                    label: const Text('REPOSITORY'),
-                    onPressed: () => launch('/repository.html'),
-                  ),
-                  separator,
-                  const Divider(thickness: 2.0),
-                  separator,
-                  RaisedButton.icon(
-                    icon: const Icon(Icons.android),
-                    label: const Text('INFRA AGENTS'),
-                    onPressed: () => Navigator.pushReplacementNamed(context, '/agents'),
-                  ),
-                ],
-              ),
+            child: ListView(
+              children: <Widget>[
+                const HeaderText('Select a dashboard'),
+                for (CocoonLink link in cocoonLinks)
+                  Column(children: <Widget>[
+                    IntrinsicWidth(
+                      child: RaisedButton.icon(
+                          icon: link.icon, label: Text(link.name.toUpperCase()), onPressed: link.action),
+                      stepWidth: 80.0,
+                    ),
+                    separator,
+                  ])
+              ],
             ),
           ),
         ),

--- a/app_flutter/lib/logic/links.dart
+++ b/app_flutter/lib/logic/links.dart
@@ -1,0 +1,88 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../agent_dashboard_page.dart';
+import '../build_dashboard_page.dart';
+import '../index_page.dart';
+
+/// Data class for storing links on the Cocoon app.
+///
+/// [name] is the text that will be shown to users for this link, [icon] is an
+/// [Icon] to represent the link, [action] is a function to perform when the
+/// link is clicked. For links to other parts of this Flutter app, [route] can
+/// be passed to highlight in the sidebar what page a user is on.
+class CocoonLink {
+  const CocoonLink({
+    this.name,
+    this.route,
+    this.action,
+    this.icon,
+  });
+
+  /// Text shown to users describing this link.
+  final String name;
+
+  /// If the link is internal to this Flutter app, this can be passed to highlight on the [NavigationDrawer] the page the user is on.
+  final String route;
+
+  /// An [Icon] to represent this link.
+  final Icon icon;
+
+  /// Callback for when the link is activated.
+  ///
+  /// Can be used to redirect to internal or external routes. Will have acess to the [BuildContext].
+  final Function action;
+}
+
+List<CocoonLink> createCocoonLinks(BuildContext context) {
+  return <CocoonLink>[
+    CocoonLink(
+      name: 'Home',
+      route: IndexPage.routeName,
+      icon: const Icon(Icons.home),
+      action: () => Navigator.pushReplacementNamed(context, IndexPage.routeName),
+    ),
+    CocoonLink(
+      name: 'Build',
+      route: BuildDashboardPage.routeName,
+      icon: const Icon(Icons.build),
+      action: () => Navigator.pushReplacementNamed(context, BuildDashboardPage.routeName),
+    ),
+    CocoonLink(
+      name: 'Benchmarks',
+      icon: const Icon(Icons.show_chart),
+      action: () => launch('/benchmarks.html'),
+    ),
+    CocoonLink(
+      name: 'Framework Benchmarks on Skia Perf',
+      icon: const Icon(Icons.show_chart),
+      action: () => launch('https://flutter-flutter-perf.skia.org/'),
+    ),
+    CocoonLink(
+      name: 'Engine Benchmarks on Skia Perf',
+      icon: const Icon(Icons.show_chart),
+      action: () => launch('https://flutter-engine-perf.skia.org/'),
+    ),
+    CocoonLink(
+      name: 'Repository',
+      icon: const Icon(Icons.info_outline),
+      action: () => launch('/repository.html'),
+    ),
+    CocoonLink(
+      name: 'Infra Agents',
+      route: AgentDashboardPage.routeName,
+      icon: const Icon(Icons.android),
+      action: () => Navigator.pushReplacementNamed(context, AgentDashboardPage.routeName),
+    ),
+    CocoonLink(
+      name: 'Source Code',
+      icon: const Icon(Icons.code),
+      action: () => launch('https://github.com/flutter/cocoon'),
+    ),
+  ];
+}

--- a/app_flutter/lib/logic/links.dart
+++ b/app_flutter/lib/logic/links.dart
@@ -10,35 +10,7 @@ import '../agent_dashboard_page.dart';
 import '../build_dashboard_page.dart';
 import '../index_page.dart';
 
-/// Data class for storing links on the Cocoon app.
-///
-/// [name] is the text that will be shown to users for this link, [icon] is an
-/// [Icon] to represent the link, [action] is a function to perform when the
-/// link is clicked. For links to other parts of this Flutter app, [route] can
-/// be passed to highlight in the sidebar what page a user is on.
-class CocoonLink {
-  const CocoonLink({
-    this.name,
-    this.route,
-    this.action,
-    this.icon,
-  });
-
-  /// Text shown to users describing this link.
-  final String name;
-
-  /// If the link is internal to this Flutter app, this can be passed to highlight on the [NavigationDrawer] the page the user is on.
-  final String route;
-
-  /// An [Icon] to represent this link.
-  final Icon icon;
-
-  /// Callback for when the link is activated.
-  ///
-  /// Can be used to redirect to internal or external routes. Will have acess to the [BuildContext].
-  final Function action;
-}
-
+/// List of links that are shown on [IndexPage] and in the [NavigationDrawer].
 List<CocoonLink> createCocoonLinks(BuildContext context) {
   return <CocoonLink>[
     CocoonLink(
@@ -85,4 +57,28 @@ List<CocoonLink> createCocoonLinks(BuildContext context) {
       action: () => launch('https://github.com/flutter/cocoon'),
     ),
   ];
+}
+
+/// Data class for storing links on the Cocoon app.
+class CocoonLink {
+  const CocoonLink({
+    this.name,
+    this.route,
+    this.action,
+    this.icon,
+  });
+
+  /// Text shown to users describing this link.
+  final String name;
+
+  /// If the link is internal to this Flutter app, this can be passed to highlight on the [NavigationDrawer] the page the user is on.
+  final String route;
+
+  /// An [Icon] to represent this link.
+  final Icon icon;
+
+  /// Callback for when the link is activated.
+  ///
+  /// Can be used to redirect to internal or external routes. Will have acess to the [BuildContext].
+  final Function action;
 }

--- a/app_flutter/lib/navigation_drawer.dart
+++ b/app_flutter/lib/navigation_drawer.dart
@@ -3,11 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-import 'agent_dashboard_page.dart';
-import 'build_dashboard_page.dart';
-import 'index_page.dart';
+import 'logic/links.dart';
 
 /// Sidebar for navigating the different pages of Cocoon.
 class NavigationDrawer extends StatelessWidget {
@@ -15,6 +12,7 @@ class NavigationDrawer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final List<CocoonLink> cocoonLinks = createCocoonLinks(context);
     final String currentRoute = ModalRoute.of(context).settings.name;
     return Drawer(
       child: ListView(
@@ -28,46 +26,13 @@ class NavigationDrawer extends StatelessWidget {
               child: Text('Flutter Dashboard'),
             ),
           ),
-          ListTile(
-            title: const Text('Home'),
-            leading: const Icon(Icons.home),
-            onTap: () => Navigator.pushReplacementNamed(context, IndexPage.routeName),
-            selected: currentRoute == '/',
-          ),
-          ListTile(
-            title: const Text('Build'),
-            leading: const Icon(Icons.build),
-            onTap: () => Navigator.pushReplacementNamed(context, BuildDashboardPage.routeName),
-            selected: currentRoute == '/build',
-          ),
-          ListTile(
-            title: const Text('Benchmarks'),
-            leading: const Icon(Icons.show_chart),
-            onTap: () => launch('/benchmarks.html'),
-          ),
-          ListTile(
-            title: const Text('Benchmarks on Skia Perf'),
-            leading: const Icon(Icons.show_chart),
-            onTap: () => launch('https://flutter-perf.skia.org/'),
-          ),
-          ListTile(
-            title: const Text('Repository'),
-            leading: const Icon(Icons.info_outline),
-            onTap: () => launch('/repository.html'),
-          ),
-          const Divider(thickness: 2.0),
-          ListTile(
-            title: const Text('Infra Agents'),
-            leading: const Icon(Icons.android),
-            onTap: () => Navigator.pushReplacementNamed(context, AgentDashboardPage.routeName),
-            selected: currentRoute == '/agents',
-          ),
-          const Divider(thickness: 2.0),
-          ListTile(
-            title: const Text('Source Code'),
-            leading: const Icon(Icons.code),
-            onTap: () => launch('https://github.com/flutter/cocoon'),
-          ),
+          for (CocoonLink link in cocoonLinks)
+            ListTile(
+              leading: link.icon,
+              title: Text(link.name),
+              onTap: link.action,
+              selected: currentRoute == link.route,
+            ),
           const AboutListTile(
             icon: FlutterLogo(),
           ),

--- a/app_flutter/test/index_page_test.dart
+++ b/app_flutter/test/index_page_test.dart
@@ -41,17 +41,8 @@ void main() {
 
     final List<Element> listTiles = find.byType(ListTile).evaluate().toList();
 
-    expect(raisedButtons, hasLength(6));
-    expect(listTiles.length, greaterThanOrEqualTo(raisedButtons.length + 1));
-
     expect(getDescendant<Text>(of: raisedButtons.last).data, 'SIGN IN');
     expect(getDescendant<Text>(of: listTiles.first).data, 'Home');
-
-    for (int index = 0; index < raisedButtons.length - 1; index += 1) {
-      expect(getDescendant<Icon>(of: raisedButtons[index]).icon, getDescendant<Icon>(of: listTiles[index + 1]).icon);
-      expect(getDescendant<Text>(of: raisedButtons[index]).data,
-          getDescendant<Text>(of: listTiles[index + 1]).data.toUpperCase());
-    }
   });
 
   testWidgets('shows navigation buttons for dashboards', (WidgetTester tester) async {
@@ -59,7 +50,8 @@ void main() {
 
     expect(find.text('BUILD'), findsOneWidget);
     expect(find.text('BENCHMARKS'), findsOneWidget);
-    expect(find.text('BENCHMARKS ON SKIA PERF'), findsOneWidget);
+    expect(find.text('FRAMEWORK BENCHMARKS ON SKIA PERF'), findsOneWidget);
+    expect(find.text('ENGINE BENCHMARKS ON SKIA PERF'), findsOneWidget);
     expect(find.text('REPOSITORY'), findsOneWidget);
     expect(find.text('INFRA AGENTS'), findsOneWidget);
   });

--- a/app_flutter/test/navigation_drawer_test.dart
+++ b/app_flutter/test/navigation_drawer_test.dart
@@ -25,11 +25,12 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
       expect(find.text('Build'), findsOneWidget);
       expect(find.text('Benchmarks'), findsOneWidget);
-      expect(find.text('Benchmarks on Skia Perf'), findsOneWidget);
+      expect(find.text('Framework Benchmarks on Skia Perf'), findsOneWidget);
+      expect(find.text('Engine Benchmarks on Skia Perf'), findsOneWidget);
       expect(find.text('Repository'), findsOneWidget);
       expect(find.text('Infra Agents'), findsOneWidget);
       expect(find.text('Source Code'), findsOneWidget);
-      expect(find.text('About Test'), findsOneWidget);
+      expect(find.text('About Test', skipOffstage: false), findsOneWidget);
     });
 
     testWidgets('build navigates to build Flutter route', (WidgetTester tester) async {
@@ -111,7 +112,7 @@ void main() {
       );
     });
 
-    testWidgets('skia perf opens skia perf url', (WidgetTester tester) async {
+    testWidgets('skia perf links opens skia perf url', (WidgetTester tester) async {
       const MethodChannel urlLauncherChannel = MethodChannel('plugins.flutter.io/url_launcher');
       final List<MethodCall> log = <MethodCall>[];
       urlLauncherChannel.setMockMethodCallHandler((MethodCall methodCall) async => log.add(methodCall));
@@ -122,7 +123,7 @@ void main() {
         ),
       );
 
-      const String skiaPerfText = 'Benchmarks on Skia Perf';
+      const String skiaPerfText = 'Engine Benchmarks on Skia Perf';
       expect(find.text(skiaPerfText), findsOneWidget);
       await tester.tap(find.text(skiaPerfText));
       await tester.pump();
@@ -131,7 +132,7 @@ void main() {
         log,
         <Matcher>[
           isMethodCall('launch', arguments: <String, Object>{
-            'url': 'https://flutter-perf.skia.org/',
+            'url': 'https://flutter-engine-perf.skia.org/',
             'useSafariVC': true,
             'useWebView': false,
             'enableJavaScript': false,
@@ -185,9 +186,10 @@ void main() {
         ),
       );
 
-      expect(find.text('Source Code'), findsOneWidget);
-      await tester.tap(find.text('Source Code'));
-      await tester.pump();
+      const String githubLinkText = 'Source Code';
+      expect(find.text(githubLinkText), findsOneWidget);
+      await tester.tap(find.text(githubLinkText));
+      await tester.pump(const Duration(seconds: 4));
 
       expect(
         log,

--- a/app_flutter/test/navigation_drawer_test.dart
+++ b/app_flutter/test/navigation_drawer_test.dart
@@ -30,7 +30,9 @@ void main() {
       expect(find.text('Repository'), findsOneWidget);
       expect(find.text('Infra Agents'), findsOneWidget);
       expect(find.text('Source Code'), findsOneWidget);
-      expect(find.text('About Test', skipOffstage: false), findsOneWidget);
+      await tester.drag(find.text('Source Code'), const Offset(0.0, -100));
+      await tester.pump();
+      expect(find.text('About Test'), findsOneWidget);
     });
 
     testWidgets('build navigates to build Flutter route', (WidgetTester tester) async {

--- a/app_flutter/test/navigation_drawer_test.dart
+++ b/app_flutter/test/navigation_drawer_test.dart
@@ -186,10 +186,9 @@ void main() {
         ),
       );
 
-      const String githubLinkText = 'Source Code';
-      expect(find.text(githubLinkText), findsOneWidget);
-      await tester.tap(find.text(githubLinkText));
-      await tester.pump(const Duration(seconds: 4));
+      expect(find.text('Source Code'), findsOneWidget);
+      await tester.tap(find.text('Source Code'));
+      await tester.pump();
 
       expect(
         log,


### PR DESCRIPTION
Create a generic list of the links used in Cocoon. This makes it for future additions to only need to be added to one place.

Additionally, add the new skia perfs links.

# Issues

Closes https://github.com/flutter/flutter/issues/61677