### PR TITLE
Pull checks state from flutter-dashboard app.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -198,10 +198,12 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       final String sha = commit['oid'] as String;
       final List<Map<String, dynamic>> statuses =
           (commit['status']['contexts'] as List<dynamic>).cast<Map<String, dynamic>>();
-      final List<Map<String, dynamic>> checkRuns =
-          (commit['checkSuites']['nodes'].single['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
+      List<Map<String, dynamic>> checkRuns;
+      if (commit['checkSuites']['nodes'] != null && (commit['checkSuites']['nodes'] as List<dynamic>).isNotEmpty) {
+        checkRuns =
+            (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
+      }
       final Set<String> failingStatuses = <String>{};
-
       final bool ciSuccessful = await _checkStatuses(
         sha,
         failingStatuses,
@@ -255,7 +257,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         }
       }
     }
-
+    checkRuns = checkRuns ?? <Map<String, dynamic>>[];
     log.info('Validating name: $name, branch: $branch, checks: $checkRuns');
     for (Map<String, dynamic> checkRun in checkRuns) {
       final String name = checkRun['name'] as String;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -203,6 +203,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         checkRuns =
             (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
       }
+      checkRuns = checkRuns ?? <Map<String, dynamic>>[];
       final Set<String> failingStatuses = <String>{};
       final bool ciSuccessful = await _checkStatuses(
         sha,
@@ -257,7 +258,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         }
       }
     }
-    checkRuns = checkRuns ?? <Map<String, dynamic>>[];
     log.info('Validating name: $name, branch: $branch, checks: $checkRuns');
     for (Map<String, dynamic> checkRun in checkRuns) {
       final String name = checkRun['name'] as String;

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -29,6 +29,8 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                       state
                     }
                   }
+                  # (appId: 64368) == flutter-dashbord. We only care about
+                  # flutter-dashboard checks.
                   checkSuites(last:1, filterBy: { appId: 64368 } ) {
                     nodes {
                       checkRuns(first:100) {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -29,7 +29,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                       state
                     }
                   }
-                  checkSuites(first:1) {
+                  checkSuites(last:1, filterBy: { appId: 64368 } ) {
                     nodes {
                       checkRuns(first:100) {
                         nodes {


### PR DESCRIPTION
The checks validation was using the first or last checksuite to collect
all the check runs to validate. The first checksuite contains cirrus
checks and the last one contains the checks from wip app. This caused
several rollers landing changes without validating all the luci
builders.

Bug:
  https://github.com/flutter/flutter/issues/62211