### PR TITLE
Fix agent timeouts

### DIFF
--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -45,7 +45,7 @@ class CocoonTask {
     this.timeoutInMinutes = 0,
     this.key,
     this.cloudAuthToken,
-  }) :  assert(name != null),
+  })  : assert(name != null),
         assert(revision != null),
         assert(timeoutInMinutes != null);
 

--- a/agent/lib/src/agent.dart
+++ b/agent/lib/src/agent.dart
@@ -42,10 +42,12 @@ class CocoonTask {
   CocoonTask({
     @required this.name,
     @required this.revision,
-    @required this.timeoutInMinutes,
+    this.timeoutInMinutes = 0,
     this.key,
     this.cloudAuthToken,
-  });
+  }) :  assert(name != null),
+        assert(revision != null),
+        assert(timeoutInMinutes != null);
 
   /// Task name as it appears on dashboards and in logs.
   final String name;

--- a/agent/lib/src/commands/ci.dart
+++ b/agent/lib/src/commands/ci.dart
@@ -22,6 +22,9 @@ const Duration _sleepBetweenBuilds = const Duration(seconds: 10);
 /// Maximum amount of time we're allowing Flutter to install.
 const Duration _kInstallationTimeout = const Duration(minutes: 20);
 
+/// Fallback timeout if a test takes too long and needs to be killed.
+const Duration _kGlobalTestRunnerTimeout = const Duration(hours: 1);
+
 /// Runs the agent in continuous integration mode.
 ///
 /// In this mode the agent runs in an infinite loop, continuously asking for
@@ -187,7 +190,7 @@ class ContinuousIntegrationCommand extends Command {
   }
 
   Future<Null> _runTask(CocoonTask task) async {
-    TaskResult result = await runTask(agent, task);
+    TaskResult result = await runTask(agent, task, fallbackTimeout: _kGlobalTestRunnerTimeout);
     if (result.succeeded) {
       await agent.reportSuccess(task.key, result.data, result.benchmarkScoreKeys);
     } else {

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -48,7 +48,7 @@ class RunCommand extends Command {
       await killAllRunningProcessesOnWindows('dart');
     }
 
-    CocoonTask task = CocoonTask(name: taskName, revision: revision, timeoutInMinutes: 30);
+    CocoonTask task = CocoonTask(name: taskName, revision: revision, timeoutInMinutes: 0);
     TaskResult result;
     try {
       if (task.revision != null) {

--- a/agent/lib/src/commands/run.dart
+++ b/agent/lib/src/commands/run.dart
@@ -48,12 +48,10 @@ class RunCommand extends Command {
       await killAllRunningProcessesOnWindows('dart');
     }
 
-    CocoonTask task = CocoonTask(name: taskName, revision: revision, timeoutInMinutes: 0);
+    CocoonTask task = CocoonTask(name: taskName, revision: revision);
     TaskResult result;
     try {
       if (task.revision != null) {
-        // Sync flutter outside of the task so it does not contribute to
-        // the task timeout.
         await getFlutterAt(task.revision).timeout(const Duration(minutes: 10));
       } else {
         logger.info('NOTE: No --revision specified. Running on current checkout.');


### PR DESCRIPTION
Remove 15 minute timeout hard coded into runner (which is used whether
tests are run locally or as part of CI), and add a 1-hour fallback
timeout to the CI runner.

https://github.com/flutter/flutter/issues/62419