### PR TITLE
[agent] Overwrites code signing config of infra-dialog

### DIFF
--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -168,19 +168,13 @@ Future<HealthCheckResult> closeIosDialog(
     await inDirectory(dialogDir, () async {
       List<String> command =
           'xcrun xcodebuild -project infra-dialog.xcodeproj -scheme infra-dialog -destination id=${d.deviceId} test'.split(' ');
-      // Overwrites code signing config if that exists.
-      Map<String, String> env = <String, String>{};
+      // Overwrites code signing config when that exists.
       if (pf.environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] != null) {
-        env['CODE_SIGN_STYLE'] = pf.environment['FLUTTER_XCODE_CODE_SIGN_STYLE'];
+        command.add("CODE_SIGN_STYLE=${pf.environment['FLUTTER_XCODE_CODE_SIGN_STYLE']}");
+        command.add("DEVELOPMENT_TEAM=${pf.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM']}");
+        command.add("PROVISIONING_PROFILE_SPECIFIER=${pf.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER']}");
       }
-      if (pf.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'] != null) {
-        env['DEVELOPMENT_TEAM'] = pf.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM'];
-      }
-      if (pf.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'] != null) {
-        env['PROVISIONING_PROFILE_SPECIFIER'] = pf.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER'];
-      }
-
-      Process proc = await pm.start(command, workingDirectory: dialogDir.path, environment: env);
+      Process proc = await pm.start(command, workingDirectory: dialogDir.path);
       logger.info('Executing: $command');
       // Discards stdout and stderr as they are too large.
       await proc.stdout.drain<Object>();

--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -150,7 +150,9 @@ Future<HealthCheckResult> removeCachedData(
 /// The dialogs often cause test flakiness and performance regressions.
 @visibleForTesting
 Future<HealthCheckResult> closeIosDialog(
-    {ProcessManager pm = const LocalProcessManager(), DeviceDiscovery discovery, platform.Platform pl = const platform.LocalPlatform()}) async {
+    {ProcessManager pm = const LocalProcessManager(),
+    DeviceDiscovery discovery,
+    platform.Platform pl = const platform.LocalPlatform()}) async {
   if (discovery == null) {
     discovery = devices;
   }
@@ -167,8 +169,11 @@ Future<HealthCheckResult> closeIosDialog(
     // Runs the single XCUITest in infra-dialog.
     await inDirectory(dialogDir, () async {
       List<String> command =
-          'xcrun xcodebuild -project infra-dialog.xcodeproj -scheme infra-dialog -destination id=${d.deviceId} test'.split(' ');
-      // Overwrites code signing config when that exists.
+          'xcrun xcodebuild -project infra-dialog.xcodeproj -scheme infra-dialog -destination id=${d.deviceId} test'
+              .split(' ');
+      // By default the above command relies on automatic code signing, while on devicelab machines
+      // it should utilize manual code signing as that is more stable. Below overwrites the code
+      // signing config if one exists in the environment.
       if (pl.environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] != null) {
         command.add("CODE_SIGN_STYLE=${pl.environment['FLUTTER_XCODE_CODE_SIGN_STYLE']}");
         command.add("DEVELOPMENT_TEAM=${pl.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM']}");

--- a/agent/lib/src/health.dart
+++ b/agent/lib/src/health.dart
@@ -150,7 +150,7 @@ Future<HealthCheckResult> removeCachedData(
 /// The dialogs often cause test flakiness and performance regressions.
 @visibleForTesting
 Future<HealthCheckResult> closeIosDialog(
-    {ProcessManager pm = const LocalProcessManager(), DeviceDiscovery discovery, platform.Platform pf = const platform.LocalPlatform()}) async {
+    {ProcessManager pm = const LocalProcessManager(), DeviceDiscovery discovery, platform.Platform pl = const platform.LocalPlatform()}) async {
   if (discovery == null) {
     discovery = devices;
   }
@@ -169,10 +169,10 @@ Future<HealthCheckResult> closeIosDialog(
       List<String> command =
           'xcrun xcodebuild -project infra-dialog.xcodeproj -scheme infra-dialog -destination id=${d.deviceId} test'.split(' ');
       // Overwrites code signing config when that exists.
-      if (pf.environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] != null) {
-        command.add("CODE_SIGN_STYLE=${pf.environment['FLUTTER_XCODE_CODE_SIGN_STYLE']}");
-        command.add("DEVELOPMENT_TEAM=${pf.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM']}");
-        command.add("PROVISIONING_PROFILE_SPECIFIER=${pf.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER']}");
+      if (pl.environment['FLUTTER_XCODE_CODE_SIGN_STYLE'] != null) {
+        command.add("CODE_SIGN_STYLE=${pl.environment['FLUTTER_XCODE_CODE_SIGN_STYLE']}");
+        command.add("DEVELOPMENT_TEAM=${pl.environment['FLUTTER_XCODE_DEVELOPMENT_TEAM']}");
+        command.add("PROVISIONING_PROFILE_SPECIFIER=${pl.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER']}");
       }
       Process proc = await pm.start(command, workingDirectory: dialogDir.path);
       logger.info('Executing: $command');

--- a/agent/test/src/health_test.dart
+++ b/agent/test/src/health_test.dart
@@ -109,7 +109,7 @@ void main() {
 
     test('succeeded', () async {
       Process proc = FakeProcess(0);
-      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'), environment: anyNamed('environment')))
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(proc));
 
       HealthCheckResult res = await closeIosDialog(pm: pm, discovery: discovery);
@@ -119,7 +119,7 @@ void main() {
 
     test('failed', () async {
       Process proc = FakeProcess(123);
-      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'), environment: anyNamed('environment')))
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(proc));
 
       expect(

--- a/agent/test/src/health_test.dart
+++ b/agent/test/src/health_test.dart
@@ -109,18 +109,30 @@ void main() {
 
     test('succeeded', () async {
       Process proc = FakeProcess(0);
-      when(pm.start(any, workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(proc));
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'))).thenAnswer((_) => Future.value(proc));
 
       HealthCheckResult res = await closeIosDialog(pm: pm, discovery: discovery);
 
       expect(res.succeeded, isTrue);
     });
 
+    test('succeeded with code signing overwrite', () async {
+      Process proc = FakeProcess(0);
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'))).thenAnswer((_) => Future.value(proc));
+      platform.Platform pl = platform.FakePlatform(environment: <String, String>{
+        'FLUTTER_XCODE_CODE_SIGN_STYLE': 'Manual',
+        'FLUTTER_XCODE_DEVELOPMENT_TEAM': 'S8QB4VV633',
+        'FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER': 'a name with space',
+      });
+
+      HealthCheckResult res = await closeIosDialog(pm: pm, discovery: discovery, pl: pl);
+
+      expect(res.succeeded, isTrue);
+    });
+
     test('failed', () async {
       Process proc = FakeProcess(123);
-      when(pm.start(any, workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(proc));
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'))).thenAnswer((_) => Future.value(proc));
 
       expect(
         closeIosDialog(pm: pm, discovery: discovery),

--- a/agent/test/src/health_test.dart
+++ b/agent/test/src/health_test.dart
@@ -109,7 +109,8 @@ void main() {
 
     test('succeeded', () async {
       Process proc = FakeProcess(0);
-      when(pm.start(any, workingDirectory: anyNamed("workingDirectory"))).thenAnswer((_) => Future.value(proc));
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'), environment: anyNamed('environment')))
+          .thenAnswer((_) => Future.value(proc));
 
       HealthCheckResult res = await closeIosDialog(pm: pm, discovery: discovery);
 
@@ -118,7 +119,8 @@ void main() {
 
     test('failed', () async {
       Process proc = FakeProcess(123);
-      when(pm.start(any, workingDirectory: anyNamed("workingDirectory"))).thenAnswer((_) => Future.value(proc));
+      when(pm.start(any, workingDirectory: anyNamed('workingDirectory'), environment: anyNamed('environment')))
+          .thenAnswer((_) => Future.value(proc));
 
       expect(
         closeIosDialog(pm: pm, discovery: discovery),


### PR DESCRIPTION
If an existing code singing config exists on a test bed, we should use that one in order to build the infra-dialog project.

Bug: flutter/flutter#54792