### PR TITLE
Move the github client auth closer to where it will be used.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -128,7 +128,6 @@ class LuciBuildService {
     assert(prNumber != null);
     assert(commitSha != null);
     assert(slug != null);
-    final github.GitHub githubClient = await config.createGitHubClient(slug.owner, slug.name);
     if (!config.githubPresubmitSupportedRepo(slug.name)) {
       throw BadRequestException('Repository ${slug.name} is not supported by this service.');
     }
@@ -158,6 +157,7 @@ class LuciBuildService {
     }
 
     final List<Request> requests = <Request>[];
+    final github.GitHub githubClient = await config.createGitHubClient(slug.owner, slug.name);
     for (String builder in builderNames) {
       log.info('Trigger build for: $builder');
       final BuilderId builderId = BuilderId(


### PR DESCRIPTION
Github client is now using short lived tokens and in some cases when we
need to validate is builds exist and cancel them the token expired in
the middle of the request. We are moving the github client creation and
authentication to the place it will be used instead of creating at the
beginning of the method.

Bug:
  https://github.com/flutter/flutter/issues/62233