### PR TITLE
Truncate commit message at 1500 chars.

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -156,7 +156,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
           authorAvatarUrl: commit.author.avatarUrl,
           // The field has a size of 1500 we need to ensure the commit message
           // is at most 1500 chars long.
-          message: truncate(commit.commit.message, 1499, omission: ''),
+          message: truncate(commit.commit.message, 1490, omission: '...'),
           branch: branch,
         ));
       } else {

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -10,6 +10,7 @@ import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
+import 'package:truncate/truncate.dart';
 import 'package:yaml/yaml.dart';
 
 import '../datastore/cocoon_config.dart';
@@ -153,7 +154,9 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
           sha: commit.sha,
           author: commit.author.login,
           authorAvatarUrl: commit.author.avatarUrl,
-          message: commit.commit.message,
+          // The field has a size of 1500 we need to ensure the commit message
+          // is at most 1500 chars long.
+          message: truncate(commit.commit.message, 1499, omission: ''),
           branch: branch,
         ));
       } else {

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   protobuf: ^1.0.0
   yaml: ^2.1.16
   corsac_jwt: ^0.2.2
+  truncate: ^2.1.2
 
 dev_dependencies:
   build_runner: ^1.0.0


### PR DESCRIPTION
Commit messages can be longer than 1500 chars however the limit in the
datastore field is 1500 chars. We are truncating commit messages when
they are longer than 1500 chars.

Bug:
  https://github.com/flutter/flutter/issues/62789