### PR TITLE
Refactor and Update flutter-gold check

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -158,25 +158,13 @@ class Config {
       '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
       'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get goldenBreakingChangeMessage => 'Changes to golden files are considered breaking changes, so consult '
-      '[Handling Breaking Changes](https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes) '
-      'to proceed. While there are exceptions to this rule, if this patch modifies '
-      'an existing golden file, it is probably not an exception. Only new golden '
-      'file tests, or downstream changes like those from skia updates are '
-      'considered non-breaking.\n\n'
-      'For more guidance, visit '
-      '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
-      '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
-      'and make sure this patch meets those guidelines before LGTMing.';
-
   String get goldenTriageMessage => 'Nice merge! 🎉\n'
       'It looks like this PR made changes to golden files. If these changes have '
       'not been triaged as a tryjob, be sure to visit '
       '[Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) '
       'to triage the results when post-submit testing has completed. The status '
       'of these tests can be seen on the '
-      '[Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).\n'
-      'Also, be sure to include this change in the [Changelog](https://github.com/flutter/flutter/wiki/Changelog).\n\n'
+      '[Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).\n\n'
       'For more information about working with golden files, see the wiki page '
       '[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).';
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -158,15 +158,31 @@ class Config {
       '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
       'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get goldenTriageMessage => 'Nice merge! 🎉\n'
-      'It looks like this PR made changes to golden files. If these changes have '
-      'not been triaged as a tryjob, be sure to visit '
-      '[Flutter Gold](https://flutter-gold.skia.org/?query=source_type%3Dflutter) '
-      'to triage the results when post-submit testing has completed. The status '
-      'of these tests can be seen on the '
-      '[Flutter Dashboard](https://flutter-dashboard.appspot.com/build.html).\n\n'
-      'For more information about working with golden files, see the wiki page '
-      '[Writing a Golden File Test for package:flutter/flutter](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).';
+  String get flutterGoldPending => 'Pending.';
+
+  String get flutterGoldSuccess => 'All golden file tests have passed.';
+
+  String get flutterGoldChanges => 'Image changes have been found for '
+    'this pull request.';
+
+  String flutterGoldInitialAlert(String url) => 'Golden file changes have been found for this pull '
+    'request. Click [here to view and triage]($url) '
+    '(e.g. because this is an intentional change).\n\n'
+    'If you are still iterating on this change and are not ready to '
+    'resolve the images on the Flutter Gold dashboard, consider marking this PR '
+    'as a draft pull request above. You will still be able to view image results '
+    'on the dashboard, commenting will be silenced, and the check will not try to resolve itself until '
+    'marked ready for review.\n\n';
+
+  String flutterGoldFollowUpAlert(String url) => 'Golden file changes are available for triage from new commit, '
+    'Click [here to view]($url).\n\n';
+
+  String get flutterGoldAlertConstant => 'For more guidance, visit '
+    '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
+    '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
+    'and make sure this patch meets those guidelines before LGTMing.\n\n';
+
+  String flutterGoldCommentID(PullRequest pr) => '_Changes reported for pull request #${pr.number} at sha ${pr.head.sha}_\n\n';
 
   int get maxTaskRetries => 2;
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -163,26 +163,27 @@ class Config {
   String get flutterGoldSuccess => 'All golden file tests have passed.';
 
   String get flutterGoldChanges => 'Image changes have been found for '
-    'this pull request.';
+      'this pull request.';
 
   String flutterGoldInitialAlert(String url) => 'Golden file changes have been found for this pull '
-    'request. Click [here to view and triage]($url) '
-    '(e.g. because this is an intentional change).\n\n'
-    'If you are still iterating on this change and are not ready to '
-    'resolve the images on the Flutter Gold dashboard, consider marking this PR '
-    'as a draft pull request above. You will still be able to view image results '
-    'on the dashboard, commenting will be silenced, and the check will not try to resolve itself until '
-    'marked ready for review.\n\n';
+      'request. Click [here to view and triage]($url) '
+      '(e.g. because this is an intentional change).\n\n'
+      'If you are still iterating on this change and are not ready to '
+      'resolve the images on the Flutter Gold dashboard, consider marking this PR '
+      'as a draft pull request above. You will still be able to view image results '
+      'on the dashboard, commenting will be silenced, and the check will not try to resolve itself until '
+      'marked ready for review.\n\n';
 
   String flutterGoldFollowUpAlert(String url) => 'Golden file changes are available for triage from new commit, '
-    'Click [here to view]($url).\n\n';
+      'Click [here to view]($url).\n\n';
 
   String get flutterGoldAlertConstant => 'For more guidance, visit '
-    '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
-    '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
-    'and make sure this patch meets those guidelines before LGTMing.\n\n';
+      '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
+      '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
+      'and make sure this patch meets those guidelines before LGTMing.\n\n';
 
-  String flutterGoldCommentID(PullRequest pr) => '_Changes reported for pull request #${pr.number} at sha ${pr.head.sha}_\n\n';
+  String flutterGoldCommentID(PullRequest pr) =>
+      '_Changes reported for pull request #${pr.number} at sha ${pr.head.sha}_\n\n';
 
   int get maxTaskRetries => 2;
 

--- a/app_dart/lib/src/model/appengine/github_gold_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_gold_status_update.dart
@@ -21,6 +21,12 @@ class GithubGoldStatusUpdate extends Model {
     id = key?.id;
   }
 
+  // The flutter-gold status cannot report a `failure` status
+  // due to auto-rollers. This is why we hold a `pending` status
+  // when there are image changes. This provides the opportunity
+  // for images to be triaged, and the auto-roller to proceed.
+  // For more context, see: https://github.com/flutter/flutter/issues/48744
+
   static const String statusCompleted = 'success';
 
   static const String statusRunning = 'pending';

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -97,12 +97,14 @@ class GithubWebhook extends RequestHandler<Body> {
         // If it was closed without merging, cancel any outstanding tryjobs.
         // We'll leave unfinished jobs if it was merged since we care about those
         // results.
+      if (!pr.merged) {
         await luciBuildService.cancelBuilds(
           pullRequestEvent.repository.slug(),
           pr.number,
           pr.head.sha,
           'Pull request closed',
         );
+      }
         break;
       case 'edited':
         // Editing a PR should not trigger new jobs, but may update whether

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -277,7 +277,6 @@ class GithubWebhook extends RequestHandler<Body> {
       if (await _isIgnoredForGold(eventAction, pr)) {
         isGoldenChange = true;
         labels.add('will affect goldens');
-        labels.add('severe: API break');
         labels.add('a: tests');
       }
 
@@ -324,13 +323,6 @@ class GithubWebhook extends RequestHandler<Body> {
 
     if (!hasTests && needsTests && !pr.draft) {
       final String body = config.missingTestsPullRequestMessage;
-      if (!await _alreadyCommented(gitHubClient, pr, slug, body)) {
-        await gitHubClient.issues.createComment(slug, pr.number, body);
-      }
-    }
-
-    if (isGoldenChange) {
-      final String body = config.goldenBreakingChangeMessage;
       if (!await _alreadyCommented(gitHubClient, pr, slug, body)) {
         await gitHubClient.issues.createComment(slug, pr.number, body);
       }

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -97,14 +97,14 @@ class GithubWebhook extends RequestHandler<Body> {
         // If it was closed without merging, cancel any outstanding tryjobs.
         // We'll leave unfinished jobs if it was merged since we care about those
         // results.
-      if (!pr.merged) {
-        await luciBuildService.cancelBuilds(
-          pullRequestEvent.repository.slug(),
-          pr.number,
-          pr.head.sha,
-          'Pull request closed',
-        );
-      }
+        if (!pr.merged) {
+          await luciBuildService.cancelBuilds(
+            pullRequestEvent.repository.slug(),
+            pr.number,
+            pr.head.sha,
+            'Pull request closed',
+          );
+        }
         break;
       case 'edited':
         // Editing a PR should not trigger new jobs, but may update whether

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:cocoon_service/src/model/github/checks.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
@@ -28,7 +27,7 @@ final RegExp kEngineTestRegExp = RegExp(r'tests?\.(dart|java|mm|m|cc)$');
 
 @immutable
 class GithubWebhook extends RequestHandler<Body> {
-  GithubWebhook(Config config, this.buildBucketClient, this.luciBuildService, this.githubChecksService)
+  const GithubWebhook(Config config, this.buildBucketClient, this.luciBuildService, this.githubChecksService)
       : assert(buildBucketClient != null),
         super(config: config);
 

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -235,7 +235,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     RepositorySlug slug,
   ) async {
     String body;
-    if (await _isFirstComment(gitHubClient, pr, slug)) {
+    if (await _alreadyCommented(gitHubClient, pr, slug)) {
       body = config.flutterGoldInitialAlert(_getTriageUrl(pr.number));
     } else {
       body = config.flutterGoldFollowUpAlert(_getTriageUrl(pr.number));
@@ -259,20 +259,6 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       }
     }
     return false;
-  }
-
-  Future<bool> _isFirstComment(
-    GitHub gitHubClient,
-    PullRequest pr,
-    RepositorySlug slug,
-  ) async {
-    final Stream<IssueComment> comments = gitHubClient.issues.listCommentsByIssue(slug, pr.number);
-    await for (IssueComment comment in comments) {
-      if (comment.body.contains(config.flutterGoldInitialAlert(_getTriageUrl(pr.number)))) {
-        return false;
-      }
-    }
-    return true;
   }
 }
 

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -91,7 +91,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       final List<dynamic> cirrusChecks =
           cirrusResults.firstWhere((CirrusResult cirrusResult) => cirrusResult.branch == 'pull/${pr.number}').tasks;
       for (dynamic check in cirrusChecks) {
-        final String status = check['status'] as String;
+        final String status = check['status'].toUpperCase() as String;
         final String taskName = check['name'] as String;
 
         log.debug('Found Cirrus build status for pull request #${pr.number}, commit '
@@ -130,9 +130,9 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         log.debug('Found luci checks: $checkRuns');
         for (Map<String, dynamic> checkRun in checkRuns) {
           final String name = checkRun['name'] as String;
-          if (checkRun['status'] != 'COMPLETED') {
+          if (checkRun['status'] != null && checkRun['status'].toUpperCase() != 'COMPLETED') {
             luciIncompleteChecks.add(name);
-          } else if (checkRun['conclusion'] != 'SUCCESS') {
+          } else if (checkRun['conclusion'] != null && checkRun['conclusion'].toUpperCase() != 'SUCCESS') {
             luciIncompleteChecks.add(name);
           }
         }
@@ -333,16 +333,6 @@ query ChecksForPullRequest($sPullRequest: int!) {
       commits(last: 1) {
         nodes {
           commit {
-            abbreviatedOid
-            oid
-            committedDate
-            pushedDate
-            status {
-              contexts {
-                context
-                state
-              }
-            }
             # (appId: 64368) == flutter-dashboard. We only care about
             # flutter-dashboard checks.
             checkSuites(last: 1, filterBy: {appId: 64368}) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -276,8 +276,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       if (comment.body.contains(config.flutterGoldInitialAlert(_getTriageUrl(pr.number)))) {
         return false;
       }
-      return true;
     }
+    return true;
   }
 }
 

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -240,7 +240,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     RepositorySlug slug,
   ) async {
     String body;
-    if (await _alreadyCommented(gitHubClient, pr, slug)) {
+    if (await _isFirstComment(gitHubClient, pr, slug)) {
       body = config.flutterGoldInitialAlert(_getTriageUrl(pr.number));
     } else {
       body = config.flutterGoldFollowUpAlert(_getTriageUrl(pr.number));
@@ -264,6 +264,20 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       }
     }
     return false;
+  }
+
+  Future<bool> _isFirstComment(
+    GitHub gitHubClient,
+    PullRequest pr,
+    RepositorySlug slug,
+  ) async {
+    final Stream<IssueComment> comments = gitHubClient.issues.listCommentsByIssue(slug, pr.number);
+    await for (IssueComment comment in comments) {
+      if (comment.body.contains(config.flutterGoldInitialAlert(_getTriageUrl(pr.number)))) {
+        return false;
+      }
+      return true;
+    }
   }
 }
 

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -119,7 +119,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         final Map<String, dynamic> commit = prData['commits']['nodes'].single['commit'] as Map<String, dynamic>;
         List<Map<String, dynamic>> checkRuns;
         if (commit['checkSuites']['nodes'] != null && (commit['checkSuites']['nodes'] as List<dynamic>).isNotEmpty) {
-          checkRuns = (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
+          checkRuns = (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>)
+              .cast<Map<String, dynamic>>();
         }
         checkRuns = checkRuns ?? <Map<String, dynamic>>[];
         log.debug('Found luci checks: $checkRuns');
@@ -140,12 +141,16 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           // should just be pending. Any draft PRs are considered pending
           // until marked ready for review.
           log.debug('Waiting for checks to be completed.');
-          statusRequest =
-              _createStatus(GithubGoldStatusUpdate.statusRunning, config.flutterGoldPending, pr.number);
+          statusRequest = _createStatus(GithubGoldStatusUpdate.statusRunning, config.flutterGoldPending, pr.number);
         } else {
           // Get Gold status.
           final String goldStatus = await _getGoldStatus(pr, log);
-          statusRequest = _createStatus(goldStatus, goldStatus == GithubGoldStatusUpdate.statusRunning ? config.flutterGoldChanges : config.flutterGoldSuccess, pr.number);
+          statusRequest = _createStatus(
+              goldStatus,
+              goldStatus == GithubGoldStatusUpdate.statusRunning
+                  ? config.flutterGoldChanges
+                  : config.flutterGoldSuccess,
+              pr.number);
           log.debug('New status for potential update: ${statusRequest.state}, ${statusRequest.description}');
           if (goldStatus == GithubGoldStatusUpdate.statusRunning && !await _alreadyCommented(gitHubClient, pr, slug)) {
             log.debug('Notifying for triage.');
@@ -262,11 +267,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   }
 }
 
-Future<Map<String, dynamic>> _queryGraphQL(
-  Logging log,
-  GraphQLClient client,
-  int prNumber
-) async {
+Future<Map<String, dynamic>> _queryGraphQL(Logging log, GraphQLClient client, int prNumber) async {
   final QueryResult result = await client.query(
     QueryOptions(
       document: pullRequestChecksQuery,

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -35,7 +35,6 @@ void main() {
     MockPullRequestsService pullRequestsService;
     MockBuildBucketClient mockBuildBucketClient;
     RequestHandlerTester tester;
-    MockHttpClient mockHttpClient;
     const String serviceAccountEmail = 'test@test';
     LuciBuildService luciBuildService;
     ServiceAccountInfo serviceAccountInfo;
@@ -54,7 +53,6 @@ void main() {
       request = FakeHttpRequest();
       config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
       gitHubClient = MockGitHub();
-      mockHttpClient = MockHttpClient();
       issuesService = MockIssuesService();
       pullRequestsService = MockPullRequestsService();
       mockBuildBucketClient = MockBuildBucketClient();
@@ -73,8 +71,7 @@ void main() {
 
       mockGithubChecksService = MockGithubChecksService();
 
-      webhook = GithubWebhook(config, mockBuildBucketClient, luciBuildService, mockGithubChecksService,
-          skiaClient: mockHttpClient);
+      webhook = GithubWebhook(config, mockBuildBucketClient, luciBuildService, mockGithubChecksService);
 
       when(gitHubClient.issues).thenReturn(issuesService);
       when(gitHubClient.pullRequests).thenReturn(pullRequestsService);
@@ -83,7 +80,6 @@ void main() {
       config.wrongBaseBranchPullRequestMessageValue = 'wrongBaseBranchPullRequestMessage';
       config.releaseBranchPullRequestMessageValue = 'releaseBranchPullRequestMessage';
       config.missingTestsPullRequestMessageValue = 'missingTestPullRequestMessage';
-      config.goldenTriageMessageValue = 'goldenTriageMessage';
       config.githubOAuthTokenValue = 'githubOAuthKey';
       config.webhookKeyValue = keyString;
       config.githubClient = gitHubClient;
@@ -169,12 +165,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -219,12 +209,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -274,12 +258,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -323,12 +301,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -366,12 +338,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -417,12 +383,6 @@ void main() {
         ]),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -490,11 +450,6 @@ void main() {
         );
       });
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-
       await tester.post(webhook);
 
       verify(issuesService.addLabelsToIssue(
@@ -537,11 +492,6 @@ void main() {
           responses: <Response>[],
         );
       });
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
       await tester.post(webhook);
 
@@ -586,11 +536,6 @@ void main() {
           responses: <Response>[],
         );
       });
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
       await tester.post(webhook);
 
@@ -637,11 +582,6 @@ void main() {
           responses: <Response>[],
         );
       });
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
       await tester.post(webhook);
 
@@ -695,164 +635,6 @@ void main() {
       ));
     });
 
-    test('Labels Golden changes based on Skia Gold ignore, comments to notify', () async {
-      const int issueNumber = 1234;
-      request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = jsonTemplate('opened', issueNumber, kDefaultBranchName);
-      final Uint8List body = utf8.encode(request.body) as Uint8List;
-      final Uint8List key = utf8.encode(keyString) as Uint8List;
-      final String hmac = getHmac(body, key);
-      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
-      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-
-      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer((_) => Stream<PullRequestFile>.value(
-            PullRequestFile()..filename = 'some_change.dart',
-          ));
-
-      when(issuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer(
-        (_) => Stream<IssueComment>.value(
-          IssueComment()..body = 'some other comment',
-        ),
-      );
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(
-          utf8.encode(skiaIgnoreTemplate(pullRequestNumber: issueNumber.toString())) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
-        return const BatchResponse(
-          responses: <Response>[],
-        );
-      });
-
-      await tester.post(webhook);
-
-      verify(issuesService.addLabelsToIssue(
-        slug,
-        issueNumber,
-        <String>[
-          'will affect goldens',
-          'a: tests',
-        ],
-      )).called(1);
-    });
-
-    test('Golden triage comment when closed && merged from ignores', () async {
-      const int issueNumber = 1234;
-      request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = jsonTemplate(
-        'closed',
-        issueNumber,
-        kDefaultBranchName,
-        merged: true,
-      );
-      final Uint8List body = utf8.encode(request.body) as Uint8List;
-      final Uint8List key = utf8.encode(keyString) as Uint8List;
-      final String hmac = getHmac(body, key);
-      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
-      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-
-      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer((_) => Stream<PullRequestFile>.value(
-            PullRequestFile()..filename = 'some_change.dart',
-          ));
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(
-          utf8.encode(skiaIgnoreTemplate(pullRequestNumber: issueNumber.toString())) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-
-      await tester.post(webhook);
-
-      verify(issuesService.createComment(
-        slug,
-        issueNumber,
-        argThat(contains(config.goldenTriageMessageValue)),
-      )).called(1);
-    });
-
-    test('No golden triage comment when closed && !merged from labels', () async {
-      const int issueNumber = 123;
-      request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = jsonTemplate('closed', issueNumber, kDefaultBranchName);
-      final Uint8List body = utf8.encode(request.body) as Uint8List;
-      final Uint8List key = utf8.encode(keyString) as Uint8List;
-      final String hmac = getHmac(body, key);
-      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
-      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-
-      when(issuesService.listLabelsByIssue(any, issueNumber)).thenAnswer((_) {
-        return Stream<IssueLabel>.fromIterable(<IssueLabel>[
-          IssueLabel()..name = 'will affect goldens',
-        ]);
-      });
-
-      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
-        return const BatchResponse(
-          responses: <Response>[
-            Response(
-              searchBuilds: SearchBuildsResponse(
-                builds: <Build>[],
-              ),
-            ),
-          ],
-        );
-      });
-
-      await tester.post(webhook);
-
-      verifyNever(issuesService.createComment(
-        slug,
-        issueNumber,
-        argThat(contains(config.goldenTriageMessageValue)),
-      ));
-    });
-
-    test('No golden triage comment when closed && !merged from ignores', () async {
-      const int issueNumber = 1234;
-      request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = jsonTemplate('closed', issueNumber, kDefaultBranchName);
-      final Uint8List body = utf8.encode(request.body) as Uint8List;
-      final Uint8List key = utf8.encode(keyString) as Uint8List;
-      final String hmac = getHmac(body, key);
-      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
-      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-
-      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer((_) => Stream<PullRequestFile>.value(
-            PullRequestFile()..filename = 'some_change.dart',
-          ));
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(
-          utf8.encode(skiaIgnoreTemplate(pullRequestNumber: issueNumber.toString())) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-
-      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
-        return const BatchResponse(
-          responses: <Response>[
-            Response(
-              searchBuilds: SearchBuildsResponse(
-                builds: <Build>[],
-              ),
-            ),
-          ],
-        );
-      });
-
-      await tester.post(webhook);
-
-      verifyNever(issuesService.createComment(
-        slug,
-        issueNumber,
-        argThat(contains(config.goldenTriageMessageValue)),
-      ));
-    });
-
     test('Cancels builds when pull request is closed without merging', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
@@ -866,13 +648,6 @@ void main() {
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer((_) => Stream<PullRequestFile>.value(
             PullRequestFile()..filename = 'some_change.dart',
           ));
-
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(
-          utf8.encode(skiaIgnoreTemplate(pullRequestNumber: issueNumber.toString())) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
@@ -924,13 +699,7 @@ void main() {
             PullRequestFile()..filename = 'some_change.dart',
           ));
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
-      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+     when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
         );
@@ -973,12 +742,6 @@ void main() {
         ),
       );
 
-      final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-      final MockHttpClientResponse mockHttpResponse =
-          MockHttpClientResponse(utf8.encode(skiaIgnoreTemplate()) as Uint8List);
-      when(mockHttpClient.getUrl(Uri.parse('https://flutter-gold.skia.org/json/ignores')))
-          .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-      when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
@@ -1406,26 +1169,10 @@ class MockPullRequestsService extends Mock implements PullRequestsService {}
 // ignore: must_be_immutable
 class MockBuildBucketClient extends Mock implements BuildBucketClient {}
 
-String skiaIgnoreTemplate({String pullRequestNumber = '0000'}) {
-  return '''
-    [
-      {
-        "id": "7579425228619212078",
-        "name": "contributor@getMail.com",
-        "updatedBy": "contributor@getMail.com",
-        "expires": "2019-09-06T21:28:18.815336Z",
-        "query": "ext=png&name=widgets.golden_file_test",
-        "note": "https://github.com/flutter/flutter/pull/$pullRequestNumber"
-      }
-    ]
-  ''';
-}
-
 String jsonTemplate(String action, int number, String baseRef,
         {String login = 'flutter',
         String headRef = 'wait_for_reassemble',
         bool includeCqLabel = false,
-        bool includeGoldLabel = false,
         bool isDraft = false,
         bool merged = false,
         String repoFullName = 'flutter/flutter',
@@ -1493,15 +1240,6 @@ String jsonTemplate(String action, int number, String baseRef,
         "color": "207de5",
         "default": false
       },
-      ${includeGoldLabel ? '''
-      {
-        "id": 283480100,
-        "node_id": "MDU6TGFiZWwyODM0ODAxMDA=",
-        "url": "https://api.github.com/repos/$repoFullName/labels/tool",
-        "name": "will affect goldens",
-        "color": "5319e7",
-        "default": false
-      },''' : ''}
       ${includeCqLabel ? '''
       {
         "id": 283480100,

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -83,7 +83,6 @@ void main() {
       config.wrongBaseBranchPullRequestMessageValue = 'wrongBaseBranchPullRequestMessage';
       config.releaseBranchPullRequestMessageValue = 'releaseBranchPullRequestMessage';
       config.missingTestsPullRequestMessageValue = 'missingTestPullRequestMessage';
-      config.goldenBreakingChangeMessageValue = 'goldenBreakingChangeMessage';
       config.goldenTriageMessageValue = 'goldenTriageMessage';
       config.githubOAuthTokenValue = 'githubOAuthKey';
       config.webhookKeyValue = keyString;
@@ -735,15 +734,8 @@ void main() {
         issueNumber,
         <String>[
           'will affect goldens',
-          'severe: API break',
           'a: tests',
         ],
-      )).called(1);
-
-      verify(issuesService.createComment(
-        slug,
-        issueNumber,
-        argThat(contains(config.goldenBreakingChangeMessageValue)),
       )).called(1);
     });
 

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -699,7 +699,7 @@ void main() {
             PullRequestFile()..filename = 'some_change.dart',
           ));
 
-     when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[],
         );

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -118,7 +118,6 @@ void main() {
           return Stream<PullRequest>.fromIterable(prsFromGitHub);
         });
         config.githubClient = github;
-        config.goldenBreakingChangeMessageValue = 'goldenBreakingChangeMessage';
         clientContext.isDevelopmentEnvironment = false;
       });
 
@@ -176,14 +175,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -225,14 +223,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -262,14 +259,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -310,14 +306,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -370,14 +365,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -413,14 +407,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
       });
@@ -460,14 +453,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -513,14 +505,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -573,14 +564,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           )).called(1);
 
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           )).called(1);
         });
 
@@ -634,14 +624,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           )).called(1);
 
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           )).called(1);
         });
 
@@ -694,7 +683,6 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           )).called(1);
 
@@ -754,14 +742,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -799,14 +786,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
 
@@ -844,14 +830,13 @@ void main() {
             pr.number,
             <String>[
               'will affect goldens',
-              'severe: API break',
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(config.goldenBreakingChangeMessageValue)),
+            argThat(contains('Changes reported for pull request')),
           ));
         });
       });
@@ -945,14 +930,13 @@ void main() {
           pr.number,
           <String>[
             'will affect goldens',
-            'severe: API break',
           ],
         ));
 
         verifyNever(issuesService.createComment(
           slug,
           pr.number,
-          argThat(contains(config.goldenBreakingChangeMessageValue)),
+          argThat(contains('Changes reported for pull request')),
         ));
       });
     });

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -27,6 +27,8 @@ import '../src/service/fake_graphql_client.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
+  const String kGoldenFileLabel = 'will affect goldens';
+
   group('PushGoldStatusToGithub', () {
     FakeConfig config;
     FakeClientContext clientContext;
@@ -77,6 +79,12 @@ void main() {
         return createGithubQueryResult(luciStatuses);
       };
       config.githubGraphQLClient = githubGraphQLClient;
+      config.flutterGoldPendingValue = 'pending';
+      config.flutterGoldChangesValue = 'changes';
+      config.flutterGoldSuccessValue = 'success';
+      config.flutterGoldAlertConstantValue = 'flutter gold alert';
+      config.flutterGoldInitialAlertValue = 'initial';
+      config.flutterGoldFollowUpAlertValue = 'follow-up';
 
       handler = PushGoldStatusToGithub(
         config,
@@ -197,14 +205,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -216,7 +224,7 @@ void main() {
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
-            'This check is waiting for other checks to finish.',
+            config.flutterGoldPendingValue,
           );
           db.values[status.key] = status;
 
@@ -245,14 +253,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -264,7 +272,7 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusCompleted,
               'abc',
-              'All golden file tests have passed.');
+              config.flutterGoldSuccessValue,);
           db.values[status.key] = status;
 
           // Checks complete
@@ -284,14 +292,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -305,7 +313,7 @@ void main() {
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
-            'This check is waiting for the all clear from Gold.',
+            config.flutterGoldPendingValue,
           );
           db.values[status.key] = status;
 
@@ -333,14 +341,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -354,9 +362,7 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusRunning,
               'abc',
-              'Image changes have been found for '
-                  'this pull request. Visit https://flutter-gold.skia.org/changelists '
-                  'to view and triage (e.g. because this is an intentional change).');
+              config.flutterGoldChangesValue,);
           db.values[status.key] = status;
 
           // Checks complete
@@ -380,8 +386,7 @@ void main() {
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
             (_) => Stream<IssueComment>.value(
               IssueComment()
-                ..body = 'Changes reported for pull request '
-                    '#${pr.number} at sha ${pr.head.sha}',
+                ..body = config.flutterGoldCommentID(pr),
             ),
           );
 
@@ -396,14 +401,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -439,14 +444,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
       });
@@ -485,14 +490,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -540,14 +545,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -603,14 +608,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           )).called(1);
 
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           )).called(1);
         });
 
@@ -624,7 +629,7 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusRunning,
               'abc',
-              'This check is waiting for all other checks to be completed.');
+              config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks complete
@@ -670,14 +675,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           )).called(1);
 
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           )).called(1);
         });
 
@@ -690,7 +695,7 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusRunning,
               'abc',
-              'This check is waiting for all other checks to be completed.');
+              config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks complete
@@ -723,7 +728,7 @@ void main() {
             (_) => Stream<IssueComment>.value(
               IssueComment()
                 ..body =
-                    'Golden file changes have been found for this pull request.',
+                    config.flutterGoldInitialAlertValue,
             ),
           );
 
@@ -738,7 +743,7 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           )).called(1);
 
@@ -746,7 +751,7 @@ void main() {
             slug,
             pr.number,
             argThat(contains(
-                'Golden file changes are available for triage from new commit,')),
+                config.flutterGoldFollowUpAlertValue)),
           )).called(1);
         });
 
@@ -759,7 +764,7 @@ void main() {
               pr,
               GithubGoldStatusUpdate.statusRunning,
               'abc',
-              'This check is waiting for all other checks to be completed.');
+              config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks completed
@@ -805,14 +810,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -851,14 +856,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
 
@@ -896,14 +901,14 @@ void main() {
             slug,
             pr.number,
             <String>[
-              'will affect goldens',
+              kGoldenFileLabel,
             ],
           ));
 
           verifyNever(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains('Changes reported for pull request')),
+            argThat(contains(config.flutterGoldCommentID(pr))),
           ));
         });
       });
@@ -921,7 +926,7 @@ void main() {
             completedPR,
             GithubGoldStatusUpdate.statusCompleted,
             'abc',
-            'All golden file tests have passed');
+            config.flutterGoldSuccessValue);
         final GithubGoldStatusUpdate followUpStatus =
             newStatusUpdate(followUpPR, '', '', '');
         db.values[completedStatus.key] = completedStatus;
@@ -982,7 +987,7 @@ void main() {
           pr,
           GithubGoldStatusUpdate.statusRunning,
           'abc',
-          'This check is waiting for the all clear from Gold.',
+          config.flutterGoldPendingValue,
         );
         db.values[status.key] = status;
 
@@ -994,8 +999,8 @@ void main() {
         luciStatuses = <dynamic>[
           <String, String>{
             'name': 'Linux',
-            'status': 'in_progress',
-            'conclusion': 'neutral'
+            'status': null,
+            'conclusion': null,
           }
         ];
 
@@ -1010,14 +1015,14 @@ void main() {
           slug,
           pr.number,
           <String>[
-            'will affect goldens',
+            kGoldenFileLabel,
           ],
         ));
 
         verifyNever(issuesService.createComment(
           slug,
           pr.number,
-          argThat(contains('Changes reported for pull request')),
+          argThat(contains(config.flutterGoldCommentID(pr))),
         ));
       });
     });

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -67,14 +67,12 @@ void main() {
         maxAttempts: 2,
       );
 
-      cirrusGraphQLClient.mutateResultForOptions =
-          (MutationOptions options) => QueryResult();
+      cirrusGraphQLClient.mutateResultForOptions = (MutationOptions options) => QueryResult();
       cirrusGraphQLClient.queryResultForOptions = (QueryOptions options) {
         return createCirrusQueryResult(cirrusStatuses, branch);
       };
 
-      githubGraphQLClient.mutateResultForOptions =
-          (MutationOptions options) => QueryResult();
+      githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => QueryResult();
       githubGraphQLClient.queryResultForOptions = (QueryOptions options) {
         return createGithubQueryResult(luciStatuses);
       };
@@ -113,11 +111,8 @@ void main() {
 
       test('Does nothing', () async {
         config.githubClient = ThrowingGitHub();
-        db.onCommit =
-            (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
-                throw AssertionError();
-        db.addOnQuery<GithubGoldStatusUpdate>(
-            (Iterable<GithubGoldStatusUpdate> results) {
+        db.onCommit = (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) => throw AssertionError();
+        db.addOnQuery<GithubGoldStatusUpdate>((Iterable<GithubGoldStatusUpdate> results) {
           throw AssertionError();
         });
         final Body body = await tester.get<Body>(handler);
@@ -147,8 +142,7 @@ void main() {
         clientContext.isDevelopmentEnvironment = false;
       });
 
-      GithubGoldStatusUpdate newStatusUpdate(
-          PullRequest pr, String statusUpdate, String sha, String description) {
+      GithubGoldStatusUpdate newStatusUpdate(PullRequest pr, String statusUpdate, String sha, String description) {
         return GithubGoldStatusUpdate(
           key: db.emptyKey.append(GithubGoldStatusUpdate),
           status: statusUpdate,
@@ -160,8 +154,7 @@ void main() {
         );
       }
 
-      PullRequest newPullRequest(int number, String sha, String baseRef,
-          {bool draft = false}) {
+      PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false}) {
         return PullRequest()
           ..number = 123
           ..head = (PullRequestHead()..sha = 'abc')
@@ -171,11 +164,8 @@ void main() {
 
       group('does not update GitHub or Datastore', () {
         setUp(() {
-          db.onCommit =
-              (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) =>
-                  throw AssertionError();
-          when(repositoriesService.createStatus(any, any, any))
-              .thenThrow(AssertionError());
+          db.onCommit = (List<gcloud_db.Model> insert, List<gcloud_db.Key> deletes) => throw AssertionError();
+          when(repositoriesService.createStatus(any, any, any)).thenThrow(AssertionError());
         });
 
         test('if there are no PRs', () async {
@@ -234,11 +224,7 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'in_progress',
-              'conclusion': 'neutral'
-            }
+            <String, String>{'name': 'Linux', 'status': 'in_progress', 'conclusion': 'neutral'}
           ];
           branch = 'pull/123';
 
@@ -269,10 +255,11 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr,
-              GithubGoldStatusUpdate.statusCompleted,
-              'abc',
-              config.flutterGoldSuccessValue,);
+            pr,
+            GithubGoldStatusUpdate.statusCompleted,
+            'abc',
+            config.flutterGoldSuccessValue,
+          );
           db.values[status.key] = status;
 
           // Checks complete
@@ -303,9 +290,7 @@ void main() {
           ));
         });
 
-        test(
-            'same commit, cirrus checks complete, luci still running, last status running',
-            () async {
+        test('same commit, cirrus checks complete, luci still running, last status running', () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
@@ -323,11 +308,7 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'in_progress',
-              'conclusion': 'neutral'
-            }
+            <String, String>{'name': 'Linux', 'status': 'in_progress', 'conclusion': 'neutral'}
           ];
 
           final Body body = await tester.get<Body>(handler);
@@ -352,17 +333,17 @@ void main() {
           ));
         });
 
-        test(
-            'same commit, checks complete, last status & gold status is running/awaiting triage, should not comment',
+        test('same commit, checks complete, last status & gold status is running/awaiting triage, should not comment',
             () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr,
-              GithubGoldStatusUpdate.statusRunning,
-              'abc',
-              config.flutterGoldChangesValue,);
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldChangesValue,
+          );
           db.values[status.key] = status;
 
           // Checks complete
@@ -373,20 +354,16 @@ void main() {
 
           // Gold status is running
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
             (_) => Stream<IssueComment>.value(
-              IssueComment()
-                ..body = config.flutterGoldCommentID(pr),
+              IssueComment()..body = config.flutterGoldCommentID(pr),
             ),
           );
 
@@ -412,8 +389,7 @@ void main() {
           ));
         });
 
-        test('does nothing for branches not staged to land on master',
-            () async {
+        test('does nothing for branches not staged to land on master', () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'release');
           prsFromGitHub = <PullRequest>[pr];
@@ -426,11 +402,7 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
 
           final Body body = await tester.get<Body>(handler);
@@ -470,11 +442,7 @@ void main() {
             <String, String>{'status': 'EXECUTING', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'in_progress',
-              'conclusion': 'neutral'
-            }
+            <String, String>{'name': 'Linux', 'status': 'in_progress', 'conclusion': 'neutral'}
           ];
           branch = 'pull/123';
 
@@ -514,24 +482,17 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
           // Change detected by Gold
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobEmpty()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
@@ -556,8 +517,7 @@ void main() {
           ));
         });
 
-        test('new commit, checks complete, change detected, should comment',
-            () async {
+        test('new commit, checks complete, change detected, should comment', () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
@@ -570,24 +530,17 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
           // Change detected by Gold
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
@@ -619,17 +572,13 @@ void main() {
           )).called(1);
         });
 
-        test(
-            'same commit, checks complete, last status was waiting & gold status is needing triage, should comment',
+        test('same commit, checks complete, last status was waiting & gold status is needing triage, should comment',
             () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr,
-              GithubGoldStatusUpdate.statusRunning,
-              'abc',
-              config.flutterGoldPendingValue);
+          final GithubGoldStatusUpdate status =
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks complete
@@ -638,24 +587,17 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
           // Gold status is running
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
@@ -686,16 +628,12 @@ void main() {
           )).called(1);
         });
 
-        test('uses shorter comment after first comment to reduce noise',
-            () async {
+        test('uses shorter comment after first comment to reduce noise', () async {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr,
-              GithubGoldStatusUpdate.statusRunning,
-              'abc',
-              config.flutterGoldPendingValue);
+          final GithubGoldStatusUpdate status =
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks complete
@@ -704,31 +642,22 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'completed': 'in_progress',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'completed': 'in_progress', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
           // Gold status is running
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobDigests()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
             (_) => Stream<IssueComment>.value(
-              IssueComment()
-                ..body =
-                    config.flutterGoldInitialAlertValue,
+              IssueComment()..body = config.flutterGoldInitialAlertValue,
             ),
           );
 
@@ -750,21 +679,16 @@ void main() {
           verify(issuesService.createComment(
             slug,
             pr.number,
-            argThat(contains(
-                config.flutterGoldFollowUpAlertValue)),
+            argThat(contains(config.flutterGoldFollowUpAlertValue)),
           )).called(1);
         });
 
-        test('same commit, checks complete, new status, should not comment',
-            () async {
+        test('same commit, checks complete, new status, should not comment', () async {
           // Same commit: abc
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
-              pr,
-              GithubGoldStatusUpdate.statusRunning,
-              'abc',
-              config.flutterGoldPendingValue);
+          final GithubGoldStatusUpdate status =
+              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue);
           db.values[status.key] = status;
 
           // Checks completed
@@ -773,24 +697,17 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
           // New status: completed/triaged/no changes
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-          final MockHttpClientResponse mockHttpResponse =
-              MockHttpClientResponse(utf8.encode(tryjobEmpty()));
+          final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
           when(mockHttpClient.getUrl(Uri.parse(
                   'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
-              .thenAnswer(
-                  (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-          when(mockHttpRequest.close()).thenAnswer(
-              (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+              .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+          when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
             (_) => Stream<IssueComment>.value(
@@ -821,11 +738,9 @@ void main() {
           ));
         });
 
-        test('delivers pending state for draft PRs, does not query Gold',
-            () async {
+        test('delivers pending state for draft PRs, does not query Gold', () async {
           // New commit, draft PR
-          final PullRequest pr =
-              newPullRequest(123, 'abc', 'master', draft: true);
+          final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
@@ -836,11 +751,7 @@ void main() {
             <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'success'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
           ];
           branch = 'pull/123';
 
@@ -867,8 +778,7 @@ void main() {
           ));
         });
 
-        test('delivers pending state for failing checks, does not query Gold',
-            () async {
+        test('delivers pending state for failing checks, does not query Gold', () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
@@ -881,11 +791,7 @@ void main() {
             <String, String>{'status': 'ABORTED', 'name': 'framework-2'}
           ];
           luciStatuses = <dynamic>[
-            <String, String>{
-              'name': 'Linux',
-              'status': 'completed',
-              'conclusion': 'failure'
-            }
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'failure'}
           ];
           branch = 'pull/123';
 
@@ -913,22 +819,16 @@ void main() {
         });
       });
 
-      test(
-          'Completed pull request does not skip follow-up prs with early return',
-          () async {
+      test('Completed pull request does not skip follow-up prs with early return', () async {
         final PullRequest completedPR = newPullRequest(123, 'abc', 'master');
         final PullRequest followUpPR = newPullRequest(456, 'def', 'master');
         prsFromGitHub = <PullRequest>[
           completedPR,
           followUpPR,
         ];
-        final GithubGoldStatusUpdate completedStatus = newStatusUpdate(
-            completedPR,
-            GithubGoldStatusUpdate.statusCompleted,
-            'abc',
-            config.flutterGoldSuccessValue);
-        final GithubGoldStatusUpdate followUpStatus =
-            newStatusUpdate(followUpPR, '', '', '');
+        final GithubGoldStatusUpdate completedStatus =
+            newStatusUpdate(completedPR, GithubGoldStatusUpdate.statusCompleted, 'abc', config.flutterGoldSuccessValue);
+        final GithubGoldStatusUpdate followUpStatus = newStatusUpdate(followUpPR, '', '', '');
         db.values[completedStatus.key] = completedStatus;
         db.values[followUpStatus.key] = followUpStatus;
 
@@ -938,31 +838,22 @@ void main() {
           <String, String>{'status': 'COMPLETED', 'name': 'framework-2'}
         ];
         luciStatuses = <dynamic>[
-          <String, String>{
-            'name': 'Linux',
-            'status': 'completed',
-            'conclusion': 'success'
-          }
+          <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
         ];
         branch = 'pull/123';
 
         // New status: completed/triaged/no changes
         final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
-        final MockHttpClientResponse mockHttpResponse =
-            MockHttpClientResponse(utf8.encode(tryjobEmpty()));
+        final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
         when(mockHttpClient.getUrl(Uri.parse(
                 'http://flutter-gold.skia.org/json/changelist/github/${completedPR.number}/${completedPR.head.sha}/untriaged')))
-            .thenAnswer(
-                (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+            .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
         when(mockHttpClient.getUrl(Uri.parse(
                 'http://flutter-gold.skia.org/json/changelist/github/${followUpPR.number}/${followUpPR.head.sha}/untriaged')))
-            .thenAnswer(
-                (_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
-        when(mockHttpRequest.close()).thenAnswer(
-            (_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
+            .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
+        when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
-        when(issuesService.listCommentsByIssue(slug, completedPR.number))
-            .thenAnswer(
+        when(issuesService.listCommentsByIssue(slug, completedPR.number)).thenAnswer(
           (_) => Stream<IssueComment>.value(
             IssueComment()..body = 'some other comment',
           ),
@@ -978,8 +869,7 @@ void main() {
         expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
       });
 
-      test('accounts for null status description when parsing for Luci builds',
-          () async {
+      test('accounts for null status description when parsing for Luci builds', () async {
         // Same commit
         final PullRequest pr = newPullRequest(123, 'abc', 'master');
         prsFromGitHub = <PullRequest>[pr];
@@ -1039,16 +929,8 @@ QueryResult createCirrusQueryResult(List<dynamic> statuses, String branch) {
           'id': '1',
           'branch': branch,
           'latestGroupTasks': <dynamic>[
-            <String, dynamic>{
-              'id': '1',
-              'name': statuses.first['name'],
-              'status': statuses.first['status']
-            },
-            <String, dynamic>{
-              'id': '2',
-              'name': statuses.last['name'],
-              'status': statuses.last['status']
-            }
+            <String, dynamic>{'id': '1', 'name': statuses.first['name'], 'status': statuses.first['status']},
+            <String, dynamic>{'id': '2', 'name': statuses.last['name'], 'status': statuses.last['status']}
           ],
         }
       ],

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -30,7 +30,6 @@ class FakeConfig implements Config {
     this.wrongBaseBranchPullRequestMessageValue,
     this.wrongHeadBranchPullRequestMessageValue,
     this.releaseBranchPullRequestMessageValue,
-    this.goldenBreakingChangeMessageValue,
     this.goldenTriageMessageValue,
     this.webhookKeyValue,
     this.luciTryBuildersValue,
@@ -66,7 +65,6 @@ class FakeConfig implements Config {
   String wrongBaseBranchPullRequestMessageValue;
   String wrongHeadBranchPullRequestMessageValue;
   String releaseBranchPullRequestMessageValue;
-  String goldenBreakingChangeMessageValue;
   String goldenTriageMessageValue;
   String webhookKeyValue;
   String flutterBuildValue;
@@ -141,9 +139,6 @@ class FakeConfig implements Config {
 
   @override
   String get releaseBranchPullRequestMessage => releaseBranchPullRequestMessageValue;
-
-  @override
-  String get goldenBreakingChangeMessage => goldenBreakingChangeMessageValue;
 
   @override
   String get goldenTriageMessage => goldenTriageMessageValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -30,7 +30,6 @@ class FakeConfig implements Config {
     this.wrongBaseBranchPullRequestMessageValue,
     this.wrongHeadBranchPullRequestMessageValue,
     this.releaseBranchPullRequestMessageValue,
-    this.goldenTriageMessageValue,
     this.webhookKeyValue,
     this.luciTryBuildersValue,
     this.luciProdBuildersValue,
@@ -46,6 +45,13 @@ class FakeConfig implements Config {
     this.flutterBuildDescriptionValue,
     this.flutterBranchesValue,
     this.maxRecordsValue,
+    this.flutterGoldPendingValue,
+    this.flutterGoldSuccessValue,
+    this.flutterGoldChangesValue,
+    this.flutterGoldInitialAlertValue,
+    this.flutterGoldFollowUpAlertValue,
+    this.flutterGoldAlertConstantValue,
+    this.flutterGoldCommentIDValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -65,7 +71,6 @@ class FakeConfig implements Config {
   String wrongBaseBranchPullRequestMessageValue;
   String wrongHeadBranchPullRequestMessageValue;
   String releaseBranchPullRequestMessageValue;
-  String goldenTriageMessageValue;
   String webhookKeyValue;
   String flutterBuildValue;
   String flutterBuildDescriptionValue;
@@ -79,6 +84,13 @@ class FakeConfig implements Config {
   RepositorySlug flutterSlugValue;
   List<String> flutterBranchesValue;
   int maxRecordsValue;
+  String flutterGoldPendingValue;
+  String flutterGoldSuccessValue;
+  String flutterGoldChangesValue;
+  String flutterGoldInitialAlertValue;
+  String flutterGoldFollowUpAlertValue;
+  String flutterGoldAlertConstantValue;
+  String flutterGoldCommentIDValue;
 
   @override
   int get luciTryInfraFailureRetries => luciTryInfraFailureRetriesValue;
@@ -114,6 +126,27 @@ class FakeConfig implements Config {
   int get maxRecords => maxRecordsValue;
 
   @override
+  String get flutterGoldPending => flutterGoldPendingValue;
+
+  @override
+  String get flutterGoldSuccess => flutterGoldSuccessValue;
+
+  @override
+  String get flutterGoldChanges => flutterGoldChangesValue;
+
+  @override
+  String flutterGoldInitialAlert(String url) => flutterGoldInitialAlertValue;
+
+  @override
+  String flutterGoldFollowUpAlert(String url) => flutterGoldFollowUpAlertValue;
+
+  @override
+  String get flutterGoldAlertConstant => flutterGoldAlertConstantValue;
+
+  @override
+  String flutterGoldCommentID(PullRequest pr) => flutterGoldCommentIDValue;
+
+  @override
   int get commitNumber => commitNumberValue;
 
   @override
@@ -139,9 +172,6 @@ class FakeConfig implements Config {
 
   @override
   String get releaseBranchPullRequestMessage => releaseBranchPullRequestMessageValue;
-
-  @override
-  String get goldenTriageMessage => goldenTriageMessageValue;
 
   @override
   Future<String> get webhookKey async => webhookKeyValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -48,10 +48,9 @@ class FakeConfig implements Config {
     this.flutterGoldPendingValue,
     this.flutterGoldSuccessValue,
     this.flutterGoldChangesValue,
+    this.flutterGoldAlertConstantValue,
     this.flutterGoldInitialAlertValue,
     this.flutterGoldFollowUpAlertValue,
-    this.flutterGoldAlertConstantValue,
-    this.flutterGoldCommentIDValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -87,10 +86,9 @@ class FakeConfig implements Config {
   String flutterGoldPendingValue;
   String flutterGoldSuccessValue;
   String flutterGoldChangesValue;
+  String flutterGoldAlertConstantValue;
   String flutterGoldInitialAlertValue;
   String flutterGoldFollowUpAlertValue;
-  String flutterGoldAlertConstantValue;
-  String flutterGoldCommentIDValue;
 
   @override
   int get luciTryInfraFailureRetries => luciTryInfraFailureRetriesValue;
@@ -144,7 +142,7 @@ class FakeConfig implements Config {
   String get flutterGoldAlertConstant => flutterGoldAlertConstantValue;
 
   @override
-  String flutterGoldCommentID(PullRequest pr) => flutterGoldCommentIDValue;
+  String flutterGoldCommentID(PullRequest pr) => 'PR ${pr.number}, at ${pr.head.sha}';
 
   @override
   int get commitNumber => commitNumberValue;


### PR DESCRIPTION
This updates and refactors the functionality of the flutter-dashboard bot as it relates to the flutter-gold check.
- Fixes https://github.com/flutter/flutter/issues/62682
  - Bot was broken by switch from status to check
  - follows the same pattern of `check_for_waiting_pull_requests` to query checkSuites, have not found a way to confirm yet
  - updated tests
- Removes gold logic from the `github_webhook`
  - This is no longer applicable
  - updated tests
- Updates the config to include flutter-gold Strings for status and notifications
  - updated fake config and relevant tests