### PR TITLE
Save engine build status to bigquery

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:github/github.dart';
+import 'package:googleapis/bigquery/v2.dart';
 
 import '../foundation/typedefs.dart';
 
@@ -98,4 +99,26 @@ Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClie
   }
   final List<dynamic> builderList = builderMap['builders'] as List<dynamic>;
   return builderList.map((dynamic builder) => builder as Map<String, dynamic>).toList();
+}
+
+Future<void> insertBigquery(
+    String tableName, Map<String, dynamic> data, TabledataResourceApi tabledataResourceApi, Logging log) async {
+  // Define const variables for [BigQuery] operations.
+  const String projectId = 'flutter-dashboard';
+  const String dataset = 'cocoon';
+  final String table = tableName;
+  final List<Map<String, Object>> requestRows = <Map<String, Object>>[];
+
+  requestRows.add(<String, Object>{
+    'json': data,
+  });
+
+  // Obtain [rows] to be inserted to [BigQuery].
+  final TableDataInsertAllRequest request = TableDataInsertAllRequest.fromJson(<String, Object>{'rows': requestRows});
+
+  try {
+    await tabledataResourceApi.insertAll(request, projectId, dataset, table);
+  } on ApiRequestError {
+    log.warning('Failed to add build status to BigQuery: $ApiRequestError');
+  }
 }

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:github/github.dart';
-import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -41,10 +41,10 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    //if (authContext.clientContext.isDevelopmentEnvironment) {
+    if (authContext.clientContext.isDevelopmentEnvironment) {
       // Don't push GitHub status from the local dev server.
-    //  return Body.empty;
-    //}
+      return Body.empty;
+    }
 
     final LuciService luciService = luciServiceProvider(this);
     final Map<LuciBuilder, List<LuciTask>> luciTasks = await luciService.getRecentTasks(repo: 'engine');
@@ -65,7 +65,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
       'Repo': 'engine'
     };
     await insertBigquery(bigqueryTableName, bigqueryData, await config.createTabledataResourceApi(), log);
-/*
+
     final RepositorySlug slug = RepositorySlug('flutter', 'engine');
     final DatastoreService datastore = datastoreProvider(config.db);
     final GitHub github = await config.createGitHubClient(slug.owner, slug.name);
@@ -95,7 +95,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
       }
     }
     await datastore.insert(updates);
-    log.debug('Committed all updates');*/
+    log.debug('Committed all updates');
     return Body.empty;
   }
 

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -177,11 +177,11 @@ void main() {
       FakeLogging log;
 
       setUp(() {
-      tabledataResourceApi = FakeTabledataResourceApi();
-      log = FakeLogging();
-    });
+        tabledataResourceApi = FakeTabledataResourceApi();
+        log = FakeLogging();
+      });
       test('Insert data to bigquery', () async {
-        await insertBigquery('test', <String, dynamic>{'test':'test'}, tabledataResourceApi, log);
+        await insertBigquery('test', <String, dynamic>{'test': 'test'}, tabledataResourceApi, log);
         final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
         expect(tableDataList.totalRows, '1');
       });

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -7,9 +7,12 @@ import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:github/github.dart';
+import 'package:googleapis/bigquery/v2.dart';
 import 'package:test/test.dart';
+
 import 'package:cocoon_service/src/foundation/utils.dart';
 
+import '../src/bigquery/fake_tabledata_resource.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/fake_logging.dart';
 
@@ -166,6 +169,21 @@ void main() {
         final RepositorySlug result = await repoNameForBuilder(builders, 'Cocoon');
         expect(result, isNotNull);
         expect(result.fullName, equals('flutter/cocoon'));
+      });
+    });
+
+    group('bigquery', () {
+      FakeTabledataResourceApi tabledataResourceApi;
+      FakeLogging log;
+
+      setUp(() {
+      tabledataResourceApi = FakeTabledataResourceApi();
+      log = FakeLogging();
+    });
+      test('Insert data to bigquery', () async {
+        await insertBigquery('test', <String, dynamic>{'test':'test'}, tabledataResourceApi, log);
+        final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
+        expect(tableDataList.totalRows, '1');
       });
     });
   });

--- a/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
-import 'package:googleapis/bigquery/v2.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -121,12 +120,8 @@ void main() {
 
       expect(status.status, 'success');
       await tester.get(handler);
-      final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
       expect(status.status, 'failure');
       expect(status.updateTimeMillis, isNotNull);
-
-      /// Test for [BigQuery] insert
-      expect(tableDataList.totalRows, '1');
     });
   });
 }


### PR DESCRIPTION
Framework build status has been collected to monitor the tree status. It would be useful to track the build status of Engine as well.  
By saving status to BigQuery, we can further show its trending chart in datastudio.

\cc @pcsosinski 