### PR TITLE
Add repo support when querying supported luci builders for different repos

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -75,7 +75,7 @@ class Config {
     return await getBuilders(Providers.freshHttpClient, loggingService, twoSecondLinearBackoff, bucket);
   }
 
-  Future<List<Map<String, dynamic>>> _getRepoLuciBuilders(String bucket, String repo) async {
+  Future<List<Map<String, dynamic>>> getRepoLuciBuilders(String bucket, String repo) async {
     return await getRepoBuilders(Providers.freshHttpClient, loggingService, twoSecondLinearBackoff, bucket, repo);
   }
 
@@ -115,15 +115,6 @@ class Config {
   Future<List<Map<String, dynamic>>> get luciTryBuilders => _getLuciBuilders('try');
 
   Future<List<Map<String, dynamic>>> get luciProdBuilders => _getLuciBuilders('prod');
-
-  Future<List<Map<String, dynamic>>> get flutterLuciTryBuilders => _getRepoLuciBuilders('try', 'flutter');
-  Future<List<Map<String, dynamic>>> get engineLuciTryBuilders => _getRepoLuciBuilders('try', 'engine');
-  Future<List<Map<String, dynamic>>> get cocoonLuciTryBuilders => _getRepoLuciBuilders('try', 'cocoon');
-  Future<List<Map<String, dynamic>>> get packagesLuciTryBuilders => _getRepoLuciBuilders('try', 'pacakges');
-  Future<List<Map<String, dynamic>>> get flutterLuciProdBuilders => _getRepoLuciBuilders('prod', 'flutter');
-  Future<List<Map<String, dynamic>>> get engineLuciProdBuilders => _getRepoLuciBuilders('prod', 'engine');
-  Future<List<Map<String, dynamic>>> get cocoonLuciProdBuilders => _getRepoLuciBuilders('prod', 'cocoon');
-  Future<List<Map<String, dynamic>>> get packagesLuciProdBuilders => _getRepoLuciBuilders('prod', 'packages');
 
   Future<String> get oauthClientId => _getSingleValue('OAuthClientId');
 

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -75,6 +75,10 @@ class Config {
     return await getBuilders(Providers.freshHttpClient, loggingService, twoSecondLinearBackoff, bucket);
   }
 
+  Future<List<Map<String, dynamic>>> _getRepoLuciBuilders(String bucket, String repo) async {
+    return await getRepoBuilders(Providers.freshHttpClient, loggingService, twoSecondLinearBackoff, bucket, repo);
+  }
+
   Future<String> _getSingleValue(String id) async {
     final Uint8List cacheValue = await _cache.getOrCreate(
       configCacheName,
@@ -111,6 +115,15 @@ class Config {
   Future<List<Map<String, dynamic>>> get luciTryBuilders => _getLuciBuilders('try');
 
   Future<List<Map<String, dynamic>>> get luciProdBuilders => _getLuciBuilders('prod');
+
+  Future<List<Map<String, dynamic>>> get flutterLuciTryBuilders => _getRepoLuciBuilders('try', 'flutter');
+  Future<List<Map<String, dynamic>>> get engineLuciTryBuilders => _getRepoLuciBuilders('try', 'engine');
+  Future<List<Map<String, dynamic>>> get cocoonLuciTryBuilders => _getRepoLuciBuilders('try', 'cocoon');
+  Future<List<Map<String, dynamic>>> get packagesLuciTryBuilders => _getRepoLuciBuilders('try', 'pacakges');
+  Future<List<Map<String, dynamic>>> get flutterLuciProdBuilders => _getRepoLuciBuilders('prod', 'flutter');
+  Future<List<Map<String, dynamic>>> get engineLuciProdBuilders => _getRepoLuciBuilders('prod', 'engine');
+  Future<List<Map<String, dynamic>>> get cocoonLuciProdBuilders => _getRepoLuciBuilders('prod', 'cocoon');
+  Future<List<Map<String, dynamic>>> get packagesLuciProdBuilders => _getRepoLuciBuilders('prod', 'packages');
 
   Future<String> get oauthClientId => _getSingleValue('OAuthClientId');
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -94,12 +94,7 @@ Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClie
       branchHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/cocoon/master/app_dart/dev/$filename');
   builderContent ??= '{"builders":[]}';
   Map<String, dynamic> builderMap;
-  try {
-    builderMap = json.decode(builderContent) as Map<String, dynamic>;
-  } on FormatException catch (e) {
-    log.error('error: $e');
-    builderMap = <String, dynamic>{'builders': <dynamic>[]};
-  }
+  builderMap = json.decode(builderContent) as Map<String, dynamic>;
   final List<dynamic> builderList = builderMap['builders'] as List<dynamic>;
   return builderList.map((dynamic builder) => builder as Map<String, dynamic>).toList();
 }
@@ -107,19 +102,13 @@ Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClie
 /// Gets supported luci builders based on [bucket] and [repo] via GitHub http request.
 Future<List<Map<String, dynamic>>> getRepoBuilders(HttpClientProvider branchHttpClientProvider, Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator, String bucket, String repo) async {
-  String filePath = repo == 'engine' ? '$repo/master/ci/dev/' : '$repo/master/dev/';
+  final String filePath = repo == 'engine' ? '$repo/master/ci/dev/' : '$repo/master/dev/';
   final String fileName = bucket == 'try' ? 'try_builders.json' : 'prod_builders.json';
-  filePath = '$filePath$fileName';
   String builderContent =
-      await remoteFileContent(branchHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/$filePath');
+      await remoteFileContent(branchHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/$filePath$fileName');
   builderContent ??= '{"builders":[]}';
   Map<String, dynamic> builderMap;
-  try {
-    builderMap = json.decode(builderContent) as Map<String, dynamic>;
-  } on FormatException catch (e) {
-    log.error('error: $e');
-    builderMap = <String, dynamic>{'builders': <dynamic>[]};
-  }
+  builderMap = json.decode(builderContent) as Map<String, dynamic>;
   final List<dynamic> builderList = builderMap['builders'] as List<dynamic>;
   return builderList.map((dynamic builder) => builder as Map<String, dynamic>).toList();
 }

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -11,7 +11,6 @@ import 'package:appengine/appengine.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 
-import '../datastore/cocoon_config.dart';
 import '../foundation/typedefs.dart';
 
 /// Signature for a function that calculates the backoff duration to wait in
@@ -143,44 +142,4 @@ Future<void> insertBigquery(
   } on ApiRequestError {
     log.warning('Failed to add build status to BigQuery: $ApiRequestError');
   }
-}
-
-/// Returns luci try builders for difference repo by calling corresponding config getters.
-Future<List<Map<String, dynamic>>> getLuciTryBuilders(String repo, Config config) async {
-  List<Map<String, dynamic>> luciTryBuilders;
-  switch (repo) {
-    case 'flutter':
-      luciTryBuilders = await config.flutterLuciTryBuilders;
-      break;
-    case 'engine':
-      luciTryBuilders = await config.engineLuciTryBuilders;
-      break;
-    case 'cocoon':
-      luciTryBuilders = await config.cocoonLuciTryBuilders;
-      break;
-    case 'packages':
-      luciTryBuilders = await config.packagesLuciTryBuilders;
-      break;
-  }
-  return luciTryBuilders;
-}
-
-/// Returns luci prod builders for difference repo by calling corresponding config getters.
-Future<List<Map<String, dynamic>>> getLuciProdBuilders(String repo, Config config) async {
-  List<Map<String, dynamic>> luciProdBuilders;
-  switch (repo) {
-    case 'flutter':
-      luciProdBuilders = await config.flutterLuciProdBuilders;
-      break;
-    case 'engine':
-      luciProdBuilders = await config.engineLuciProdBuilders;
-      break;
-    case 'cocoon':
-      luciProdBuilders = await config.cocoonLuciProdBuilders;
-      break;
-    case 'packages':
-      luciProdBuilders = await config.packagesLuciProdBuilders;
-      break;
-  }
-  return luciProdBuilders;
 }

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -85,6 +85,8 @@ Future<RepositorySlug> repoNameForBuilder(List<Map<String, dynamic>> builders, S
 }
 
 /// Gets supported luci builders based on [bucket] via GitHub http request.
+///
+// TODO(keyonghan): to be removed when APIs are updated to call getRepoBuilders, https://github.com/flutter/flutter/issues/62429
 Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClientProvider, Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator, String bucket) async {
   final String filename = bucket == 'try' ? 'luci_try_builders.json' : 'luci_prod_builders.json';

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -85,6 +85,7 @@ Future<RepositorySlug> repoNameForBuilder(List<Map<String, dynamic>> builders, S
   return RepositorySlug('flutter', repoName);
 }
 
+/// Gets supported luci builders based on [bucket] via GitHub http request.
 Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClientProvider, Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator, String bucket) async {
   final String filename = bucket == 'try' ? 'luci_try_builders.json' : 'luci_prod_builders.json';
@@ -102,7 +103,7 @@ Future<List<Map<String, dynamic>>> getBuilders(HttpClientProvider branchHttpClie
   return builderList.map((dynamic builder) => builder as Map<String, dynamic>).toList();
 }
 
-/// Gets supported luci builders based on [bucket] via GitHub http request.
+/// Gets supported luci builders based on [bucket] and [repo] via GitHub http request.
 Future<List<Map<String, dynamic>>> getRepoBuilders(HttpClientProvider branchHttpClientProvider, Logging log,
     GitHubBackoffCalculator gitHubBackoffCalculator, String bucket, String repo) async {
   String filePath = repo == 'engine' ? '$repo/master/ci/dev/' : '$repo/master/dev/';
@@ -144,6 +145,7 @@ Future<void> insertBigquery(
   }
 }
 
+/// Returns luci try builders for difference repo by calling corresponding config getters.
 Future<List<Map<String, dynamic>>> getLuciTryBuilders(String repo, Config config) async {
   List<Map<String, dynamic>> luciTryBuilders;
   switch (repo) {
@@ -163,6 +165,7 @@ Future<List<Map<String, dynamic>>> getLuciTryBuilders(String repo, Config config
   return luciTryBuilders;
 }
 
+/// Returns luci prod builders for difference repo by calling corresponding config getters.
 Future<List<Map<String, dynamic>>> getLuciProdBuilders(String repo, Config config) async {
   List<Map<String, dynamic>> luciProdBuilders;
   switch (repo) {

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -127,14 +127,6 @@ void main() {
         expect(builders[0]['repo'], 'cocoon');
       });
 
-      test('logs error and returns empty list when json file is invalid', () async {
-        lucBuilderHttpClient.request.response.body = '{"builders":[';
-        final List<Map<String, dynamic>> builders =
-            await getBuilders(() => lucBuilderHttpClient, log, (int attempt) => Duration.zero, 'try');
-        expect(log.records.where(hasLevel(LogLevel.ERROR)), isNotEmpty);
-        expect(builders.length, 0);
-      });
-
       test('returns empty list when http request fails', () async {
         int retry = 0;
         lucBuilderHttpClient.onIssueRequest = (FakeHttpClientRequest request) => retry++;
@@ -161,14 +153,6 @@ void main() {
         expect(builders.length, 2);
         expect(builders[0]['name'], 'Cocoon');
         expect(builders[0]['repo'], 'cocoon');
-      });
-
-      test('logs error and returns empty list when json file is invalid', () async {
-        lucBuilderHttpClient.request.response.body = '{"builders":[';
-        final List<Map<String, dynamic>> builders =
-            await getRepoBuilders(() => lucBuilderHttpClient, log, (int attempt) => Duration.zero, 'try', 'test');
-        expect(log.records.where(hasLevel(LogLevel.ERROR)), isNotEmpty);
-        expect(builders.length, 0);
       });
 
       test('returns empty list when http request fails', () async {

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -35,6 +35,14 @@ class FakeConfig implements Config {
     this.webhookKeyValue,
     this.luciTryBuildersValue,
     this.luciProdBuildersValue,
+    this.flutterLuciTryBuildersValue,
+    this.flutterLuciProdBuildersValue,
+    this.engineLuciTryBuildersValue,
+    this.engineLuciProdBuildersValue,
+    this.cocoonLuciTryBuildersValue,
+    this.cocoonLuciProdBuildersValue,
+    this.packagesLuciTryBuildersValue,
+    this.packagesLuciProdBuildersValue,
     this.loggingServiceValue,
     this.tabledataResourceApi,
     this.githubService,
@@ -73,6 +81,14 @@ class FakeConfig implements Config {
   String flutterBuildDescriptionValue;
   List<Map<String, dynamic>> luciTryBuildersValue;
   List<Map<String, dynamic>> luciProdBuildersValue;
+  List<Map<String, dynamic>> flutterLuciTryBuildersValue;
+  List<Map<String, dynamic>> flutterLuciProdBuildersValue;
+  List<Map<String, dynamic>> engineLuciTryBuildersValue;
+  List<Map<String, dynamic>> engineLuciProdBuildersValue;
+  List<Map<String, dynamic>> cocoonLuciTryBuildersValue;
+  List<Map<String, dynamic>> cocoonLuciProdBuildersValue;
+  List<Map<String, dynamic>> packagesLuciTryBuildersValue;
+  List<Map<String, dynamic>> packagesLuciProdBuildersValue;
   Logging loggingServiceValue;
   String waitingForTreeToGoGreenLabelNameValue;
   ServiceAccountCredentials taskLogServiceAccountValue;
@@ -162,6 +178,30 @@ class FakeConfig implements Config {
 
   @override
   Future<List<Map<String, dynamic>>> get luciProdBuilders async => luciProdBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get flutterLuciTryBuilders async => flutterLuciTryBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get engineLuciTryBuilders async => engineLuciTryBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get cocoonLuciTryBuilders async => cocoonLuciTryBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get packagesLuciTryBuilders async => packagesLuciProdBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get flutterLuciProdBuilders async => flutterLuciProdBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get engineLuciProdBuilders async => engineLuciProdBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get cocoonLuciProdBuilders async => cocoonLuciProdBuildersValue;
+
+  @override
+  Future<List<Map<String, dynamic>>> get packagesLuciProdBuilders async => packagesLuciProdBuildersValue;
 
   @override
   Logging get loggingService => loggingServiceValue;

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/datastore/cocoon_config.dart';
@@ -35,14 +36,6 @@ class FakeConfig implements Config {
     this.webhookKeyValue,
     this.luciTryBuildersValue,
     this.luciProdBuildersValue,
-    this.flutterLuciTryBuildersValue,
-    this.flutterLuciProdBuildersValue,
-    this.engineLuciTryBuildersValue,
-    this.engineLuciProdBuildersValue,
-    this.cocoonLuciTryBuildersValue,
-    this.cocoonLuciProdBuildersValue,
-    this.packagesLuciTryBuildersValue,
-    this.packagesLuciProdBuildersValue,
     this.loggingServiceValue,
     this.tabledataResourceApi,
     this.githubService,
@@ -81,14 +74,6 @@ class FakeConfig implements Config {
   String flutterBuildDescriptionValue;
   List<Map<String, dynamic>> luciTryBuildersValue;
   List<Map<String, dynamic>> luciProdBuildersValue;
-  List<Map<String, dynamic>> flutterLuciTryBuildersValue;
-  List<Map<String, dynamic>> flutterLuciProdBuildersValue;
-  List<Map<String, dynamic>> engineLuciTryBuildersValue;
-  List<Map<String, dynamic>> engineLuciProdBuildersValue;
-  List<Map<String, dynamic>> cocoonLuciTryBuildersValue;
-  List<Map<String, dynamic>> cocoonLuciProdBuildersValue;
-  List<Map<String, dynamic>> packagesLuciTryBuildersValue;
-  List<Map<String, dynamic>> packagesLuciProdBuildersValue;
   Logging loggingServiceValue;
   String waitingForTreeToGoGreenLabelNameValue;
   ServiceAccountCredentials taskLogServiceAccountValue;
@@ -180,30 +165,6 @@ class FakeConfig implements Config {
   Future<List<Map<String, dynamic>>> get luciProdBuilders async => luciProdBuildersValue;
 
   @override
-  Future<List<Map<String, dynamic>>> get flutterLuciTryBuilders async => flutterLuciTryBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get engineLuciTryBuilders async => engineLuciTryBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get cocoonLuciTryBuilders async => cocoonLuciTryBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get packagesLuciTryBuilders async => packagesLuciProdBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get flutterLuciProdBuilders async => flutterLuciProdBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get engineLuciProdBuilders async => engineLuciProdBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get cocoonLuciProdBuilders async => cocoonLuciProdBuildersValue;
-
-  @override
-  Future<List<Map<String, dynamic>>> get packagesLuciProdBuilders async => packagesLuciProdBuildersValue;
-
-  @override
   Logging get loggingService => loggingServiceValue;
 
   @override
@@ -248,5 +209,10 @@ class FakeConfig implements Config {
   @override
   bool isChecksSupportedRepo(RepositorySlug slug) {
     return '${slug.owner}/${slug.name}' == 'flutter/cocoon';
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getRepoLuciBuilders(String bucket, String repo) async {
+    return (json.decode('[{"name": "Linux", "repo": "$repo"}]') as List<dynamic>).cast<Map<String, dynamic>>();
   }
 }


### PR DESCRIPTION
Existing cocoon supports querying luci builders as a whole for all different repos. Now we have moved configs to different repos, this PR provides logic to support querying targeted repo luci builders.

Old existing logic will be removed once we updated corresponding APIs to point to the new changes.

Related: https://github.com/flutter/flutter/issues/62429