### PR TITLE
Update luci builder json keys

### DIFF
--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -188,11 +188,11 @@ class LuciBuilder {
   final String repo;
 
   /// Flag the result of this builder as blocker or not.
-  @JsonKey(required: true, disallowNullValue: true)
+  @JsonKey()
   final bool flaky;
 
   /// The name of the devicelab task associated with this builder.
-  @JsonKey()
+  @JsonKey(name: 'task_name')
   final String taskName;
 
   /// Serializes this object to a JSON primitive.

--- a/app_dart/lib/src/service/luci.g.dart
+++ b/app_dart/lib/src/service/luci.g.dart
@@ -9,12 +9,12 @@ part of 'luci.dart';
 // **************************************************************************
 
 LuciBuilder _$LuciBuilderFromJson(Map<String, dynamic> json) {
-  $checkKeys(json, requiredKeys: const ['name', 'repo', 'flaky'], disallowNullValues: const ['name', 'repo', 'flaky']);
+  $checkKeys(json, requiredKeys: const ['name', 'repo'], disallowNullValues: const ['name', 'repo']);
   return LuciBuilder(
     name: json['name'] as String,
     repo: json['repo'] as String,
     flaky: json['flaky'] as bool,
-    taskName: json['taskName'] as String,
+    taskName: json['task_name'] as String,
   );
 }
 
@@ -29,7 +29,7 @@ Map<String, dynamic> _$LuciBuilderToJson(LuciBuilder instance) {
 
   writeNotNull('name', instance.name);
   writeNotNull('repo', instance.repo);
-  writeNotNull('flaky', instance.flaky);
-  val['taskName'] = instance.taskName;
+  val['flaky'] = instance.flaky;
+  val['task_name'] = instance.taskName;
   return val;
 }


### PR DESCRIPTION
This PR fixes below two errors:

```
NoSuchMethodError: The getter 'length' was called on null.
Receiver: null
Tried calling: length
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
#1      BuildBucketClient.batch (package:cocoon_service/src/service/buildbucket.dart:118:28)
<asynchronous suspension>
#2      LuciService.getBuilds (package:cocoon_service/src/service/luci.dart:150:65)
#3      LuciService.getBranchRecentTasks (package:cocoon_service/src/service/luci.dart:61:42)
<asynchronous suspension>
#4      RefreshChromebotStatus.get (package:cocoon_service/src/request_handlers/refresh_chromebot_status.dart:51:93)
#5      RequestHandler.service.<anonymous closure> (package:cocoon_service/src/request_handling/request_handler.dart:46:28)
<asynchronous suspension>
```

```
Instance of 'MissingRequiredKeysException'
#0      $checkKeys (package:json_annotation/src/allowed_keys_helpers.dart:26:7)
#1      _$LuciBuilderFromJson (package:cocoon_service/src/service/luci.g.dart:12:3)
#2      new LuciBuilder.fromJson (package:cocoon_service/src/service/luci.dart:180:62)
#3      LuciBuilder.getProdBuilders.<anonymous closure> (package:cocoon_service/src/service/luci.dart:204:68)
```

Related: https://github.com/flutter/cocoon/pull/904, https://github.com/flutter/flutter/pull/63492