### PR TITLE
Save taskName rather than builderName to datastore when refreshing github commits

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -203,7 +203,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
 
     final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
     for (LuciBuilder builder in prodBuilders) {
-      tasks.add(newTask(builder.name, 'chromebot', <String>['can-update-github'], builder.flaky, 0));
+      tasks.add(newTask(builder.taskName, 'chromebot', <String>['can-update-github'], builder.flaky, 0));
     }
 
     final YamlMap yaml = await _loadDevicelabManifest(sha);


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/904/files, just replacing builder name with taskName. Using builder name blocks refresh-chromebot-status API.

The result is dashboard fails to get updated.
<img width="189" alt="Screen Shot 2020-08-11 at 7 00 38 PM" src="https://user-images.githubusercontent.com/54558023/89966876-f8c71d00-dc04-11ea-94f6-09219d421ba2.png">
