### PR TITLE
Enable class BranchLuciBuilder as map key by overriding hashCode & ==

### DIFF
--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -164,6 +164,17 @@ class BranchLuciBuilder {
 
   final String branch;
   final LuciBuilder luciBuilder;
+
+  @override
+  int get hashCode => '${luciBuilder.toString()},$branch'.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is BranchLuciBuilder &&
+      other.luciBuilder.name == luciBuilder.name &&
+      other.luciBuilder.taskName == luciBuilder.taskName &&
+      other.luciBuilder.repo == luciBuilder.repo &&
+      other.luciBuilder.flaky == luciBuilder.flaky;
 }
 
 @immutable

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -10,13 +10,15 @@ void main() {
   BranchLuciBuilder branchLuciBuilder1;
   BranchLuciBuilder branchLuciBuilder2;
 
-  test('listCommits decodes all relevant fields of each commit', () async {
-    branchLuciBuilder1 = const BranchLuciBuilder(luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
-    branchLuciBuilder2 = const BranchLuciBuilder(luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
+  test('validates effectiveness of class BranchLuciBuilder as a map key', () async {
+    branchLuciBuilder1 = const BranchLuciBuilder(
+        luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
+    branchLuciBuilder2 = const BranchLuciBuilder(
+        luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
     final Map<BranchLuciBuilder, String> map = <BranchLuciBuilder, String>{};
     map[branchLuciBuilder1] = 'test1';
     map[branchLuciBuilder2] = 'test2';
-    
+
     expect(map[branchLuciBuilder1], 'test2');
   });
 }

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/service/luci.dart';
+
+import 'package:test/test.dart';
+
+void main() {
+  BranchLuciBuilder branchLuciBuilder1;
+  BranchLuciBuilder branchLuciBuilder2;
+
+  test('listCommits decodes all relevant fields of each commit', () async {
+    branchLuciBuilder1 = const BranchLuciBuilder(luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
+    branchLuciBuilder2 = const BranchLuciBuilder(luciBuilder: LuciBuilder(name: 'abc', repo: 'def', flaky: false, taskName: 'ghi'), branch: 'jkl');
+    final Map<BranchLuciBuilder, String> map = <BranchLuciBuilder, String>{};
+    map[branchLuciBuilder1] = 'test1';
+    map[branchLuciBuilder2] = 'test2';
+    
+    expect(map[branchLuciBuilder1], 'test2');
+  });
+}


### PR DESCRIPTION
Cocoon has been using `BranchLuciBuilder` as a map key when refreshing chromebot status. When multiple runs happen for a commit `sha`, the map is expected to update the value of existing key of `branchLuciBuilder`. But it treats the key (which shares same values) as a new key, failing to update with real LUCI statuses.

This PR fixes the above issue by overriding `hashCode` and operator `==`.