### PR TITLE
Fix calculation of engine github status.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -100,11 +100,8 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
 
   String _getLatestStatus(List<LuciTask> tasks) {
     for (LuciTask task in tasks) {
-      switch (task.status) {
-        case Task.statusFailed:
-          return GithubBuildStatusUpdate.statusFailure;
-        case Task.statusSucceeded:
-          return GithubBuildStatusUpdate.statusSuccess;
+      if (task.status == Task.statusFailed) {
+        return GithubBuildStatusUpdate.statusFailure;
       }
     }
     return GithubBuildStatusUpdate.statusSuccess;


### PR DESCRIPTION
The calculation of the engine github status was failing when the first
task succeded and subsequent tasks failed.

Bug:
  https://github.com/flutter/flutter/issues/64061