### PR TITLE
Change agent timeout from 10 to 30 minutes

### DIFF
--- a/app_dart/lib/src/request_handlers/update_agent_health_history.dart
+++ b/app_dart/lib/src/request_handlers/update_agent_health_history.dart
@@ -19,7 +19,9 @@ import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
 import '../service/datastore.dart';
 
-const Duration maxHealthCheckAge = Duration(minutes: 10);
+// Please also change [minutesUntilAgentIsUnresponsive] in
+// app_flutter/lib/logic/agent_health_details.dart to match this value.
+const Duration maxHealthCheckAge = Duration(minutes: 30);
 
 @immutable
 class UpdateAgentHealthHistory extends ApiRequestHandler<Body> {

--- a/app_flutter/lib/logic/agent_health_details.dart
+++ b/app_flutter/lib/logic/agent_health_details.dart
@@ -53,7 +53,7 @@ class AgentHealthDetails {
             hasSshConnectivity;
 
   @visibleForTesting
-  static const int minutesUntilAgentIsUnresponsive = 10;
+  static const int minutesUntilAgentIsUnresponsive = 30;
 
   static const String _hasSshConnectivity = 'ssh-connectivity: succeeded';
   static const String _hasHealthyDevices = 'has-healthy-devices: succeeded';

--- a/app_flutter/lib/logic/agent_health_details.dart
+++ b/app_flutter/lib/logic/agent_health_details.dart
@@ -52,6 +52,8 @@ class AgentHealthDetails {
             canPerformHealthCheck &&
             hasSshConnectivity;
 
+  // Please also change [maxHealthCheckAge] in
+  // app_dart/lib/src/request_handlers/update_agent_health_history.dart to match this value.
   @visibleForTesting
   static const int minutesUntilAgentIsUnresponsive = 30;
 


### PR DESCRIPTION
The agent dashboard often shows false warnings about agent timeouts, as health checks and test execution has increased the time between two agent pings. This PR will reduce false warnings by increasing the timeout to 30 minutes.

Also update the backend metrics calculation to use this new threshold.