### PR TITLE
Reland deleted logic to calculate tree status and add logging.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -100,10 +100,21 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
 
   String _getLatestStatus(List<LuciTask> tasks) {
     for (LuciTask task in tasks) {
-      if (task.status == Task.statusFailed) {
-        return GithubBuildStatusUpdate.statusFailure;
+      if (task.ref != 'refs/heads/master') {
+        log.debug('Skipping ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
+        continue;
+      }
+      switch (task.status) {
+        case Task.statusFailed:
+          log.debug('Using ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
+          return GithubBuildStatusUpdate.statusFailure;
+        case Task.statusSucceeded:
+          log.debug('Using ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
+          return GithubBuildStatusUpdate.statusSuccess;
       }
     }
-    return GithubBuildStatusUpdate.statusSuccess;
+    // No state means we don't have a state for the last 40 commits which should
+    // close the tree.
+    return GithubBuildStatusUpdate.statusFailure;
   }
 }

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -98,6 +98,8 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     return Body.empty;
   }
 
+  /// This function gets called with the last 40 builds fo a given builder ordered
+  /// by creation time starting with the last one first.
   String _getLatestStatus(List<LuciTask> tasks) {
     for (LuciTask task in tasks) {
       if (task.ref != 'refs/heads/master') {

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -110,6 +110,7 @@ class LuciService {
         ref: ref,
         status: _luciStatusToTaskStatus[build.status],
         buildNumber: build.number,
+        builderName: build.builderId.builder,
       ));
     }
     return results;
@@ -218,15 +219,17 @@ class LuciBuilder {
 
 @immutable
 class LuciTask {
-  const LuciTask({
-    @required this.commitSha,
-    @required this.ref,
-    @required this.status,
-    @required this.buildNumber,
-  })  : assert(commitSha != null),
+  const LuciTask(
+      {@required this.commitSha,
+      @required this.ref,
+      @required this.status,
+      @required this.buildNumber,
+      @required this.builderName})
+      : assert(commitSha != null),
         assert(ref != null),
         assert(status != null),
-        assert(buildNumber != null);
+        assert(buildNumber != null),
+        assert(builderName != null);
 
   /// The GitHub commit at which this task is being run.
   final String commitSha;
@@ -239,4 +242,7 @@ class LuciTask {
 
   /// The build number of this task.
   final int buildNumber;
+
+  /// The builder name of this task.
+  final String builderName;
 }

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -76,11 +76,11 @@ class LuciService {
       results[branchLuciBuilder] ??= <String, List<LuciTask>>{};
       results[branchLuciBuilder][commit] ??= <LuciTask>[];
       results[branchLuciBuilder][commit].add(LuciTask(
-        commitSha: commit,
-        ref: ref,
-        status: _luciStatusToTaskStatus[build.status],
-        buildNumber: build.number,
-      ));
+          commitSha: commit,
+          ref: ref,
+          status: _luciStatusToTaskStatus[build.status],
+          buildNumber: build.number,
+          builderName: build.builderId.builder));
     }
     return results;
   }

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -54,7 +54,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'def': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'def', ref: 'refs/heads/master', status: Task.statusSucceeded, buildNumber: 1)
+                          commitSha: 'def',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -85,7 +89,12 @@ void main() {
               key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'def': <LuciTask>[
-                      const LuciTask(commitSha: 'unknown', ref: 'unknown', status: Task.statusSucceeded, buildNumber: 1)
+                      const LuciTask(
+                          commitSha: 'unknown',
+                          ref: 'unknown',
+                          status: Task.statusSucceeded,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -110,7 +119,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'abc': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusSucceeded, buildNumber: 1)
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -136,7 +149,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'abc': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusSucceeded, buildNumber: 1)
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -164,7 +181,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'abc': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusSucceeded, buildNumber: 1)
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -190,9 +211,17 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'abc': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusSucceeded, buildNumber: 2),
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 2,
+                          builderName: 'abc'),
                       const LuciTask(
-                          commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusFailed, buildNumber: 1)
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusFailed,
+                          buildNumber: 1,
+                          builderName: 'abc')
                     ],
                   });
       when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
@@ -219,7 +248,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'def': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'def', ref: 'refs/heads/master', status: Task.statusFailed, buildNumber: 1),
+                          commitSha: 'def',
+                          ref: 'refs/heads/master',
+                          status: Task.statusFailed,
+                          buildNumber: 1,
+                          builderName: 'abc'),
                     ],
                   });
       final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> testLuciTasks =
@@ -229,7 +262,11 @@ void main() {
               value: (dynamic builder) => <String, List<LuciTask>>{
                     'def': <LuciTask>[
                       const LuciTask(
-                          commitSha: 'def', ref: 'refs/heads/test', status: Task.statusSucceeded, buildNumber: 2)
+                          commitSha: 'def',
+                          ref: 'refs/heads/test',
+                          status: Task.statusSucceeded,
+                          buildNumber: 2,
+                          builderName: 'abc')
                     ],
                   });
       luciTasks.addAll(testLuciTasks);


### PR DESCRIPTION
We are not sure yet what is causing the tree to status to be green when
there are failures. We are reverting the previous logic, using only
builds of master for the calculation and adding logs to identify the
cause of the problem when it happens again.

Bug:
  https://github.com/flutter/flutter/issues/64061