### PR TITLE
[app_dart] Ensure chromebot function returns a valid model

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -46,21 +46,23 @@ class Task extends Model {
   }
 
   // Represents a LUCI build.
-  Task.chromebot(
-    this.commitKey,
-    this.createTimestamp,
-    this.name,
-    this.isFlaky,
-  )   : assert(createTimestamp != null),
-        assert(name != null),
-        assert(isFlaky != null),
-        timeoutInMinutes = 0,
-        requiredCapabilities = <String>['can-update-github'],
-        stageName = 'chromebot' {
-    final Key key = commitKey?.append(Task);
-    parentKey = key?.parent;
-    id = key?.id;
-    status = Task.statusNew;
+  factory Task.chromebot(Key commitKey, int createTimestamp, String name, bool isFlaky) {
+    assert(commitKey != null);
+    assert(createTimestamp != null);
+    assert(name != null);
+    assert(isFlaky != null);
+
+    return Task(
+      key: commitKey.append(Task),
+      commitKey: commitKey,
+      createTimestamp: createTimestamp,
+      name: name,
+      isFlaky: isFlaky,
+      timeoutInMinutes: 0,
+      requiredCapabilities: <String>['can-update-github'],
+      stageName: 'chromebot',
+      status: Task.statusNew,
+    );
   }
 
   /// The task is yet to be run.

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -18,8 +19,20 @@ void main() {
       expect(() => Task()..status = 'unknown', throwsArgumentError);
     });
 
+    test('creates a valid chromebot task', () {
+      final DatastoreDB db = DatastoreDB(null);
+      final Key key = db.emptyKey.append(Task, id: 42);
+      final Task t = Task.chromebot(key, 123, 'taskName', false);
+      validateModel(t);
+    });
+
     test('disallows flaky be null', () {
       expect(() => Task.chromebot(null, 123, 'taskName', null), throwsA(isA<AssertionError>()));
     });
   });
+}
+
+void validateModel(Task task) {
+  // Throws an exception when property validation fails.
+  ModelDBImpl().toDatastoreEntity(task);
 }


### PR DESCRIPTION
The `startTimestamp` field was null and caused backend exceptions, this change will ensure the chromebot function returns a valid Task model.

Fix: https://github.com/flutter/flutter/issues/64265