### PR TITLE
Set cancelled status as failure to be able to re-run from github.

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -148,7 +148,9 @@ class GithubChecksService {
   github.CheckRunConclusion conclusionForResult(push_message.Result result) {
     switch (result) {
       case push_message.Result.canceled:
-        return github.CheckRunConclusion.cancelled;
+        // Set conclusion cancelled as a failure to ensure developers can retry
+        // tasks when builds timeout.
+        return github.CheckRunConclusion.failure;
       case push_message.Result.failure:
         return github.CheckRunConclusion.failure;
       case push_message.Result.success:


### PR DESCRIPTION
When a task times out a task the UI presents it as cancelled and does
not offer a re-run button. Setting cancelled as failed will show the
re-run button.

Bug:
  https://github.com/flutter/flutter/issues/64465