### PR TITLE
Update LUCI `DOWNLOAD ALL LOGS` url to correct builder page

### DIFF
--- a/app_flutter/lib/logic/qualified_task.dart
+++ b/app_flutter/lib/logic/qualified_task.dart
@@ -25,14 +25,16 @@ const String _luciUrl = 'https://ci.chromium.org/p/flutter';
 
 @immutable
 class QualifiedTask {
-  const QualifiedTask(this.stage, this.task);
+  const QualifiedTask(this.stage, this.task, this.builder);
 
   QualifiedTask.fromTask(Task task)
       : stage = task.stageName,
-        task = task.name;
+        task = task.name,
+        builder = task.builderName;
 
   final String stage;
   final String task;
+  final String builder;
 
   /// Get the URL for the configuration of this task.
   ///
@@ -54,21 +56,9 @@ class QualifiedTask {
       case StageName.cirrus:
         return '$_cirrusUrl/master';
       case StageName.luci:
-        return _luciSourceConfigurationUrl;
+        return '$_luciUrl/builders/luci.flutter.prod/$builder';
     }
     throw Exception('Failed to get source configuration url for $stage.');
-  }
-
-  String get _luciSourceConfigurationUrl {
-    switch (task) {
-      case 'mac_bot':
-        return '$_luciUrl/builders/luci.flutter.prod/Mac';
-      case 'linux_bot':
-        return '$_luciUrl/builders/luci.flutter.prod/Linux';
-      case 'windows_bot':
-        return '$_luciUrl/builders/luci.flutter.prod/Windows';
-    }
-    return _luciUrl;
   }
 
   /// Whether this task is run in the devicelab or not.

--- a/app_flutter/lib/logic/qualified_task.dart
+++ b/app_flutter/lib/logic/qualified_task.dart
@@ -25,7 +25,7 @@ const String _luciUrl = 'https://ci.chromium.org/p/flutter';
 
 @immutable
 class QualifiedTask {
-  const QualifiedTask(this.stage, this.task, this.builder);
+  const QualifiedTask({this.stage, this.task, this.builder});
 
   QualifiedTask.fromTask(Task task)
       : stage = task.stageName,

--- a/app_flutter/lib/widgets/task_grid.dart
+++ b/app_flutter/lib/widgets/task_grid.dart
@@ -147,7 +147,7 @@ class _TaskGridState extends State<TaskGrid> {
       commitCount += 1;
       for (final Stage stage in status.stages) {
         for (final Task task in stage.tasks) {
-          final QualifiedTask qualifiedTask = QualifiedTask(task.stageName, task.name);
+          final QualifiedTask qualifiedTask = QualifiedTask(task.stageName, task.name, task.builderName);
           if (commitCount <= 25) {
             double score = 0.0;
             if (task.attempts > 1) {

--- a/app_flutter/lib/widgets/task_grid.dart
+++ b/app_flutter/lib/widgets/task_grid.dart
@@ -147,7 +147,7 @@ class _TaskGridState extends State<TaskGrid> {
       commitCount += 1;
       for (final Stage stage in status.stages) {
         for (final Task task in stage.tasks) {
-          final QualifiedTask qualifiedTask = QualifiedTask(task.stageName, task.name, task.builderName);
+          final QualifiedTask qualifiedTask = QualifiedTask.fromTask(task);
           if (commitCount <= 25) {
             double score = 0.0;
             if (task.attempts > 1) {

--- a/app_flutter/test/logic/qualified_task_test.dart
+++ b/app_flutter/test/logic/qualified_task_test.dart
@@ -12,9 +12,10 @@ void main() {
   test('logUrl() for external tasks redirects to source configuration', () {
     final Task luciTask = Task()
       ..stageName = 'chromebot'
-      ..name = 'mac_bot';
+      ..name = 'abc'
+      ..builderName = 'def';
 
-    expect(logUrl(luciTask), 'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
+    expect(logUrl(luciTask), 'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/def');
     final Task cirrusTask = Task()..stageName = 'cirrus';
 
     expect(
@@ -47,10 +48,11 @@ void main() {
   test('QualifiedTask.sourceConfigurationUrl for luci', () {
     final Task luciTask = Task()
       ..stageName = 'chromebot'
-      ..name = 'mac_bot';
+      ..name = 'abc'
+      ..builderName = 'def';
 
     expect(QualifiedTask.fromTask(luciTask).sourceConfigurationUrl,
-        'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/Mac');
+        'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/def');
   });
 
   test('QualifiedTask.sourceConfigurationUrl for cirrus', () {
@@ -61,8 +63,8 @@ void main() {
   });
 
   test('QualifiedTask.isDevicelab', () {
-    expect(const QualifiedTask('devicelab', 'abc').isDevicelab, true);
-    expect(const QualifiedTask('devicelab_win', 'abc').isDevicelab, true);
-    expect(const QualifiedTask('cirrus', 'abc').isDevicelab, false);
+    expect(const QualifiedTask('devicelab', 'abc', null).isDevicelab, true);
+    expect(const QualifiedTask('devicelab_win', 'abc', null).isDevicelab, true);
+    expect(const QualifiedTask('cirrus', 'abc', null).isDevicelab, false);
   });
 }

--- a/app_flutter/test/logic/qualified_task_test.dart
+++ b/app_flutter/test/logic/qualified_task_test.dart
@@ -63,8 +63,8 @@ void main() {
   });
 
   test('QualifiedTask.isDevicelab', () {
-    expect(const QualifiedTask('devicelab', 'abc', null).isDevicelab, true);
-    expect(const QualifiedTask('devicelab_win', 'abc', null).isDevicelab, true);
-    expect(const QualifiedTask('cirrus', 'abc', null).isDevicelab, false);
+    expect(const QualifiedTask(stage: 'devicelab', task: 'abc').isDevicelab, true);
+    expect(const QualifiedTask(stage: 'devicelab_win', task: 'abc').isDevicelab, true);
+    expect(const QualifiedTask(stage: 'cirrus', task: 'abc').isDevicelab, false);
   });
 }

--- a/app_flutter/test/widgets/task_icon_test.dart
+++ b/app_flutter/test/widgets/task_icon_test.dart
@@ -20,7 +20,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stageName, taskName),
+            qualifiedTask: QualifiedTask(stageName, taskName, 'abc'),
           ),
         ),
       ),
@@ -42,7 +42,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
     urlLauncherChannel.setMockMethodCallHandler((MethodCall methodCall) async => log.add(methodCall));
 
-    const QualifiedTask devicelabTask = QualifiedTask('devicelab', 'test');
+    const QualifiedTask devicelabTask = QualifiedTask('devicelab', 'test', null);
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -79,7 +79,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('stage not to be named', 'macbeth'),
+            qualifiedTask: QualifiedTask('stage not to be named', 'macbeth', null),
           ),
         ),
       ),
@@ -93,7 +93,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('cirrus', 'task'),
+            qualifiedTask: QualifiedTask('cirrus', 'task', null),
           ),
         ),
       ),
@@ -108,7 +108,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('devicelab', 'task'),
+            qualifiedTask: QualifiedTask('devicelab', 'task', null),
           ),
         ),
       ),
@@ -123,7 +123,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('devicelab_win', 'task'),
+            qualifiedTask: QualifiedTask('devicelab_win', 'task', null),
           ),
         ),
       ),

--- a/app_flutter/test/widgets/task_icon_test.dart
+++ b/app_flutter/test/widgets/task_icon_test.dart
@@ -20,7 +20,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stageName, taskName, 'abc'),
+            qualifiedTask: QualifiedTask(stage: stageName, task: taskName),
           ),
         ),
       ),
@@ -42,7 +42,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
     urlLauncherChannel.setMockMethodCallHandler((MethodCall methodCall) async => log.add(methodCall));
 
-    const QualifiedTask devicelabTask = QualifiedTask('devicelab', 'test', null);
+    const QualifiedTask devicelabTask = QualifiedTask(stage: 'devicelab', task: 'test');
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -79,7 +79,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('stage not to be named', 'macbeth', null),
+            qualifiedTask: QualifiedTask(stage: 'stage not to be named', task: 'macbeth'),
           ),
         ),
       ),
@@ -93,7 +93,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('cirrus', 'task', null),
+            qualifiedTask: QualifiedTask(stage: 'cirrus', task: 'task'),
           ),
         ),
       ),
@@ -108,7 +108,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('devicelab', 'task', null),
+            qualifiedTask: QualifiedTask(stage: 'devicelab', task: 'task'),
           ),
         ),
       ),
@@ -123,7 +123,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask('devicelab_win', 'task', null),
+            qualifiedTask: QualifiedTask(stage: 'devicelab_win', task: 'task'),
           ),
         ),
       ),


### PR DESCRIPTION
This is to fix: https://github.com/flutter/flutter/issues/64669