### PR TITLE
Update endTimestamp for luci task when saving to bigquery

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -105,7 +105,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
       'ID': task.commitKey.id,
       'CreateTimestamp': task.createTimestamp,
       'StartTimestamp': task.startTimestamp,
-      'EndTimestamp': task.endTimestamp,
+      'EndTimestamp': DateTime.now().millisecondsSinceEpoch,
       'Name': task.name,
       'Attempts': task.attempts,
       'IsFlaky': task.isFlaky,


### PR DESCRIPTION
This is a follow-up of https://github.com/flutter/cocoon/pull/926.

Existing logic keeps saving 0 as endTimestamp, but we need to have this value to distinguish different records of same `sha` and same `name`.