### PR TITLE
Enable plugins repo for luci tests in cocoon

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -42,6 +42,7 @@ class Config {
     'flutter',
     'cocoon',
     'packages',
+    'plugins',
   };
 
   /// List of Github presubmit supported repos.

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -51,6 +51,7 @@ class Config {
     'flutter/engine',
     'flutter/flutter',
     'flutter/packages',
+    'flutter/plugins',
   };
 
   @visibleForTesting

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -96,7 +96,14 @@ Future<RepositorySlug> repoNameForBuilder(List<LuciBuilder> builders, String bui
 Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClientProvider luciHttpClientProvider,
     GitHubBackoffCalculator gitHubBackoffCalculator, Logging log, RepositorySlug slug, String bucket,
     {int prNumber, String commitSha = 'master'}) async {
-  final String filePath = slug.name == 'engine' ? '${slug.name}/$commitSha/ci/dev/' : '${slug.name}/$commitSha/dev/';
+  const Map<String, String> repoFilePathPrefix = <String, String>{
+    'flutter': 'dev',
+    'engine': 'ci/dev',
+    'cocoon': 'dev',
+    'plugins': '.ci/dev',
+    'packages': 'dev'
+  };
+  final String filePath = '${slug.name}/$commitSha/${repoFilePathPrefix[slug.name]}/';
   final String fileName = bucket == 'try' ? 'try_builders.json' : 'prod_builders.json';
   String builderContent =
       await remoteFileContent(luciHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/$filePath$fileName');

--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:cocoon_service/src/service/luci.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
@@ -20,8 +21,10 @@ class GetBranches extends RequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final List<String> branches = await config.flutterBranches;
+    //final List<String> branches = await config.flutterBranches;
+    final List<LuciBuilder> branches = await config.luciBuilders('prod', 'flutter');
 
-    return Body.forJson(<String, List<String>>{'Branches': branches});
+    //return Body.forJson(<String, List<String>>{'Branches': branches});
+    return Body.forJson(<String, List<LuciBuilder>>{'Branches': branches});
   }
 }

--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:cocoon_service/src/service/luci.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';

--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -21,10 +21,8 @@ class GetBranches extends RequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    //final List<String> branches = await config.flutterBranches;
-    final List<LuciBuilder> branches = await config.luciBuilders('prod', 'flutter');
+    final List<String> branches = await config.flutterBranches;
 
-    //return Body.forJson(<String, List<String>>{'Branches': branches});
-    return Body.forJson(<String, List<LuciBuilder>>{'Branches': branches});
+    return Body.forJson(<String, List<String>>{'Branches': branches});
   }
 }


### PR DESCRIPTION
This is to enable `flutter/plugins` repo in cocoon, so that LUCI try builders can be automatically triggered based on commits. `checks` validation is enabled as well.

Related issue: https://github.com/flutter/flutter/issues/56143