### PR TITLE
[app_dart] Create a FileService

### DIFF
--- a/app_dart/lib/src/model/devicelab/manifest.dart
+++ b/app_dart/lib/src/model/devicelab/manifest.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import '../appengine/agent.dart';
@@ -37,7 +38,7 @@ class Manifest {
 /// An individual task (test suite or benchmark) that runs in the Flutter
 /// devicelab.
 @JsonSerializable(anyMap: true)
-class ManifestTask {
+class ManifestTask extends Equatable {
   /// Creates a new [ManifestTask] object.
   const ManifestTask({
     this.description,
@@ -93,4 +94,20 @@ class ManifestTask {
 
   /// Serializes this object to a JSON primitive.
   Map<String, dynamic> toJson() => _$ManifestTaskToJson(this);
+
+  @override
+  String toString() {
+    final StringBuffer buf = StringBuffer()
+      ..write('$runtimeType(')
+      ..write('description: $description')
+      ..write(', stage: $stage')
+      ..write(', requiredAgentCapabilities: $requiredAgentCapabilities')
+      ..write(', isFlaky: $isFlaky')
+      ..write(', timeoutInMinutes: $timeoutInMinutes')
+      ..write(')');
+    return buf.toString();
+  }
+
+  @override
+  List<Object> get props => <Object>[description, stage, requiredAgentCapabilities, isFlaky, timeoutInMinutes];
 }

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -197,7 +197,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
 
     Manifest manifest;
     try {
-      manifest = await fileService.loadDevicelabManifest(sha, log);
+      manifest = await fileService.loadDevicelabManifest(sha);
     } catch (error) {
       response.headers.set(HttpHeaders.retryAfterHeader, '120');
       rethrow;

--- a/app_dart/lib/src/service/file_service.dart
+++ b/app_dart/lib/src/service/file_service.dart
@@ -1,0 +1,59 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:yaml/yaml.dart';
+
+import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
+import '../foundation/utils.dart';
+import '../model/devicelab/manifest.dart';
+import '../request_handling/exceptions.dart';
+
+/// FileService loads and parses the content of a file to useful data structures, typically from a remote location.
+class FileService {
+  const FileService(
+      {this.httpClientProvider = Providers.freshHttpClient, this.gitHubBackoffCalculator = twoSecondLinearBackoff});
+
+  final HttpClientProvider httpClientProvider;
+  final GitHubBackoffCalculator gitHubBackoffCalculator;
+
+  /// Loads the devicelab manifest from the flutter/flutter repository at [sha] revision.
+  /// Throws an HttpStatusException when GitHub doesn't respond.
+  Future<Manifest> loadDevicelabManifest(String sha, Logging logger) async {
+    final String path = '/flutter/flutter/$sha/dev/devicelab/manifest.yaml';
+    final Uri url = Uri.https('raw.githubusercontent.com', path);
+
+    final HttpClient client = httpClientProvider();
+    try {
+      for (int attempt = 0; attempt < 3; attempt++) {
+        final HttpClientRequest clientRequest = await client.getUrl(url);
+
+        try {
+          final HttpClientResponse clientResponse = await clientRequest.close();
+          final int status = clientResponse.statusCode;
+
+          if (status == HttpStatus.ok) {
+            final String content = await utf8.decoder.bind(clientResponse).join();
+            return Manifest.fromJson(loadYaml(content) as YamlMap);
+          } else {
+            logger.warning('Attempt to download manifest.yaml failed (HTTP $status)');
+          }
+        } catch (error, stackTrace) {
+          logger.error('Attempt to download manifest.yaml failed:\n$error\n$stackTrace');
+        }
+
+        await Future<void>.delayed(gitHubBackoffCalculator(attempt));
+      }
+    } finally {
+      client.close(force: true);
+    }
+
+    logger.error('GitHub not responding; giving up');
+    throw const HttpStatusException(HttpStatus.serviceUnavailable, 'GitHub not responding');
+  }
+}

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -197,6 +197,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.4"
   file:
     dependency: "direct main"
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   yaml: ^2.1.16
   corsac_jwt: ^0.2.2
   truncate: ^2.1.2
+  equatable: ^1.2.4
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -37,12 +37,12 @@ tasks:
 
 void main() {
   group('RefreshGithubCommits', () {
+    ApiRequestHandlerTester tester;
     FakeConfig config;
     FakeAuthenticationProvider auth;
     FakeDatastoreDB db;
     FakeHttpClient httpClient;
     FileService fileService;
-    ApiRequestHandlerTester tester;
     RefreshGithubCommits handler;
 
     List<String> githubCommits;
@@ -88,12 +88,15 @@ void main() {
 
       yieldedCommitCount = 0;
       db = FakeDatastoreDB();
+      tester = ApiRequestHandlerTester();
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi, githubService: githubService, dbValue: db);
       auth = FakeAuthenticationProvider();
       httpClient = FakeHttpClient();
-      fileService =
-          FileService(httpClientProvider: () => httpClient, gitHubBackoffCalculator: (int attempt) => Duration.zero);
-      tester = ApiRequestHandlerTester();
+      fileService = FileService(
+        httpClientProvider: () => httpClient,
+        gitHubBackoffCalculator: (int attempt) => Duration.zero,
+        loggingProvider: () => tester.log,
+      );
       handler = RefreshGithubCommits(
         config,
         auth,

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -11,6 +11,7 @@ import 'package:cocoon_service/src/request_handlers/refresh_github_commits.dart'
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/file_service.dart';
 import 'package:gcloud/db.dart' as gcloud_db;
 import 'package:gcloud/db.dart';
 import 'package:googleapis/bigquery/v2.dart';
@@ -40,7 +41,7 @@ void main() {
     FakeAuthenticationProvider auth;
     FakeDatastoreDB db;
     FakeHttpClient httpClient;
-    FakeHttpClient branchHttpClient;
+    FileService fileService;
     ApiRequestHandlerTester tester;
     RefreshGithubCommits handler;
 
@@ -90,15 +91,14 @@ void main() {
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi, githubService: githubService, dbValue: db);
       auth = FakeAuthenticationProvider();
       httpClient = FakeHttpClient();
-      branchHttpClient = FakeHttpClient();
+      fileService =
+          FileService(httpClientProvider: () => httpClient, gitHubBackoffCalculator: (int attempt) => Duration.zero);
       tester = ApiRequestHandlerTester();
       handler = RefreshGithubCommits(
         config,
         auth,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        httpClientProvider: () => httpClient,
-        branchHttpClientProvider: () => branchHttpClient,
-        gitHubBackoffCalculator: (int attempt) => Duration.zero,
+        fileService: fileService,
       );
 
       githubService.listCommitsBranch = (String branch, int hours) {

--- a/app_dart/test/service/file_service_test.dart
+++ b/app_dart/test/service/file_service_test.dart
@@ -1,0 +1,83 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/src/model/devicelab/manifest.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/file_service.dart';
+import 'package:test/test.dart';
+
+import '../src/request_handling/fake_http.dart';
+import '../src/request_handling/fake_logging.dart';
+
+const String singleTaskManifestYaml = '''
+tasks:
+  linux_test:
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+''';
+
+void main() {
+  group('FileService', () {
+    FakeHttpClient httpClient;
+    FakeLogging log;
+    FileService fileService;
+
+    setUp(() {
+      httpClient = FakeHttpClient();
+      log = FakeLogging();
+      fileService = FileService(
+        httpClientProvider: () => httpClient,
+        gitHubBackoffCalculator: (int attempt) => Duration.zero,
+        loggingProvider: () => log,
+      );
+    });
+
+    test('loads a manifest', () async {
+      httpClient.onIssueRequest = (FakeHttpClientRequest request) {
+        request.response.statusCode = HttpStatus.ok;
+      };
+      httpClient.request.response.body = singleTaskManifestYaml;
+
+      final Manifest manifest = await fileService.loadDevicelabManifest('sha123');
+      expect(manifest.tasks, <String, ManifestTask>{
+        'linux_test': const ManifestTask(
+          stage: 'devicelab',
+          requiredAgentCapabilities: <String>['linux/android'],
+          isFlaky: false,
+          timeoutInMinutes: 0,
+        )
+      });
+    });
+
+    test('retries manifest download upon HTTP failure', () async {
+      int retry = 0;
+      httpClient.onIssueRequest = (FakeHttpClientRequest request) {
+        request.response.statusCode = retry == 0 ? HttpStatus.serviceUnavailable : HttpStatus.ok;
+        retry++;
+      };
+      httpClient.request.response.body = singleTaskManifestYaml;
+
+      await fileService.loadDevicelabManifest('sha123');
+
+      expect(retry, 2);
+      expect(log.records.where(hasLevel(LogLevel.WARNING)), isNotEmpty);
+      expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+    });
+
+    test('gives up manifest download after 3 tries', () async {
+      int retry = 0;
+      httpClient.onIssueRequest = (FakeHttpClientRequest request) => retry++;
+      httpClient.request.response.statusCode = HttpStatus.serviceUnavailable;
+
+      await expectLater(fileService.loadDevicelabManifest('sha123'), throwsA(isA<HttpStatusException>()));
+
+      expect(retry, 3);
+      expect(log.records.where(hasLevel(LogLevel.WARNING)), isNotEmpty);
+      expect(log.records.where(hasLevel(LogLevel.ERROR)), isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Create a FileService for fetching remote file content. We need it in order to reuse `loadDevicelabManifest` in presubmit hooks. Also enhanced `ManifestTask` by adding `toString`, and `Equatable`.

Bug: https://github.com/flutter/flutter/issues/65046