### PR TITLE
Using builderName in luci prod config file when retrying Luci prod builder

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -60,11 +60,11 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     });
     String builder = task.builderName;
     if (builder == null) {
-        final List<LuciBuilder> builders = await config.luciBuilders('prod', 'flutter');
-        builder = builders
-            .where((LuciBuilder builder) => builder.taskName == task.name)
-            .map((LuciBuilder builder) => builder.name)
-            .single;
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', 'flutter');
+      builder = builders
+          .where((LuciBuilder builder) => builder.taskName == task.name)
+          .map((LuciBuilder builder) => builder.name)
+          .single;
     }
     await luciBuildService.rescheduleProdBuild(
       commitSha: commit.sha,

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -29,8 +29,9 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     Config config,
     AuthenticationProvider authenticationProvider,
     this.luciBuildService, {
-    @visibleForTesting this.datastoreProvider =  DatastoreService.defaultProvider,
-  })  : super(config: config, authenticationProvider: authenticationProvider);
+    @visibleForTesting DatastoreServiceProvider datastoreProvider,
+  })  : datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
+        super(config: config, authenticationProvider: authenticationProvider);
 
   final DatastoreServiceProvider datastoreProvider;
   final LuciBuildService luciBuildService;

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/luci.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:gcloud/db.dart';
 import 'package:meta/meta.dart';
@@ -28,9 +29,8 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     Config config,
     AuthenticationProvider authenticationProvider,
     this.luciBuildService, {
-    @visibleForTesting DatastoreServiceProvider datastoreProvider,
-  })  : datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
-        super(config: config, authenticationProvider: authenticationProvider);
+    @visibleForTesting this.datastoreProvider =  DatastoreService.defaultProvider,
+  })  : super(config: config, authenticationProvider: authenticationProvider);
 
   final DatastoreServiceProvider datastoreProvider;
   final LuciBuildService luciBuildService;
@@ -45,7 +45,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final ClientContext clientContext = authContext.clientContext;
     final KeyHelper keyHelper = KeyHelper(applicationContext: clientContext.applicationContext);
     final Key key = keyHelper.decode(encodedKey);
-    log.info('Rescheduling task with Key: $key');
+    log.info('Rescheduling task with Key: ${key.id}');
     final Task task = (await datastore.lookupByKey<Task>(<Key>[key])).single;
     if (task == null) {
       throw BadRequestException('No such task: $key');
@@ -57,14 +57,17 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final Commit commit = await datastore.db.lookupValue<Commit>(task.commitKey, orElse: () {
       throw BadRequestException('No such commit: ${task.commitKey}');
     });
-    const Map<String, String> builderMap = <String, String>{
-      'linux_bot': 'Linux',
-      'mac_bot': 'Mac',
-      'windows_bot': 'Windows',
-    };
+    String builder = task.builderName;
+    if (builder == null) {
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', 'flutter');
+        builder = builders
+            .where((LuciBuilder builder) => builder.taskName == task.name)
+            .map((LuciBuilder builder) => builder.name)
+            .single;
+    }
     await luciBuildService.rescheduleProdBuild(
       commitSha: commit.sha,
-      builderName: task.builderName ?? builderMap[task.name],
+      builderName: builder,
     );
     task
       ..status = Task.statusNew

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -93,6 +93,27 @@ void main() {
       expect(task.attempts, equals(1));
     });
 
+    test('Re-schedule existing task even though builderName is missing in the task', () async {
+      Task task = Task(
+          key: commit.key.append(Task, id: 4590522719010816),
+          commitKey: commit.key,
+          attempts: 0,
+          name: 'windows_bot',
+          status: 'Failed');
+      config.db.values[task.key] = task;
+      config.db.values[commit.key] = commit;
+      await tester.post(handler);
+      expect(
+        verify(mockLuciBuildService.rescheduleProdBuild(
+          commitSha: captureAnyNamed('commitSha'),
+          builderName: captureAnyNamed('builderName'),
+        )).captured,
+        <dynamic>['7d03371610c07953a5def50d500045941de516b8', 'Windows'],
+      );
+      task = config.db.values[task.key] as Task;
+      expect(task.attempts, equals(1));
+    });
+
     test('Does nothing if task already passed', () async {
       final Task task = Task(
           key: commit.key.append(Task, id: 4590522719010816),


### PR DESCRIPTION
This is to fix https://github.com/flutter/flutter/issues/64754, when `builderName` is missing in the task record.