### PR TITLE
[app_dart] Fix Dart 2.10 issue and log commands run in test_utilities

### DIFF
--- a/app_dart/test/src/request_handling/fake_http.dart
+++ b/app_dart/test/src/request_handling/fake_http.dart
@@ -858,6 +858,9 @@ class FakeHttpClientRequest extends FakeOutbound implements HttpClientRequest {
 
   @override
   Future<HttpClientResponse> get done => _doneCompleter.future;
+
+  @override
+  void abort([Object exception, StackTrace stackTrace]) => throw UnimplementedError();
 }
 
 class FakeHttpClientResponse extends FakeInbound implements HttpClientResponse {

--- a/app_flutter/lib/widgets/lattice.dart
+++ b/app_flutter/lib/widgets/lattice.dart
@@ -277,18 +277,18 @@ class _LatticeBodyElement extends RenderObjectElement implements _LatticeDelegat
   }
 
   @override
-  void insertChildRenderObject(RenderObject child, _Coordinate slot) {
+  void insertRenderObjectChild(RenderObject child, _Coordinate slot) {
     renderObject.placeChild(slot, child);
   }
 
   @override
-  void moveChildRenderObject(RenderObject child, _Coordinate slot) {
-    renderObject.placeChild(slot, child);
+  void moveRenderObjectChild(RenderObject child, _Coordinate oldSlot, _Coordinate newSlot) {
+    renderObject.placeChild(newSlot, child);
   }
 
   @override
-  void removeChildRenderObject(RenderObject child) {
-    renderObject.removeChild(child);
+  void removeRenderObjectChild(RenderObject child, _Coordinate slot) {
+    renderObject.removeChild(slot, child);
   }
 
   @override
@@ -545,8 +545,7 @@ class _RenderLatticeBody extends RenderBox {
     newChildParentData.coordinate = newCoordinate;
   }
 
-  void removeChild(RenderBox child) {
-    final _Coordinate coordinate = _childrenByRenderBox[child];
+  void removeChild(_Coordinate coordinate, RenderBox child) {
     _childrenByRenderBox.remove(child);
     if (coordinate != null) {
       _childrenByCoordinate.remove(coordinate);

--- a/app_flutter/lib/widgets/task_overlay.dart
+++ b/app_flutter/lib/widgets/task_overlay.dart
@@ -249,7 +249,9 @@ class TaskOverlayContents extends StatelessWidget {
     ///   3. Task ran (other status)
     final String runText = (task.status == TaskBox.statusInProgress)
         ? 'Running for ${runDuration.inMinutes} minutes'
-        : (task.status != TaskBox.statusNew) ? 'Run time: ${runDuration.inMinutes} minutes' : '';
+        : (task.status != TaskBox.statusNew)
+            ? 'Run time: ${runDuration.inMinutes} minutes'
+            : '';
 
     final String summaryText = <String>[
       'Attempts: ${task.attempts}',

--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -20,14 +20,18 @@ echo "#######################################################"
 
 # agent doesn't use build_runner as of this writing.
 if grep -lq "build_runner" pubspec.yaml; then
+  echo "############# build ###########"
   pub run build_runner build --delete-conflicting-outputs
+  echo "###############################"
 fi
 
 # See https://github.com/dart-lang/sdk/issues/25551 for why this is necessary.
 pub global run tuneup check
+# Only try tests if test folder exist.
 if [ -d 'test' ]; then
-  # Only try tests if test folder exist.
+  echo "############# tests ###########"
   pub run test --test-randomize-ordering-seed=random
+  echo "###############################"
 fi
 
 popd > /dev/null

--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -6,7 +6,7 @@
 # Runner for dart tests. It expects a single parameter with the full
 # path to the start folder where tests will be run.
 
-set -e
+set -ex
 
 # Build and analize
 echo "Running tests from $1"

--- a/test_utilities/bin/flutter_test_runner.sh
+++ b/test_utilities/bin/flutter_test_runner.sh
@@ -16,7 +16,7 @@
 # Runner for flutter tests. It expects a single parameter with the full
 # path to the flutter project where tests will be run.
 
-set -e
+set -ex
 
 echo "Running flutter tests from $1"
 pushd $1 > /dev/null

--- a/test_utilities/bin/licenses.sh
+++ b/test_utilities/bin/licenses.sh
@@ -6,7 +6,7 @@
 # Runner for dart tests. It expects a single parameter with the full
 # path to the start folder where tests will be run.
 
-set -e
+set -ex
 
 dir=$(dirname $0)
 

--- a/test_utilities/bin/prepare_environment.sh
+++ b/test_utilities/bin/prepare_environment.sh
@@ -6,7 +6,8 @@
 # List of commands to be run once per PR before running dart and flutter
 # tests.
 
-set -e
+set -ex
+
 pub global activate tuneup
 flutter channel beta
 flutter upgrade


### PR DESCRIPTION
Tip of tree is failing due to Dart 2.10 code landing. There's a missing field in the HttpClientRequest fake.

https://github.com/flutter/flutter/issues/63269 requires updating some of app_flutter render object usage.

Additionally, I enabled on the bash scripts logging the commands run so it's easier to reproduce issues thrown in LUCI.