### PR TITLE
[server] Handle query params and anchor tags in url

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -128,7 +128,7 @@ Future<void> main() async {
         await handler.service(request);
       } else {
         /// Requests with query parameters and anchors need to be trimmed to get the file path.
-        /// TODO(chillers): Use toFilePath(), https://github.com/dart-lang/sdk/issues/39373
+        // TODO(chillers): Use toFilePath(), https://github.com/dart-lang/sdk/issues/39373
         final int queryIndex = request.uri.path.contains('?') ? request.uri.path.indexOf('?') : request.uri.path.length;
         final int anchorIndex =
             request.uri.path.contains('#') ? request.uri.path.indexOf('#') : request.uri.path.length;

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -130,10 +130,13 @@ Future<void> main() async {
         /// Requests with query parameters and anchors need to be trimmed to get the file path.
         /// TODO(https://github.com/dart-lang/sdk/issues/39373): Use toFilePath() when it handles parameters and anchors.
         final int queryIndex = request.uri.path.contains('?') ? request.uri.path.indexOf('?') : request.uri.path.length;
-        final int anchorIndex = request.uri.path.contains('#') ? request.uri.path.indexOf('#') : request.uri.path.length;
+        final int anchorIndex =
+            request.uri.path.contains('#') ? request.uri.path.indexOf('#') : request.uri.path.length;
+
         /// Trim to the first instance of an anchor or query.
         final int trimIndex = min(queryIndex, anchorIndex);
-        final String filePath = request.uri.path.substring(0, trimIndex);;
+        final String filePath = request.uri.path.substring(0, trimIndex);
+        ;
 
         const List<String> indexRedirects = <String>['/build.html'];
         if (indexRedirects.contains(filePath)) {

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:math';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/cocoon_service.dart';
@@ -126,7 +127,13 @@ Future<void> main() async {
       if (handler != null) {
         await handler.service(request);
       } else {
-        final String filePath = request.uri.toFilePath();
+        /// Requests with query parameters and anchors need to be trimmed to get the file path.
+        /// TODO(https://github.com/dart-lang/sdk/issues/39373): Use toFilePath() when it handles parameters and anchors.
+        final int queryIndex = request.uri.path.contains('?') ? request.uri.path.indexOf('?') : request.uri.path.length;
+        final int anchorIndex = request.uri.path.contains('#') ? request.uri.path.indexOf('#') : request.uri.path.length;
+        /// Trim to the first instance of an anchor or query.
+        final int trimIndex = min(queryIndex, anchorIndex);
+        final String filePath = request.uri.path.substring(0, trimIndex);;
 
         const List<String> indexRedirects = <String>['/build.html'];
         if (indexRedirects.contains(filePath)) {

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -128,7 +128,7 @@ Future<void> main() async {
         await handler.service(request);
       } else {
         /// Requests with query parameters and anchors need to be trimmed to get the file path.
-        /// TODO(https://github.com/dart-lang/sdk/issues/39373): Use toFilePath() when it handles parameters and anchors.
+        /// TODO(chillers): Use toFilePath(), https://github.com/dart-lang/sdk/issues/39373
         final int queryIndex = request.uri.path.contains('?') ? request.uri.path.indexOf('?') : request.uri.path.length;
         final int anchorIndex =
             request.uri.path.contains('#') ? request.uri.path.indexOf('#') : request.uri.path.length;
@@ -136,7 +136,6 @@ Future<void> main() async {
         /// Trim to the first instance of an anchor or query.
         final int trimIndex = min(queryIndex, anchorIndex);
         final String filePath = request.uri.path.substring(0, trimIndex);
-        ;
 
         const List<String> indexRedirects = <String>['/build.html'];
         if (indexRedirects.contains(filePath)) {


### PR DESCRIPTION
In the latest Flutter dev channel, assets can have a versioning tag appended to them (eg `/main.dart.js?v=2752228646`). This causes the cocoon frontend to fail to load.

## Issues

Fixes https://github.com/flutter/flutter/issues/66041

## Test

I deployed this server with the dev channel to:

https://testchillers-dot-flutter-dashboard.appspot.com/