### PR TITLE
Do not automatically deflake flaky tasks

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -75,7 +75,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     if (newStatus == Task.statusFailed) {
       // Attempt to de-flake the test.
       final int maxRetries = config.maxTaskRetries;
-      if (task.attempts >= maxRetries) {
+      if (task.attempts >= maxRetries || task.isFlaky) {
         task.status = Task.statusFailed;
         task.reason = 'Task failed on agent';
         task.endTimestamp = DateTime.now().millisecondsSinceEpoch;

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -26,7 +26,11 @@ void main() {
 
     setUp(() {
       final FakeDatastoreDB datastoreDB = FakeDatastoreDB();
-      config = FakeConfig(dbValue: datastoreDB, tabledataResourceApi: tabledataResourceApi, maxTaskRetriesValue: 2,);
+      config = FakeConfig(
+        dbValue: datastoreDB,
+        tabledataResourceApi: tabledataResourceApi,
+        maxTaskRetriesValue: 2,
+      );
       tester = ApiRequestHandlerTester();
       tester.requestData = <String, dynamic>{
         'TaskKey':
@@ -74,11 +78,11 @@ void main() {
       final Commit commit = Commit(
           key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
       final Task task = Task(
-          key: commit.key.append(Task, id: 4590522719010816),
-          attempts: 1,
-          commitKey: commit.key,
-          isFlaky: false,
-          requiredCapabilities: <String>['ios'],
+        key: commit.key.append(Task, id: 4590522719010816),
+        attempts: 1,
+        commitKey: commit.key,
+        isFlaky: false,
+        requiredCapabilities: <String>['ios'],
       );
       config.db.values[commit.key] = commit;
       config.db.values[task.key] = task;
@@ -97,11 +101,11 @@ void main() {
       final Commit commit = Commit(
           key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
       final Task task = Task(
-          key: commit.key.append(Task, id: 4590522719010816),
-          attempts: 1,
-          commitKey: commit.key,
-          isFlaky: true,
-          requiredCapabilities: <String>['ios'],
+        key: commit.key.append(Task, id: 4590522719010816),
+        attempts: 1,
+        commitKey: commit.key,
+        isFlaky: true,
+        requiredCapabilities: <String>['ios'],
       );
       config.db.values[commit.key] = commit;
       config.db.values[task.key] = task;

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     setUp(() {
       final FakeDatastoreDB datastoreDB = FakeDatastoreDB();
-      config = FakeConfig(dbValue: datastoreDB, tabledataResourceApi: tabledataResourceApi);
+      config = FakeConfig(dbValue: datastoreDB, tabledataResourceApi: tabledataResourceApi, maxTaskRetriesValue: 2,);
       tester = ApiRequestHandlerTester();
       tester.requestData = <String, dynamic>{
         'TaskKey':
@@ -68,6 +68,53 @@ void main() {
       /// Test for [BigQuery] insert
       expect(tableDataList.totalRows, '1');
       expect(value['RequiredCapabilities'], <String>['ios']);
+    });
+
+    test('failed tasks are automatically retried', () async {
+      final Commit commit = Commit(
+          key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 4590522719010816),
+          attempts: 1,
+          commitKey: commit.key,
+          isFlaky: false,
+          requiredCapabilities: <String>['ios'],
+      );
+      config.db.values[commit.key] = commit;
+      config.db.values[task.key] = task;
+      tester.requestData = <String, dynamic>{
+        'TaskKey':
+            'ag9zfnR2b2xrZXJ0LXRlc3RyWAsSCUNoZWNrbGlzdCI4Zmx1dHRlci9mbHV0dGVyLzdkMDMzNzE2MTBjMDc5NTNhNWRlZjUwZDUwMDA0NTk0MWRlNTE2YjgMCxIEVGFzaxiAgIDg5eGTCAw',
+        'NewStatus': 'Failed',
+      };
+
+      await tester.post(handler);
+
+      expect(task.status, 'New');
+    });
+
+    test('flaky failed tasks are not automatically retried', () async {
+      final Commit commit = Commit(
+          key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
+      final Task task = Task(
+          key: commit.key.append(Task, id: 4590522719010816),
+          attempts: 1,
+          commitKey: commit.key,
+          isFlaky: true,
+          requiredCapabilities: <String>['ios'],
+      );
+      config.db.values[commit.key] = commit;
+      config.db.values[task.key] = task;
+      tester.requestData = <String, dynamic>{
+        'TaskKey':
+            'ag9zfnR2b2xrZXJ0LXRlc3RyWAsSCUNoZWNrbGlzdCI4Zmx1dHRlci9mbHV0dGVyLzdkMDMzNzE2MTBjMDc5NTNhNWRlZjUwZDUwMDA0NTk0MWRlNTE2YjgMCxIEVGFzaxiAgIDg5eGTCAw',
+        'NewStatus': 'Failed',
+      };
+
+      await tester.post(handler);
+
+      expect(task.status, 'Failed');
+      expect(task.attempts, 1);
     });
   });
 }


### PR DESCRIPTION
Flaky tasks do not block the tree, but we still invest capacity to try and deflake them.

While prototyping the MILO redesign, I noticed this could be an issue with the iOS capacity.

![Column of flaky ios tasks retried](https://user-images.githubusercontent.com/2148558/93515641-c7b1ca80-f8dd-11ea-88e5-099afb2eca3e.png)
