### PR TITLE
Fix flutter-gold for stale PRs

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -169,8 +169,8 @@ class Config {
       'this pull request.';
 
   String get flutterGoldStalePR => 'This pull request has not been updated in a '
-    'while. Please update this pull request to receive results from Gold, or '
-    'close it.';
+      'while. Please update this pull request to receive results from Gold, or '
+      'close it.';
 
   String get flutterGoldDraftChange => 'This pull request has been changed to a '
       'draft. The currently pending flutter-gold status will not be able '

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -168,6 +168,10 @@ class Config {
   String get flutterGoldChanges => 'Image changes have been found for '
       'this pull request.';
 
+  String get flutterGoldStalePR => 'This pull request has not been updated in a '
+    'while. Please update this pull request to receive results from Gold, or '
+    'close it.';
+
   String get flutterGoldDraftChange => 'This pull request has been changed to a '
       'draft. The currently pending flutter-gold status will not be able '
       'to resolve until a new commit is pushed or the change is marked ready for '

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -56,8 +56,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       // Check when this PR was last updated. Gold does not keep results after
       // >20 days. If a PR has gone stale, we should draw attention to it to be
       // updated or closed.
-      final DateTime updatedAt = pr.updatedAt;
-      final DateTime twentyDaysAgo = DateTime.now().subtract(const Duration(days: 20));
+      final DateTime updatedAt = pr.updatedAt.toUtc();
+      final DateTime twentyDaysAgo = DateTime.now().toUtc().subtract(const Duration(days: 20));
       if (updatedAt.isBefore(twentyDaysAgo)) {
         log.debug('Stale PR, no gold status to report.');
         if (!await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldStalePR)) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -53,6 +53,20 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     final List<GithubGoldStatusUpdate> statusUpdates = <GithubGoldStatusUpdate>[];
     log.debug('Beginning Gold checks...');
     await for (PullRequest pr in gitHubClient.pullRequests.list(slug)) {
+      // Check when this PR was last updated. Gold does not keep results after
+      // >20 days. If a PR has gone stale, we should draw attention to it to be
+      // updated or closed.
+      final DateTime updatedAt = pr.updatedAt;
+      final DateTime twentyDaysAgo = DateTime.now().subtract(const Duration(days: 20));
+      if (updatedAt.isBefore(twentyDaysAgo)) {
+        log.debug('Stale PR, no gold status to report.');
+        if (!await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldStalePR)) {
+          log.debug('Notifying for stale PR.');
+          await gitHubClient.issues.createComment(slug, pr.number, config.flutterGoldStalePR);
+        }
+        continue;
+      }
+
       // Get last known Gold status from datastore.
       final GithubGoldStatusUpdate lastUpdate = await datastore.queryLastGoldUpdate(slug, pr);
       CreateStatus statusRequest;
@@ -183,7 +197,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     // has not finished ingesting the results.
     await Future<void>.delayed(const Duration(seconds: 10));
     final Uri requestForTryjobStatus =
-        Uri.parse('http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged');
+        Uri.parse('http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged');
     String rawResponse;
     try {
       final HttpClientRequest request = await goldClient.getUrl(requestForTryjobStatus);

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -74,6 +74,7 @@ void main() {
       config.flutterGoldInitialAlertValue = 'initial';
       config.flutterGoldFollowUpAlertValue = 'follow-up';
       config.flutterGoldDraftChangeValue = 'draft';
+      config.flutterGoldStalePRValue = 'stale';
 
       handler = PushGoldStatusToGithub(
         config,
@@ -143,12 +144,13 @@ void main() {
         );
       }
 
-      PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false}) {
+      PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false, DateTime updated}) {
         return PullRequest()
           ..number = 123
           ..head = (PullRequestHead()..sha = 'abc')
           ..base = (PullRequestHead()..ref = baseRef)
-          ..draft = draft;
+          ..draft = draft
+          ..updatedAt = updated ?? DateTime.now();
       }
 
       group('does not update GitHub or Datastore', () {
@@ -294,7 +296,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -428,6 +430,88 @@ void main() {
             any,
           ));
         });
+
+        test('does not post for stale PRs, does not query Gold, stale comment', () async {
+          // New commit, draft PR
+          final PullRequest pr = newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          db.values[status.key] = status;
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
+          ];
+
+          // Have not already commented for this commit.
+          when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
+              (_) => Stream<IssueComment>.value(
+              IssueComment()..body = 'some other comment',
+            ),
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+
+          // Should not apply labels, should comment to update
+          verifyNever(issuesService.addLabelsToIssue(
+            slug,
+            pr.number,
+            <String>[
+              kGoldenFileLabel,
+            ],
+          ));
+
+          verify(issuesService.createComment(
+            slug,
+            pr.number,
+            argThat(contains(config.flutterGoldStalePRValue)),
+          )).called(1);
+        });
+
+        test('will only comment once on stale PRs', () async {
+          // New commit, draft PR
+          final PullRequest pr = newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          db.values[status.key] = status;
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'Linux', 'status': 'completed', 'conclusion': 'success'}
+          ];
+
+          // Already commented to update.
+          when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
+              (_) => Stream<IssueComment>.value(
+              IssueComment()..body = config.flutterGoldStalePRValue,
+            ),
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 0);
+          expect(log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
+          expect(log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
+
+          // Should not apply labels or make comments
+          verifyNever(issuesService.addLabelsToIssue(
+            slug,
+            pr.number,
+            <String>[
+              kGoldenFileLabel,
+            ],
+          ));
+
+          verifyNever(issuesService.createComment(
+            slug,
+            pr.number,
+            any,
+          ));
+        });
       });
 
       group('updates GitHub and/or Datastore', () {
@@ -517,7 +601,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -560,7 +644,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -612,7 +696,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -662,7 +746,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobDigests()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -722,7 +806,7 @@ void main() {
           final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
           final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
           when(mockHttpClient.getUrl(Uri.parse(
-                  'http://flutter-gold.skia.org/json/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
+                  'http://flutter-gold.skia.org/json/v1/changelist/github/${pr.number}/${pr.head.sha}/untriaged')))
               .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
           when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 
@@ -893,10 +977,10 @@ void main() {
         final MockHttpClientRequest mockHttpRequest = MockHttpClientRequest();
         final MockHttpClientResponse mockHttpResponse = MockHttpClientResponse(utf8.encode(tryjobEmpty()));
         when(mockHttpClient.getUrl(Uri.parse(
-                'http://flutter-gold.skia.org/json/changelist/github/${completedPR.number}/${completedPR.head.sha}/untriaged')))
+                'http://flutter-gold.skia.org/json/v1/changelist/github/${completedPR.number}/${completedPR.head.sha}/untriaged')))
             .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
         when(mockHttpClient.getUrl(Uri.parse(
-                'http://flutter-gold.skia.org/json/changelist/github/${followUpPR.number}/${followUpPR.head.sha}/untriaged')))
+                'http://flutter-gold.skia.org/json/v1/changelist/github/${followUpPR.number}/${followUpPR.head.sha}/untriaged')))
             .thenAnswer((_) => Future<MockHttpClientRequest>.value(mockHttpRequest));
         when(mockHttpRequest.close()).thenAnswer((_) => Future<MockHttpClientResponse>.value(mockHttpResponse));
 

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -433,7 +433,8 @@ void main() {
 
         test('does not post for stale PRs, does not query Gold, stale comment', () async {
           // New commit, draft PR
-          final PullRequest pr = newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
+          final PullRequest pr =
+              newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
@@ -445,7 +446,7 @@ void main() {
 
           // Have not already commented for this commit.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
+            (_) => Stream<IssueComment>.value(
               IssueComment()..body = 'some other comment',
             ),
           );
@@ -474,7 +475,8 @@ void main() {
 
         test('will only comment once on stale PRs', () async {
           // New commit, draft PR
-          final PullRequest pr = newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
+          final PullRequest pr =
+              newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
           db.values[status.key] = status;
@@ -486,7 +488,7 @@ void main() {
 
           // Already commented to update.
           when(issuesService.listCommentsByIssue(slug, pr.number)).thenAnswer(
-              (_) => Stream<IssueComment>.value(
+            (_) => Stream<IssueComment>.value(
               IssueComment()..body = config.flutterGoldStalePRValue,
             ),
           );

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -53,6 +53,7 @@ class FakeConfig implements Config {
     this.flutterGoldInitialAlertValue,
     this.flutterGoldFollowUpAlertValue,
     this.flutterGoldDraftChangeValue,
+    this.flutterGoldStalePRValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -90,6 +91,7 @@ class FakeConfig implements Config {
   String flutterGoldInitialAlertValue;
   String flutterGoldFollowUpAlertValue;
   String flutterGoldDraftChangeValue;
+  String flutterGoldStalePRValue;
 
   @override
   int get luciTryInfraFailureRetries => luciTryInfraFailureRetriesValue;
@@ -135,6 +137,9 @@ class FakeConfig implements Config {
 
   @override
   String get flutterGoldDraftChange => flutterGoldDraftChangeValue;
+
+  @override
+  String get flutterGoldStalePR => flutterGoldStalePRValue;
 
   @override
   String flutterGoldInitialAlert(String url) => flutterGoldInitialAlertValue;

--- a/app_flutter/lib/widgets/task_overlay.dart
+++ b/app_flutter/lib/widgets/task_overlay.dart
@@ -249,9 +249,7 @@ class TaskOverlayContents extends StatelessWidget {
     ///   3. Task ran (other status)
     final String runText = (task.status == TaskBox.statusInProgress)
         ? 'Running for ${runDuration.inMinutes} minutes'
-        : (task.status != TaskBox.statusNew)
-            ? 'Run time: ${runDuration.inMinutes} minutes'
-            : '';
+        : (task.status != TaskBox.statusNew) ? 'Run time: ${runDuration.inMinutes} minutes' : '';
 
     final String summaryText = <String>[
       'Attempts: ${task.attempts}',

--- a/app_flutter/lib/widgets/task_overlay.dart
+++ b/app_flutter/lib/widgets/task_overlay.dart
@@ -249,7 +249,9 @@ class TaskOverlayContents extends StatelessWidget {
     ///   3. Task ran (other status)
     final String runText = (task.status == TaskBox.statusInProgress)
         ? 'Running for ${runDuration.inMinutes} minutes'
-        : (task.status != TaskBox.statusNew) ? 'Run time: ${runDuration.inMinutes} minutes' : '';
+        : (task.status != TaskBox.statusNew)
+            ? 'Run time: ${runDuration.inMinutes} minutes'
+            : '';
 
     final String summaryText = <String>[
       'Attempts: ${task.attempts}',


### PR DESCRIPTION
This patches a bug where the flutter-gold check is stuck on old PRs.
Gold no longer caches image results >20 days old, so we need to account for that in the check.
This could also be helpful in cleaning up old PRs that aren't active. :) 

Maybe the bot should just close them if they have not been update in so long? Not sure.

I also added `v1` to the endpoints as part of the new versioning Gold is doing. :)

Fixes https://github.com/flutter/flutter/issues/65979