### PR TITLE
[build-dashboard] Revert get-status refresh rate back to original timing

### DIFF
--- a/app_flutter/lib/state/build.dart
+++ b/app_flutter/lib/state/build.dart
@@ -66,7 +66,7 @@ class BuildState extends ChangeNotifier {
 
   /// How often to query the Cocoon backend for the current build state.
   @visibleForTesting
-  final Duration refreshRate = const Duration(seconds: 10);
+  final Duration refreshRate = const Duration(seconds: 30);
 
   /// Timer that calls [_fetchStatusUpdates] on a set interval.
   @visibleForTesting


### PR DESCRIPTION
This reverts back to the AngularDart dashboard's timing.

This was set to 10 seconds due to most users being on networks without data caps. With everyone working from home, the app is downloading ~200 KB every 10 seconds.

This should reduce the amount of repainting happening, and reduce the flickering in the GitHub avatars.