### PR TITLE
[build-dashboard] Use Flutter Image.Network instead of CachedNetworkImage

### DIFF
--- a/app_flutter/lib/widgets/commit_author_avatar.dart
+++ b/app_flutter/lib/widgets/commit_author_avatar.dart
@@ -46,7 +46,7 @@ class CommitAuthorAvatar extends StatelessWidget {
     );
 
     return WebImage(
-      imageUrl: commit.authorAvatarUrl, 
+      imageUrl: commit.authorAvatarUrl,
       placeholder: avatar,
     );
   }

--- a/app_flutter/lib/widgets/commit_author_avatar.dart
+++ b/app_flutter/lib/widgets/commit_author_avatar.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:typed_data';
-
+import 'package:app_flutter/widgets/web_image.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
 import 'package:cocoon_service/protos.dart' show Commit;
 
@@ -16,30 +13,12 @@ import 'package:cocoon_service/protos.dart' show Commit;
 /// with the author's first name and a color arbitrarily but deterministically generated
 /// from the avatar's name.
 class CommitAuthorAvatar extends StatelessWidget {
-  CommitAuthorAvatar({
+  const CommitAuthorAvatar({
     Key key,
     this.commit,
-    this.width = 50,
-    this.height = 50,
-    http.Client client,
-  })  : httpClient = client ?? http.Client(),
-        super(key: key);
+  }) : super(key: key);
 
   final Commit commit;
-
-  /// Width passed to [Image].
-  final double width;
-
-  /// Height passed to [Image].
-  final double height;
-
-  /// Client to make network requests to.
-  final http.Client httpClient;
-
-  Future<Uint8List> _getAvatarBytes() async {
-    final http.Response response = await httpClient.get(commit.authorAvatarUrl);
-    return response.bodyBytes;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,23 +45,9 @@ class CommitAuthorAvatar extends StatelessWidget {
       ),
     );
 
-    /// GitHub endpoint may throw an exception instead, which will have less bytes
-    /// than required to construct an image from. A quick hack to ensure enough data
-    /// exists for [Image.memory] can decode an image.
-    const int minimumImageBytes = 10;
-
-    return FutureBuilder<Uint8List>(
-      future: _getAvatarBytes(),
-      builder: (BuildContext context, AsyncSnapshot<Uint8List> snapshot) {
-        if (snapshot.hasData && snapshot.data.length > minimumImageBytes) {
-          return Image.memory(
-            snapshot.data,
-            width: width,
-            height: height,
-          );
-        }
-        return avatar;
-      },
+    return WebImage(
+      imageUrl: commit.authorAvatarUrl, 
+      placeholder: avatar,
     );
   }
 }

--- a/app_flutter/lib/widgets/sign_in_button.dart
+++ b/app_flutter/lib/widgets/sign_in_button.dart
@@ -31,12 +31,10 @@ class SignInButton extends StatelessWidget {
         /// On sign out, there's a second where the user is null before isAuthenticated catches up.
         if (isAuthenticated.data == true && authService.user != null) {
           return PopupMenuButton<_SignInButtonAction>(
-            // TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
-            // CanvasKit currently cannot render a NetworkImage because of CORS issues.
             child: WebImage(
               // TODO(chillers): Switch to use avatar widget provided by google_sign_in plugin
               imageUrl: authService.user?.photoUrl,
-              placeholder: (BuildContext context, String url) => Padding(
+              placeholder: Padding(
                 child: Text(authService.user.email),
                 padding: const EdgeInsets.only(right: 10.0, top: 20.0),
               ),

--- a/app_flutter/lib/widgets/web_image.dart
+++ b/app_flutter/lib/widgets/web_image.dart
@@ -4,26 +4,19 @@
 
 import 'dart:io';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-/// Helper widget for easily switching between the normal widget and
-/// CanvasKit specific widgets. Since CanvasKit is under active development,
-/// the Flutter framework is not fully supported yet.
+/// Helper widget for switching between a network image and a placeholder.
 ///
-/// This also bypasses CachedNetworkImageProvider when testing is enabled,
-/// because that widget relies on plugins and plugins aren't available in tests.
-// Remove the skia part of this workaround when the following issues have been removed:
-// TODO(chillers): Show a Network Image. https://github.com/flutter/flutter/issues/45955
+/// This bypasses network image provider when testing to not surface the
+/// HTTP errors in tests by default.
 class WebImage extends StatelessWidget {
   const WebImage({
     Key key,
     bool enabled,
     this.imageUrl,
-    this.imageBuilder,
     this.placeholder,
-    this.errorWidget,
   })  : _enabled = enabled,
         super(key: key);
 
@@ -43,28 +36,20 @@ class WebImage extends StatelessWidget {
     if (!kIsWeb && Platform.environment.containsKey('FLUTTER_TEST')) {
       return false;
     }
-    // Unlike FLUTTER_TEST, the FLUTTER_WEB_USE_SKIA key is set during compilation.
-    if (const bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false)) {
-      return false;
-    }
     return true;
   }
 
+  /// The url to fetch the image from.
   final String imageUrl;
-  final ImageWidgetBuilder imageBuilder;
-  final PlaceholderWidgetBuilder placeholder;
-  final LoadingErrorWidgetBuilder errorWidget;
+
+  /// Widget to fall back to if environment does not support network images.
+  final Widget placeholder;
 
   @override
   Widget build(BuildContext context) {
     if (enabled) {
-      return CachedNetworkImage(
-        imageUrl: imageUrl,
-        imageBuilder: imageBuilder,
-        placeholder: placeholder,
-        errorWidget: errorWidget,
-      );
+      return Image.network(imageUrl);
     }
-    return placeholder(context, imageUrl);
+    return placeholder;
   }
 }

--- a/app_flutter/pubspec.lock
+++ b/app_flutter/pubspec.lock
@@ -78,13 +78,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.1.0"
-  cached_network_image:
-    dependency: "direct main"
-    description:
-      name: cached_network_image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   characters:
     dependency: transitive
     description:
@@ -223,13 +216,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_cache_manager:
-    dependency: transitive
-    description:
-      name: flutter_cache_manager
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -471,34 +457,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety"
-  path_provider:
-    dependency: transitive
-    description:
-      name: path_provider
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.6.14"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+2"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.4+4"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
   pedantic:
     dependency: transitive
     description:
@@ -506,13 +464,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0-nullsafety"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.1"
   platform_detect:
     dependency: transitive
     description:
@@ -541,13 +492,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0-nullsafety"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.13"
   protobuf:
     dependency: transitive
     description:
@@ -658,20 +602,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety"
-  sqflite:
-    dependency: transitive
-    description:
-      name: sqflite
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1+1"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2+1"
   stack_trace:
     dependency: transitive
     description:
@@ -693,13 +623,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -784,13 +707,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.1+1"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.2"
   uuid_enhanced:
     dependency: transitive
     description:
@@ -840,13 +756,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.5"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   yaml:
     dependency: transitive
     description:

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
-  cached_network_image: ^2.0.0
   cocoon_service:
     path: ../app_dart
   google_sign_in: ^4.5.3

--- a/app_flutter/test/widgets/commit_author_avatar_test.dart
+++ b/app_flutter/test/widgets/commit_author_avatar_test.dart
@@ -2,86 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:core';
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
-import 'package:mockito/mockito.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit;
 
 import 'package:app_flutter/widgets/commit_author_avatar.dart';
-
-/// Example image data copied from Flutter SDK [Image.memory] tests.
-/// https://github.com/flutter/flutter/blob/master/packages/flutter/test/painting/image_data.dart
-const List<int> kTransparentImage = <int>[
-  0x89,
-  0x50,
-  0x4E,
-  0x47,
-  0x0D,
-  0x0A,
-  0x1A,
-  0x0A,
-  0x00,
-  0x00,
-  0x00,
-  0x0D,
-  0x49,
-  0x48,
-  0x44,
-  0x52,
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x08,
-  0x06,
-  0x00,
-  0x00,
-  0x00,
-  0x1F,
-  0x15,
-  0xC4,
-  0x89,
-  0x00,
-  0x00,
-  0x00,
-  0x0A,
-  0x49,
-  0x44,
-  0x41,
-  0x54,
-  0x78,
-  0x9C,
-  0x63,
-  0x00,
-  0x01,
-  0x00,
-  0x00,
-  0x05,
-  0x00,
-  0x01,
-  0x0D,
-  0x0A,
-  0x2D,
-  0xB4,
-  0x00,
-  0x00,
-  0x00,
-  0x00,
-  0x49,
-  0x45,
-  0x4E,
-  0x44,
-  0xAE,
-];
 
 void main() {
   testWidgets('Authors with same initial have differently coloured avatars', (WidgetTester tester) async {
@@ -108,54 +34,4 @@ void main() {
     expect(avatars, hasLength(2));
     expect(avatars.first.backgroundColor, isNot(avatars.last.backgroundColor));
   });
-
-  testWidgets('Show avatar when network request fails', (WidgetTester tester) async {
-    final Commit commit = Commit()..author = 'Mike';
-    final http.Client mockClient = MockHttpClient();
-    when(mockClient.get(any)).thenAnswer((_) async => Future<http.Response>.value(http.Response('123', 404)));
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Column(
-          children: <Widget>[
-            CommitAuthorAvatar(
-              commit: commit,
-              client: mockClient,
-            ),
-          ],
-        ),
-      ),
-    );
-    // Ensure builder is finished.
-    await tester.pumpAndSettle();
-
-    expect(find.text('M'), findsNWidgets(1));
-  });
-
-  testWidgets('Show avatar when network request succeeds', (WidgetTester tester) async {
-    final Commit commit = Commit()..author = 'Mike';
-    final http.Client mockClient = MockHttpClient();
-    when(mockClient.get(any)).thenAnswer(
-        (_) async => Future<http.Response>.value(http.Response.bytes(Uint8List.fromList(kTransparentImage), 200)));
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Column(
-          children: <Widget>[
-            CommitAuthorAvatar(
-              commit: commit,
-              client: mockClient,
-            ),
-          ],
-        ),
-      ),
-    );
-    // Ensure builder is finished.
-    await tester.pumpAndSettle();
-
-    expect(find.text('M'), findsNWidgets(0));
-    expect(find.byType(Image), findsNWidgets(1));
-  });
 }
-
-class MockHttpClient extends Mock implements http.Client {}


### PR DESCRIPTION
CachedNetworkImage is failing to show images in CanvasKit. Initially, we used it as Image.network did not offer any caching strategy but that has been added since.

This reverts the changes in https://github.com/flutter/cocoon/pull/946 and switches the `CachedNetworkImage` to `Image.network`.

This fixes the flickering in the dashboard as whenever the widgets get redrawn, they make an http request for the image.

## Issues

https://github.com/flutter/flutter/issues/49725