### PR TITLE
[app_dart] Add config cache flush endpoint

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -54,6 +54,11 @@ Future<void> main() async {
       '/api/authorize-agent': AuthorizeAgent(config, authProvider),
       '/api/check-waiting-pull-requests': CheckForWaitingPullRequests(config, authProvider),
       '/api/create-agent': CreateAgent(config, authProvider),
+      '/api/flush-cache': FlushCache(
+        config,
+        authProvider,
+        cache: cache,
+      ),
       '/api/get-authentication-status': GetAuthenticationStatus(config, authProvider),
       '/api/get-log': GetLog(config, authProvider),
       '/api/github-webhook-pullrequest': GithubWebhook(

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -7,6 +7,7 @@ export 'src/request_handlers/append_log.dart';
 export 'src/request_handlers/authorize_agent.dart';
 export 'src/request_handlers/check_for_waiting_pull_requests.dart';
 export 'src/request_handlers/create_agent.dart';
+export 'src/request_handlers/flush_cache.dart';
 export 'src/request_handlers/get_authentication_status.dart';
 export 'src/request_handlers/get_benchmarks.dart';
 export 'src/request_handlers/get_branches.dart';

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -54,6 +54,7 @@ class Config {
     'flutter/plugins',
   };
 
+  /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 
   @visibleForTesting

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -54,7 +54,6 @@ class Config {
     'flutter/plugins',
   };
 
-  @visibleForTesting
   static const String configCacheName = 'config';
 
   @visibleForTesting

--- a/app_dart/lib/src/request_handlers/flush_cache.dart
+++ b/app_dart/lib/src/request_handlers/flush_cache.dart
@@ -18,11 +18,11 @@ import '../service/cache_service.dart';
 class FlushCache extends ApiRequestHandler<Body> {
   const FlushCache(
     Config config,
-    AuthenticationProvider authenticationProvider, { @required this.cache,
+    AuthenticationProvider authenticationProvider, {
+    @required this.cache,
   }) : super(config: config, authenticationProvider: authenticationProvider);
 
   final CacheService cache;
-
 
   static const String cacheKeyParam = 'key';
 

--- a/app_dart/lib/src/request_handlers/flush_cache.dart
+++ b/app_dart/lib/src/request_handlers/flush_cache.dart
@@ -1,0 +1,40 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import '../datastore/cocoon_config.dart';
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/authentication.dart';
+import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
+import '../service/cache_service.dart';
+
+/// Trigger a cache flush on a config key.
+@immutable
+class FlushCache extends ApiRequestHandler<Body> {
+  const FlushCache(
+    Config config,
+    AuthenticationProvider authenticationProvider, { @required this.cache,
+  }) : super(config: config, authenticationProvider: authenticationProvider);
+
+  final CacheService cache;
+
+
+  static const String cacheKeyParam = 'key';
+
+  @override
+  Future<Body> get() async {
+    final String cacheKey = request.uri.queryParameters[cacheKeyParam];
+    if (cacheKey == null) {
+      throw const BadRequestException('Missing required query parameter: $cacheKeyParam');
+    }
+
+    await cache.purge(Config.configCacheName, cacheKey);
+
+    return Body.empty;
+  }
+}

--- a/app_dart/lib/src/request_handlers/flush_cache.dart
+++ b/app_dart/lib/src/request_handlers/flush_cache.dart
@@ -27,14 +27,15 @@ class FlushCache extends ApiRequestHandler<Body> {
 
   final CacheService cache;
 
+  /// Name of the query parameter passed to the endpoint.
+  ///
+  /// The value is expected to be an existing value from [CocoonConfig].
   static const String cacheKeyParam = 'key';
 
   @override
   Future<Body> get() async {
+    checkRequiredQueryParameters(<String>[cacheKeyParam]);
     final String cacheKey = request.uri.queryParameters[cacheKeyParam];
-    if (cacheKey == null) {
-      throw const BadRequestException('Missing required query parameter: $cacheKeyParam');
-    }
 
     // To validate cache flushes, validate that the key exists.
     await cache.getOrCreate(

--- a/app_dart/lib/src/request_handling/api_request_handler.dart
+++ b/app_dart/lib/src/request_handling/api_request_handler.dart
@@ -50,6 +50,16 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
     }
   }
 
+  /// Throws a [BadRequestException] if any of [requiredQueryParameters] are missing from [requestData].
+  @protected
+  void checkRequiredQueryParameters(List<String> requiredQueryParameters) {
+    final Iterable<String> missingParams = requiredQueryParameters
+      ..removeWhere(request.uri.queryParameters.containsKey);
+    if (missingParams.isNotEmpty) {
+      throw BadRequestException('Missing required parameter: ${missingParams.join(', ')}');
+    }
+  }
+
   /// The authentication context associated with the HTTP request.
   ///
   /// This is guaranteed to be non-null. If the request was unauthenticated,

--- a/app_dart/test/request_handlers/flush_cache_test.dart
+++ b/app_dart/test/request_handlers/flush_cache_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cocoon_service/src/datastore/cocoon_config.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/cache_service.dart';
+import 'package:gcloud/db.dart';
+import 'package:test/test.dart';
+
+import 'package:cocoon_service/src/request_handlers/flush_cache.dart';
+import 'package:cocoon_service/src/request_handling/body.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_http.dart';
+
+void main() {
+  group('FlushCache', () {
+    FakeConfig config;
+    ApiRequestHandlerTester tester;
+    FlushCache handler;
+    CacheService cache;
+
+    setUp(() {
+      tester = ApiRequestHandlerTester();
+      cache = CacheService(inMemory: true);
+      config = FakeConfig();
+      handler = FlushCache(
+        config,
+        FakeAuthenticationProvider(),
+        cache: cache,
+      );
+    });
+
+    test('cache is empty when given an existing config key', () async {
+      const String cacheKey = 'test';
+      await cache.set(
+        Config.configCacheName,
+        cacheKey,
+        Uint8List.fromList('123'.codeUnits),
+      );
+
+      tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
+        FlushCache.cacheKeyParam: cacheKey,
+      });
+      await tester.get(handler);
+
+      expect(await cache.getOrCreate(Config.configCacheName, cacheKey), null);
+    });
+
+    test('raises error if cache key not passed', () async {
+      expect(tester.get(handler), throwsA(isA<BadRequestException>()));
+    });
+
+    test('raises error if cache key does not exist', () async {
+      tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
+        FlushCache.cacheKeyParam: 'abc',
+      });
+      expect(tester.get(handler), throwsA(isA<NotFoundException>()));
+    });
+  });
+}

--- a/app_dart/test/request_handlers/flush_cache_test.dart
+++ b/app_dart/test/request_handlers/flush_cache_test.dart
@@ -2,18 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:cocoon_service/src/datastore/cocoon_config.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/service/cache_service.dart';
-import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
+import 'package:cocoon_service/src/datastore/cocoon_config.dart';
 import 'package:cocoon_service/src/request_handlers/flush_cache.dart';
-import 'package:cocoon_service/src/request_handling/body.dart';
-import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/cache_service.dart';
 
 import '../src/datastore/fake_cocoon_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';


### PR DESCRIPTION
This is to make it easier to flush the cache. The current process requires getting access to a VM instance in the GCP project, getting access to redis, and then flushing.

Instead, this endpoint can be added to the release playbook to make changes propagate immediately.

## Issues

Fixes https://github.com/flutter/flutter/issues/66372

## Tests

Check purge happens, param passed, and cache key exists.