### PR TITLE
Set timeout to 30 min for cloud build of cocoon

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
     entrypoint: '/bin/bash'
     args: ['cloud_build/deploy.sh', '$PROJECT_ID', '$SHORT_SHA', '$_GAE_PROMOTE']
 
-timeout: 1200s
+timeout: 1800s
 
 images: ['gcr.io/$PROJECT_ID/flutter']
 tags: ['cloud-builders-community']


### PR DESCRIPTION
Now with https://github.com/flutter/cocoon/pull/951, we are building cocoon together with the flutter image. The whole process needs longer than 20 minutes, and results in timeout.
<img width="427" alt="Screen Shot 2020-09-22 at 12 16 35 PM" src="https://user-images.githubusercontent.com/54558023/93927273-7c2c6180-fccd-11ea-8f65-98e171951589.png">

This PR extends the timeout to be 30 minuts.