### PR TITLE
Add verbose flags to flutter config and doctor

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -510,10 +510,10 @@ Future<Null> getFlutter(String revision) async {
     await exec('git', ['checkout', revision]);
   });
 
-  await flutter('config', options: ['--no-analytics']);
+  await flutter('config', options: ['--no-analytics', '--verbose']);
 
   section('flutter doctor');
-  await flutter('doctor');
+  await flutter('doctor', options: ['--verbose']);
 
   section('flutter update-packages');
   await flutter('update-packages');


### PR DESCRIPTION
Investigation for flaky `config` call. https://github.com/flutter/flutter/issues/65413
Add `--verbose` to doctor for good measure (will let us see tethered device OS version).