### PR TITLE
Fix status update condition in refresh-chromebot-status API

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -83,7 +83,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
         final String buildNumberList =
             luciTasks.reversed.map((LuciTask luciTask) => luciTask.buildNumber.toString()).toList().join(',');
         if (buildNumberList != datastoreTask.task.buildNumberList ||
-            luciTasks.last.status != datastoreTask.task.status) {
+            luciTasks.first.status != datastoreTask.task.status) {
           final Task update = datastoreTask.task;
           update.status = luciTasks.first.status;
           update.buildNumberList = buildNumberList;


### PR DESCRIPTION
There is a bug in existing `refresh-chromebot-status` API: the logic compares with datastore status with the oldest LUCI build's status. This will cause confusion when re-run is triggered.

This PR updates the logic to use latest build's status to do comparison and then update the datastore and dashboard.