### PR TITLE
Add option compiler dart2js to `app` build yaml to recover flutter benchmark dashboard

### DIFF
--- a/app/build.yaml
+++ b/app/build.yaml
@@ -8,6 +8,7 @@ targets:
         generate_for:
         - web/**.dart
         options:
+          compiler: dart2js
           dart2js_args:
           - --dump-info
           - --fast-startup


### PR DESCRIPTION
Due to recent upgrading `build_web_compilers` to `2.10.0` from `2.7.2`, flutter benchmark dashboard fails to render.

This pr adds option `compiler: dart2js` to make it work. It is validated to work locally.

Related issue: https://github.com/flutter/flutter/issues/67457