### PR TITLE
Separate flutter image build configs from existing cocoon build yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,8 +3,6 @@
 # by new commits to `master` branch.
 
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/flutter', '.']
   # Build app_flutter.
   - name: gcr.io/$PROJECT_ID/flutter
     entrypoint: '/bin/bash'
@@ -20,7 +18,4 @@ steps:
     entrypoint: '/bin/bash'
     args: ['cloud_build/deploy.sh', '$PROJECT_ID', '$SHORT_SHA', '$_GAE_PROMOTE']
 
-timeout: 1800s
-
-images: ['gcr.io/$PROJECT_ID/flutter']
-tags: ['cloud-builders-community']
+timeout: 1200s

--- a/flutter_image_build.yaml
+++ b/flutter_image_build.yaml
@@ -1,0 +1,10 @@
+# Builds a new flutter image, which is used to build cocoon dashboard.
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/flutter', '.']
+
+timeout: 1200s
+
+images: ['gcr.io/$PROJECT_ID/flutter']
+tags: ['cloud-builders-community']


### PR DESCRIPTION
Existing cloud build yaml file includes both flutter image build and cocoon build, which will be auto built daily on workdays.

Potential issues:

- flutter image build is based on `dev` channel, and it is a waste of resources to keep building the same version between two `dev` releases.
- `dev` release happens approximately on a weekly basis, if there is a bug (like: https://github.com/flutter/flutter/issues/67319) in upstream, but gets fixed in `master`, it will take a week before the fix shows up in `dev`.

This PR separates the flutter image build out of cocoon to provide flexibility to build new flutter images, and save resources as well.

Will create a separate trigger based on this new yaml file to build flutter image.

Related issue: https://github.com/flutter/flutter/issues/67457