### PR TITLE
Add verbose logging to test utilities

### DIFF
--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -30,7 +30,7 @@ pub global run tuneup check
 # Only try tests if test folder exist.
 if [ -d 'test' ]; then
   echo "############# tests ###########"
-  pub run test --test-randomize-ordering-seed=random
+  pub run test --test-randomize-ordering-seed=random --reporter expanded
   echo "###############################"
 fi
 

--- a/test_utilities/bin/flutter_test_runner.bat
+++ b/test_utilities/bin/flutter_test_runner.bat
@@ -21,6 +21,6 @@ PUSHD %1
 CALL flutter packages get
 CALL flutter analyze
 CALL flutter format --line-length=120 --set-exit-if-changed lib/ test/
-CALL flutter test --test-randomize-ordering-seed=random
+CALL flutter test --test-randomize-ordering-seed=random --verbose
 
 POPD

--- a/test_utilities/bin/flutter_test_runner.sh
+++ b/test_utilities/bin/flutter_test_runner.sh
@@ -24,7 +24,7 @@ pushd $1 > /dev/null
 flutter packages get
 flutter analyze
 dartfmt --line-length=120 --set-exit-if-changed --dry-run lib/ test/
-flutter test --test-randomize-ordering-seed=random
+flutter test --test-randomize-ordering-seed=random --verbose
 
 popd > /dev/null
 


### PR DESCRIPTION
This will make it easier to view logs from infra on cocoon. For example, https://github.com/flutter/flutter/issues/67681 has logs that get collated into one line which ends up being hard to parse.