### PR TITLE
Selectable raw health details and agent name

### DIFF
--- a/app_flutter/lib/widgets/agent_tile.dart
+++ b/app_flutter/lib/widgets/agent_tile.dart
@@ -51,7 +51,7 @@ class AgentTile extends StatelessWidget {
           foregroundColor: Colors.white,
           child: _getIconFromId(agent.agentId),
         ),
-        title: Text(agent.agentId),
+        title: SelectableText(agent.agentId),
         subtitle: AgentHealthDetailsBar(agentHealthDetails),
         trailing: PopupMenuButton<_AgentTileAction>(
           itemBuilder: (BuildContext context) => <PopupMenuEntry<_AgentTileAction>>[
@@ -112,7 +112,7 @@ class AgentTile extends StatelessWidget {
       context: context,
       builder: (BuildContext context) => SimpleDialog(
         children: <Widget>[
-          Text(rawHealthDetails),
+          SelectableText(rawHealthDetails),
         ],
       ),
     );


### PR DESCRIPTION
Make the agent name selectable so it can be copied:
![Screen Shot 2020-10-20 at 5 23 08 PM](https://user-images.githubusercontent.com/682784/96658257-ed752980-12f8-11eb-9c3f-2c191932bf84.png)

Also raw health details so the IP can be easily copied.
![Screen Shot 2020-10-20 at 5 27 21 PM](https://user-images.githubusercontent.com/682784/96658524-873cd680-12f9-11eb-9e2c-214528b647a2.png)


See also #662