### PR TITLE
Add catch exception logic for missing branch when refreshing github commits

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -67,7 +67,13 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
         lastCommitTimestampMills = lastProcessedCommit[0].timestamp;
       }
 
-      final List<RepositoryCommit> commits = await githubService.listCommits(slug, branch, lastCommitTimestampMills);
+      List<RepositoryCommit> commits;
+      try {
+        commits = await githubService.listCommits(slug, branch, lastCommitTimestampMills);
+      } on GitHubError catch (error) {
+        log.error('$error');
+        continue;
+      }
 
       final List<Commit> newCommits = await _getNewCommits(commits, datastore, branch);
 


### PR DESCRIPTION
Cocoon refreshes github commits for each branch defined in [`branches.txt`](https://github.com/flutter/cocoon/blob/master/app_dart/dev/branches.txt). This is assuming that branch exists in `flutter/flutter`. 

However when a branch is not defined in `flutter/flutter`, but added in `branches.txt`, cocoon backend API will fail with 
```
GitHub Error: Requested Resource was Not Found
```

This PR is to fix the issue.

Related issue: https://github.com/flutter/flutter/issues/69039