### PR TITLE
[app_flutter] Remove authorized agent UI

### DIFF
--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -218,39 +218,6 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   @override
-  Future<CocoonResponse<String>> authorizeAgent(Agent agent, String idToken) async {
-    assert(agent != null);
-    assert(idToken != null);
-
-    final String authorizeAgentUrl = apiEndpoint('/api/authorize-agent');
-
-    /// This endpoint returns JSON {'Token': [Token]}
-    final http.Response response = await _client.post(
-      authorizeAgentUrl,
-      headers: <String, String>{'X-Flutter-IdToken': idToken},
-      body: jsonEncode(<String, Object>{
-        'AgentID': agent.agentId,
-      }),
-    );
-
-    if (response.statusCode != HttpStatus.ok) {
-      return const CocoonResponse<String>.error('/api/authorize-agent did not respond with 200');
-    }
-
-    Map<String, Object> responseBody;
-    try {
-      responseBody = jsonDecode(response.body);
-      if (responseBody['Token'] == null) {
-        return const CocoonResponse<String>.error('/api/authorize-agent returned unexpected response');
-      }
-    } catch (e) {
-      return const CocoonResponse<String>.error('/api/authorize-agent returned unexpected response');
-    }
-
-    return CocoonResponse<String>.data(responseBody['Token']);
-  }
-
-  @override
   Future<void> reserveTask(Agent agent, String idToken) async {
     assert(agent != null);
     assert(idToken != null);

--- a/app_flutter/lib/service/cocoon.dart
+++ b/app_flutter/lib/service/cocoon.dart
@@ -58,9 +58,6 @@ abstract class CocoonService {
   /// Returns an auth token used to authorize the agent.
   Future<CocoonResponse<String>> createAgent(String agentId, List<String> capabilities, String idToken);
 
-  /// Generate a new access token for [agent].
-  Future<CocoonResponse<String>> authorizeAgent(Agent agent, String idToken);
-
   /// Attempt to assign a new task to [agent].
   ///
   /// If no task can be assigned, a null value is returned.

--- a/app_flutter/lib/service/dev_cocoon.dart
+++ b/app_flutter/lib/service/dev_cocoon.dart
@@ -60,10 +60,6 @@ class DevelopmentCocoonService implements CocoonService {
       const CocoonResponse<String>.data('abc123');
 
   @override
-  Future<CocoonResponse<String>> authorizeAgent(Agent agent, String idToken) async =>
-      const CocoonResponse<String>.data('def345');
-
-  @override
   Future<void> reserveTask(Agent agent, String idToken) => null;
 
   static const List<String> _agentKinds = <String>[

--- a/app_flutter/lib/state/agent.dart
+++ b/app_flutter/lib/state/agent.dart
@@ -41,9 +41,6 @@ class AgentState extends ChangeNotifier {
   @visibleForTesting
   static const String errorMessageCreatingAgent = 'An error occurred creating agent';
 
-  @visibleForTesting
-  static const String errorMessageAuthorizingAgent = 'An error occurred authorizing agent';
-
   /// How often to query the Cocoon backend for the current agent statuses.
   @visibleForTesting
   final Duration refreshRate = const Duration(minutes: 1);
@@ -114,24 +111,6 @@ class AgentState extends ChangeNotifier {
     }
     if (response.error != null) {
       _errors.send('$errorMessageCreatingAgent: ${response.error}');
-    }
-    return response.data;
-  }
-
-  /// Generates a new access token for [agent].
-  ///
-  /// If an error occurs, [errors] will be updated with
-  /// the message [errorMessageAuthorizingAgent].
-  Future<String> authorizeAgent(Agent agent) async {
-    final CocoonResponse<String> response = await cocoonService.authorizeAgent(
-      agent,
-      await authService.idToken,
-    );
-    if (!_active) {
-      return null;
-    }
-    if (response.error != null) {
-      _errors.send('$errorMessageAuthorizingAgent: ${response.error}');
     }
     return response.data;
   }

--- a/app_flutter/lib/widgets/agent_tile.dart
+++ b/app_flutter/lib/widgets/agent_tile.dart
@@ -12,14 +12,13 @@ import 'agent_health_details_bar.dart';
 import 'now.dart';
 
 /// Values to be used in [PopupMenu] to know what action to execute.
-enum _AgentTileAction { details, authorize, reserve }
+enum _AgentTileAction { details, reserve }
 
 /// A card for showing the information from an [Agent].
 ///
 /// Summarizes [Agent.healthDetails] into a row of icons.
 ///
-/// Offers the ability to view the agent raw health details, re-authorize the
-/// agent, and attempt to reserve a task for the agent.
+/// Offers the ability to view the agent raw health details and attempt to reserve a task for the agent.
 class AgentTile extends StatelessWidget {
   const AgentTile({
     Key key,
@@ -30,9 +29,6 @@ class AgentTile extends StatelessWidget {
   final AgentState agentState;
 
   final AgentHealthDetails agentHealthDetails;
-
-  @visibleForTesting
-  static const Duration authorizeAgentSnackbarDuration = Duration(seconds: 5);
 
   @visibleForTesting
   static const Duration reserveTaskSnackbarDuration = Duration(seconds: 5);
@@ -60,10 +56,6 @@ class AgentTile extends StatelessWidget {
               value: _AgentTileAction.details,
             ),
             const PopupMenuItem<_AgentTileAction>(
-              child: Text('Authorize agent'),
-              value: _AgentTileAction.authorize,
-            ),
-            const PopupMenuItem<_AgentTileAction>(
               child: Text('Reserve task'),
               value: _AgentTileAction.reserve,
             ),
@@ -73,9 +65,6 @@ class AgentTile extends StatelessWidget {
             switch (value) {
               case _AgentTileAction.details:
                 _showHealthDetailsDialog(context, agent.healthDetails);
-                break;
-              case _AgentTileAction.authorize:
-                _authorizeAgent(context, agent);
                 break;
               case _AgentTileAction.reserve:
                 _reserveTask(context, agent);
@@ -118,26 +107,6 @@ class AgentTile extends StatelessWidget {
     );
   }
 
-  /// Call [authorizeAgent] to Cocoon for [agent] and show the new access token.
-  ///
-  /// On success, displays a [SnackBar] telling the user the access token can
-  /// be found in their console.
-  ///
-  /// If the request fails, [AgentDashboardPage] will handle the error and show
-  /// a [SnackBar].
-  Future<void> _authorizeAgent(BuildContext context, Agent agent) async {
-    final String token = await agentState.authorizeAgent(agent);
-    if (token != null) {
-      // TODO(chillers): Copy the token to clipboard when web has support. https://github.com/flutter/flutter/issues/46020
-      debugPrint('token: $token');
-
-      Scaffold.of(context).showSnackBar(const SnackBar(
-        content: Text('Check console for token'),
-        duration: authorizeAgentSnackbarDuration,
-      ));
-    }
-  }
-
   /// Call [reserveTask] to Cocoon for [agent] and show the information for
   /// the [Task] that was reserved.
   ///
@@ -151,7 +120,7 @@ class AgentTile extends StatelessWidget {
     await agentState.reserveTask(agent);
     Scaffold.of(context).showSnackBar(const SnackBar(
       content: Text('Check console for reserve task info'),
-      duration: authorizeAgentSnackbarDuration,
+      duration: reserveTaskSnackbarDuration,
     ));
   }
 }

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -534,60 +534,6 @@ void main() {
     });
   });
 
-  group('AppEngine CocoonService authorize agent', () {
-    AppEngineCocoonService service;
-    Response fakeResponse;
-
-    setUp(() {
-      service = AppEngineCocoonService(client: MockClient((Request request) async => fakeResponse));
-    });
-
-    test('should return token if request succeeds', () async {
-      fakeResponse = Response('{"Token": "abc123"}', 200);
-      final CocoonResponse<String> response = await service.authorizeAgent(
-        Agent()..agentId = 'id123',
-        'fakeAccessToken',
-      );
-      expect(response.data, 'abc123');
-      expect(response.error, isNull);
-    });
-
-    test('should return error if request failed', () async {
-      fakeResponse = Response('', 500);
-      expect((await service.authorizeAgent(Agent()..agentId = 'id123', 'fakeAccessToken')).error,
-          '/api/authorize-agent did not respond with 200');
-    });
-
-    test('should return error if token is null', () async {
-      fakeResponse = Response('', 200);
-      expect((await service.authorizeAgent(Agent()..agentId = 'id123', 'fakeAccessToken')).error,
-          '/api/authorize-agent returned unexpected response');
-    });
-
-    /// This requires a separate test run on the web platform.
-    test('should query correct endpoint whether web or mobile', () async {
-      service = AppEngineCocoonService(client: MockClient((Request request) async {
-        expect(request.url.toString(), kIsWeb ? '/api/authorize-agent' : '$baseApiUrl/api/authorize-agent');
-        return Response('', 200);
-      }));
-
-      await service.authorizeAgent(Agent()..agentId = 'id123', 'fakeAccessToken');
-    });
-
-    test('should send correct headers and body', () async {
-      service = AppEngineCocoonService(client: MockClient((Request request) async {
-        expect(request.headers, <String, String>{
-          'X-Flutter-IdToken': 'fakeAccessToken',
-          'content-type': 'text/plain; charset=utf-8',
-        });
-        expect(request.body, '{"AgentID":"id123"}');
-        return Response('', 200);
-      }));
-
-      await service.authorizeAgent(Agent()..agentId = 'id123', 'fakeAccessToken');
-    });
-  });
-
   group('AppEngine CocoonService reserve task', () {
     AppEngineCocoonService service;
     Response fakeResponse;

--- a/app_flutter/test/state/agent_test.dart
+++ b/app_flutter/test/state/agent_test.dart
@@ -101,19 +101,6 @@ void main() {
       agentState.dispose();
     });
 
-    test('authorize agent calls cocoon service', () async {
-      final AgentState agentState = AgentState(cocoonService: mockCocoonService, authService: mockSignInService);
-      when(mockCocoonService.authorizeAgent(any, any)).thenAnswer(
-        (_) async => const CocoonResponse<String>.data('abc123'),
-      );
-      verifyNever(mockCocoonService.authorizeAgent(any, any));
-
-      await agentState.authorizeAgent(Agent());
-
-      verify(mockCocoonService.authorizeAgent(any, any)).called(1);
-      agentState.dispose();
-    });
-
     test('reserve task calls cocoon service', () async {
       final AgentState agentState = AgentState(cocoonService: mockCocoonService, authService: mockSignInService);
       verifyNever(mockCocoonService.reserveTask(any, any));

--- a/app_flutter/test/utils/fake_agent_state.dart
+++ b/app_flutter/test/utils/fake_agent_state.dart
@@ -45,9 +45,6 @@ class FakeAgentState extends ChangeNotifier implements AgentState {
   ];
 
   @override
-  Future<String> authorizeAgent(Agent agent) async => 'abc123';
-
-  @override
   Future<String> createAgent(String agentId, List<String> capabilities) async => 'def456';
 
   @override

--- a/app_flutter/test/widgets/agent_tile_test.dart
+++ b/app_flutter/test/widgets/agent_tile_test.dart
@@ -95,33 +95,6 @@ able-to-perform-health-check: succeeded''';
       expect(find.text(agent.healthDetails), findsOneWidget);
     });
 
-    testWidgets('authorize agent calls api', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Now.fixed(
-          dateTime: nowTime,
-          child: MaterialApp(
-            home: AgentTile(
-              agentHealthDetails: agentHealthDetails,
-              agentState: mockAgentState,
-            ),
-          ),
-        ),
-      );
-
-      // open the agent tile menu
-      await tester.tap(find.byIcon(Icons.more_vert));
-      await tester.pumpAndSettle();
-
-      verifyNever(mockAgentState.authorizeAgent(any));
-
-      expect(find.text('Authorize agent'), findsOneWidget);
-
-      await tester.tap(find.text('Authorize agent'));
-      await tester.pump();
-
-      verify(mockAgentState.authorizeAgent(any)).called(1);
-    });
-
     testWidgets('reserve task calls api', (WidgetTester tester) async {
       await tester.pumpWidget(
         Now.fixed(


### PR DESCRIPTION
This tends to be accidentally clicked by users. With the migration to LUCI, we'll remove this to remove a source of issues with the cocoon agents.

Most of this is removing authorize agent code. There is one change where I needed to update the snackbar duration to be the correct variable.