### PR TITLE
[app_dart] Fix static files with no extension 500ing

### DIFF
--- a/app_dart/lib/src/request_handling/static_file_handler.dart
+++ b/app_dart/lib/src/request_handling/static_file_handler.dart
@@ -36,6 +36,7 @@ class StaticFileHandler extends RequestHandler<Body> {
     /// The map of mimeTypes not found in [mime] package.
     final Map<String, String> mimeTypeMap = <String, String>{
       '.map': 'application/json',
+      '': 'text/plain',
     };
 
     final String resultPath = filePath == '/' ? '/index.html' : filePath;
@@ -44,7 +45,7 @@ class StaticFileHandler extends RequestHandler<Body> {
     const String basePath = 'build/web';
     final File file = fs.file('$basePath$resultPath');
     if (file.existsSync()) {
-      final String mimeType = lookupMimeType(resultPath) ?? mimeTypeMap[path.extension(file.path)];
+      final String mimeType = mimeTypeMap.containsKey(path.extension(file.path)) ? mimeTypeMap[path.extension(file.path)] : lookupMimeType(resultPath);
       response.headers.contentType = ContentType.parse(mimeType);
       return Body.forStream(file.openRead().cast<Uint8List>());
     } else {

--- a/app_dart/lib/src/request_handling/static_file_handler.dart
+++ b/app_dart/lib/src/request_handling/static_file_handler.dart
@@ -45,7 +45,9 @@ class StaticFileHandler extends RequestHandler<Body> {
     const String basePath = 'build/web';
     final File file = fs.file('$basePath$resultPath');
     if (file.existsSync()) {
-      final String mimeType = mimeTypeMap.containsKey(path.extension(file.path)) ? mimeTypeMap[path.extension(file.path)] : lookupMimeType(resultPath);
+      final String mimeType = mimeTypeMap.containsKey(path.extension(file.path))
+          ? mimeTypeMap[path.extension(file.path)]
+          : lookupMimeType(resultPath);
       response.headers.contentType = ContentType.parse(mimeType);
       return Body.forStream(file.openRead().cast<Uint8List>());
     } else {

--- a/app_dart/test/request_handling/static_file_handler_test.dart
+++ b/app_dart/test/request_handling/static_file_handler_test.dart
@@ -30,8 +30,8 @@ void main() {
       tester = RequestHandlerTester();
       fs = MemoryFileSystem();
       fs.file('build/web/$indexFileName').createSync(recursive: true);
-      fs.file('build/web/$indexFileName').writeAsString(indexFileContent);
-      fs.file('build/web/$dartMapFileName').writeAsString('[{}]');
+      fs.file('build/web/$indexFileName').writeAsStringSync(indexFileContent);
+      fs.file('build/web/$dartMapFileName').writeAsStringSync('[{}]');
     });
 
     Future<String> _decodeHandlerBody(Body body) {
@@ -60,6 +60,16 @@ void main() {
       expect(body, isNotNull);
       final String response = await _decodeHandlerBody(body);
       expect(response, '[{}]');
+    });
+
+    test('No extension files default to plain text', () async {
+      fs.file('build/web/NOTICE').writeAsStringSync('abc');
+      final StaticFileHandler staticFileHandler = StaticFileHandler('/NOTICE', config: config, fs: fs);
+
+      final Body body = await tester.get(staticFileHandler);
+      expect(body, isNotNull);
+      final String response = await _decodeHandlerBody(body);
+      expect(response, 'abc');
     });
   });
 }


### PR DESCRIPTION
# Issue

When viewing licenses, there's a 500 error on the endpoint as the `package:mime` functionality fails due to there being no explicit file extension.

# Tests

Added a regression test for this functionality

# Preview

https://testchillers-dot-flutter-dashboard.appspot.com/#/

Click the side bar > About Flutter Dashboard > View Licenses

Licenses should show now

In the prod version this endpoint 500s