### PR TITLE
[app_dart] Task statuses can be updated without task keys

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -23,7 +23,7 @@ import '../service/datastore.dart';
 
 /// Endpoint for task runners to update Cocoon with test run information.
 ///
-/// This handlers requires (1) task identifier and (2) task status information.
+/// This handler requires (1) task identifier and (2) task status information.
 ///
 /// 1. There are two ways to identify tasks:
 ///  A. [taskKeyParam] (Legacy Cocoon agents)
@@ -61,6 +61,11 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
   @override
   Future<UpdateTaskStatusResponse> post() async {
     checkRequiredParameters(<String>[newStatusParam]);
+    if (requestData.containsKey(taskKeyParam)) {
+      checkRequiredParameters(<String>[taskKeyParam]);
+    } else {
+      checkRequiredParameters(<String>[gitBranchParam, gitShaParam, taskNameParam]);
+    }
 
     final DatastoreService datastore = datastoreProvider(config.db);
     final String newStatus = requestData[newStatusParam] as String;

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -120,5 +120,31 @@ void main() {
       expect(task.status, 'Failed');
       expect(task.attempts, 1);
     });
+
+    test('non-task key requests can update tasks', () async {
+      final Commit commit = Commit(
+          key:
+              config.db.emptyKey.append(Commit, id: 'flutter/flutter/master/7d03371610c07953a5def50d500045941de516b8'));
+      final Task task = Task(
+        key: commit.key.append(Task, id: 4590522719010816),
+        name: 'integration_ui_ios',
+        attempts: 1,
+        isFlaky: true, // mark flaky so it doesn't get auto-retried
+        commitKey: commit.key,
+      );
+      config.db.values[commit.key] = commit;
+      config.db.values[task.key] = task;
+      tester.requestData = <String, dynamic>{
+        UpdateTaskStatus.gitBranchParam: 'master',
+        UpdateTaskStatus.gitShaParam: '7d03371610c07953a5def50d500045941de516b8',
+        UpdateTaskStatus.newStatusParam: 'Failed',
+        UpdateTaskStatus.taskNameParam: 'integration_ui_ios',
+      };
+
+      await tester.post(handler);
+
+      expect(task.status, 'Failed');
+      expect(task.attempts, 1);
+    });
   });
 }

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/appengine/time_series.dart';
 import 'package:cocoon_service/src/request_handlers/update_task_status.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/db.dart';
 import 'package:googleapis/bigquery/v2.dart';
@@ -121,7 +122,7 @@ void main() {
       expect(task.attempts, 1);
     });
 
-    test('non-task key requests can update tasks', () async {
+    test('task name requests can update tasks', () async {
       final Commit commit = Commit(
           key:
               config.db.emptyKey.append(Commit, id: 'flutter/flutter/master/7d03371610c07953a5def50d500045941de516b8'));
@@ -145,6 +146,16 @@ void main() {
 
       expect(task.status, 'Failed');
       expect(task.attempts, 1);
+    });
+
+    test('task name requests when task does not exists returns exception', () async {
+      tester.requestData = <String, dynamic>{
+        UpdateTaskStatus.gitBranchParam: 'master',
+        UpdateTaskStatus.gitShaParam: '7d03371610c07953a5def50d500045941de516b8',
+        UpdateTaskStatus.newStatusParam: 'Failed',
+        UpdateTaskStatus.taskNameParam: 'integration_ui_ios',
+      };
+      expect(tester.post(handler), throwsA(isA<InternalServerError>()));
     });
   });
 }


### PR DESCRIPTION
Migrating the DeviceLab to LUCI requires updating Cocoon to work with what LUCI knows. LUCI runs will not know the task key they are running. Instead, they know the git sha, git branch, and task name. This updates the request handler to process those to find corresponding task.

# Issue

https://github.com/flutter/flutter/issues/66191

# Tests

Added a unit test for this use case