### PR TITLE
[app_dart] Add swarming authentication provider

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -25,6 +25,7 @@ Future<void> main() async {
 
     final Config config = Config(dbService, cache);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);
+    final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config);
     final BuildBucketClient buildBucketClient = BuildBucketClient(
       accessTokenService: AccessTokenService.defaultProvider(config),
     );
@@ -98,7 +99,7 @@ Future<void> main() async {
       '/api/update-agent-health': UpdateAgentHealth(config, authProvider),
       '/api/update-agent-health-history': UpdateAgentHealthHistory(config, authProvider),
       '/api/update-benchmark-targets': UpdateBenchmarkTargets(config, authProvider),
-      '/api/update-task-status': UpdateTaskStatus(config, authProvider),
+      '/api/update-task-status': UpdateTaskStatus(config, swarmingAuthProvider),
       '/api/update-timeseries': UpdateTimeSeries(config, authProvider),
       '/api/vacuum-clean': VacuumClean(config, authProvider),
       '/api/public/build-status': CacheRequestHandler<Body>(

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -37,6 +37,7 @@ export 'src/request_handling/cache_request_handler.dart';
 export 'src/request_handling/proxy_request_handler.dart';
 export 'src/request_handling/request_handler.dart';
 export 'src/request_handling/static_file_handler.dart';
+export 'src/request_handling/swarming_authentication.dart';
 export 'src/service/access_token_provider.dart';
 export 'src/service/buildbucket.dart';
 export 'src/service/cache_service.dart';

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -128,7 +128,7 @@ class AuthenticationProvider {
         if (agentAuthToken == null) {
           throw const Unauthenticated('Missing required HTTP header: Agent-Auth-Token');
         }
-        if (!_compareHashAndPassword(agent.authToken, agentAuthToken)) {
+        if (!compareHashAndPassword(agent.authToken, agentAuthToken)) {
           throw Unauthenticated('Invalid agent: $agentId');
         }
       }
@@ -223,7 +223,8 @@ class AuthenticationProvider {
   // This method is expensive (run time of ~1,500ms!). If the server starts
   // handling any meaningful API traffic, we should move request processing
   // to dedicated isolates in a pool.
-  static bool _compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
+  // TODO(chillers): Remove when DeviceLab has migrated to LUCI, https://github.com/flutter/flutter/projects/151#card-47536851
+  bool compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
     final String serverAuthTokenHashAscii = ascii.decode(serverAuthTokenHash);
     final DBCrypt crypt = DBCrypt();
     try {

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -1,0 +1,135 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:dbcrypt/dbcrypt.dart';
+import 'package:gcloud/db.dart';
+import 'package:meta/meta.dart';
+
+import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
+import '../model/appengine/agent.dart';
+
+import 'exceptions.dart';
+
+/// Class capable of authenticating [HttpRequest]s for infra endpoints.
+///
+/// This class implements an ACL on a [RequestHandler] to ensure only automated
+/// systems can access the endpoints.
+///
+/// There are two types of authentication this class supports:
+///
+///  1. If the request has the `'Agent-ID'` HTTP header set to the ID of the
+///     Cocoon agent making the request and the `'Agent-Auth-Token'` HTTP
+///     header set to the hashed password of the agent, then the request will
+///     be authenticated as a request being made on behalf of an agent, and the
+///     [RequestContext.agent] field will be set.
+///
+///     The password should be hashed using the bcrypt algorithm. See
+///     <https://en.wikipedia.org/wiki/Bcrypt> or
+///     <https://www.usenix.org/legacy/event/usenix99/provos/provos.pdf> for
+///     more details.
+///
+///  2. If the request has the `Service-Account-Token` HTTP header, the token
+///     will be authenticated as a LUCI bot. This token is validated against
+///     Google Auth APIs.
+///
+/// If none of the above authentication methods yield an authenticated
+/// request, then the request is unauthenticated, and any call to
+/// [authenticate] will throw an [Unauthenticated] exception.
+// TODO(chillers): Remove (1) when DeviceLab has migrated to LUCI, https://github.com/flutter/flutter/projects/151#card-47536851
+@immutable
+class SwarmingAuthenticationProvider extends AuthenticationProvider {
+  const SwarmingAuthenticationProvider(
+    this._config, {
+    this.clientContextProvider = Providers.serviceScopeContext,
+    this.loggingProvider = Providers.serviceScopeLogger,
+    HttpClientProvider httpClientProvider = Providers.freshHttpClient,
+  }) : super(
+          _config,
+          clientContextProvider: clientContextProvider,
+          httpClientProvider: httpClientProvider,
+          loggingProvider: loggingProvider,
+        );
+
+  /// The Cocoon config, guaranteed to be non-null.
+  final Config _config;
+
+  /// Provides the App Engine client context as part of the
+  /// [AuthenticatedContext].
+  ///
+  /// This is guaranteed to be non-null.
+  final ClientContextProvider clientContextProvider;
+
+  /// Provides the logger.
+  ///
+  /// This is guaranteed to be non-null.
+  final LoggingProvider loggingProvider;
+
+  static const String kAgentIdHeader = 'Agent-ID';
+
+  /// Name of the header that LUCI requests will put their service account token.
+  static const String kSwarmingTokenHeader = 'Service-Account-Token';
+
+  /// Authenticates the specified [request] and returns the associated
+  /// [AuthenticatedContext].
+  ///
+  /// See the class documentation on [AuthenticationProvider] for a discussion
+  /// of the different types of authentication that are accepted.
+  ///
+  /// This will throw an [Unauthenticated] exception if the request is
+  /// unauthenticated.
+  @override
+  Future<AuthenticatedContext> authenticate(HttpRequest request) async {
+    final String agentId = request.headers.value(kAgentIdHeader);
+    final String swarmingToken = request.headers.value(kSwarmingTokenHeader);
+
+    final ClientContext clientContext = clientContextProvider();
+    final Logging log = loggingProvider();
+
+    if (agentId != null) {
+      // Authenticate as an agent. Note that it could simultaneously be cron
+      // and agent, or Google account and agent.
+      final Key agentKey = _config.db.emptyKey.append(Agent, id: agentId);
+      final Agent agent = await _config.db.lookupValue<Agent>(agentKey, orElse: () {
+        throw Unauthenticated('Invalid agent: $agentId');
+      });
+
+      if (!clientContext.isDevelopmentEnvironment) {
+        final String agentAuthToken = request.headers.value('Agent-Auth-Token');
+        if (agentAuthToken == null) {
+          throw const Unauthenticated('Missing required HTTP header: Agent-Auth-Token');
+        }
+        if (!_compareHashAndPassword(agent.authToken, agentAuthToken)) {
+          throw Unauthenticated('Invalid agent: $agentId');
+        }
+      }
+
+      return AuthenticatedContext(agent: agent, clientContext: clientContext);
+    } else if (swarmingToken != null) {
+      return await authenticateIdToken(swarmingToken, clientContext: clientContext, log: log);
+    }
+
+    throw const Unauthenticated('Request rejected due to not from LUCI or Cocoon agent');
+  }
+
+  // This method is expensive (run time of ~1,500ms!). If the server starts
+  // handling any meaningful API traffic, we should move request processing
+  // to dedicated isolates in a pool.
+  static bool _compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
+    final String serverAuthTokenHashAscii = ascii.decode(serverAuthTokenHash);
+    final DBCrypt crypt = DBCrypt();
+    try {
+      return crypt.checkpw(clientAuthToken, serverAuthTokenHashAscii);
+    } on String catch (error) {
+      // The bcrypt password hash in the cloud datastore is invalid.
+      throw InternalServerError(error);
+    }
+  }
+}

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -3,12 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/cocoon_service.dart';
-import 'package:dbcrypt/dbcrypt.dart';
 import 'package:gcloud/db.dart';
 import 'package:meta/meta.dart';
 
@@ -106,7 +104,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
         if (agentAuthToken == null) {
           throw const Unauthenticated('Missing required HTTP header: Agent-Auth-Token');
         }
-        if (!_compareHashAndPassword(agent.authToken, agentAuthToken)) {
+        if (!compareHashAndPassword(agent.authToken, agentAuthToken)) {
           throw Unauthenticated('Invalid agent: $agentId');
         }
       }
@@ -117,19 +115,5 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
     }
 
     throw const Unauthenticated('Request rejected due to not from LUCI or Cocoon agent');
-  }
-
-  // This method is expensive (run time of ~1,500ms!). If the server starts
-  // handling any meaningful API traffic, we should move request processing
-  // to dedicated isolates in a pool.
-  static bool _compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
-    final String serverAuthTokenHashAscii = ascii.decode(serverAuthTokenHash);
-    final DBCrypt crypt = DBCrypt();
-    try {
-      return crypt.checkpw(clientAuthToken, serverAuthTokenHashAscii);
-    } on String catch (error) {
-      // The bcrypt password hash in the cloud datastore is invalid.
-      throw InternalServerError(error);
-    }
   }
 }

--- a/app_dart/test/request_handling/swarming_authentication_test.dart
+++ b/app_dart/test/request_handling/swarming_authentication_test.dart
@@ -1,0 +1,181 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'package:cocoon_service/src/model/appengine/agent.dart';
+import 'package:cocoon_service/src/request_handling/authentication.dart' show AuthenticatedContext;
+import 'package:cocoon_service/src/request_handling/swarming_authentication.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_http.dart';
+import '../src/request_handling/fake_logging.dart';
+
+void main() {
+  group('SwarmingAuthenticationProvider', () {
+    FakeConfig config;
+    FakeClientContext clientContext;
+    FakeLogging log;
+    FakeHttpRequest request;
+    SwarmingAuthenticationProvider auth;
+
+    setUp(() {
+      config = FakeConfig();
+      clientContext = FakeClientContext();
+      log = FakeLogging();
+      request = FakeHttpRequest();
+      auth = SwarmingAuthenticationProvider(
+        config,
+        clientContextProvider: () => clientContext,
+        loggingProvider: () => log,
+      );
+    });
+
+    group('when agent id is specified in header', () {
+      Agent agent;
+
+      setUp(() {
+        agent = Agent(
+          key: config.db.emptyKey.append(Agent, id: 'aid'),
+          authToken: ascii.encode(r'$2a$10$4UicEmMSoqzUtWTQAR1s/.qUrmh7oQTyz1MI.f7qt6.jJ6kPipdKq'),
+        );
+        request.headers.set('Agent-ID', agent.key.id);
+      });
+
+      test('throws Unauthenticated if agent lookup fails', () async {
+        expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+      });
+
+      group('and in development environment', () {
+        setUp(() {
+          clientContext.isDevelopmentEnvironment = true;
+        });
+
+        test('succeeds if agent lookup succeeds', () async {
+          config.db.values[agent.key] = agent;
+          final AuthenticatedContext result = await auth.authenticate(request);
+          expect(result.agent, same(agent));
+          expect(result.clientContext, same(clientContext));
+        });
+      });
+
+      group('and not in development environment', () {
+        setUp(() {
+          clientContext.isDevelopmentEnvironment = false;
+        });
+
+        test('fails if agent lookup succeeds but auth token is not provided', () async {
+          config.db.values[agent.key] = agent;
+          expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+        });
+
+        test('fails if agent lookup succeeds but auth token is invalid', () async {
+          config.db.values[agent.key] = agent;
+          request.headers.set('Agent-Auth-Token', 'invalid_token');
+          expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+        });
+
+        test('succeeds if agent lookup succeeds and valid auth token provided', () async {
+          config.db.values[agent.key] = agent;
+          request.headers.set('Agent-Auth-Token', 'password');
+          final AuthenticatedContext result = await auth.authenticate(request);
+          expect(result.agent, same(agent));
+          expect(result.clientContext, same(clientContext));
+        });
+      });
+    });
+
+    test('fails for App Engine cronjobs', () async {
+      request.headers.set('X-Appengine-Cron', 'true');
+      expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+    });
+
+    group('when id token is given', () {
+      FakeHttpClient httpClient;
+      FakeHttpClientResponse verifyTokenResponse;
+
+      setUp(() {
+        httpClient = FakeHttpClient();
+        verifyTokenResponse = httpClient.request.response;
+        auth = SwarmingAuthenticationProvider(
+          config,
+          clientContextProvider: () => clientContext,
+          httpClientProvider: () => httpClient,
+          loggingProvider: () => log,
+        );
+      });
+
+      test('auth succeeds with authenticated service account token', () async {});
+
+      test('auth fails with unauthenticated service account token', () async {
+        httpClient = FakeHttpClient(
+            onIssueRequest: (FakeHttpClientRequest request) => verifyTokenResponse
+              ..statusCode = HttpStatus.unauthorized
+              ..body = 'Invalid token');
+        verifyTokenResponse = httpClient.request.response;
+        auth = SwarmingAuthenticationProvider(
+          config,
+          clientContextProvider: () => clientContext,
+          httpClientProvider: () => httpClient,
+          loggingProvider: () => log,
+        );
+        config.oauthClientIdValue = 'client-id';
+
+        request.headers.add(SwarmingAuthenticationProvider.kSwarmingTokenHeader, 'unauthenticated token');
+
+        expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+      });
+
+      test('auth fails with user token in cookie', () async {
+        httpClient = FakeHttpClient(onIssueRequest: (FakeHttpClientRequest request) {
+          if (request.uri.queryParameters['id_token'] == 'bad-header') {
+            return verifyTokenResponse
+              ..statusCode = HttpStatus.unauthorized
+              ..body = 'Invalid token: bad-header';
+          }
+          return verifyTokenResponse
+            ..statusCode = HttpStatus.ok
+            ..body = '{"aud": "client-id", "hd": "google.com"}';
+        });
+        verifyTokenResponse = httpClient.request.response;
+        auth = SwarmingAuthenticationProvider(
+          config,
+          clientContextProvider: () => clientContext,
+          httpClientProvider: () => httpClient,
+          loggingProvider: () => log,
+        );
+        config.oauthClientIdValue = 'client-id';
+
+        request.cookies.add(FakeCookie(name: 'X-Flutter-IdToken', value: 'authenticated'));
+        request.headers.add('X-Flutter-IdToken', 'bad-header');
+
+        expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+      });
+
+      test('auth fails with user id token in header', () async {
+        httpClient = FakeHttpClient(
+            onIssueRequest: (FakeHttpClientRequest request) => verifyTokenResponse
+              ..statusCode = HttpStatus.ok
+              ..body = '{"aud": "client-id", "hd": "google.com"}');
+        verifyTokenResponse = httpClient.request.response;
+        auth = SwarmingAuthenticationProvider(
+          config,
+          clientContextProvider: () => clientContext,
+          httpClientProvider: () => httpClient,
+          loggingProvider: () => log,
+        );
+        config.oauthClientIdValue = 'client-id';
+
+        request.headers.add('X-Flutter-IdToken', 'authenticated');
+
+        expect(auth.authenticate(request), throwsA(isA<Unauthenticated>()));
+      });
+    });
+  });
+}

--- a/app_dart/test/src/request_handling/fake_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_authentication.dart
@@ -42,6 +42,11 @@ class FakeAuthenticationProvider implements AuthenticationProvider {
       throw const Unauthenticated('Not authenticated');
     }
   }
+
+  @override
+  bool compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
+    throw UnimplementedError();
+  }
 }
 
 // ignore: must_be_immutable


### PR DESCRIPTION
Add a `SwarmingAuthenticationProvider` that is a child of the existing `AuthenticationProvider`. This provider only authenticates for Cocoon agents and LUCI swarming bot service accounts.

This ensures a given `RequestHandler` can only be updated through these methods (enforcing an ACL). For now, I added this to the `update-task-status`, but we should do a greater security review to audit endpoints that should only be used by automated systems.

Added LUCI swarming authentication which reuses the existing Google authentication.

# Issues
https://github.com/flutter/flutter/issues/66191

# Tests

- Added tests that ensure this child class does not grant the same permissions as the parent
- Added tests for LUCI auth being passed to id token
