### PR TITLE
Add retries to buildbucket tries.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -10,6 +10,7 @@ import 'package:cocoon_service/src/model/github/checks.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:github/github.dart' as github;
 import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 
 import '../../cocoon_service.dart';
 import '../model/appengine/service_account_info.dart';
@@ -204,7 +205,14 @@ class LuciBuildService {
         ),
       );
     }
-    await buildBucketClient.batch(BatchRequest(requests: requests));
+    const RetryOptions r = RetryOptions(maxAttempts: 3);
+    await r.retry(
+      () async {
+        await buildBucketClient.batch(BatchRequest(requests: requests));
+      },
+      retryIf: (Exception e) => e is BuildBucketException,
+    );
+
     return true;
   }
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -205,7 +205,10 @@ class LuciBuildService {
         ),
       );
     }
-    const RetryOptions r = RetryOptions(maxAttempts: 3);
+    const RetryOptions r = RetryOptions(
+      maxAttempts: 3,
+      delayFactor: Duration(seconds: 2),
+    );
     await r.retry(
       () async {
         await buildBucketClient.batch(BatchRequest(requests: requests));


### PR DESCRIPTION
Sometimes the buildbucket requests are raising exceptions and github
status stays on pending forever.

Bug: https://github.com/flutter/flutter/issues/69589