### PR TITLE
add cirrus config to build docker image on dockerfile diffs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-# Not used at this time.
-#
-# This empty file prevents Cirrus from auto-detecting the Dockerfile and
-# building it.
+task:
+  container:
+    # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
+    dockerfile: "Dockerfile"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,4 @@
+# Not used at this time.
+#
+# This empty file prevents Cirrus from auto-detecting the Dockerfile and
+# building it.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-task:
+build_docker_task:
   container:
     # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
     dockerfile: "Dockerfile"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,3 +2,5 @@ task:
   container:
     # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
     dockerfile: "Dockerfile"
+  # No-op test. We just want to ensure the Dockerfile builds.
+  test_script: true


### PR DESCRIPTION
Currently, Cirrus will auto-detect the Dockerfile in this repo and build it at every commit. This built docker image is not used. This change will explicitly build the docker image only on dockerfile diffs.