### PR TITLE
[app_flutter] Migrate Flutter deprecations and fix new analyze lints

### DIFF
--- a/app_flutter/lib/widgets/agent_tile.dart
+++ b/app_flutter/lib/widgets/agent_tile.dart
@@ -118,7 +118,7 @@ class AgentTile extends StatelessWidget {
   /// a [SnackBar].
   Future<void> _reserveTask(BuildContext context, Agent agent) async {
     await agentState.reserveTask(agent);
-    Scaffold.of(context).showSnackBar(const SnackBar(
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
       content: Text('Check console for reserve task info'),
       duration: reserveTaskSnackbarDuration,
     ));

--- a/app_flutter/lib/widgets/error_brook_watcher.dart
+++ b/app_flutter/lib/widgets/error_brook_watcher.dart
@@ -60,7 +60,7 @@ class _ErrorBrookWatcherState extends State<ErrorBrookWatcher> {
         Text(error),
       ],
     );
-    Scaffold.of(context).showSnackBar(
+    ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: snackbarContent,
         backgroundColor: Theme.of(context).errorColor,

--- a/app_flutter/lib/widgets/task_grid.dart
+++ b/app_flutter/lib/widgets/task_grid.dart
@@ -319,7 +319,7 @@ class _TaskGridState extends State<TaskGrid> {
           position: (this.context.findRenderObject() as RenderBox)
               .localToGlobal(localPosition, ancestor: Overlay.of(context).context.findRenderObject()),
           task: task,
-          showSnackBarCallback: Scaffold.of(this.context).showSnackBar,
+          showSnackBarCallback: ScaffoldMessenger.of(context).showSnackBar,
           closeCallback: _closeOverlay,
           buildState: widget.buildState,
           commit: commit,

--- a/app_flutter/pubspec.lock
+++ b/app_flutter/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.2"
   build:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.2"
   cli_util:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.2"
   cocoon_service:
     dependency: "direct main"
     description:
@@ -126,7 +126,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.4"
   convert:
     dependency: transitive
     description:
@@ -162,13 +162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.2"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
   dart_style:
     dependency: transitive
     description:
@@ -196,7 +189,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.2"
   file:
     dependency: transitive
     description:
@@ -365,7 +358,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.1"
+    version: "0.6.3-nullsafety.2"
   json_annotation:
     dependency: transitive
     description:
@@ -386,14 +379,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.2"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.5"
   mime:
     dependency: transitive
     description:
@@ -456,14 +449,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.2"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.2"
   platform_detect:
     dependency: transitive
     description:
@@ -491,7 +484,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety.1"
+    version: "1.5.0-nullsafety.3"
   protobuf:
     dependency: transitive
     description:
@@ -587,70 +580,70 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.4"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety.1"
+    version: "0.10.10-nullsafety.3"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.3"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.4"
+    version: "1.10.0-nullsafety.5"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.2"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.5"
+    version: "1.16.0-nullsafety.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.5"
+    version: "0.3.12-nullsafety.7"
   truncate:
     dependency: transitive
     description:
@@ -664,7 +657,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.4"
   url_launcher:
     dependency: "direct main"
     description:
@@ -720,7 +713,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.4"
   vm_service:
     dependency: transitive
     description:
@@ -764,5 +757,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-234.0.dev"
+  dart: ">=2.12.0-0 <=2.12.0-15.0.dev"
   flutter: ">=1.16.0 <2.0.0"

--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -4,6 +4,7 @@
 
 name: app_flutter
 description: The Flutter dashboard.
+publish_to: none
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -21,15 +22,10 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-
   cocoon_service:
     path: ../app_dart
+  flutter:
+    sdk: flutter
   google_sign_in: ^4.5.3
   provider: ^4.0.0
   url_launcher: ^5.4.1
@@ -37,9 +33,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mockito: ^4.0.0
   path: ^1.6.4
   test: ^1.6.0
-  mockito: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Original:
```
   info • 'showSnackBar' is deprecated and shouldn't be used. Use ScaffoldMessenger.showSnackBar. This feature was deprecated after v1.23.0-14.0.pre. • lib/widgets/agent_tile.dart:121:26 • deprecated_member_use
   info • 'showSnackBar' is deprecated and shouldn't be used. Use ScaffoldMessenger.showSnackBar. This feature was deprecated after v1.23.0-14.0.pre. • lib/widgets/error_brook_watcher.dart:63:26 • deprecated_member_use
   info • 'showSnackBar' is deprecated and shouldn't be used. Use ScaffoldMessenger.showSnackBar. This feature was deprecated after v1.23.0-14.0.pre. • lib/widgets/task_grid.dart:322:59 • deprecated_member_use
   info • Sort pub dependencies • pubspec.yaml:29:3 • sort_pub_dependencies
warning • Publishable packages can't have path dependencies • pubspec.yaml:32:5 • invalid_dependency
   info • Sort pub dependencies • pubspec.yaml:42:3 • sort_pub_dependencies
```

Cleaned up the pubspec and migrated `showSnackBar` calls.