### PR TITLE
Specify pubsub topic use when rescheduling prod builds.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -418,6 +418,9 @@ class LuciBuildService {
       properties: <String, String>{
         'git_ref': commitSha,
       },
+      notify: const NotificationConfig(
+        pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
+      ),
     ));
   }
 }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -419,7 +419,7 @@ class LuciBuildService {
         'git_ref': commitSha,
       },
       notify: const NotificationConfig(
-        pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
+        pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds-prod',
       ),
     ));
   }


### PR DESCRIPTION
This PR adds the new pubsub topic to use when cocoon reschedules a prod build. This is part of the solution for https://github.com/flutter/flutter/issues/69621. We will need to also specify the notification to happen when the task is initially scheduled by luci.