### PR TITLE
[app_dart] Add access token authentication for swarming tasks

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -198,6 +198,9 @@ class Config {
   String flutterGoldCommentID(PullRequest pr) =>
       '_Changes reported for pull request #${pr.number} at sha ${pr.head.sha}_\n\n';
 
+  /// Post submit service account email used by LUCI swarming tasks.
+  String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
+
   int get maxTaskRetries => 2;
 
   /// The number of times to retry a LUCI job on infra failures.

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -64,37 +64,34 @@ import 'exceptions.dart';
 @immutable
 class AuthenticationProvider {
   const AuthenticationProvider(
-    this._config, {
-    ClientContextProvider clientContextProvider = Providers.serviceScopeContext,
-    HttpClientProvider httpClientProvider = Providers.freshHttpClient,
-    LoggingProvider loggingProvider = Providers.serviceScopeLogger,
+    this.config, {
+    this.clientContextProvider = Providers.serviceScopeContext,
+    this.httpClientProvider = Providers.freshHttpClient,
+    this.loggingProvider = Providers.serviceScopeLogger,
   })  : assert(_config != null),
         assert(clientContextProvider != null),
         assert(httpClientProvider != null),
-        assert(loggingProvider != null),
-        _clientContextProvider = clientContextProvider,
-        _httpClientProvider = httpClientProvider,
-        _loggingProvider = loggingProvider;
+        assert(loggingProvider != null);
 
   /// The Cocoon config, guaranteed to be non-null.
-  final Config _config;
+  final Config config;
 
   /// Provides the App Engine client context as part of the
   /// [AuthenticatedContext].
   ///
   /// This is guaranteed to be non-null.
-  final ClientContextProvider _clientContextProvider;
+  final ClientContextProvider clientContextProvider;
 
   /// Provides the HTTP client that will be used (if necessary) to verify OAuth
   /// ID tokens (JWT tokens).
   ///
   /// This is guaranteed to be non-null.
-  final HttpClientProvider _httpClientProvider;
+  final HttpClientProvider httpClientProvider;
 
   /// Provides the logger.
   ///
   /// This is guaranteed to be non-null.
-  final LoggingProvider _loggingProvider;
+  final LoggingProvider loggingProvider;
 
   /// Authenticates the specified [request] and returns the associated
   /// [AuthenticatedContext].

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -110,8 +110,8 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
   ///
   /// Access tokens are the legacy authentication strategy for Google OAuth, where ID tokens
   /// are the new technique to use. LUCI auth only generates access tokens, and must be
-  /// validated against a different endpoint. We only validate access tokens if they belong
-  /// to a DeviceLab service account.
+  /// validated against a different endpoint. We only authenticate access tokens 
+  /// if they belong to a LUCI prod service account.
   ///
   /// If LUCI auth adds id tokens, we can switch to that and remove this.
   Future<AuthenticatedContext> authenticateAccessToken(String accessToken,

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -110,7 +110,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
   ///
   /// Access tokens are the legacy authentication strategy for Google OAuth, where ID tokens
   /// are the new technique to use. LUCI auth only generates access tokens, and must be
-  /// validated against a different endpoint. We only authenticate access tokens 
+  /// validated against a different endpoint. We only authenticate access tokens
   /// if they belong to a LUCI prod service account.
   ///
   /// If LUCI auth adds id tokens, we can switch to that and remove this.

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -253,4 +253,7 @@ class FakeConfig implements Config {
     }
     return <LuciBuilder>[];
   }
+
+  @override
+  String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 }

--- a/app_dart/test/src/request_handling/fake_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_authentication.dart
@@ -5,6 +5,8 @@
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
+import 'package:cocoon_service/src/datastore/cocoon_config.dart';
+import 'package:cocoon_service/src/foundation/typedefs.dart';
 import 'package:gcloud/db.dart';
 
 import 'package:cocoon_service/src/model/appengine/agent.dart';
@@ -47,6 +49,18 @@ class FakeAuthenticationProvider implements AuthenticationProvider {
   bool compareHashAndPassword(List<int> serverAuthTokenHash, String clientAuthToken) {
     throw UnimplementedError();
   }
+
+  @override
+  ClientContextProvider get clientContextProvider => throw UnimplementedError();
+
+  @override
+  Config get config => throw UnimplementedError();
+
+  @override
+  HttpClientProvider get httpClientProvider => throw UnimplementedError();
+
+  @override
+  LoggingProvider get loggingProvider => throw UnimplementedError();
 }
 
 // ignore: must_be_immutable


### PR DESCRIPTION
Switches `SwarmingAuthenticationProvider` id token authentication to access token.

Make some members in `AuthenticationProvider` public to remove code duplication in `SwarmingAuthenticationProvider`.

# Issues
https://github.com/flutter/flutter/issues/66191

# Tests

Switched tests from id token to access token equivalents.

Check that only the LUCI prod account is authenticated.