### PR TITLE
[app_dart] Fix update-task-status branch param name

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -45,7 +45,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
   final DatastoreServiceProvider datastoreProvider;
 
-  static const String gitBranchParam = 'Branch';
+  static const String gitBranchParam = 'CommitBranch';
   static const String gitShaParam = 'CommitSha';
   static const String newStatusParam = 'NewStatus';
   static const String resultsParam = 'ResultData';


### PR DESCRIPTION
This should match what the DeviceLab test runner uses (or vice versa). [Source](https://cs.opensource.google/flutter/flutter/+/master:dev/devicelab/lib/framework/cocoon.dart;l=85-90)

I think the DeviceLab test runner is more specific so I'll update Cocoon to match.

# Test

https://chromium-swarm.appspot.com/task?id=4fd36cbb6d373b10 - Failed on this

This requires a recipe run to validate.

# Issues

https://github.com/flutter/flutter/issues/66191