### PR TITLE
[app_dart] Fix update-task-status query filter with extra space

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -158,7 +158,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final Key commitKey = _constructCommitKey(datastore);
 
     final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)
-      ..filter('name = ', requestData[taskNameParam]);
+      ..filter('name =', requestData[taskNameParam]);
     final List<Task> tasks = await query.run().toList();
     if (tasks.length != 1) {
       throw const InternalServerError('Multiple tasks found');

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -136,6 +136,8 @@ class FakeQuery<T extends Model> implements Query<T> {
 
   @override
   void filter(String filterString, Object comparisonObject) {
+    // In production, Datastore filters cannot have a space at the end.
+    assert(filterString.trim() == filterString);
     filters.add(FakeFilterSpec._(filterString, comparisonObject));
   }
 


### PR DESCRIPTION
Datastore in production differs slightly from our test service. It cannot have a space at the end of the filter, otherwise an error is thrown.

# Issue

https://logs.chromium.org/logs/flutter/led/chillers_google.com/226e07e7f862d86628e3b6b73e7b54061ff3caea821ec3915b83c298f8d60937/+/steps/run_web_benchmarks_canvaskit/0/stdout

500 on devicelab luci task due to this filter.

# Test

Added assert check to test datastore service to prevent future issues like this.