### PR TITLE
Stop adding cirrus task to datastore when refreshing new github commits

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -202,13 +202,10 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       );
     }
 
-    final List<Task> tasks = <Task>[
-      // These built-in tasks are not listed in the manifest.
-      newTask('cirrus', 'cirrus', <String>['can-update-github'], false, 0),
-    ];
-
+    final List<Task> tasks = <Task>[];
     final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
     for (LuciBuilder builder in prodBuilders) {
+      // These built-in tasks are not listed in the manifest.
       tasks.add(Task.chromebot(commitKey, createTimestamp, builder.taskName, builder.flaky ?? false));
     }
 

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -145,7 +145,7 @@ void main() {
       httpClient.request.response.body = singleTaskManifestYaml;
       final Body body = await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 6);
-      expect(db.values.values.whereType<Task>().length, 12);
+      expect(db.values.values.whereType<Task>().length, 10);
       expect(await body.serialize().toList(), isEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.WARNING)), isEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);
@@ -195,7 +195,7 @@ void main() {
       httpClient.request.response.body = singleTaskManifestYaml;
       final Body body = await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 3);
-      expect(db.values.values.whereType<Task>().length, 12);
+      expect(db.values.values.whereType<Task>().length, 10);
       expect(db.values.values.whereType<Commit>().map<String>(toSha), <String>['1', '2', '4']);
       expect(db.values.values.whereType<Commit>().map<int>(toTimestamp), <int>[1, 2, 4]);
       expect(await body.serialize().toList(), isEmpty);
@@ -216,7 +216,7 @@ void main() {
       final Body body = await tester.get<Body>(handler);
       expect(retry, 2);
       expect(db.values.values.whereType<Commit>().length, 1);
-      expect(db.values.values.whereType<Task>().length, 6);
+      expect(db.values.values.whereType<Task>().length, 5);
       expect(await body.serialize().toList(), isEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.WARNING)), isNotEmpty);
       expect(tester.log.records.where(hasLevel(LogLevel.ERROR)), isEmpty);


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/997