### PR TITLE
[app_dart] update-task-status only updates chromebot tasks when given LUCI information

### DIFF
--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -160,13 +160,12 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final String taskName = requestData[taskNameParam];
     final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)..filter('name =', taskName);
     final List<Task> tasks = await query.run().toList();
-    if (tasks.length == 1) {
-      return tasks.first;
+    if (tasks.length != 1) {
+      log.warn('Found ${tasks.length} entries for $taskName');
+      throw const InternalServerError('Expected to find 1 task for $taskName, but found ${tasks.length}');
     }
 
-    log.warn('Found ${tasks.length} entries for $taskName');
-    throw const InternalServerError('Expected to find 1 task for $taskName,'
-        'but found ${tasks.length}');
+    return tasks.first;
   }
 
   /// Construct the Datastore key for [Commit] that is the ancestor to this [Task].

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -159,7 +159,16 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
     final String taskName = requestData[taskNameParam] as String;
     final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)..filter('name =', taskName);
-    final List<Task> tasks = await query.run().toList();
+    final List<Task> initialTasks = await query.run().toList();
+    // Expected initialTasks will return one CocoonAgentTask and one LuciTask.
+    // TODO(chillers): After migration to LUCI this can be removed as there will only be one entry, https://github.com/flutter/flutter/projects/151
+    final List<Task> tasks = <Task>[];
+    for (Task task in initialTasks) {
+      if (task.stageName == 'chromebot') {
+        tasks.add(task);
+      }
+    }
+
     if (tasks.length != 1) {
       log.error('Found ${tasks.length} entries for $taskName');
       throw InternalServerError('Expected to find 1 task for $taskName, but found ${tasks.length}');

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -157,14 +157,16 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
   Future<Task> _getTaskFromNamedParams(DatastoreService datastore) async {
     final Key commitKey = _constructCommitKey(datastore);
 
-    final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)
-      ..filter('name =', requestData[taskNameParam]);
+    final String taskName = requestData[taskNameParam];
+    final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)..filter('name =', taskName);
     final List<Task> tasks = await query.run().toList();
-    if (tasks.length != 1) {
-      throw const InternalServerError('Multiple tasks found');
+    if (tasks.length == 1) {
+      return tasks.first;
     }
 
-    return tasks.first;
+    log.warn('Found ${tasks.length} entries for $taskName');
+    throw const InternalServerError('Expected to find 1 task for $taskName,'
+        'but found ${tasks.length}');
   }
 
   /// Construct the Datastore key for [Commit] that is the ancestor to this [Task].

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -157,12 +157,12 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
   Future<Task> _getTaskFromNamedParams(DatastoreService datastore) async {
     final Key commitKey = _constructCommitKey(datastore);
 
-    final String taskName = requestData[taskNameParam];
+    final String taskName = requestData[taskNameParam] as String;
     final Query<Task> query = datastore.db.query<Task>(ancestorKey: commitKey)..filter('name =', taskName);
     final List<Task> tasks = await query.run().toList();
     if (tasks.length != 1) {
-      log.warn('Found ${tasks.length} entries for $taskName');
-      throw const InternalServerError('Expected to find 1 task for $taskName, but found ${tasks.length}');
+      log.error('Found ${tasks.length} entries for $taskName');
+      throw InternalServerError('Expected to find 1 task for $taskName, but found ${tasks.length}');
     }
 
     return tasks.first;

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -198,5 +198,29 @@ void main() {
       expect(cocoonTask.status, Task.statusNew);
       expect(cocoonTask.attempts, 0);
     });
+
+    test('task name request fails when there is only a Cocoon task', () async {
+      final Commit commit = Commit(
+          key:
+              config.db.emptyKey.append(Commit, id: 'flutter/flutter/master/7d03371610c07953a5def50d500045941de516b8'));
+      config.db.values[commit.key] = commit;
+      final Task cocoonTask = Task(
+        key: commit.key.append(Task, id: 4590522719010816),
+        name: 'integration_ui_ios',
+        attempts: 0,
+        isFlaky: true, // mark flaky so it doesn't get auto-retried
+        commitKey: commit.key,
+        status: Task.statusNew,
+        stageName: 'devicelab',
+      );
+      config.db.values[cocoonTask.key] = cocoonTask;
+      tester.requestData = <String, dynamic>{
+        UpdateTaskStatus.gitBranchParam: 'master',
+        UpdateTaskStatus.gitShaParam: '7d03371610c07953a5def50d500045941de516b8',
+        UpdateTaskStatus.newStatusParam: 'Failed',
+        UpdateTaskStatus.taskNameParam: 'integration_ui_ios',
+      };
+      expect(tester.post(handler), throwsA(isA<InternalServerError>()));
+    });
   });
 }


### PR DESCRIPTION
Give more informative messages when errors occur.

Only update chromebot tasks when given the LUCI information. This is needed for the DeviceLab migration to LUCI as there will be some period of time where a chromebot and devicelab task both have the same name.

# Tests

- Added check for Cocoon task exists but not a LUCI one
- Cocoon and LUCI task
- There's an existing one for only a LUCI task