### PR TITLE
Update saltstack for devicelab salt provision

### DIFF
--- a/dev/provision_salt.sh
+++ b/dev/provision_salt.sh
@@ -12,12 +12,12 @@ MINION_PLIST_PATH=/Library/LaunchDaemons/com.saltstack.salt.minion.plist
 # Pins the version to 2019.2.0 and Python 2 to be compatible with Fuchsia salt master.
 function install_salt() {
   if [[ "$(uname)" == 'Linux' ]]; then
-    wget -O - https://repo.saltstack.com/apt/debian/9/amd64/archive/2019.2.0/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
-    echo 'deb http://repo.saltstack.com/apt/debian/9/amd64/archive/2019.2.0 stretch main' | sudo tee /etc/apt/sources.list.d/saltstack.list
+    wget -O - https://repo.saltstack.com/py3/debian/10/amd64/3002/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+    echo 'deb http://repo.saltstack.com/py3/debian/10/amd64/3002 buster main' | sudo tee /etc/apt/sources.list.d/saltstack.list
     sudo apt update
     sudo apt install salt-minion
   elif [[ "$(uname)" == 'Darwin' ]]; then
-    curl https://repo.saltstack.com/osx/salt-2019.2.0-py2-x86_64.pkg -o /tmp/salt.pkg
+    curl https://repo.saltstack.com/osx/salt-3002.1-py3-x86_64.pkg -o /tmp/salt.pkg
     sudo installer -pkg /tmp/salt.pkg -target /
   fi
 }


### PR DESCRIPTION
Update the versions to make it consistent with other linux/mac bots.