### PR TITLE
[app_dart] Use LuciBuilder when creating chromebot tasks

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -56,6 +56,7 @@ class Task extends Model {
     assert(builder.flaky != null);
     return Task(
       attempts: 1,
+      builderName: builder.name,
       commitKey: commitKey,
       createTimestamp: createTimestamp,
       isFlaky: builder.flaky ?? false,

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -4,7 +4,9 @@
 
 import 'package:gcloud/db.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
+import '../../service/luci.dart';
 import 'commit.dart';
 import 'key_converter.dart';
 
@@ -45,24 +47,25 @@ class Task extends Model {
     id = key?.id;
   }
 
-  // Represents a LUCI build.
-  factory Task.chromebot(Key commitKey, int createTimestamp, String name, bool isFlaky) {
-    assert(commitKey != null);
-    assert(createTimestamp != null);
-    assert(name != null);
-    assert(isFlaky != null);
-
+  /// Construct [Task] from a [LuciBuilder].
+  factory Task.chromebot({
+    @required Key commitKey,
+    @required int createTimestamp,
+    @required LuciBuilder builder,
+  }) {
+    assert(builder.flaky != null);
     return Task(
-      key: commitKey.append(Task),
+      attempts: 1,
       commitKey: commitKey,
       createTimestamp: createTimestamp,
-      name: name,
-      isFlaky: isFlaky,
-      timeoutInMinutes: 0,
+      isFlaky: builder.flaky ?? false,
+      key: commitKey.append(Task),
+      // The task name of a builder is what Cocoon uses for the name.
+      name: builder.taskName,
       requiredCapabilities: <String>['can-update-github'],
       stageName: 'chromebot',
       status: Task.statusNew,
-      attempts: 1,
+      timeoutInMinutes: 0,
     );
   }
 

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -206,7 +206,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
     for (LuciBuilder builder in prodBuilders) {
       // These built-in tasks are not listed in the manifest.
-      tasks.add(Task.chromebot(commitKey, createTimestamp, builder.taskName, builder.flaky ?? false));
+      tasks.add(Task.chromebot(commitKey: commitKey, createTimestamp: createTimestamp, builder: builder));
     }
 
     final YamlMap yaml = await _loadDevicelabManifest(sha);

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -29,8 +29,14 @@ void main() {
         taskName: 'taskName',
         flaky: false,
       );
-      final Task t = Task.chromebot(commitKey: key, createTimestamp: 123, builder: builder);
-      validateModel(t);
+      final Task task = Task.chromebot(commitKey: key, createTimestamp: 123, builder: builder);
+      validateModel(task);
+      expect(task.name, 'taskName');
+      expect(task.builderName, 'builderAbc');
+      expect(task.createTimestamp, 123);
+      expect(task.isFlaky, false);
+      expect(task.requiredCapabilities, <String>['can-update-github']);
+      expect(task.timeoutInMinutes, 0);
     });
 
     test('disallows flaky be null', () {

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/service/luci.dart';
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
@@ -22,12 +23,27 @@ void main() {
     test('creates a valid chromebot task', () {
       final DatastoreDB db = DatastoreDB(null);
       final Key key = db.emptyKey.append(Task, id: 42);
-      final Task t = Task.chromebot(key, 123, 'taskName', false);
+      const LuciBuilder builder = LuciBuilder(
+        name: 'builderAbc',
+        repo: 'flutter/flutter',
+        taskName: 'taskName',
+        flaky: false,
+      );
+      final Task t = Task.chromebot(commitKey: key, createTimestamp: 123, builder: builder);
       validateModel(t);
     });
 
     test('disallows flaky be null', () {
-      expect(() => Task.chromebot(null, 123, 'taskName', null), throwsA(isA<AssertionError>()));
+      final DatastoreDB db = DatastoreDB(null);
+      final Key key = db.emptyKey.append(Task, id: 42);
+      const LuciBuilder builder = LuciBuilder(
+        name: 'builderAbc',
+        repo: 'flutter/flutter',
+        taskName: 'taskName',
+        flaky: null,
+      );
+      expect(
+          () => Task.chromebot(commitKey: key, createTimestamp: 123, builder: builder), throwsA(isA<AssertionError>()));
     });
   });
 }


### PR DESCRIPTION
Use `LuciBuilder` to populate the chromebot tasks. The information in `prod_builders.json` is enough to populate some extra values on creation, mainly `builderName`.

# Issues

Fixes https://github.com/flutter/flutter/issues/69839 - `builderName` was not available on new chromebot tasks

https://github.com/flutter/flutter/issues/66191 - `builderName` is not initially populated on LUCI tasks, and can cause race condition failures depending on when datastore refreshed from luci

# Test

Updated chromebot task to expect correct values.