### PR TITLE
Preserve LUCI infra failures in Cocoon

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -93,6 +93,7 @@ class Task extends Model {
   /// The list of legal values for the [status] property.
   static const List<String> legalStatusValues = <String>[
     statusNew,
+    statusInfraFailure,
     statusInProgress,
     statusSucceeded,
     statusFailed,

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -73,6 +73,9 @@ class Task extends Model {
   /// The task is yet to be run.
   static const String statusNew = 'New';
 
+  /// The task failed to run due to an unexpected issue.
+  static const String statusInfraFailure = 'Infra Failure';
+
   /// The task is currently running.
   static const String statusInProgress = 'In Progress';
 

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -14,6 +14,7 @@ import '../model/appengine/task.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../service/buildbucket.dart';
 import '../service/datastore.dart';
 import '../service/luci.dart';
 
@@ -33,6 +34,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
 
   static LuciService _createLuciService(ApiRequestHandler<dynamic> handler) {
     return LuciService(
+      buildBucketClient: BuildBucketClient(),
       config: handler.config,
       clientContext: handler.authContext.clientContext,
     );

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -14,6 +14,7 @@ import '../model/appengine/task.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../service/buildbucket.dart';
 import '../service/datastore.dart';
 import '../service/luci.dart';
 
@@ -39,6 +40,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
 
   static LuciService _createLuciService(ApiRequestHandler<dynamic> handler) {
     return LuciService(
+      buildBucketClient: BuildBucketClient(),
       config: handler.config,
       clientContext: handler.authContext.clientContext,
     );

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -119,7 +119,7 @@ class BuildStatusService {
   }
 
   bool _isFailed(Task task) {
-    return task.status == Task.statusFailed;
+    return task.status == Task.statusFailed || task.status == Task.statusInfraFailure;
   }
 
   bool _isSuccessful(Task task) {

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -150,7 +150,6 @@ void main() {
         expect(status, BuildStatus.failed);
       });
 
-
       test('returns failure when a task has an infra failure', () async {
         db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
         int row = 0;

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -2,9 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/service/luci.dart';
+import 'package:mockito/mockito.dart';
 
 import 'package:test/test.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/request_handling/fake_authentication.dart';
+import '../src/service/fake_github_service.dart';
+import '../src/utilities/mocks.dart';
 
 void main() {
   BranchLuciBuilder branchLuciBuilder1;
@@ -20,5 +27,47 @@ void main() {
     map[branchLuciBuilder2] = 'test2';
 
     expect(map[branchLuciBuilder1], 'test2');
+  });
+
+  test('luci status matches expected cocoon status', () async {
+    final FakeConfig config = FakeConfig(githubService: FakeGithubService());
+    final FakeClientContext clientContext = FakeClientContext();
+    final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
+    final LuciService service =
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+    final List<Build> builds = List<Build>.generate(
+      luciStatusToTaskStatus.keys.length,
+      (int index) => Build(
+        id: index,
+        number: index,
+        builderId: const BuilderId(
+          project: 'flutter',
+          bucket: 'prod',
+          builder: 'Linux',
+        ),
+        status: luciStatusToTaskStatus.keys.toList()[index],
+      ),
+    );
+    when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+      return BatchResponse(
+        responses: <Response>[
+          Response(
+            searchBuilds: SearchBuildsResponse(builds: builds),
+          ),
+        ],
+      );
+    });
+
+    final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTaskBranchMap =
+        await service.getBranchRecentTasks(repo: 'flutter');
+    // There's no branch logic so there is only one entry
+    expect(luciTaskBranchMap.keys.length, 1);
+    final Map<String, List<LuciTask>> luciTaskMap = luciTaskBranchMap.values.first;
+    final List<LuciTask> luciTasks = luciTaskMap['unknown'];
+    for (LuciTask luciTask in luciTasks) {
+      // Get associated luci builder to verify status is mapped correctly
+      final Build luciBuild = builds[luciTask.buildNumber];
+      expect(luciTask.status, luciStatusToTaskStatus[luciBuild.status]);
+    }
   });
 }

--- a/app_flutter/lib/widgets/task_box.dart
+++ b/app_flutter/lib/widgets/task_box.dart
@@ -16,6 +16,7 @@ class TaskBox {
   static const String statusNew = 'New';
   static const String statusSkipped = 'Skipped';
   static const String statusSucceeded = 'Succeeded';
+  static const String statusInfraFailure = 'Infra Failure';
   static const String statusInProgress = 'In Progress';
 
   /// A lookup table to define the background color for this TaskBox.
@@ -26,6 +27,7 @@ class TaskBox {
     statusNew: Colors.grey,
     statusSkipped: Colors.transparent,
     statusSucceeded: Colors.green,
+    statusInfraFailure: Colors.purple,
     statusInProgress: Colors.yellow,
   };
 }


### PR DESCRIPTION
LUCI publishes this status, and would be helpful to differentiate infra failures on the dashboard versus test failures. This also allows us to reduce tree closures due to infra causes

This PR takes LUCI builds that were infra failures and keeps the status. Previously, they were marked as failures.

# Issue

https://github.com/flutter/flutter/issues/70331

# Test

Added table test for the app_dart changes

Flutter app already has a similar table test that uses the map to validate expectations