### PR TITLE
Add dependabot to roller accounts list

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -245,6 +245,7 @@ class Config {
   Set<String> get rollerAccounts => const <String>{
         'skia-flutter-autoroll',
         'engine-flutter-autoroll',
+        'dependabot[bot]',
       };
 
   Future<String> generateJsonWebToken() async {


### PR DESCRIPTION
[GitHub dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) was turned on in flutter/flutter with https://github.com/flutter/flutter/pull/71602.  PRs will look something like this: https://github.com/flutter/flutter/pull/62379

Currently it's only turned on to update the LUCI docker image macOS Gemfile.

Add the bot to the list of autoroller accounts so it will auto-merge when the tests pass.  Its name really includes those brackets:
https://api.github.com/users/dependabot%5Bbot%5D