### PR TITLE
Add build script for device_doctor

### DIFF
--- a/device_doctor/.gitignore
+++ b/device_doctor/.gitignore
@@ -1,0 +1,12 @@
+# CIPD and Dart-SDK binaries
+.cipd/
+dart-sdk/
+
+# Build outputs
+.dart_tool/
+build/
+.ssh/
+
+# Dart
+.packages
+!pubspec.lock

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -31,7 +31,7 @@ Future<void> main(List<String> args) async {
     })
     ..addOption('$deviceOSFlag', help: 'Supported device OS: android and ios.', callback: (String value) {
       if (!supportedDeviceOS.contains(value)) {
-        throw FormatException('Invalid value for option --action: $value');
+        throw FormatException('Invalid value for option --device-os: $value');
       }
     })
     ..addFlag('$helpFlag', help: 'Prints usage info.');

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -14,7 +14,6 @@ const List<String> supportedDeviceOS = <String>['ios', 'android'];
 
 /// These values will be initialized in `_checkArgs` function,
 /// and used in `main` function.
-String _action;
 String _deviceOS;
 
 /// Manage healthcheck and recovery for devices.
@@ -37,7 +36,6 @@ Future<void> main(List<String> args) async {
     ..addFlag('$helpFlag', help: 'Prints usage info.');
 
   final ArgResults argResults = parser.parse(args);
-  _action = argResults[actionFlag];
   _deviceOS = argResults[deviceOSFlag];
 
   DeviceDiscovery(_deviceOS);

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -315,7 +315,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.9"
+    version: "0.9.7+1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -336,7 +336,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
@@ -429,4 +429,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-76.0.dev"
+  dart: ">=2.10.0-78 <2.11.0"

--- a/device_doctor/tool/buil.sh
+++ b/device_doctor/tool/buil.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Fetches corresponding dart sdk from CIPD for different platforms, builds
+# an executable binary of device_doctor to `build` folder.
+#
+# This currently supports linux, mac and windows.
+
+set -e
+
+command -v cipd > /dev/null || {
+  echo "Please install CIPD (available from depot_tools) and add to path first.";
+  exit -1;
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+OS="`uname`"
+
+if [[ "{$OS}" == "Linux" || "{$OS}" == "Darwin" ]]; then
+  cipd ensure -ensure-file $DIR/ensure_file -root $DIR
+else
+  # dart2native is not available in stable yet for windows.
+  cipd ensure -ensure-file $DIR/ensure_file_windows -root $DIR
+fi
+pushd $DIR/..
+
+if [[ -d "build" ]]; then
+  echo "Please remove the build directory before proceeding"
+  exit -1
+fi
+
+mkdir -p build
+if [[ $OS == "Linux" || $OS == "Darwin" ]]; then
+  tool/dart-sdk/bin/pub get
+  tool/dart-sdk/bin/dart2native bin/main.dart -o build/device_doctor
+else
+  tool/dart-sdk/bin/pub.bat get
+  tool/dart-sdk/bin/dart2native.bat bin/main.dart -o build/device_doctor.exe
+fi
+
+if [[ $OS == "Darwin" ]]; then
+  mkdir -p build/tool
+  cp -rf tool/infra-dialog build/tool/
+fi
+
+popd

--- a/device_doctor/tool/ensure_file
+++ b/device_doctor/tool/ensure_file
@@ -1,0 +1,3 @@
+$ServiceURL https://chrome-infra-packages.appspot.com/
+
+dart/dart-sdk/${os}-${arch} stable

--- a/device_doctor/tool/ensure_file_windows
+++ b/device_doctor/tool/ensure_file_windows
@@ -1,0 +1,3 @@
+$ServiceURL https://chrome-infra-packages.appspot.com/
+
+dart/dart-sdk/${os}-${arch} beta

--- a/tests.yaml
+++ b/tests.yaml
@@ -31,3 +31,6 @@ tasks:
 
   - task: repo_dashboard
     script: test_utilities/bin/flutter_test_runner.sh
+
+  - task: device_doctor
+    script: test_utilities/bin/dart_test_runner.sh


### PR DESCRIPTION
This creates the build script to build device_doctor. Currently it supports linux, mac, and windows.

Tests will be added from flutter/infra, and recipe side once this is in.

Related issue: https://github.com/flutter/flutter/issues/66193