### PR TITLE
make github bot wrong merge base test more lenient

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -333,7 +333,7 @@ class GithubWebhook extends RequestHandler<Body> {
       return;
     }
     final RegExp candidateTest = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
-    if (pr.base.ref == pr.head.ref && candidateTest.hasMatch(pr.head.ref)) {
+    if (candidateTest.hasMatch(pr.base.ref) && candidateTest.hasMatch(pr.head.ref)) {
       // This is most likely a release branch
       body = config.releaseBranchPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, slug, body)) {

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -222,7 +222,7 @@ void main() {
         'opened',
         issueNumber,
         'flutter-1.20-candidate.7',
-        headRef: 'flutter-1.20-candidate.7',
+        headRef: 'cherrypicks-flutter-1.20-candidate.7',
       );
       final Uint8List body = utf8.encode(request.body) as Uint8List;
       final Uint8List key = utf8.encode(keyString) as Uint8List;


### PR DESCRIPTION
The former release process advised that branches on a user's mirror should be named the same as the release branch they were going to merge into. The new process advises prefixing their user branch with `cherrypicks-`. Thus, make this test in the github bot more lenient, just requiring both base ref and head ref to match the regex, and not requiring them to be exactly the same.