### PR TITLE
Create bat script for device_doctor windows build

### DIFF
--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -1,0 +1,29 @@
+@ECHO off
+REM Copyright 2020 The Flutter Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
+REM Checks if cipd command is available.
+FOR /F "tokens=*" %%g IN ('where cipd') do (SET CIPD=%%g)
+IF %ERRORLEVEL% NEQ 0 (
+        ECHO "Please install CIPD (available from depot_tools) and add to path first.";
+        EXIT
+)
+
+REM `path` is \path\to\device_doctor\tool\
+REM `DIR` is \path\to\device_doctor\tool
+SET path=%~dp0
+SET DIR=%path:~0,-1%
+%CIPD% ensure --ensure-file %path%\ensure_file_windows -root %DIR%
+
+REM `BUILD_DIR` is \path\to\device_doctor
+for %%a in (%DIR:~0,-1%) do set "BUILD_DIR=%%~dpa"
+PUSHD %BUILD_DIR%
+if exist %BUILD_DIR%\build (
+        ECHO "Please remove the build directory before proceeding"
+        EXIT
+)
+MKDIR %BUILD_DIR%\build
+
+tool\dart-sdk\bin\pub.bat get
+tool\dart-sdk\bin\dart2native.bat bin\main.dart -o build\device_doctor.exe

--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -2,7 +2,6 @@
 :: Use of this source code is governed by a BSD-style license that can be
 :: found in the LICENSE file.
 
-@ECHO off
 REM Checks if cipd command is available.
 FOR /F "tokens=*" %%g IN ('where cipd') do (SET CIPD=%%g)
 IF %ERRORLEVEL% NEQ 0 (

--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -1,8 +1,8 @@
-@ECHO off
-REM Copyright 2020 The Flutter Authors. All rights reserved.
-REM Use of this source code is governed by a BSD-style license that can be
-REM found in the LICENSE file.
+:: Copyright 2020 The Flutter Authors. All rights reserved.
+:: Use of this source code is governed by a BSD-style license that can be
+:: found in the LICENSE file.
 
+@ECHO off
 REM Checks if cipd command is available.
 FOR /F "tokens=*" %%g IN ('where cipd') do (SET CIPD=%%g)
 IF %ERRORLEVEL% NEQ 0 (

--- a/device_doctor/tool/build.sh
+++ b/device_doctor/tool/build.sh
@@ -6,7 +6,7 @@
 # Fetches corresponding dart sdk from CIPD for different platforms, builds
 # an executable binary of device_doctor to `build` folder.
 #
-# This currently supports linux, mac and windows.
+# This currently supports linux and mac.
 
 set -e
 

--- a/device_doctor/tool/build.sh
+++ b/device_doctor/tool/build.sh
@@ -18,12 +18,8 @@ command -v cipd > /dev/null || {
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 OS="`uname`"
 
-if [[ "{$OS}" == "Linux" || "{$OS}" == "Darwin" ]]; then
-  cipd ensure -ensure-file $DIR/ensure_file -root $DIR
-else
-  # dart2native is not available in stable yet for windows.
-  cipd ensure -ensure-file $DIR/ensure_file_windows -root $DIR
-fi
+cipd ensure -ensure-file $DIR/ensure_file -root $DIR
+
 pushd $DIR/..
 
 if [[ -d "build" ]]; then
@@ -32,13 +28,8 @@ if [[ -d "build" ]]; then
 fi
 
 mkdir -p build
-if [[ $OS == "Linux" || $OS == "Darwin" ]]; then
-  tool/dart-sdk/bin/pub get
-  tool/dart-sdk/bin/dart2native bin/main.dart -o build/device_doctor
-else
-  tool/dart-sdk/bin/pub.bat get
-  tool/dart-sdk/bin/dart2native.bat bin/main.dart -o build/device_doctor.exe
-fi
+tool/dart-sdk/bin/pub get
+tool/dart-sdk/bin/dart2native bin/main.dart -o build/device_doctor
 
 if [[ $OS == "Darwin" ]]; then
   mkdir -p build/tool


### PR DESCRIPTION
Existing build.sh works for all platforms, but LUCI bot is more comfortable with a `.bat` file for windows.

This PR creates a corresponding `.bat` build file for windows, parallel to the `build.sh` for linux and mac. 