### PR TITLE
Revert "[app_dart] Pass branch when rescheduling prod builds"

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -416,7 +416,6 @@ class LuciBuildService {
         'user_agent': const <String>['luci-scheduler'],
       },
       properties: <String, String>{
-        'branch': 'refs/heads/$branch',
         'git_ref': commitSha,
       },
     ));


### PR DESCRIPTION
Reverts flutter/cocoon#1027

This breaks in prod. flutter/flutter#72007

We need to switch how the recipe pulls the branch (use gitiles instead of the property)