### PR TITLE
Add support to device_doctor for device property check

### DIFF
--- a/agent/test/src/adb_test.dart
+++ b/agent/test/src/adb_test.dart
@@ -261,6 +261,12 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
+  Future<String> shellEval(String command, List<String> arguments, {Map<String, String> env}) async {
+    commandLog.add(CommandArgs(command: command, arguments: arguments, env: env));
+    return output;
+  }
+
+  @override
   Future<Null> shellExec(String command, List<String> arguments, {Map<String, String> env}) async {
     commandLog.add(CommandArgs(command: command, arguments: arguments, env: env));
     dynamic exitError = exitErrorFactory();

--- a/agent/test/src/adb_test.dart
+++ b/agent/test/src/adb_test.dart
@@ -261,12 +261,6 @@ class FakeDevice extends AndroidDevice {
   }
 
   @override
-  Future<String> shellEval(String command, List<String> arguments, {Map<String, String> env}) async {
-    commandLog.add(CommandArgs(command: command, arguments: arguments, env: env));
-    return output;
-  }
-
-  @override
   Future<Null> shellExec(String command, List<String> arguments, {Map<String, String> env}) async {
     commandLog.add(CommandArgs(command: command, arguments: arguments, env: env));
     dynamic exitError = exitErrorFactory();

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -17,19 +17,21 @@ const List<String> supportedDeviceOS = <String>['ios', 'android'];
 String _action;
 String _deviceOS;
 
-/// Manage `healthcheck` and `recovery` for devices.
+/// Manage `healthcheck`, `recovery`, and `properties` for devices.
 ///
 /// For `healthcheck`, if no device is found or any health check fails an stderr will be logged,
 /// and an exception will be thrown.
 ///
 /// For `recovery`, it will do cleanup, reboot, etc. to try bringing device back to a working state.
 ///
+/// For `properties`, it will return device properties/dimensions, like manufacture, base_buildid, etc.
+///
 /// Usage:
 /// dart main.dart --action <healthcheck|recovery> --deviceOS <android|ios>
 Future<void> main(List<String> args) async {
   final ArgParser parser = ArgParser();
   parser
-    ..addOption('$actionFlag', help: 'Supported actions are healthcheck, recovery and propertycheck.',
+    ..addOption('$actionFlag', help: 'Supported actions are healthcheck, recovery and properties.',
         callback: (String value) {
       if (!supportedOptions.contains(value)) {
         throw FormatException('\n-----\n'
@@ -61,7 +63,7 @@ Future<void> main(List<String> args) async {
     case 'recovery':
       await deviceDiscovery.recoverDevices();
       break;
-    case 'propertycheck':
-      await deviceDiscovery.checkDeviceProperties();
+    case 'properties':
+      await deviceDiscovery.deviceProperties();
   }
 }

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -8,9 +8,8 @@ import 'package:device_doctor/device_doctor.dart';
 
 const String actionFlag = 'action';
 const String deviceOSFlag = 'device-os';
-const String propertiesFlag = 'properties';
 const String helpFlag = 'help';
-const List<String> supportedOptions = <String>['healthcheck', 'recovery'];
+const List<String> supportedOptions = <String>['healthcheck', 'recovery', 'propertycheck'];
 const List<String> supportedDeviceOS = <String>['ios', 'android'];
 
 /// These values will be initialized in `_checkArgs` function,
@@ -30,7 +29,8 @@ String _deviceOS;
 Future<void> main(List<String> args) async {
   final ArgParser parser = ArgParser();
   parser
-    ..addOption('$actionFlag', help: 'Supported actions are healthcheck and recovery.', callback: (String value) {
+    ..addOption('$actionFlag', help: 'Supported actions are healthcheck, recovery and propertycheck.',
+        callback: (String value) {
       if (!supportedOptions.contains(value)) {
         throw FormatException('\n-----\n'
             'Invalid value for option --action: $value.'
@@ -61,5 +61,7 @@ Future<void> main(List<String> args) async {
     case 'recovery':
       await deviceDiscovery.recoverDevices();
       break;
+    case 'propertycheck':
+      await deviceDiscovery.checkDeviceProperties();
   }
 }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -103,7 +103,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   /// It supports multiple devices, but here we are assuming only one device is attached.
   @override
   Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager}) async {
-    final List<AndroidDevice> devices = await discoverDevices();
+    final List<AndroidDevice> devices = await discoverDevices(processManager: processManager);
     if (devices.isEmpty) {
       return <String, List<String>>{};
     }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -102,12 +102,12 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   ///
   /// It supports multiple devices, but here we are assuming only one device is attached.
   @override
-  Future<Map<String, List<String>>> deviceProperties({ProcessManager processManager}) async {
+  Future<Map<String, String>> deviceProperties({ProcessManager processManager}) async {
     final List<AndroidDevice> devices = await discoverDevices(processManager: processManager);
     if (devices.isEmpty) {
-      return <String, List<String>>{};
+      return <String, String>{};
     }
-    final Map<String, List<String>> properties = await getDeviceProperties(devices[0], processManager: processManager);
+    final Map<String, String> properties = await getDeviceProperties(devices[0], processManager: processManager);
     stdout.write(json.encode(properties));
     return properties;
   }
@@ -116,9 +116,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   ///
   /// Refer function `get_dimensions` from
   /// https://source.chromium.org/chromium/infra/infra/+/master:luci/appengine/swarming/swarming_bot/api/platforms/android.py
-  Future<Map<String, List<String>>> getDeviceProperties(AndroidDevice device, {ProcessManager processManager}) async {
+  Future<Map<String, String>> getDeviceProperties(AndroidDevice device, {ProcessManager processManager}) async {
     processManager ??= LocalProcessManager();
-    final Map<String, List<String>> deviceProperties = <String, List<String>>{};
+    final Map<String, String> deviceProperties = <String, String>{};
     final Map<String, String> propertyMap = <String, String>{};
     LineSplitter.split(
             await eval('adb', <String>['-s', device.deviceId, 'shell', 'getprop'], processManager: processManager))
@@ -127,11 +127,11 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       propertyMap[propertyList[0].trim()] = propertyList[1].trim();
     });
 
-    deviceProperties['device_os_flavor'] = <String>[propertyMap['ro.product.brand']];
-    final String device_os = propertyMap['ro.build.id'];
-    deviceProperties['device_os'] = <String>[device_os[0], device_os];
-    deviceProperties['device_os_type'] = <String>[propertyMap['ro.build.type']];
-    deviceProperties['device_type'] = <String>[propertyMap['ro.product.model'], propertyMap['ro.product.board']];
+    deviceProperties['product_brand'] = propertyMap['ro.product.brand'];
+    deviceProperties['build_id'] = propertyMap['ro.build.id'];
+    deviceProperties['build_type'] = propertyMap['ro.build.type'];
+    deviceProperties['product_model'] = propertyMap['ro.product.model'];
+    deviceProperties['product_board'] = propertyMap['ro.product.board'];
     return deviceProperties;
   }
 

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -102,12 +102,12 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   ///
   /// It supports multiple devices, but here we are assuming only one device is attached.
   @override
-  Future<Map<String, List<String>>> checkDeviceProperties() async {
+  Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager}) async {
     final List<AndroidDevice> devices = await discoverDevices();
     if (devices.isEmpty) {
       return <String, List<String>>{};
     }
-    final Map<String, List<String>> properties = await getDeviceProperties(devices[0]);
+    final Map<String, List<String>> properties = await getDeviceProperties(devices[0], processManager: processManager);
     stdout.write(json.encode(properties));
     return properties;
   }

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -32,7 +32,7 @@ abstract class DeviceDiscovery {
   /// Checks and returns the device properties, like manufacturer, base_buildid, etc.
   ///
   /// Currently it supports only android devices, but can extend to iOS devices.
-  Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager});
+  Future<Map<String, List<String>>> deviceProperties({ProcessManager processManager});
 
   /// Recovers the device.
   Future<void> recoverDevices();

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -32,7 +32,7 @@ abstract class DeviceDiscovery {
   /// Checks and returns the device properties, like manufacturer, base_buildid, etc.
   ///
   /// Currently it supports only android devices, but can extend to iOS devices.
-  Future<Map<String, List<String>>> deviceProperties({ProcessManager processManager});
+  Future<Map<String, String>> deviceProperties({ProcessManager processManager});
 
   /// Recovers the device.
   Future<void> recoverDevices();

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -27,6 +27,9 @@ abstract class DeviceDiscovery {
   /// Checks the health of the available devices.
   Future<Map<String, List<HealthCheckResult>>> checkDevices();
 
+  /// Checks and returns the device properties, like manufacturer, base_buildid, etc.
+  Future<Map<String, List<String>>> checkDeviceProperties();
+
   /// Recovers the device.
   Future<void> recoverDevices();
 }

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -28,6 +28,8 @@ abstract class DeviceDiscovery {
   Future<Map<String, List<HealthCheckResult>>> checkDevices();
 
   /// Checks and returns the device properties, like manufacturer, base_buildid, etc.
+  ///
+  /// Currently it supports only android devices, but can extend to iOS devices.
   Future<Map<String, List<String>>> checkDeviceProperties();
 
   /// Recovers the device.

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:process/process.dart';
+
 import 'android_device.dart';
 import 'health.dart';
 import 'ios_device.dart';
@@ -30,7 +32,7 @@ abstract class DeviceDiscovery {
   /// Checks and returns the device properties, like manufacturer, base_buildid, etc.
   ///
   /// Currently it supports only android devices, but can extend to iOS devices.
-  Future<Map<String, List<String>>> checkDeviceProperties();
+  Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager});
 
   /// Recovers the device.
   Future<void> recoverDevices();

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -48,6 +48,19 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   }
 
   @override
+  Future<Map<String, List<String>>> checkDeviceProperties() async {
+    final List<IosDevice> devices = await discoverDevices();
+    if (devices.isEmpty) {
+      return <String, List<String>>{};
+    }
+    return getDeviceProperties(devices[0]);
+  }
+
+  Future<Map<String, List<String>>> getDeviceProperties(IosDevice device) async {
+    return <String, List<String>>{};
+  }
+
+  @override
   Future<void> recoverDevices() async {
     for (Device device in await discoverDevices()) {
       await device.recover();

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -48,12 +48,9 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     return results;
   }
 
-  /// iOS device property check is not needed at this moment.
-  ///
-  /// But we will implement this to replace existing chromium side bot config logic
-  /// after devicelab migration to LUCI is done.
+  /// Checks and returns the device properties.
   @override
-  Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager}) async {
+  Future<Map<String, List<String>>> deviceProperties({ProcessManager processManager}) async {
     return <String, List<String>>{};
   }
 

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -47,16 +47,12 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     return results;
   }
 
+  /// iOS device property check is not needed at this moment.
+  ///
+  /// But we will implement this to replace existing chromium side bot config logic
+  /// after devicelab migration to LUCI is done.
   @override
   Future<Map<String, List<String>>> checkDeviceProperties() async {
-    final List<IosDevice> devices = await discoverDevices();
-    if (devices.isEmpty) {
-      return <String, List<String>>{};
-    }
-    return getDeviceProperties(devices[0]);
-  }
-
-  Future<Map<String, List<String>>> getDeviceProperties(IosDevice device) async {
     return <String, List<String>>{};
   }
 

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert' show LineSplitter;
 
 import 'package:meta/meta.dart';
+import 'package:process/process.dart';
 
 import 'device.dart';
 import 'health.dart';
@@ -52,7 +53,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   /// But we will implement this to replace existing chromium side bot config logic
   /// after devicelab migration to LUCI is done.
   @override
-  Future<Map<String, List<String>>> checkDeviceProperties() async {
+  Future<Map<String, List<String>>> checkDeviceProperties({ProcessManager processManager}) async {
     return <String, List<String>>{};
   }
 

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -50,8 +50,8 @@ class IosDeviceDiscovery implements DeviceDiscovery {
 
   /// Checks and returns the device properties.
   @override
-  Future<Map<String, List<String>>> deviceProperties({ProcessManager processManager}) async {
-    return <String, List<String>>{};
+  Future<Map<String, String>> deviceProperties({ProcessManager processManager}) async {
+    return <String, String>{};
   }
 
   @override

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -343,7 +343,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
@@ -436,4 +436,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-157.0.dev"
+  dart: ">=2.10.0-78 <2.11.0"

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -70,7 +70,8 @@ void main() {
 
       process = FakeProcess(0, out: <List<int>>[utf8.encode('')]);
 
-      expect(await deviceDiscovery.checkDeviceProperties(), equals(<String, List<String>>{}));
+      expect(await deviceDiscovery.checkDeviceProperties(processManager: processManager),
+          equals(<String, List<String>>{}));
     });
 
     test('get device properties', () async {

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -48,4 +48,64 @@ void main() {
           throwsA(TypeMatcher<TimeoutException>()));
     });
   });
+
+  group('AndroidDeviceProperties', () {
+    AndroidDeviceDiscovery deviceDiscovery;
+    MockProcessManager processManager;
+    Process device_os_flavor_process;
+    Process device_os_process;
+    Process device_os_type_process;
+    Process device_type_model_process;
+    Process device_type_board_process;
+    Process process;
+
+    setUp(() {
+      deviceDiscovery = AndroidDeviceDiscovery();
+      processManager = MockProcessManager();
+    });
+
+    test('returns empty when no device is attached', () async {
+      when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      process = FakeProcess(0, out: <List<int>>[utf8.encode('')]);
+
+      expect(await deviceDiscovery.checkDeviceProperties(), equals(<String, List<String>>{}));
+    });
+
+    test('get device properties', () async {
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.brand'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(device_os_flavor_process));
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.build.id'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(device_os_process));
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.build.type'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(device_os_type_process));
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.model'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(device_type_model_process));
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.board'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(device_type_board_process));
+
+      device_os_flavor_process = FakeProcess(0, out: <List<int>>[utf8.encode('motorola')]);
+      device_os_process = FakeProcess(0, out: <List<int>>[utf8.encode('NPJS25.93-14-18')]);
+      device_os_type_process = FakeProcess(0, out: <List<int>>[utf8.encode('user')]);
+      device_type_model_process = FakeProcess(0, out: <List<int>>[utf8.encode('Moto G (4)')]);
+      device_type_board_process = FakeProcess(0, out: <List<int>>[utf8.encode('msm8952')]);
+
+      Map<String, List<String>> deviceProperties = await deviceDiscovery
+          .getDeviceProperties(AndroidDevice(deviceId: 'ZY223JQNMR'), processManager: processManager);
+
+      const Map<String, List<String>> expectedProperties = <String, List<String>>{
+        'device_os_flavor': <String>['motorola'],
+        'device_os': <String>['N', 'NPJS25.93-14-18'],
+        'device_os_type': <String>['user'],
+        'device_type': <String>['Moto G (4)', 'msm8952']
+      };
+      expect(deviceProperties, equals(expectedProperties));
+    });
+  });
 }

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -58,6 +58,7 @@ void main() {
     Process device_type_model_process;
     Process device_type_board_process;
     Process process;
+    List<List<int>> output;
 
     setUp(() {
       deviceDiscovery = AndroidDeviceDiscovery();
@@ -67,8 +68,11 @@ void main() {
     test('returns empty when no device is attached', () async {
       when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
-
-      process = FakeProcess(0, out: <List<int>>[utf8.encode('')]);
+      
+      StringBuffer sb = new StringBuffer();
+      sb.writeln('List of devices attached');
+      output = <List<int>>[utf8.encode(sb.toString())];
+      process = FakeProcess(0, out: output);
 
       expect(await deviceDiscovery.checkDeviceProperties(processManager: processManager),
           equals(<String, List<String>>{}));

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -52,13 +52,9 @@ void main() {
   group('AndroidDeviceProperties', () {
     AndroidDeviceDiscovery deviceDiscovery;
     MockProcessManager processManager;
-    Process device_os_flavor_process;
-    Process device_os_process;
-    Process device_os_type_process;
-    Process device_type_model_process;
-    Process device_type_board_process;
+    Process property_process;
     Process process;
-    List<List<int>> output;
+    String output;
 
     setUp(() {
       deviceDiscovery = AndroidDeviceDiscovery();
@@ -69,46 +65,34 @@ void main() {
       when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
-      StringBuffer sb = new StringBuffer();
-      sb.writeln('List of devices attached');
-      output = <List<int>>[utf8.encode(sb.toString())];
-      process = FakeProcess(0, out: output);
+      output = 'List of devices attached';
+      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
 
-      expect(await deviceDiscovery.checkDeviceProperties(processManager: processManager),
-          equals(<String, List<String>>{}));
+      expect(await deviceDiscovery.deviceProperties(processManager: processManager), equals(<String, List<String>>{}));
     });
 
     test('get device properties', () async {
-      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.brand'],
+      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop'],
               workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(device_os_flavor_process));
-      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.build.id'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(device_os_process));
-      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.build.type'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(device_os_type_process));
-      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.model'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(device_type_model_process));
-      when(processManager.start(<dynamic>['adb', '-s', 'ZY223JQNMR', 'shell', 'getprop', 'ro.product.board'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(device_type_board_process));
+          .thenAnswer((_) => Future.value(property_process));
 
-      device_os_flavor_process = FakeProcess(0, out: <List<int>>[utf8.encode('motorola')]);
-      device_os_process = FakeProcess(0, out: <List<int>>[utf8.encode('NPJS25.93-14-18')]);
-      device_os_type_process = FakeProcess(0, out: <List<int>>[utf8.encode('user')]);
-      device_type_model_process = FakeProcess(0, out: <List<int>>[utf8.encode('Moto G (4)')]);
-      device_type_board_process = FakeProcess(0, out: <List<int>>[utf8.encode('msm8952')]);
+      output = '''[ro.product.brand]: [abc]
+      [ro.build.id]: [def]
+      [ro.build.type]: [ghi]
+      [ro.product.model]: [jkl]
+      [ro.product.board]: [mno]
+      ''';
+
+      property_process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
 
       Map<String, List<String>> deviceProperties = await deviceDiscovery
           .getDeviceProperties(AndroidDevice(deviceId: 'ZY223JQNMR'), processManager: processManager);
 
       const Map<String, List<String>> expectedProperties = <String, List<String>>{
-        'device_os_flavor': <String>['motorola'],
-        'device_os': <String>['N', 'NPJS25.93-14-18'],
-        'device_os_type': <String>['user'],
-        'device_type': <String>['Moto G (4)', 'msm8952']
+        'device_os_flavor': <String>['abc'],
+        'device_os': <String>['d', 'def'],
+        'device_os_type': <String>['ghi'],
+        'device_type': <String>['jkl', 'mno']
       };
       expect(deviceProperties, equals(expectedProperties));
     });

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -68,7 +68,7 @@ void main() {
       output = 'List of devices attached';
       process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
 
-      expect(await deviceDiscovery.deviceProperties(processManager: processManager), equals(<String, List<String>>{}));
+      expect(await deviceDiscovery.deviceProperties(processManager: processManager), equals(<String, String>{}));
     });
 
     test('get device properties', () async {
@@ -85,14 +85,15 @@ void main() {
 
       property_process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
 
-      Map<String, List<String>> deviceProperties = await deviceDiscovery
+      Map<String, String> deviceProperties = await deviceDiscovery
           .getDeviceProperties(AndroidDevice(deviceId: 'ZY223JQNMR'), processManager: processManager);
 
-      const Map<String, List<String>> expectedProperties = <String, List<String>>{
-        'device_os_flavor': <String>['abc'],
-        'device_os': <String>['d', 'def'],
-        'device_os_type': <String>['ghi'],
-        'device_type': <String>['jkl', 'mno']
+      const Map<String, String> expectedProperties = <String, String>{
+        'product_brand': 'abc',
+        'build_id': 'def',
+        'build_type': 'ghi',
+        'product_model': 'jkl',
+        'product_board': 'mno'
       };
       expect(deviceProperties, equals(expectedProperties));
     });

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -68,7 +68,7 @@ void main() {
     test('returns empty when no device is attached', () async {
       when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
-      
+
       StringBuffer sb = new StringBuffer();
       sb.writeln('List of devices attached');
       output = <List<int>>[utf8.encode(sb.toString())];


### PR DESCRIPTION
As devicelab tasks are being migrated to LUCI, we need to support mac/ios, mac/android, linux/android, and windows/android.

However chromium bot config is not supporting `mac/android` device dimensions query. This PR adds functionality to support that, so that chromium bot can call device_doctor to obtain the device properties and further help pick up builders correctly.

Related issue: https://github.com/flutter/flutter/issues/72760, https://github.com/flutter/flutter/issues/66193, https://github.com/flutter/flutter/issues/72835