### PR TITLE
Enable device_doctor try builders for cocoon pre-submit

### DIFF
--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -4,6 +4,21 @@
          "name":"Cocoon",
          "repo":"cocoon",
          "enabled":true
+      },
+      {
+         "name":"Linux device_doctor",
+         "repo":"cocoon",
+         "enabled":true
+      },
+      {
+         "name":"Mac device_doctor",
+         "repo":"cocoon",
+         "enabled":true
+      },
+      {
+         "name":"Windows device_doctor",
+         "repo":"cocoon",
+         "enabled":true
       }
    ]
 }

--- a/dev/try_builders.json
+++ b/dev/try_builders.json
@@ -8,17 +8,20 @@
       {
          "name":"Linux device_doctor",
          "repo":"cocoon",
-         "enabled":true
+         "enabled":true,
+         "run_if": ["device_doctor/**"]
       },
       {
          "name":"Mac device_doctor",
          "repo":"cocoon",
-         "enabled":true
+         "enabled":true,
+         "run_if": ["device_doctor/**"]
       },
       {
          "name":"Windows device_doctor",
          "repo":"cocoon",
-         "enabled":true
+         "enabled":true,
+         "run_if": ["device_doctor/**"]
       }
    ]
 }


### PR DESCRIPTION
Pre-submit device_doctor try builders have been configured in https://github.com/flutter/infra/pull/317
This PR follows up to enable them in cocoon repo.

Related issue: https://github.com/flutter/flutter/issues/72835