### PR TITLE
Copy device_doctor license to build

### DIFF
--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -26,3 +26,5 @@ MKDIR %BUILD_DIR%\build
 
 tool\dart-sdk\bin\pub.bat get
 tool\dart-sdk\bin\dart2native.bat bin\main.dart -o build\device_doctor.exe
+
+xcopy %BUILD_DIR%\LICENSE %BUILD_DIR%\build\.

--- a/device_doctor/tool/build.sh
+++ b/device_doctor/tool/build.sh
@@ -31,6 +31,8 @@ mkdir -p build
 tool/dart-sdk/bin/pub get
 tool/dart-sdk/bin/dart2native bin/main.dart -o build/device_doctor
 
+cp -f LICENSE build/
+
 if [[ $OS == "Darwin" ]]; then
   mkdir -p build/tool
   cp -rf tool/infra-dialog build/tool/


### PR DESCRIPTION
This PR copy LICENSE to the build package tool.

Related issue: https://github.com/flutter/flutter/issues/72835