### PR TITLE
Device_doctor: add healthcheck to android device

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -95,6 +95,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       results['android-device-${device.deviceId}'] = checks;
     }
+    await healthcheck(results);
     return results;
   }
 

--- a/device_doctor/lib/src/health.dart
+++ b/device_doctor/lib/src/health.dart
@@ -88,14 +88,12 @@ class HealthCheckResult {
 Future<void> healthcheck(Map<String, List<HealthCheckResult>> deviceChecks) async {
   if (deviceChecks.isEmpty) {
     stderr.writeln('No healthy device is available');
-    throw StateError('No healthy device is available');
   }
   for (String deviceID in deviceChecks.keys) {
     List<HealthCheckResult> checks = deviceChecks[deviceID];
     for (HealthCheckResult healthCheckResult in checks) {
       if (!healthCheckResult.succeeded) {
         stderr.writeln('${healthCheckResult.name} check failed with: ${healthCheckResult.details}');
-        throw StateError('$deviceID: ${healthCheckResult.name} check failed with: ${healthCheckResult.details}');
       } else {
         stdout.writeln('${healthCheckResult.name} check succeeded');
       }

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -343,7 +343,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
@@ -436,4 +436,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-78 <2.11.0"
+  dart: ">=2.12.0-0.0 <=2.12.0-169.0.dev"

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -30,7 +30,8 @@ void main() {
 
     test('checkDevices without device', () async {
       deviceDiscovery.outputs = <dynamic>[''];
-      await expectLater(deviceDiscovery.checkDevices(), throwsStateError);
+      Map<String, List<HealthCheckResult>> results = await deviceDiscovery.checkDevices();
+      await expectLater(results.keys.length, 0);
     });
 
     test('checkDevices with device', () async {


### PR DESCRIPTION
`healthcheck` was conducted but it failed to analyze results and communicate with console for android device. This PR adds it.

This PR also removes unnecessary `throw`.