### PR TITLE
Check autoroller author by ID instead of name

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -238,14 +238,15 @@ class Config {
     return ServiceAccountCredentials.fromJson(json.decode(rawValue));
   }
 
-  /// The names of autoroller accounts for the repositories.
+  /// The user IDs of autoroller accounts for the repositories.
   ///
   /// These accounts should not need reviews before merging. See
   /// https://github.com/flutter/flutter/wiki/Autorollers
-  Set<String> get rollerAccounts => const <String>{
-        'skia-flutter-autoroll',
-        'engine-flutter-autoroll',
-        'dependabot[bot]',
+  /// Find the ID number via https://api.github.com/users/<username>
+  Set<int> get rollerAccounts => const <int>{
+        37626415, // skia-flutter-autoroll
+        42042535, // engine-flutter-autoroll
+        49699333, // dependabot[bot]
       };
 
   Future<String> generateJsonWebToken() async {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -191,12 +191,12 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       if (utcDate.add(const Duration(hours: 1)).isAfter(DateTime.now().toUtc())) {
         continue;
       }
-      final String author = pullRequest['author']['login'] as String;
+      final int authorId = pullRequest['author']['id'] as int;
       final String id = pullRequest['id'] as String;
       final int number = pullRequest['number'] as int;
 
       final Set<String> changeRequestAuthors = <String>{};
-      final bool hasApproval = config.rollerAccounts.contains(author) ||
+      final bool hasApproval = config.rollerAccounts.contains(authorId) ||
           _checkApproval(
             (pullRequest['reviews']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>(),
             changeRequestAuthors,

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -819,7 +819,8 @@ class PullRequestHelper {
     this.author = 'some_rando',
     this.authorId = 565656,
     this.reviews = const <PullRequestReviewHelper>[
-      PullRequestReviewHelper(authorName: 'member', authorId: 9876, state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
+      PullRequestReviewHelper(
+          authorName: 'member', authorId: 9876, state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
     ],
     this.lastCommitHash = oid,
     this.lastCommitStatuses = const <StatusHelper>[StatusHelper.flutterBuildSuccess],

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -79,7 +79,7 @@ class FakeConfig implements Config {
   Logging loggingServiceValue;
   String waitingForTreeToGoGreenLabelNameValue;
   ServiceAccountCredentials taskLogServiceAccountValue;
-  Set<String> rollerAccountsValue;
+  Set<int> rollerAccountsValue;
   int luciTryInfraFailureRetriesValue;
   RepositorySlug flutterSlugValue;
   List<String> flutterBranchesValue;
@@ -202,7 +202,7 @@ class FakeConfig implements Config {
   Future<ServiceAccountCredentials> get taskLogServiceAccount async => taskLogServiceAccountValue;
 
   @override
-  Set<String> get rollerAccounts => rollerAccountsValue;
+  Set<int> get rollerAccounts => rollerAccountsValue;
 
   @override
   bool githubPresubmitSupportedRepo(String repositoryName) {


### PR DESCRIPTION
[GitHub dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically) was added to the [autorollers list,](https://github.com/flutter/cocoon/pull/1017) but [fluttergithubbot removed the `waiting for tree to go green` label](https://github.com/flutter/flutter/pull/73689#issuecomment-757678283).

Speculating, this may be a problem with the brackets in `dependabot[bot]` username.  Check autoroller IDs instead of usernames.

Fixes https://github.com/flutter/flutter/issues/73723