### PR TITLE
Auto rerun framework Mac builders with infra failure

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -78,7 +78,7 @@ Future<void> main() async {
       '/api/push-build-status-to-github': PushBuildStatusToGithub(config, authProvider),
       '/api/push-gold-status-to-github': PushGoldStatusToGithub(config, authProvider),
       '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(config, authProvider),
-      '/api/refresh-chromebot-status': RefreshChromebotStatus(config, authProvider),
+      '/api/refresh-chromebot-status': RefreshChromebotStatus(config, authProvider, luciBuildService),
       '/api/refresh-github-commits': RefreshGithubCommits(config, authProvider),
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -203,6 +203,9 @@ class Config {
 
   int get maxTaskRetries => 2;
 
+  /// Max retries for Luci builder with infra failure.
+  int get maxLuciTaskRetries => 1;
+
   /// The number of times to retry a LUCI job on infra failures.
   int get luciTryInfraFailureRetries => 2;
 

--- a/app_dart/lib/src/model/luci/buildbucket.dart
+++ b/app_dart/lib/src/model/luci/buildbucket.dart
@@ -567,7 +567,7 @@ class Input extends JsonBody {
   static Input fromJson(Map<String, dynamic> json) => _$InputFromJson(json);
 
   /// The build properties of a build.
-  final Map<String, String> properties;
+  final Map<String, dynamic> properties;
 
   /// The [GitilesCommit] information for a build.
   final GitilesCommit gitilesCommit;

--- a/app_dart/lib/src/model/luci/buildbucket.g.dart
+++ b/app_dart/lib/src/model/luci/buildbucket.g.dart
@@ -404,9 +404,7 @@ Map<String, dynamic> _$NotificationConfigToJson(NotificationConfig instance) {
 
 Input _$InputFromJson(Map<String, dynamic> json) {
   return Input(
-    properties: (json['properties'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    ),
+    properties: json['properties'] as Map<String, dynamic>,
     gitilesCommit:
         json['gitilesCommit'] == null ? null : GitilesCommit.fromJson(json['gitilesCommit'] as Map<String, dynamic>),
     experimental: json['experimental'] as bool,

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -11,7 +11,6 @@ import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../foundation/utils.dart';
 import '../model/appengine/task.dart';
-import '../model/luci/buildbucket.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -11,18 +11,21 @@ import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../foundation/utils.dart';
 import '../model/appengine/task.dart';
+import '../model/luci/buildbucket.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
 import '../service/buildbucket.dart';
 import '../service/datastore.dart';
 import '../service/luci.dart';
+import '../service/luci_build_service.dart';
 
 @immutable
 class RefreshChromebotStatus extends ApiRequestHandler<Body> {
   const RefreshChromebotStatus(
     Config config,
-    AuthenticationProvider authenticationProvider, {
+    AuthenticationProvider authenticationProvider,
+    this.luciBuildService, {
     @visibleForTesting LuciServiceProvider luciServiceProvider,
     @visibleForTesting DatastoreServiceProvider datastoreProvider,
     @visibleForTesting this.branchHttpClientProvider = Providers.freshHttpClient,
@@ -33,6 +36,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
         assert(gitHubBackoffCalculator != null),
         super(config: config, authenticationProvider: authenticationProvider);
 
+  final LuciBuildService luciBuildService;
   final LuciServiceProvider luciServiceProvider;
   final DatastoreServiceProvider datastoreProvider;
   final HttpClientProvider branchHttpClientProvider;
@@ -80,25 +84,46 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     /// [builderNumberList] when luci rerun happens, and update [devicelabTask]
     /// status when the status of latest luci run changes.
     for (FullTask datastoreTask in datastoreTasks) {
-      if (luciTasksMap.containsKey(datastoreTask.commit.sha)) {
-        final List<LuciTask> luciTasks = luciTasksMap[datastoreTask.commit.sha];
-        final String buildNumberList =
-            luciTasks.reversed.map((LuciTask luciTask) => luciTask.buildNumber.toString()).toList().join(',');
-        if (buildNumberList != datastoreTask.task.buildNumberList ||
-            luciTasks.first.status != datastoreTask.task.status) {
-          final Task update = datastoreTask.task;
-          update.status = luciTasks.first.status;
-          update.buildNumberList = buildNumberList;
-          update.builderName = builder.name;
-          update.luciBucket = 'luci.flutter.prod';
-          await datastore.insert(<Task>[update]);
-          // Save luci task record to BigQuery only when task finishes.
-          if (update.status == Task.statusFailed || update.status == Task.statusSucceeded) {
-            await _insertBigquery(update);
-          }
+      final String commitSha = datastoreTask.commit.sha;
+      if (!luciTasksMap.containsKey(commitSha)) {
+        continue;
+      }
+      final List<LuciTask> luciTasks = luciTasksMap[commitSha];
+      final String buildNumberList =
+          luciTasks.reversed.map((LuciTask luciTask) => luciTask.buildNumber.toString()).toList().join(',');
+      final LuciTask latestLuciTask = luciTasks.first;
+      if (buildNumberList != datastoreTask.task.buildNumberList || latestLuciTask.status != datastoreTask.task.status) {
+        final Task update = datastoreTask.task;
+        update.status = latestLuciTask.status;
+
+        if (_shouldRerunTask(latestLuciTask, update.attempts)) {
+          await luciBuildService.rescheduleProdBuild(
+            commitSha: commitSha,
+            builderName: latestLuciTask.builderName,
+          );
+          update.status = Task.statusNew;
+          update.attempts += 1;
+        }
+
+        update.buildNumberList = buildNumberList;
+        update.builderName = builder.name;
+        update.luciBucket = 'luci.flutter.prod';
+        await datastore.insert(<Task>[update]);
+        // Save luci task record to BigQuery only when task finishes.
+        if (update.status == Task.statusFailed || update.status == Task.statusSucceeded) {
+          await _insertBigquery(update);
         }
       }
     }
+  }
+
+  /// Auto-rerun Mac builders with `infra failure`.
+  ///
+  /// This is a workaround for -9 retcode issue: https://github.com/flutter/flutter/issues/68322.
+  bool _shouldRerunTask(LuciTask luciTask, int attempts) {
+    return luciTask.builderName.contains('Mac') &&
+        luciTask.status == Task.statusInfraFailure &&
+        attempts < config.maxTaskRetries;
   }
 
   Future<void> _insertBigquery(Task task) async {

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -85,7 +85,8 @@ class LuciService {
           ref: ref,
           status: luciStatusToTaskStatus[build.status],
           buildNumber: build.number,
-          builderName: build.builderId.builder));
+          builderName: build.builderId.builder,
+          summaryMarkdown: build.summaryMarkdown,));
     }
     return results;
   }
@@ -147,6 +148,8 @@ class LuciService {
               builder: builder.name,
             ),
           ),
+          fields:
+              'builds.*.id,builds.*.input,builds.*.builder,builds.*.number,builds.*.status,builds.*.summaryMarkdown',
         ),
       );
     }).toList();
@@ -236,7 +239,8 @@ class LuciTask {
       @required this.ref,
       @required this.status,
       @required this.buildNumber,
-      @required this.builderName})
+      @required this.builderName,
+      this.summaryMarkdown})
       : assert(commitSha != null),
         assert(ref != null),
         assert(status != null),
@@ -257,4 +261,7 @@ class LuciTask {
 
   /// The builder name of this task.
   final String builderName;
+
+  /// The builder name of this task.
+  final String summaryMarkdown;
 }

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -81,12 +81,13 @@ class LuciService {
       results[branchLuciBuilder] ??= <String, List<LuciTask>>{};
       results[branchLuciBuilder][commit] ??= <LuciTask>[];
       results[branchLuciBuilder][commit].add(LuciTask(
-          commitSha: commit,
-          ref: ref,
-          status: luciStatusToTaskStatus[build.status],
-          buildNumber: build.number,
-          builderName: build.builderId.builder,
-          summaryMarkdown: build.summaryMarkdown,));
+        commitSha: commit,
+        ref: ref,
+        status: luciStatusToTaskStatus[build.status],
+        buildNumber: build.number,
+        builderName: build.builderId.builder,
+        summaryMarkdown: build.summaryMarkdown,
+      ));
     }
     return results;
   }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -14,11 +14,14 @@ import 'package:retry/retry.dart';
 
 import '../../cocoon_service.dart';
 import '../model/appengine/service_account_info.dart';
-import '../model/appengine/task.dart';
 import '../model/luci/buildbucket.dart';
 import '../model/luci/push_message.dart' as push_message;
 import '../service/luci.dart';
 import 'buildbucket.dart';
+
+/// List of Mac builders that have shards, and hit -9 retcode issue:
+/// https://github.com/flutter/flutter/issues/68322
+const List<String> kMacBuildersWithShards = <String>['Mac build_tests', 'Mac framework_tests', 'Mac tool_tests'];
 
 /// Class to interact with LUCI buildbucket to get, trigger
 /// and cancel builds for github repos. It uses [config.luciTryBuilders] to
@@ -431,9 +434,7 @@ class LuciBuildService {
     @required int taskAttempts,
     String repo = 'flutter',
   }) async {
-    if (luciTask.builderName.contains('Mac') &&
-        luciTask.status == Task.statusInfraFailure &&
-        taskAttempts < config.maxLuciTaskRetries) {
+    if (_shouldRerunBuilder(luciTask) && taskAttempts < config.maxLuciTaskRetries) {
       await rescheduleProdBuild(
         commitSha: commitSha,
         builderName: luciTask.builderName,
@@ -442,5 +443,14 @@ class LuciBuildService {
       return true;
     }
     return false;
+  }
+
+  bool _shouldRerunBuilder(LuciTask luciTask) {
+    if (luciTask.summaryMarkdown == null || !luciTask.builderName.contains('Mac')) {
+      return false;
+    }
+    return luciTask.summaryMarkdown.contains('retcode: -9') ||
+        (kMacBuildersWithShards.contains(luciTask.builderName) &&
+            luciTask.summaryMarkdown == 'Step(\'display builds.build(s) failed\') (retcode: 1)');
   }
 }

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -546,7 +546,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
@@ -674,4 +674,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0 <2.11.0"
+  dart: ">=2.12.0-0.0 <=2.12.0-169.0.dev"

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -546,7 +546,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
@@ -674,4 +674,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-169.0.dev"
+  dart: ">=2.10.0 <2.11.0"

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -48,321 +48,334 @@ void main() {
       );
     });
 
-    test('do not update task status when SHA does not match', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'def': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'def',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+    group('without builder rerun', () {
+      setUp(() {
+        when(mockLuciBuildService.checkRerunBuilder(
+                commitSha: anyNamed('commitSha'),
+                luciTask: anyNamed('luciTask'),
+                taskAttempts: anyNamed('taskAttempts')))
+            .thenAnswer((_) => Future<bool>.value(false));
       });
 
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusNew);
-    });
+      test('do not update task status when SHA does not match', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
 
-    test('do not update task status when commitSha/ref is unknown', () async {
-      final Commit commit = Commit(
-        key: config.db.emptyKey.append(Commit, id: 'abc'),
-        sha: 'abc',
-      );
-      final Task task = Task(
-        key: commit.key.append(Task, id: 123),
-        commitKey: commit.key,
-        status: Task.statusNew,
-      );
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'def': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'def',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
 
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'def': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'unknown',
-                          ref: 'unknown',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusNew);
       });
 
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusNew);
-    });
-
-    test('do not update task status when branch does not match', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc', branch: 'test');
-      final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
-      });
-
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusNew);
-    });
-
-    test('update task status and buildNumber when buildNumberList does not match', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
-      });
-
-      expect(task.status, Task.statusNew);
-      expect(task.buildNumberList, isNull);
-      await tester.get(handler);
-      expect(task.status, Task.statusSucceeded);
-      expect(task.buildNumberList, '1');
-    });
-
-    test('save data to BigQuery when task finishes', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
-      });
-
-      await tester.get(handler);
-      final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
-      expect(tableDataList.totalRows, '1');
-    });
-
-    test('update task status and buildNumber when status does not match', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(
-          key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
-      });
-
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusSucceeded);
-    });
-
-    test('rerun Mac builder when hiting recipe infra failure', () async {
-      config.maxTaskRetriesValue = 2;
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(
+      test('do not update task status when commitSha/ref is unknown', () async {
+        final Commit commit = Commit(
+          key: config.db.emptyKey.append(Commit, id: 'abc'),
+          sha: 'abc',
+        );
+        final Task task = Task(
           key: commit.key.append(Task, id: 123),
           commitKey: commit.key,
-          status: Task.statusInProgress,
-          buildNumberList: '1',
-          attempts: 0,
-          builderName: 'Mac abc');
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
+          status: Task.statusNew,
+        );
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
 
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              <LuciBuilder>[const LuciBuilder(name: 'Mac abc', repo: 'flutter', taskName: 'def', flaky: false)],
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusInfraFailure,
-                          buildNumber: 1,
-                          builderName: 'Mac abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'def': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'unknown',
+                            ref: 'unknown',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusNew);
       });
 
-      expect(task.status, Task.statusInProgress);
-      await tester.get(handler);
-      expect(
-        verify(mockLuciBuildService.rescheduleProdBuild(
-          commitSha: captureAnyNamed('commitSha'),
-          builderName: captureAnyNamed('builderName'),
-        )).captured,
-        <dynamic>['abc', 'Mac abc'],
-      );
-      expect(task.status, Task.statusNew);
-      expect(task.attempts, 1);
+      test('do not update task status when branch does not match', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc', branch: 'test');
+        final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusNew);
+      });
+
+      test('update task status and buildNumber when buildNumberList does not match', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        expect(task.buildNumberList, isNull);
+        await tester.get(handler);
+        expect(task.status, Task.statusSucceeded);
+        expect(task.buildNumberList, '1');
+      });
+
+      test('save data to BigQuery when task finishes', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        await tester.get(handler);
+        final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
+        expect(tableDataList.totalRows, '1');
+      });
+
+      test('update task status and buildNumber when status does not match', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(
+            key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusSucceeded);
+      });
+
+      test('update task status with latest status when multilple reruns exist', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(
+            key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusSucceeded,
+                            buildNumber: 2,
+                            builderName: 'abc'),
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusFailed,
+                            buildNumber: 1,
+                            builderName: 'abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusSucceeded);
+        expect(task.buildNumberList, '1,2');
+      });
+
+      test('update task status for non master branch', () async {
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'def'), sha: 'def', branch: 'test');
+        final Task task = Task(key: commit.key.append(Task, id: 456), commitKey: commit.key, status: Task.statusNew);
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
+
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'def': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'def',
+                            ref: 'refs/heads/master',
+                            status: Task.statusFailed,
+                            buildNumber: 1,
+                            builderName: 'abc'),
+                      ],
+                    });
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> testLuciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                await LuciBuilder.getProdBuilders('flutter', config),
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'test'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'def': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'def',
+                            ref: 'refs/heads/test',
+                            status: Task.statusSucceeded,
+                            buildNumber: 2,
+                            builderName: 'abc')
+                      ],
+                    });
+        luciTasks.addAll(testLuciTasks);
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
+
+        expect(task.status, Task.statusNew);
+        await tester.get(handler);
+        expect(task.status, Task.statusSucceeded);
+      });
     });
 
-    test('update task status with latest status when multilple reruns exist', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
-      final Task task = Task(
-          key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
-
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'abc': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusSucceeded,
-                          buildNumber: 2,
-                          builderName: 'abc'),
-                      const LuciTask(
-                          commitSha: 'abc',
-                          ref: 'refs/heads/master',
-                          status: Task.statusFailed,
-                          buildNumber: 1,
-                          builderName: 'abc')
-                    ],
-                  });
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+    group('without builder rerun', () {
+      setUp(() {
+        when(mockLuciBuildService.checkRerunBuilder(
+                commitSha: anyNamed('commitSha'),
+                luciTask: anyNamed('luciTask'),
+                taskAttempts: anyNamed('taskAttempts')))
+            .thenAnswer((_) => Future<bool>.value(true));
       });
 
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusSucceeded);
-      expect(task.buildNumberList, '1,2');
-    });
+      test('rerun Mac builder when hiting recipe infra failure', () async {
+        config.maxTaskRetriesValue = 2;
+        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc');
+        final Task task = Task(
+            key: commit.key.append(Task, id: 123),
+            commitKey: commit.key,
+            status: Task.statusInProgress,
+            buildNumberList: '1',
+            attempts: 0,
+            builderName: 'Mac abc');
+        config.db.values[commit.key] = commit;
+        config.db.values[task.key] = task;
 
-    test('update task status for non master branch', () async {
-      final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'def'), sha: 'def', branch: 'test');
-      final Task task = Task(key: commit.key.append(Task, id: 456), commitKey: commit.key, status: Task.statusNew);
-      config.db.values[commit.key] = commit;
-      config.db.values[task.key] = task;
+        final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
+                <LuciBuilder>[const LuciBuilder(name: 'Mac abc', repo: 'flutter', taskName: 'def', flaky: false)],
+                key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
+                value: (dynamic builder) => <String, List<LuciTask>>{
+                      'abc': <LuciTask>[
+                        const LuciTask(
+                            commitSha: 'abc',
+                            ref: 'refs/heads/master',
+                            status: Task.statusInfraFailure,
+                            buildNumber: 1,
+                            builderName: 'Mac abc')
+                      ],
+                    });
+        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+            .thenAnswer((Invocation invocation) {
+          return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        });
 
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'def': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'def',
-                          ref: 'refs/heads/master',
-                          status: Task.statusFailed,
-                          buildNumber: 1,
-                          builderName: 'abc'),
-                    ],
-                  });
-      final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> testLuciTasks =
-          Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-              await LuciBuilder.getProdBuilders('flutter', config),
-              key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'test'),
-              value: (dynamic builder) => <String, List<LuciTask>>{
-                    'def': <LuciTask>[
-                      const LuciTask(
-                          commitSha: 'def',
-                          ref: 'refs/heads/test',
-                          status: Task.statusSucceeded,
-                          buildNumber: 2,
-                          builderName: 'abc')
-                    ],
-                  });
-      luciTasks.addAll(testLuciTasks);
-      when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
-          .thenAnswer((Invocation invocation) {
-        return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
+        expect(task.status, Task.statusInProgress);
+        await tester.get(handler);
+        expect(task.status, Task.statusNew);
+        expect(task.attempts, 1);
       });
-
-      expect(task.status, Task.statusNew);
-      await tester.get(handler);
-      expect(task.status, Task.statusSucceeded);
     });
   });
 }

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -5,10 +5,12 @@
 import 'dart:convert';
 import 'dart:core';
 
+import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/luci.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';
@@ -334,6 +336,83 @@ void main() {
         repo: 'flutter',
       );
       verify(mockBuildBucketClient.scheduleBuild(any)).called(1);
+    });
+  });
+
+  group('checkRerunBuilder', () {
+    setUp(() {
+      serviceAccountInfo = const ServiceAccountInfo(email: 'abc@abcd.com');
+      config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
+      mockBuildBucketClient = MockBuildBucketClient();
+      service = LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+    });
+
+    test('Rerun a Mac builder with infra failure', () async {
+      config.maxLuciTaskRetriesValue = 1;
+      const LuciTask luciTask = LuciTask(
+          commitSha: 'abc',
+          ref: 'refs/heads/master',
+          status: Task.statusInfraFailure,
+          buildNumber: 1,
+          builderName: 'Mac abc');
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commitSha: 'abc',
+        luciTask: luciTask,
+        taskAttempts: 0,
+        repo: 'flutter',
+      );
+      expect(rerunFlag, true);
+    });
+
+    test('Do not rerun a Mac builder with non-infra failure', () async {
+      config.maxLuciTaskRetriesValue = 1;
+      const LuciTask luciTask = LuciTask(
+          commitSha: 'abc',
+          ref: 'refs/heads/master',
+          status: Task.statusFailed,
+          buildNumber: 1,
+          builderName: 'Mac abc');
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commitSha: 'abc',
+        luciTask: luciTask,
+        taskAttempts: 0,
+        repo: 'flutter',
+      );
+      expect(rerunFlag, false);
+    });
+
+    test('Do not rerun a non-Mac builder', () async {
+      config.maxLuciTaskRetriesValue = 1;
+      const LuciTask luciTask = LuciTask(
+          commitSha: 'abc',
+          ref: 'refs/heads/master',
+          status: Task.statusInfraFailure,
+          buildNumber: 1,
+          builderName: 'Linux abc');
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commitSha: 'abc',
+        luciTask: luciTask,
+        taskAttempts: 0,
+        repo: 'flutter',
+      );
+      expect(rerunFlag, false);
+    });
+
+    test('Do not rerun a Mac builder exceeding attempt limit', () async {
+      config.maxLuciTaskRetriesValue = 1;
+      const LuciTask luciTask = LuciTask(
+          commitSha: 'abc',
+          ref: 'refs/heads/master',
+          status: Task.statusInfraFailure,
+          buildNumber: 1,
+          builderName: 'Mac abc');
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commitSha: 'abc',
+        luciTask: luciTask,
+        taskAttempts: 1,
+        repo: 'flutter',
+      );
+      expect(rerunFlag, false);
     });
   });
 }

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -25,6 +25,7 @@ class FakeConfig implements Config {
     this.githubClient,
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
+    this.maxLuciTaskRetriesValue,
     this.commitNumberValue,
     this.keyHelperValue,
     this.oauthClientIdValue,
@@ -65,6 +66,7 @@ class FakeConfig implements Config {
   FakeDatastoreDB dbValue;
   ServiceAccountInfo deviceLabServiceAccountValue;
   int maxTaskRetriesValue;
+  int maxLuciTaskRetriesValue;
   int commitNumberValue;
   FakeKeyHelper keyHelperValue;
   String oauthClientIdValue;
@@ -122,6 +124,9 @@ class FakeConfig implements Config {
 
   @override
   int get maxTaskRetries => maxTaskRetriesValue;
+
+  @override
+  int get maxLuciTaskRetries => maxLuciTaskRetriesValue;
 
   @override
   int get maxRecords => maxRecordsValue;


### PR DESCRIPTION
This is a workaround for issue https://github.com/flutter/flutter/issues/68322.

An alternative is to filter `-9 recode` via `Build` property `summaryMarkdown`. However `-9 recode` does not show up in parent `summaryMarkdown` for builders with shards, but exists in sub-builders `summaryMarkdown`. This makes it difficult to correctly filter corresponding builders for rerun.

Since most existing `infra failure` Mac builders are related to `-9 recode` issue, and it doesn't hurt to rerun the small portion of other `infra failure` builders, here we are rerunning all Mac builders which fail with `infra failures`. 

This PR focuses only on framework repo. We need to do the same for engine in a separate PR.