### PR TITLE
Follow up of luci auto rerurn

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -95,8 +95,9 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
         final Task update = datastoreTask.task;
         update.status = latestLuciTask.status;
 
+        /// Use `update.attempts - 1` as the `retries` to skip the initial run.
         if (await luciBuildService.checkRerunBuilder(
-            commitSha: commitSha, luciTask: latestLuciTask, taskAttempts: update.attempts - 1)) {
+            commitSha: commitSha, luciTask: latestLuciTask, retries: update.attempts - 1)) {
           update.status = Task.statusNew;
           update.attempts += 1;
         }

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -96,7 +96,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
         update.status = latestLuciTask.status;
 
         if (await luciBuildService.checkRerunBuilder(
-            commitSha: commitSha, luciTask: latestLuciTask, taskAttempts: update.attempts)) {
+            commitSha: commitSha, luciTask: latestLuciTask, taskAttempts: update.attempts - 1)) {
           update.status = Task.statusNew;
           update.attempts += 1;
         }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -14,6 +14,7 @@ import 'package:retry/retry.dart';
 
 import '../../cocoon_service.dart';
 import '../model/appengine/service_account_info.dart';
+import '../model/appengine/task.dart';
 import '../model/luci/buildbucket.dart';
 import '../model/luci/push_message.dart' as push_message;
 import '../service/luci.dart';
@@ -446,7 +447,9 @@ class LuciBuildService {
   }
 
   bool _shouldRerunBuilder(LuciTask luciTask) {
-    if (luciTask.summaryMarkdown == null || !luciTask.builderName.contains('Mac')) {
+    if (luciTask.summaryMarkdown == null ||
+        !luciTask.builderName.contains('Mac') ||
+        luciTask.status != Task.statusInfraFailure) {
       return false;
     }
     return luciTask.summaryMarkdown.contains('retcode: -9') ||

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -432,10 +432,10 @@ class LuciBuildService {
   Future<bool> checkRerunBuilder({
     @required String commitSha,
     @required LuciTask luciTask,
-    @required int taskAttempts,
+    @required int retries,
     String repo = 'flutter',
   }) async {
-    if (_shouldRerunBuilder(luciTask) && taskAttempts < config.maxLuciTaskRetries) {
+    if (_shouldRerunBuilder(luciTask) && retries < config.maxLuciTaskRetries) {
       await rescheduleProdBuild(
         commitSha: commitSha,
         builderName: luciTask.builderName,

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -51,7 +51,7 @@ void main() {
     group('without builder rerun', () {
       setUp(() {
         when(mockLuciBuildService.checkRerunBuilder(
-                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('taskAttempts')))
+                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('retries')))
             .thenAnswer((_) => Future<bool>.value(false));
       });
 
@@ -331,7 +331,7 @@ void main() {
     group('without builder rerun', () {
       setUp(() {
         when(mockLuciBuildService.checkRerunBuilder(
-                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('taskAttempts')))
+                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('retries')))
             .thenAnswer((_) => Future<bool>.value(true));
       });
 

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -51,9 +51,7 @@ void main() {
     group('without builder rerun', () {
       setUp(() {
         when(mockLuciBuildService.checkRerunBuilder(
-                commitSha: anyNamed('commitSha'),
-                luciTask: anyNamed('luciTask'),
-                retries: anyNamed('taskAttempts')))
+                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('taskAttempts')))
             .thenAnswer((_) => Future<bool>.value(false));
       });
 
@@ -333,9 +331,7 @@ void main() {
     group('without builder rerun', () {
       setUp(() {
         when(mockLuciBuildService.checkRerunBuilder(
-                commitSha: anyNamed('commitSha'),
-                luciTask: anyNamed('luciTask'),
-                retries: anyNamed('taskAttempts')))
+                commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('taskAttempts')))
             .thenAnswer((_) => Future<bool>.value(true));
       });
 

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -53,7 +53,7 @@ void main() {
         when(mockLuciBuildService.checkRerunBuilder(
                 commitSha: anyNamed('commitSha'),
                 luciTask: anyNamed('luciTask'),
-                taskAttempts: anyNamed('taskAttempts')))
+                retries: anyNamed('taskAttempts')))
             .thenAnswer((_) => Future<bool>.value(false));
       });
 
@@ -335,7 +335,7 @@ void main() {
         when(mockLuciBuildService.checkRerunBuilder(
                 commitSha: anyNamed('commitSha'),
                 luciTask: anyNamed('luciTask'),
-                taskAttempts: anyNamed('taskAttempts')))
+                retries: anyNamed('taskAttempts')))
             .thenAnswer((_) => Future<bool>.value(true));
       });
 

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -406,7 +406,7 @@ void main() {
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
           ref: 'refs/heads/master',
-          status: Task.statusFailed,
+          status: Task.statusInfraFailure,
           buildNumber: 1,
           builderName: 'Mac abc',
           summaryMarkdown: 'test failure');
@@ -450,6 +450,24 @@ void main() {
         commitSha: 'abc',
         luciTask: luciTask,
         taskAttempts: 1,
+        repo: 'flutter',
+      );
+      expect(rerunFlag, false);
+    });
+
+    test('Do not rerun a Mac builder with non-infra failure: with shards', () async {
+      config.maxLuciTaskRetriesValue = 1;
+      const LuciTask luciTask = LuciTask(
+          commitSha: 'abc',
+          ref: 'refs/heads/master',
+          status: Task.statusFailed,
+          buildNumber: 1,
+          builderName: 'Mac tool_tests',
+          summaryMarkdown: 'Step(\'display builds.build(s) failed\') (retcode: 1)');
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commitSha: 'abc',
+        luciTask: luciTask,
+        taskAttempts: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, false);

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -359,7 +359,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, true);
@@ -377,7 +377,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, true);
@@ -395,7 +395,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, false);
@@ -413,7 +413,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, false);
@@ -431,7 +431,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, false);
@@ -449,7 +449,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 1,
+        retries: 1,
         repo: 'flutter',
       );
       expect(rerunFlag, false);
@@ -467,7 +467,7 @@ void main() {
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
-        taskAttempts: 0,
+        retries: 0,
         repo: 'flutter',
       );
       expect(rerunFlag, false);


### PR DESCRIPTION
This PR makes two changes:

1. `task.attempts` includes the first run, so here we minus 1 when making rerun trials check.
2. Add `infra failure` check for rerun. There is a corner case: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20tool_tests/1389/overview, which has same `summaryMarkdown` as the one with shards -9.