### PR TITLE
skip try jobs for unmergeable PRs

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -152,6 +152,12 @@ class Config {
 
   Future<String> get webhookKey => _getSingleValue('WebhookKey');
 
+  String get mergeConflictPullRequestMessage => 'This pull request is not '
+      'mergeable in its current state, likely because of a merge conflict. '
+      'Pre-submit CI jobs were not triggered. Pushing a new commit to this '
+      'branch that resolves the issue will result in pre-submit jobs being '
+      'scheduled.';
+
   String get missingTestsPullRequestMessage => 'It looks like this pull '
       'request may not have tests. Please make sure to add tests before merging. '
       'If you need an exemption to this rule, contact Hixie on the #hackers '

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -1079,8 +1079,7 @@ void main() {
         final MockIssuesService mockIssuesService = MockIssuesService();
         when(gitHubClient.issues).thenReturn(mockIssuesService);
         final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-        when(mockIssuesService.listCommentsByIssue(slug, issueNumber))
-            .thenAnswer((Invocation _invocation) {
+        when(mockIssuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer((Invocation _invocation) {
           return Stream<IssueComment>.fromIterable(<IssueComment>[]);
         });
 

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -30,7 +30,8 @@ class FakeConfig implements Config {
     this.keyHelperValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
-    this.missingTestsPullRequestMessageValue,
+    this.mergeConflictPullRequestMessageValue = 'default mergeConflictPullRequestMessageValue',
+    this.missingTestsPullRequestMessageValue = 'default missingTestsPullRequestMessageValue',
     this.wrongBaseBranchPullRequestMessageValue,
     this.wrongHeadBranchPullRequestMessageValue,
     this.releaseBranchPullRequestMessageValue,
@@ -71,6 +72,7 @@ class FakeConfig implements Config {
   FakeKeyHelper keyHelperValue;
   String oauthClientIdValue;
   String githubOAuthTokenValue;
+  String mergeConflictPullRequestMessageValue;
   String missingTestsPullRequestMessageValue;
   String wrongBaseBranchPullRequestMessageValue;
   String wrongHeadBranchPullRequestMessageValue;
@@ -172,6 +174,9 @@ class FakeConfig implements Config {
 
   @override
   Future<String> get githubOAuthToken async => githubOAuthTokenValue;
+
+  @override
+  String get mergeConflictPullRequestMessage => mergeConflictPullRequestMessageValue;
 
   @override
   String get missingTestsPullRequestMessage => missingTestsPullRequestMessageValue;


### PR DESCRIPTION
We were initially skipping try jobs for PRs explicitly marked "unmergeable" by github, but this logic was lost in some refactor. This again skips unmergeable PRs, with an added comment that the author needs to resolve the merge conflict.