### PR TITLE
Allow 'flutter config --no-analytics' to fail

### DIFF
--- a/agent/lib/src/utils.dart
+++ b/agent/lib/src/utils.dart
@@ -516,7 +516,7 @@ Future<Null> getFlutter(String revision) async {
     await exec('git', ['checkout', revision]);
   });
 
-  await flutter('config', options: ['--no-analytics', '--verbose']);
+  await flutter('config', options: ['--no-analytics', '--verbose'], canFail: true);
 
   section('flutter doctor');
   await flutter('doctor', options: ['--verbose']);


### PR DESCRIPTION
Investigation for flaky `flutter config` call. Allow the command to fail to see if we actually get some real logging.  Not sure why there's no [stdout logging](https://github.com/flutter/cocoon/pull/659) for when this fails.  

https://github.com/flutter/flutter/issues/65413