### PR TITLE
Let Cocoon write into metrics center

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -16,6 +16,7 @@ import 'package:googleapis_auth/auth.dart';
 import 'package:graphql/client.dart' hide Cache;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
+import 'package:metrics_center/metrics_center.dart';
 
 import '../../cocoon_service.dart';
 import '../foundation/providers.dart';
@@ -337,6 +338,12 @@ class Config {
   Future<GithubService> createGithubService(String owner, String repository) async {
     final GitHub github = await createGitHubClient(owner, repository);
     return GithubService(github);
+  }
+
+  Future<FlutterDestination> createMetricsDestination() async {
+    return await FlutterDestination.makeFromCredentialsJson(
+      (await deviceLabServiceAccount).toJson(),
+    );
   }
 
   bool githubPresubmitSupportedRepo(String repositoryName) {

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -340,6 +340,12 @@ class Config {
     return GithubService(github);
   }
 
+  /// Return a [FlutterDestination] (subclass of [MetricsDestination]) for
+  /// storing all Flutter-related performance metrics (framework, engine, ...).
+  ///
+  /// The destination is created from the [deviceLabServiceAccount] credentials
+  /// so the destination storage (e.g., the GCS bucket) must grant access to
+  /// that account.
   Future<FlutterDestination> createMetricsDestination() async {
     return await FlutterDestination.makeFromCredentialsJson(
       (await deviceLabServiceAccount).toJson(),

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -8,6 +8,7 @@ import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
+import 'package:metrics_center/metrics_center.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../model/appengine/commit.dart';
@@ -104,6 +105,10 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       await _insertBigquery(commit, task);
     }
 
+    await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
+    // TODO(liyuqian): remove the TimeSeries and TimeSeriesValue code below once
+    // metrics center migration is done.
+
     // TODO(tvolkert): PushBuildStatusToGithub
     for (String scoreKey in scoreKeys) {
       final TimeSeries series = await _getOrCreateTimeSeries(task, scoreKey, datastore);
@@ -120,6 +125,38 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       await datastore.insert(<TimeSeriesValue>[seriesValue]);
     }
     return UpdateTaskStatusResponse(task);
+  }
+
+  Future<void> _writeToMetricsCenter(
+    Map<String, dynamic> resultData,
+    List<String> scoreKeys,
+    Commit commit,
+    Task task,
+  ) async {
+    final FlutterDestination metricsDestination =
+      await FlutterDestination.makeFromCredentialsJson(
+        (await config.deviceLabServiceAccount).toJson(),
+      );
+    final List<MetricPoint> metricPoints = <MetricPoint>[];
+    for (String scoreKey in scoreKeys) {
+      metricPoints.add(
+        MetricPoint(
+          (resultData[scoreKey] as num).toDouble(),
+          <String, String>{
+            kGithubRepoKey: kFlutterEngineRepo,
+            kGitRevisionKey: commit.sha,
+            'branch': commit.branch,
+            kNameKey: task.name,
+            kSubResultKey: scoreKey,
+            // The unit should be encoded either in task.name or scoreKey
+            // so we don't have to depend on TimeSeries or TimeSeriesValue to
+            // know that. It allows us to remove the code and data that are
+            // related to TimeSeries and TimeSeriesValue.
+          },
+        ),
+      );
+    }
+    await metricsDestination.update(metricPoints);
   }
 
   /// Retrieve [Task] to update from [DatastoreService].

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -105,16 +105,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       await _insertBigquery(commit, task);
     }
 
-    // TODO(liyuqian): before merging the PR, remove this try block to let the
-    // handler fail with exceptions. That way, we can get notified when
-    // unexpected failures happen in the future.
-    try {
-      await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
-    } catch (e, s) {
-      log.error('Exception: $e');
-      log.error('Stacktrace: $s');
-      log.error('Account: ${(await config.deviceLabServiceAccount).email}');
-    }
+    await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
 
     // TODO(liyuqian): remove the TimeSeries and TimeSeriesValue code below once
     // metrics center migration is done.

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -127,6 +127,12 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     return UpdateTaskStatusResponse(task);
   }
 
+  // Convert `resultData` (`requestData['ResultData']`) and `scoreKeys`
+  // (`requestData['BenchmarkScoreKeys']`) into `MetricPoint`s, and write them
+  // into `metrics_center`'s `FlutterDestination`.
+  //
+  // This enables the perf dashboard configured by the `metrics_center` (e.g.,
+  // Skia perf) to provide perf metric queries and regression alerts.
   Future<void> _writeToMetricsCenter(
     Map<String, dynamic> resultData,
     List<String> scoreKeys,

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -105,10 +105,15 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       await _insertBigquery(commit, task);
     }
 
+    // TODO(liyuqian): before merging the PR, remove this try block to let the
+    // handler fail with exceptions. That way, we can get notified when
+    // unexpected failures happen in the future.
     try {
       await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
-    } catch (e) {
-      log.error(e.toString());
+    } catch (e, s) {
+      log.error('Exception: $e');
+      log.error('Stacktrace: $s');
+      log.error('Account: ${(await config.deviceLabServiceAccount).email}');
     }
 
     // TODO(liyuqian): remove the TimeSeries and TimeSeriesValue code below once

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -133,10 +133,9 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     Commit commit,
     Task task,
   ) async {
-    final FlutterDestination metricsDestination =
-      await FlutterDestination.makeFromCredentialsJson(
-        (await config.deviceLabServiceAccount).toJson(),
-      );
+    final FlutterDestination metricsDestination = await FlutterDestination.makeFromCredentialsJson(
+      (await config.deviceLabServiceAccount).toJson(),
+    );
     final List<MetricPoint> metricPoints = <MetricPoint>[];
     for (String scoreKey in scoreKeys) {
       metricPoints.add(

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -105,7 +105,12 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
       await _insertBigquery(commit, task);
     }
 
-    await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
+    try {
+      await _writeToMetricsCenter(resultData, scoreKeys, commit, task);
+    } catch (e) {
+      log.error(e.toString());
+    }
+
     // TODO(liyuqian): remove the TimeSeries and TimeSeriesValue code below once
     // metrics center migration is done.
 

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -133,9 +133,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     Commit commit,
     Task task,
   ) async {
-    final FlutterDestination metricsDestination = await FlutterDestination.makeFromCredentialsJson(
-      (await config.deviceLabServiceAccount).toJson(),
-    );
+    final FlutterDestination metricsDestination = await config.createMetricsDestination();
     final List<MetricPoint> metricPoints = <MetricPoint>[];
     for (String scoreKey in scoreKeys) {
       metricPoints.add(

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -156,7 +156,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
         MetricPoint(
           (resultData[scoreKey] as num).toDouble(),
           <String, String>{
-            kGithubRepoKey: kFlutterEngineRepo,
+            kGithubRepoKey: kFlutterFrameworkRepo,
             kGitRevisionKey: commit.sha,
             'branch': commit.branch,
             kNameKey: task.name,

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -387,7 +387,7 @@ packages:
     source: hosted
     version: "1.3.0-nullsafety.6"
   metrics_center:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: metrics_center
       url: "https://pub.dartlang.org"

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -392,7 +392,7 @@ packages:
       name: metrics_center
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
+    version: "0.0.7"
   mime:
     dependency: "direct main"
     description:
@@ -702,4 +702,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-224.0.dev"
+  dart: ">=2.12.0-0.0 <=2.12.0-236.0.dev"

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   http: ^0.12.0
   json_annotation: ^3.0.0
   meta: ^1.1.7
+  metrics_center: 0.0.4
   mime: ^0.9.0
   neat_cache: ^1.0.1
   protobuf: ^1.0.0

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -36,7 +36,6 @@ dev_dependencies:
   build_runner: ^1.0.0
   fake_async: ^1.1.0
   json_serializable: ^3.3.0
-  metrics_center: 0.0.4
   mockito: ^4.1.0
   test: ^1.6.5
 

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   http: ^0.12.0
   json_annotation: ^3.0.0
   meta: ^1.1.7
-  metrics_center: 0.0.4
+  metrics_center: 0.0.7
   mime: ^0.9.0
   neat_cache: ^1.0.1
   protobuf: ^1.0.0

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -10,6 +10,7 @@ import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/db.dart';
 import 'package:googleapis/bigquery/v2.dart';
+import 'package:metrics_center/metrics_center.dart';
 import 'package:test/test.dart';
 
 import '../src/bigquery/fake_tabledata_resource.dart';
@@ -18,12 +19,22 @@ import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 
+class FakeFlutterDestination implements FlutterDestination {
+  @override
+  Future<void> update(List<MetricPoint> points) async {
+    lastUpdatedPoints = points;
+  }
+
+  List<MetricPoint> lastUpdatedPoints;
+}
+
 void main() {
   group('UpdateTaskStatus', () {
     FakeConfig config;
     ApiRequestHandlerTester tester;
     UpdateTaskStatus handler;
     final FakeTabledataResourceApi tabledataResourceApi = FakeTabledataResourceApi();
+    final FakeFlutterDestination fakeMetricsDestination = FakeFlutterDestination();
 
     Commit commit;
     const String commitSha = '78cbfbff4267643bb1913bc820f5ce8a3e591b40';
@@ -38,6 +49,7 @@ void main() {
         flutterBranchesValue: <String>['master'],
         tabledataResourceApi: tabledataResourceApi,
         maxTaskRetriesValue: 2,
+        metricsDestination: fakeMetricsDestination,
       );
       tester = ApiRequestHandlerTester();
       tester.requestData = <String, dynamic>{
@@ -79,6 +91,10 @@ void main() {
       /// Test for [BigQuery] insert
       expect(tableDataList.totalRows, '1');
       expect(value['RequiredCapabilities'], <String>['ios']);
+
+      /// Test for metrics center update
+      expect(fakeMetricsDestination.lastUpdatedPoints.length, equals(1));
+      expect(fakeMetricsDestination.lastUpdatedPoints[0].value, equals(3.12));
     });
 
     test('failed tasks are automatically retried', () async {

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -15,6 +15,7 @@ import 'package:graphql/client.dart';
 import 'package:googleapis/bigquery/v2.dart';
 
 import 'package:cocoon_service/src/service/luci.dart';
+import 'package:metrics_center/src/flutter.dart';
 
 import '../request_handling/fake_authentication.dart';
 import 'fake_datastore.dart';
@@ -40,6 +41,7 @@ class FakeConfig implements Config {
     this.tabledataResourceApi,
     this.githubService,
     this.cirrusGraphQLClient,
+    this.metricsDestination,
     this.taskLogServiceAccountValue,
     this.rollerAccountsValue,
     this.luciTryInfraFailureRetriesValue,
@@ -64,6 +66,7 @@ class FakeConfig implements Config {
   GraphQLClient cirrusGraphQLClient;
   TabledataResourceApi tabledataResourceApi;
   GithubService githubService;
+  FlutterDestination metricsDestination;
   FakeDatastoreDB dbValue;
   ServiceAccountInfo deviceLabServiceAccountValue;
   int maxTaskRetriesValue;
@@ -114,6 +117,9 @@ class FakeConfig implements Config {
 
   @override
   Future<GithubService> createGithubService(String owner, String repository) async => githubService;
+
+  @override
+  Future<FlutterDestination> createMetricsDestination() async => metricsDestination;
 
   @override
   FakeDatastoreDB get db => dbValue;


### PR DESCRIPTION
This needs https://github.com/flutter/cocoon/pull/1061 and the `metrics_center` change in `pubspec.yaml` from https://github.com/flutter/cocoon/pull/1060.

Once this PR is successfully deployed, we should be able to cut the dependency on Tong's desktop.
