### PR TITLE
Write healthcheck and properties to file instead of using stdout/stderr

### DIFF
--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -37,13 +37,13 @@ typedef CommitCallback = void Function(List<Model<dynamic>> inserts, List<Key<dy
 class FakeDatastoreDB implements DatastoreDB {
   FakeDatastoreDB({
     Map<Key<dynamic>, Model<dynamic>> values,
-    Map<Type, QueryCallback<dynamic>> onQuery,
+    Map<Type, QueryCallback<Model<dynamic>>> onQuery,
     this.onCommit,
   })  : values = values ?? <Key<dynamic>, Model<dynamic>>{},
-        onQuery = onQuery ?? <Type, QueryCallback<dynamic>>{};
+        onQuery = onQuery ?? <Type, QueryCallback<Model<dynamic>>>{};
 
   final Map<Key<dynamic>, Model<dynamic>> values;
-  final Map<Type, QueryCallback<dynamic>> onQuery;
+  final Map<Type, QueryCallback<Model<dynamic>>> onQuery;
   CommitCallback onCommit;
 
   /// Adds a [QueryCallback] to the set of callbacks that will be notified when
@@ -52,8 +52,8 @@ class FakeDatastoreDB implements DatastoreDB {
   /// The [callback] argument will replace any existing callback that has been
   /// specified for type `T`, as only one callback may exist per type.
   void addOnQuery<T extends Model<dynamic>>(QueryCallback<T> callback) {
-    final QueryCallback<dynamic> untypedCallback = (Iterable<dynamic> results) {
-      return callback(results.cast<T>()).cast<dynamic>();
+    final QueryCallback<Model<dynamic>> untypedCallback = (Iterable<Model<dynamic>> results) {
+      return callback(results.cast<T>()).cast<Model<dynamic>>();
     };
     onQuery[T] = untypedCallback;
   }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -96,7 +96,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       results['android-device-${device.deviceId}'] = checks;
     }
     final Map<String, String> healthCheckMap = await healthcheck(results);
-    await writeToFile(json.encode(healthCheckMap), kDeviceHealthcheckFilename);
+    await writeToFile(json.encode(healthCheckMap), kDeviceFailedHealthcheckFilename);
     return results;
   }
 

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -95,7 +95,8 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       results['android-device-${device.deviceId}'] = checks;
     }
-    await healthcheck(results);
+    final Map<String, String> healthCheckMap = await healthcheck(results);
+    await writeToFile(json.encode(healthCheckMap), kDeviceHealthcheckFilename);
     return results;
   }
 
@@ -109,7 +110,10 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       return <String, String>{};
     }
     final Map<String, String> properties = await getDeviceProperties(devices[0], processManager: processManager);
-    stdout.write(json.encode(properties));
+    final String propertiesJson = json.encode(properties);
+
+    await writeToFile(propertiesJson, kDevicePropertiesFilename);
+    stdout.write(propertiesJson);
     return properties;
   }
 

--- a/device_doctor/lib/src/health.dart
+++ b/device_doctor/lib/src/health.dart
@@ -82,21 +82,18 @@ class HealthCheckResult {
 }
 
 /// Check healthiness for discovered devices.
-///
-/// If any failed check, an explanation message will be sent to stdout and
-/// an exception will be thrown.
-Future<void> healthcheck(Map<String, List<HealthCheckResult>> deviceChecks) async {
+Future<Map<String, String>> healthcheck(Map<String, List<HealthCheckResult>> deviceChecks) async {
+  final Map<String, String> healthcheckMap = <String, String>{};
   if (deviceChecks.isEmpty) {
-    stderr.writeln('No healthy device is available');
+    healthcheckMap['Attached device'] = 'No device is available';
   }
   for (String deviceID in deviceChecks.keys) {
     List<HealthCheckResult> checks = deviceChecks[deviceID];
     for (HealthCheckResult healthCheckResult in checks) {
       if (!healthCheckResult.succeeded) {
-        stderr.writeln('${healthCheckResult.name} check failed with: ${healthCheckResult.details}');
-      } else {
-        stdout.writeln('${healthCheckResult.name} check succeeded');
+        healthcheckMap[healthCheckResult.name] = healthCheckResult.details;
       }
     }
   }
+  return healthcheckMap;
 }

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show LineSplitter;
+import 'dart:convert' show LineSplitter, json;
 
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
@@ -44,7 +44,8 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       results['ios-device-${device.deviceId}'] = checks;
     }
-    await healthcheck(results);
+    final Map<String, String> healthCheckMap = await healthcheck(results);
+    await writeToFile(json.encode(healthCheckMap), kDeviceHealthcheckFilename);
     return results;
   }
 

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -45,7 +45,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       results['ios-device-${device.deviceId}'] = checks;
     }
     final Map<String, String> healthCheckMap = await healthcheck(results);
-    await writeToFile(json.encode(healthCheckMap), kDeviceHealthcheckFilename);
+    await writeToFile(json.encode(healthCheckMap), kDeviceFailedHealthcheckFilename);
     return results;
   }
 

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -12,7 +12,7 @@ import 'package:process/process.dart';
 import 'dart:convert' show utf8;
 
 const String kDevicePropertiesFilename = '.properties';
-const String kDeviceHealthcheckFilename = '.healthcheck';
+const String kDeviceFailedHealthcheckFilename = '.failedhealthcheck';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -11,6 +11,8 @@ import 'package:process/process.dart';
 
 import 'dart:convert' show utf8;
 
+const String kDevicePropertiesFilename = '.properties';
+const String kDeviceHealthcheckFilename = '.healthcheck';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {
@@ -91,4 +93,31 @@ Iterable<String> grep(Pattern pattern, {@required String from}) {
   return from.split('\n').where((String line) {
     return line.contains(pattern);
   });
+}
+
+/// Get file based on `Platform` home directory.
+File getFile(String fileName) {
+  if (Platform.isLinux || Platform.isMacOS) {
+    return File(path.join(Platform.environment['HOME'], '$fileName'));
+  }
+  if (!Platform.isWindows) {
+    throw StateError('Unexpected platform ${Platform.operatingSystem}');
+  }
+  return File(path.join(Platform.environment['USERPROFILE'], '.$fileName'));
+}
+
+/// Write [results] to [fileName] based on `Platform` home directory.
+void writeToFile(String results, String fileName) {
+  final File file = getFile(fileName);
+  if (file.existsSync()) {
+    try {
+      file.deleteSync();
+    } on FileSystemException catch (error) {
+      print('Failed to delete ${file.path}: $error');
+    }
+  }
+  file
+    ..createSync()
+    ..writeAsStringSync(results);
+  return;
 }

--- a/device_doctor/test/src/health_test.dart
+++ b/device_doctor/test/src/health_test.dart
@@ -63,6 +63,39 @@ void main() {
       );
     });
   });
+
+  group('healthCheck', () {
+    Map<String, List<HealthCheckResult>> deviceChecks;
+
+    setUp(() async {
+      deviceChecks = <String, List<HealthCheckResult>>{};
+    });
+
+    test('with no device', () async {
+      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, String>{'Attached device': 'No device is available'});
+    });
+
+    test('with failed check', () async {
+      final List<HealthCheckResult> healthChecks = <HealthCheckResult>[
+        HealthCheckResult.success('check1'),
+        HealthCheckResult.failure('check2', 'abc')
+      ];
+      deviceChecks['device1'] = healthChecks;
+      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, String>{'check2': 'abc'});
+    });
+
+    test('without failed check', () async {
+      final List<HealthCheckResult> healthChecks = <HealthCheckResult>[
+        HealthCheckResult.success('check1'),
+        HealthCheckResult.success('check2')
+      ];
+      deviceChecks['device1'] = healthChecks;
+      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, String>{});
+    });
+  });
 }
 
 class MockPlatform extends Mock implements Platform {}


### PR DESCRIPTION
This is to write query results to a local file, avoiding issues from unexpected stdout/stderr messages.

Part of https://github.com/flutter/flutter/issues/74363