### PR TITLE
Extend device_doctor generated healthcheck results to include both success and failure

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -95,7 +95,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       results['android-device-${device.deviceId}'] = checks;
     }
-    final Map<String, String> healthCheckMap = await healthcheck(results);
+    final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);
     await writeToFile(json.encode(healthCheckMap), kDeviceFailedHealthcheckFilename);
     return results;
   }

--- a/device_doctor/lib/src/health.dart
+++ b/device_doctor/lib/src/health.dart
@@ -82,17 +82,24 @@ class HealthCheckResult {
 }
 
 /// Check healthiness for discovered devices.
-Future<Map<String, String>> healthcheck(Map<String, List<HealthCheckResult>> deviceChecks) async {
-  final Map<String, String> healthcheckMap = <String, String>{};
+Future<Map<String, Map<String, dynamic>>> healthcheck(Map<String, List<HealthCheckResult>> deviceChecks) async {
+  final Map<String, Map<String, dynamic>> healthcheckMap = <String, Map<String, dynamic>>{};
   if (deviceChecks.isEmpty) {
-    healthcheckMap['Attached device'] = 'No device is available';
+    healthcheckMap[kAttachedDeviceHealthcheckKey] = <String, dynamic>{
+      'status': false,
+      'details': kAttachedDeviceHealthcheckValue
+    };
+  } else {
+    healthcheckMap[kAttachedDeviceHealthcheckKey] = <String, dynamic>{'status': true, 'details': null};
   }
   for (String deviceID in deviceChecks.keys) {
     List<HealthCheckResult> checks = deviceChecks[deviceID];
     for (HealthCheckResult healthCheckResult in checks) {
-      if (!healthCheckResult.succeeded) {
-        healthcheckMap[healthCheckResult.name] = healthCheckResult.details;
-      }
+      final Map<String, dynamic> healthCheckResultMap = <String, dynamic>{
+        'status': healthCheckResult.succeeded,
+        'details': healthCheckResult.details
+      };
+      healthcheckMap[healthCheckResult.name] = healthCheckResultMap;
     }
   }
   return healthcheckMap;

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -44,7 +44,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       results['ios-device-${device.deviceId}'] = checks;
     }
-    final Map<String, String> healthCheckMap = await healthcheck(results);
+    final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);
     await writeToFile(json.encode(healthCheckMap), kDeviceFailedHealthcheckFilename);
     return results;
   }

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -12,7 +12,9 @@ import 'package:process/process.dart';
 import 'dart:convert' show utf8;
 
 const String kDevicePropertiesFilename = '.properties';
-const String kDeviceFailedHealthcheckFilename = '.failedhealthcheck';
+const String kDeviceFailedHealthcheckFilename = '.healthcheck';
+const String kAttachedDeviceHealthcheckKey = 'attached_device';
+const String kAttachedDeviceHealthcheckValue = 'No device is available';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {

--- a/device_doctor/test/src/health_test.dart
+++ b/device_doctor/test/src/health_test.dart
@@ -72,8 +72,10 @@ void main() {
     });
 
     test('with no device', () async {
-      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
-      expect(healthcheckMap, <String, String>{'Attached device': 'No device is available'});
+      final Map<String, Map<String, dynamic>> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, Map<String, dynamic>>{
+        kAttachedDeviceHealthcheckKey: <String, dynamic>{'status': false, 'details': kAttachedDeviceHealthcheckValue}
+      });
     });
 
     test('with failed check', () async {
@@ -82,8 +84,12 @@ void main() {
         HealthCheckResult.failure('check2', 'abc')
       ];
       deviceChecks['device1'] = healthChecks;
-      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
-      expect(healthcheckMap, <String, String>{'check2': 'abc'});
+      final Map<String, Map<String, dynamic>> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, Map<String, dynamic>>{
+        kAttachedDeviceHealthcheckKey: <String, dynamic>{'status': true, 'details': null},
+        'check1': <String, dynamic>{'status': true, 'details': null},
+        'check2': <String, dynamic>{'status': false, 'details': 'abc'}
+      });
     });
 
     test('without failed check', () async {
@@ -92,8 +98,12 @@ void main() {
         HealthCheckResult.success('check2')
       ];
       deviceChecks['device1'] = healthChecks;
-      final Map<String, String> healthcheckMap = await healthcheck(deviceChecks);
-      expect(healthcheckMap, <String, String>{});
+      final Map<String, Map<String, dynamic>> healthcheckMap = await healthcheck(deviceChecks);
+      expect(healthcheckMap, <String, Map<String, dynamic>>{
+        kAttachedDeviceHealthcheckKey: <String, dynamic>{'status': true, 'details': null},
+        'check1': <String, dynamic>{'status': true, 'details': null},
+        'check2': <String, dynamic>{'status': true, 'details': null}
+      });
     });
   });
 }


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/1064