### PR TITLE
Correct summaryMarkdown for framework LUCI -9 rerun

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -454,6 +454,7 @@ class LuciBuildService {
     }
     return luciTask.summaryMarkdown.contains('retcode: -9') ||
         (kMacBuildersWithShards.contains(luciTask.builderName) &&
-            luciTask.summaryMarkdown == 'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
+            luciTask.summaryMarkdown ==
+                'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
   }
 }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -454,6 +454,6 @@ class LuciBuildService {
     }
     return luciTask.summaryMarkdown.contains('retcode: -9') ||
         (kMacBuildersWithShards.contains(luciTask.builderName) &&
-            luciTask.summaryMarkdown == 'Step(\'display builds.build(s) failed\') (retcode: 1)');
+            luciTask.summaryMarkdown == 'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
   }
 }

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -373,7 +373,8 @@ void main() {
           status: Task.statusInfraFailure,
           buildNumber: 1,
           builderName: 'Mac tool_tests',
-          summaryMarkdown: 'Step(\'display builds.build(s) failed\') (retcode: 1)');
+          summaryMarkdown:
+              'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
@@ -391,7 +392,8 @@ void main() {
           status: Task.statusInfraFailure,
           buildNumber: 1,
           builderName: 'Mac abc',
-          summaryMarkdown: 'Step(\'display builds.build(s) failed\') (retcode: 1)');
+          summaryMarkdown:
+              'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
@@ -463,7 +465,8 @@ void main() {
           status: Task.statusFailed,
           buildNumber: 1,
           builderName: 'Mac tool_tests',
-          summaryMarkdown: 'Step(\'display builds.build(s) failed\') (retcode: 1)');
+          summaryMarkdown:
+              'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,


### PR DESCRIPTION
This is a followup of https://github.com/flutter/cocoon/pull/1054.

The correct summaryMarkdown is `recipe infra failure: Infra Failure: Step('display builds.build(s) failed') (retcode: 1)`, like in build: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20framework_tests/1492/overview

This PR updates the summaryMarkdown.

