### PR TITLE
Run manual retries with higher priority to open the tree faster.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -423,6 +423,9 @@ class LuciBuildService {
       properties: <String, String>{
         'git_ref': commitSha,
       },
+      // Run manual retries with higher priority to ensure tasks that can
+      // potentially open the tree are not wating for ~30 mins in the queue.
+      priority: 29,
     ));
   }
 


### PR DESCRIPTION
Manual retries are usually waiting for ~30 mins as they are added to the
end of the queue of tasks for the current commit. We are changing the
priorities to ensure retried tasks are not waiting for too long in the
queue.

Bug: https://github.com/flutter/flutter/issues/74692