### PR TITLE
Auto rerun engine Mac builders with infra failure

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -77,7 +77,7 @@ Future<void> main() async {
       ),
       '/api/push-build-status-to-github': PushBuildStatusToGithub(config, authProvider),
       '/api/push-gold-status-to-github': PushGoldStatusToGithub(config, authProvider),
-      '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(config, authProvider),
+      '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(config, authProvider, luciBuildService),
       '/api/refresh-chromebot-status': RefreshChromebotStatus(config, authProvider, luciBuildService),
       '/api/refresh-github-commits': RefreshGithubCommits(config, authProvider),
       '/api/reserve-task': ReserveTask(config, authProvider),

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -17,18 +17,21 @@ import '../request_handling/body.dart';
 import '../service/buildbucket.dart';
 import '../service/datastore.dart';
 import '../service/luci.dart';
+import '../service/luci_build_service.dart';
 
 @immutable
 class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
   const PushEngineStatusToGithub(
     Config config,
-    AuthenticationProvider authenticationProvider, {
+    AuthenticationProvider authenticationProvider,
+    this.luciBuildService, {
     @visibleForTesting LuciServiceProvider luciServiceProvider,
     @visibleForTesting DatastoreServiceProvider datastoreProvider,
   })  : luciServiceProvider = luciServiceProvider ?? _createLuciService,
         datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
         super(config: config, authenticationProvider: authenticationProvider);
 
+  final LuciBuildService luciBuildService;
   final LuciServiceProvider luciServiceProvider;
   final DatastoreServiceProvider datastoreProvider;
 
@@ -50,18 +53,18 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     final LuciService luciService = luciServiceProvider(this);
     final Map<LuciBuilder, List<LuciTask>> luciTasks = await luciService.getRecentTasks(repo: 'engine');
 
-    String latestStatus = GithubBuildStatusUpdate.statusSuccess;
+    String status = GithubBuildStatusUpdate.statusSuccess;
     for (List<LuciTask> tasks in luciTasks.values) {
-      latestStatus = _getLatestStatus(tasks);
-      if (latestStatus == GithubBuildStatusUpdate.statusFailure) {
-        break;
+      final String latestStatus = await _getLatestStatus(tasks);
+      if (status == GithubBuildStatusUpdate.statusSuccess && latestStatus == GithubBuildStatusUpdate.statusFailure) {
+        status = GithubBuildStatusUpdate.statusFailure;
       }
     }
     // Insert build status to bigquery.
     const String bigqueryTableName = 'BuildStatus';
     final Map<String, dynamic> bigqueryData = <String, dynamic>{
       'Timestamp': DateTime.now().millisecondsSinceEpoch,
-      'Status': latestStatus,
+      'Status': status,
       'Branch': 'master',
       'Repo': 'engine'
     };
@@ -74,19 +77,19 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     await for (PullRequest pr in github.pullRequests.list(slug)) {
       final GithubBuildStatusUpdate update = await datastore.queryLastStatusUpdate(slug, pr);
 
-      if (update.status != latestStatus) {
+      if (update.status != status) {
         log.debug('Updating status of ${slug.fullName}#${pr.number} from ${update.status}');
-        final CreateStatus request = CreateStatus(latestStatus);
+        final CreateStatus request = CreateStatus(status);
         request.targetUrl = 'https://ci.chromium.org/p/flutter/g/engine/console';
         request.context = 'luci-engine';
-        if (latestStatus != GithubBuildStatusUpdate.statusSuccess) {
+        if (status != GithubBuildStatusUpdate.statusSuccess) {
           request.description = 'Flutter build is currently broken. Please do not merge this '
               'PR unless it contains a fix to the broken build.';
         }
 
         try {
           await github.repositories.createStatus(slug, pr.head.sha, request);
-          update.status = latestStatus;
+          update.status = status;
           update.updates += 1;
           update.updateTimeMillis = DateTime.now().millisecondsSinceEpoch;
           updates.add(update);
@@ -102,7 +105,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
 
   /// This function gets called with the last 40 builds fo a given builder ordered
   /// by creation time starting with the last one first.
-  String _getLatestStatus(List<LuciTask> tasks) {
+  Future<String> _getLatestStatus(List<LuciTask> tasks) async {
     for (LuciTask task in tasks) {
       if (task.ref != 'refs/heads/master') {
         log.debug('Skipping ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
@@ -112,6 +115,11 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
         case Task.statusFailed:
         case Task.statusInfraFailure:
           log.debug('Using ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
+          await luciBuildService.checkRerunBuilder(
+              commitSha: task.commitSha,
+              luciTask: task,
+              retries: tasks.where((LuciTask element) => element.commitSha == task.commitSha).length - 1,
+              repo: 'engine');
           return GithubBuildStatusUpdate.statusFailure;
         case Task.statusSucceeded:
           log.debug('Using ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -153,6 +153,7 @@ class LuciService {
         status: luciStatusToTaskStatus[build.status],
         buildNumber: build.number,
         builderName: build.builderId.builder,
+        summaryMarkdown: build.summaryMarkdown,
       ));
     }
     return results;

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -438,6 +438,7 @@ class LuciBuildService {
     String repo = 'flutter',
   }) async {
     if (_shouldRerunBuilder(luciTask, repo) && retries < config.maxLuciTaskRetries) {
+      log.info('Rerun Mac builder: ${luciTask.builderName} for commit $commitSha');
       await rescheduleProdBuild(
         commitSha: commitSha,
         builderName: luciTask.builderName,

--- a/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
@@ -38,6 +38,7 @@ void main() {
     MockRepositoriesService repositoriesService;
     List<PullRequest> prsFromGitHub;
     FakeGithubService githubService;
+    MockLuciBuildService mockLuciBuildService;
 
     PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false}) {
       return PullRequest()
@@ -68,6 +69,7 @@ void main() {
       pullRequestsService = MockPullRequestsService();
       issuesService = MockIssuesService();
       repositoriesService = MockRepositoriesService();
+      mockLuciBuildService = MockLuciBuildService();
       config = FakeConfig(
         tabledataResourceApi: tabledataResourceApi,
         githubService: githubService,
@@ -79,6 +81,7 @@ void main() {
       handler = PushEngineStatusToGithub(
         config,
         FakeAuthenticationProvider(clientContext: clientContext),
+        mockLuciBuildService,
         luciServiceProvider: (_) => mockLuciService,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -345,6 +345,7 @@ void main() {
       config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
       mockBuildBucketClient = MockBuildBucketClient();
       service = LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
+      service.setLogger(FakeLogging());
     });
 
     test('Rerun a flutter Mac builder with infra failure: -9 in parent build', () async {

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -347,7 +347,7 @@ void main() {
       service = LuciBuildService(config, mockBuildBucketClient, serviceAccountInfo);
     });
 
-    test('Rerun a Mac builder with infra failure: -9 in parent build', () async {
+    test('Rerun a flutter Mac builder with infra failure: -9 in parent build', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
@@ -365,7 +365,7 @@ void main() {
       expect(rerunFlag, true);
     });
 
-    test('Rerun a Mac builder with infra failure: -9 in shards', () async {
+    test('Rerun a flutter Mac builder with infra failure: -9 in shards', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
@@ -384,7 +384,7 @@ void main() {
       expect(rerunFlag, true);
     });
 
-    test('Do not rerun a Mac builder with infra failure: -9 in shards but not supported builder', () async {
+    test('Do not rerun a flutter Mac builder with infra failure: -9 in shards but not supported builder', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
@@ -403,12 +403,12 @@ void main() {
       expect(rerunFlag, false);
     });
 
-    test('Do not rerun a Mac builder with non -9 retcode', () async {
+    test('Do not rerun a flutter Mac builder with non -9 retcode', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
           ref: 'refs/heads/master',
-          status: Task.statusInfraFailure,
+          status: Task.statusFailed,
           buildNumber: 1,
           builderName: 'Mac abc',
           summaryMarkdown: 'test failure');
@@ -421,7 +421,7 @@ void main() {
       expect(rerunFlag, false);
     });
 
-    test('Do not rerun a non-Mac builder', () async {
+    test('Do not rerun a flutter non-Mac builder', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
@@ -439,7 +439,7 @@ void main() {
       expect(rerunFlag, false);
     });
 
-    test('Do not rerun a Mac builder exceeding attempt limit', () async {
+    test('Do not rerun a flutter Mac builder exceeding attempt limit', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
@@ -457,23 +457,22 @@ void main() {
       expect(rerunFlag, false);
     });
 
-    test('Do not rerun a Mac builder with non-infra failure: with shards', () async {
+    test('Rerun an engine Mac builder with infra failure: -9', () async {
       config.maxLuciTaskRetriesValue = 1;
       const LuciTask luciTask = LuciTask(
           commitSha: 'abc',
           ref: 'refs/heads/master',
-          status: Task.statusFailed,
+          status: Task.statusInfraFailure,
           buildNumber: 1,
-          builderName: 'Mac tool_tests',
-          summaryMarkdown:
-              'recipe infra failure: Infra Failure: Step(\'display builds.build(s) failed\') (retcode: 1)');
+          builderName: 'Mac abc',
+          summaryMarkdown: 'Step(\'checkout source code.Checkout flutter/flutter.git fetch\') (retcode: -9)');
       final bool rerunFlag = await service.checkRerunBuilder(
         commitSha: 'abc',
         luciTask: luciTask,
         retries: 0,
-        repo: 'flutter',
+        repo: 'engine',
       );
-      expect(rerunFlag, false);
+      expect(rerunFlag, true);
     });
   });
 }

--- a/repo_dashboard/lib/services/github_service.dart
+++ b/repo_dashboard/lib/services/github_service.dart
@@ -199,7 +199,7 @@ Future<http.Response> _getResponse(Uri url) async {
     headers['If-None-Match'] = requestETag;
   }
 
-  final http.Response response = await _client.get(url.toString(), headers: headers).catchError((Error error) {
+  final http.Response response = await _client.get(url.toString(), headers: headers).catchError((Object error) {
     debugPrint('Error fetching"$url": $error');
   });
 


### PR DESCRIPTION
This is a workaround for issue flutter/flutter#68322: auto rerun Mac builders failing with -9 retcode.

This is for post-submit builders only.

