### PR TITLE
Add ouput path as an argument instead of hardcoding

### DIFF
--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -11,13 +11,16 @@ import 'package:device_doctor/device_doctor.dart';
 const String actionFlag = 'action';
 const String deviceOSFlag = 'device-os';
 const String helpFlag = 'help';
+const String outputFlag = 'output';
 const List<String> supportedOptions = <String>['healthcheck', 'recovery', 'properties'];
 const List<String> supportedDeviceOS = <String>['ios', 'android'];
+const String defaultOutputPath = '.output';
 
 /// These values will be initialized in `_checkArgs` function,
 /// and used in `main` function.
 String _action;
 String _deviceOS;
+String _output;
 
 /// Manage `healthcheck`, `recovery`, and `properties` for devices.
 ///
@@ -44,6 +47,7 @@ Future<void> main(List<String> args) async {
       'recovery': 'Clean up and reboot device.',
       'properties': 'Return device properties/dimensions.'
     })
+    ..addOption('$outputFlag', help: 'Path to the output file')
     ..addOption('$deviceOSFlag',
         help: 'Supported device OS.',
         allowed: supportedDeviceOS,
@@ -52,8 +56,9 @@ Future<void> main(List<String> args) async {
   final ArgResults argResults = parser.parse(args);
   _action = argResults[actionFlag];
   _deviceOS = argResults[deviceOSFlag];
+  _output = argResults[outputFlag] ?? defaultOutputPath;
 
-  final DeviceDiscovery deviceDiscovery = DeviceDiscovery(_deviceOS);
+  final DeviceDiscovery deviceDiscovery = DeviceDiscovery(_deviceOS, _output);
 
   switch (_action) {
     case 'healthcheck':

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -12,12 +12,12 @@ import 'ios_device.dart';
 
 /// Discovers available devices and chooses one to work with.
 abstract class DeviceDiscovery {
-  factory DeviceDiscovery(String deviceOs) {
+  factory DeviceDiscovery(String deviceOs, String output) {
     switch (deviceOs) {
       case 'ios':
-        return IosDeviceDiscovery();
+        return IosDeviceDiscovery(output);
       case 'android':
-        return AndroidDeviceDiscovery();
+        return AndroidDeviceDiscovery(output);
       default:
         throw StateError('Unsupported device operating system: $deviceOs');
     }

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -16,14 +16,16 @@ import 'utils.dart';
 ///
 /// Discovers available ios devices and chooses one to work with.
 class IosDeviceDiscovery implements DeviceDiscovery {
-  factory IosDeviceDiscovery() {
-    return _instance ??= IosDeviceDiscovery._();
+  factory IosDeviceDiscovery(String output) {
+    return _instance ??= IosDeviceDiscovery._(output);
   }
 
-  IosDeviceDiscovery._();
+  final String _outputFilePath;
+
+  IosDeviceDiscovery._(this._outputFilePath);
 
   @visibleForTesting
-  IosDeviceDiscovery.testing();
+  IosDeviceDiscovery.testing(this._outputFilePath);
 
   static IosDeviceDiscovery _instance;
 
@@ -45,7 +47,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       results['ios-device-${device.deviceId}'] = checks;
     }
     final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);
-    await writeToFile(json.encode(healthCheckMap), kDeviceFailedHealthcheckFilename);
+    await writeToFile(json.encode(healthCheckMap), _outputFilePath);
     return results;
   }
 

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -11,8 +11,6 @@ import 'package:process/process.dart';
 
 import 'dart:convert' show utf8;
 
-const String kDevicePropertiesFilename = '.properties';
-const String kDeviceFailedHealthcheckFilename = '.healthcheck';
 const String kAttachedDeviceHealthcheckKey = 'attached_device';
 const String kAttachedDeviceHealthcheckValue = 'No device is available';
 final Logger logger = Logger('DeviceDoctor');
@@ -97,20 +95,9 @@ Iterable<String> grep(Pattern pattern, {@required String from}) {
   });
 }
 
-/// Get file based on `Platform` home directory.
-File getFile(String fileName) {
-  if (Platform.isLinux || Platform.isMacOS) {
-    return File(path.join(Platform.environment['HOME'], '$fileName'));
-  }
-  if (!Platform.isWindows) {
-    throw StateError('Unexpected platform ${Platform.operatingSystem}');
-  }
-  return File(path.join(Platform.environment['USERPROFILE'], '.$fileName'));
-}
-
-/// Write [results] to [fileName] based on `Platform` home directory.
-void writeToFile(String results, String fileName) {
-  final File file = getFile(fileName);
+/// Write [results] to [filePath].
+void writeToFile(String results, String filePath) {
+  final File file = File(filePath);
   if (file.existsSync()) {
     try {
       file.deleteSync();

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -22,7 +22,7 @@ void main() {
     Process process;
 
     setUp(() {
-      deviceDiscovery = AndroidDeviceDiscovery();
+      deviceDiscovery = AndroidDeviceDiscovery('/tmp/output');
       processManager = MockProcessManager();
     });
 
@@ -57,7 +57,7 @@ void main() {
     String output;
 
     setUp(() {
-      deviceDiscovery = AndroidDeviceDiscovery();
+      deviceDiscovery = AndroidDeviceDiscovery('/tmp/output');
       processManager = MockProcessManager();
     });
 

--- a/device_doctor/test/src/fake_ios_device.dart
+++ b/device_doctor/test/src/fake_ios_device.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:device_doctor/src/ios_device.dart';
 
 class FakeIosDeviceDiscovery extends IosDeviceDiscovery {
-  FakeIosDeviceDiscovery() : super.testing();
+  FakeIosDeviceDiscovery(String output) : super.testing(output);
 
   List<dynamic> _outputs;
   int _pos = 0;

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -14,7 +14,7 @@ void main() {
     FakeIosDeviceDiscovery deviceDiscovery;
 
     setUp(() {
-      deviceDiscovery = FakeIosDeviceDiscovery();
+      deviceDiscovery = FakeIosDeviceDiscovery('/tmp/output');
     });
 
     test('deviceDiscovery', () async {


### PR DESCRIPTION
Device doctor is writing results to a hardcoded output file. 
This is to inject the output path as an argument. If not specified, it will use the current dir as the output path.

Related: https://github.com/flutter/flutter/issues/74363