### PR TITLE
Correct type in Future.catchError error handler.

### DIFF
--- a/repo_dashboard/lib/services/github_service.dart
+++ b/repo_dashboard/lib/services/github_service.dart
@@ -199,7 +199,7 @@ Future<http.Response> _getResponse(Uri url) async {
     headers['If-None-Match'] = requestETag;
   }
 
-  final http.Response response = await _client.get(url.toString(), headers: headers).catchError((Error error) {
+  final http.Response response = await _client.get(url.toString(), headers: headers).catchError((Object error) {
     debugPrint('Error fetching"$url": $error');
   });
 


### PR DESCRIPTION
This error handler must accept an Object, or it will crash at runtime.

It looks like the Error type was not necessary; the error object is only being Stringified.

The Dart analyzer at HEAD starting today reports such functions with a non-Object parameter, as part of https://github.com/dart-lang/sdk/issues/35825.