### PR TITLE
Upgrade metrics_center

### DIFF
--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   http: ^0.12.0
   json_annotation: ^3.0.0
   meta: ^1.1.7
-  metrics_center: 0.0.7
+  metrics_center: 0.0.9
   mime: ^0.9.0
   neat_cache: ^1.0.1
   protobuf: ^1.0.0


### PR DESCRIPTION
So we'll no longer write into the legacy datastore.