### PR TITLE
Stop device_doctor writing results to stdout

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -124,7 +124,6 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     final String propertiesJson = json.encode(properties);
 
     await writeToFile(propertiesJson, _outputFilePath);
-    stdout.write(propertiesJson);
     return properties;
   }
 

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -143,7 +143,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       final List<String> propertyList = property.replaceAll('[', '').replaceAll(']', '').split(': ');
 
       /// Deal with entries spanning only one line.
-      /// 
+      ///
       /// This is to skip unused entries spanninning multiple lines.
       /// For example:
       ///   [persist.sys.boot.reason.history]: [reboot,ota,1613677289


### PR DESCRIPTION
This is a post cleanup step following https://github.com/flutter/cocoon/pull/1064, which starts writing results to a local file.

Related issue: https://github.com/flutter/flutter/issues/74363