### PR TITLE
Add always visible scrollbars to build page

### DIFF
--- a/app_flutter/lib/widgets/lattice.dart
+++ b/app_flutter/lib/widgets/lattice.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 typedef Painter = void Function(Canvas canvas, Rect rect);
 
@@ -67,24 +68,32 @@ class LatticeScrollView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final TextDirection textDirection = this.textDirection ?? Directionality.of(context);
-    return Scrollable(
-      dragStartBehavior: dragStartBehavior,
-      axisDirection: textDirectionToAxisDirection(textDirection),
+    return Scrollbar(
       controller: horizontalController,
-      physics: horizontalPhysics,
-      viewportBuilder: (BuildContext context, ViewportOffset horizontalOffset) => _FakeViewport(
-        child: Scrollable(
-          dragStartBehavior: dragStartBehavior,
-          axisDirection: AxisDirection.down,
-          controller: verticalController,
-          physics: verticalPhysics,
-          viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _FakeViewport(
-            child: _LatticeBody(
-              textDirection: textDirection,
-              horizontalOffset: horizontalOffset,
-              verticalOffset: verticalOffset,
-              cells: cells,
-              cellSize: cellSize,
+      isAlwaysShown: true,
+      child: Scrollable(
+        dragStartBehavior: dragStartBehavior,
+        axisDirection: textDirectionToAxisDirection(textDirection),
+        controller: horizontalController,
+        physics: horizontalPhysics,
+        viewportBuilder: (BuildContext context, ViewportOffset horizontalOffset) => _FakeViewport(
+          child: Scrollbar(
+            isAlwaysShown: true,
+            controller: verticalController,
+            child: Scrollable(
+              dragStartBehavior: dragStartBehavior,
+              axisDirection: AxisDirection.down,
+              controller: verticalController,
+              physics: verticalPhysics,
+              viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _FakeViewport(
+                child: _LatticeBody(
+                  textDirection: textDirection,
+                  horizontalOffset: horizontalOffset,
+                  verticalOffset: verticalOffset,
+                  cells: cells,
+                  cellSize: cellSize,
+                ),
+              ),
             ),
           ),
         ),

--- a/app_flutter/lib/widgets/task_grid.dart
+++ b/app_flutter/lib/widgets/task_grid.dart
@@ -108,6 +108,13 @@ class _TaskGridState extends State<TaskGrid> {
   }
 
   @override
+  void dispose() {
+    verticalController?.dispose();
+    horizontalController?.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return LatticeScrollView(
       // TODO(ianh): Provide some vertical scroll physics that disable

--- a/app_flutter/lib/widgets/task_grid.dart
+++ b/app_flutter/lib/widgets/task_grid.dart
@@ -94,9 +94,14 @@ class _TaskGridState extends State<TaskGrid> {
   // lattice matrix each time the task grid has to update, regardless of whether
   // we've received new data or not.
 
+  ScrollController verticalController;
+  ScrollController horizontalController;
+
   @override
   void initState() {
     super.initState();
+    verticalController ??= ScrollController();
+    horizontalController ??= ScrollController();
     widget.filter?.addListener(() {
       setState(() {});
     });
@@ -113,6 +118,8 @@ class _TaskGridState extends State<TaskGrid> {
       // rather than the current hack of loading during build.
       cells: _processCommitStatuses(widget.commitStatuses, widget.filter),
       cellSize: const Size.square(TaskBox.cellSize),
+      verticalController: verticalController,
+      horizontalController: horizontalController,
     );
   }
 


### PR DESCRIPTION
I found it difficult to use the trackpad to traverse the build page. This PR adds always visible scrollbars for both vertical and horizontal scrolling.