### PR TITLE
switch from --dart-define to --web-renderer

### DIFF
--- a/cloud_build/app_flutter_build.sh
+++ b/cloud_build/app_flutter_build.sh
@@ -11,7 +11,7 @@ rm -rf build
 flutter doctor
 flutter pub get
 flutter config --enable-web
-flutter build web --dart-define FLUTTER_WEB_USE_SKIA=true
+flutter build web --web-renderer=canvaskit --release
 rm -rf ../app_dart/build
 cp -r build ../app_dart/build
 flutter clean

--- a/cloud_build/repo_dash_build.sh
+++ b/cloud_build/repo_dash_build.sh
@@ -10,7 +10,7 @@ set -e
 rm -rf build
 flutter pub get
 flutter config --enable-web
-flutter build web --dart-define FLUTTER_WEB_USE_SKIA=true
+flutter build web --web-renderer=canvaskit --release
 rm -rf ../app_dart/build/web/repository
 cp -r build/web/ ../app_dart/build/web/repository
 flutter clean


### PR DESCRIPTION
Switch from `--dart-define` to `--web-renderer`. The latter is the officially supported option. Also added `--release` for explicitness.