### PR TITLE
Override path_provider

### DIFF
--- a/repo_dashboard/pubspec.yaml
+++ b/repo_dashboard/pubspec.yaml
@@ -37,6 +37,10 @@ dev_dependencies:
     sdk: flutter
   test: ^1.6.0
 
+dependency_overrides:
+  # Override path_provider to pick up fixes for FFI changes.
+  path_provider: ^2.0.0-nullsafety.1
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
`localstorage` depends on `path_provider`'s stable version, but due to breaking changes in FFI the stable version `path_provider_windows` (and thus `path_provider`) no longer work with the latest version of Dart. This overrides that transitive dependency with one that is compatible with with Dart ToT.