### PR TITLE
Revert "Override path_provider"

### DIFF
--- a/repo_dashboard/pubspec.yaml
+++ b/repo_dashboard/pubspec.yaml
@@ -37,10 +37,6 @@ dev_dependencies:
     sdk: flutter
   test: ^1.6.0
 
-dependency_overrides:
-  # Override path_provider to pick up fixes for FFI changes.
-  path_provider: ^2.0.0-nullsafety.1
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
Reverts flutter/cocoon#1086

Not needed after the revert of the Dart SDK breaking change: https://dart-review.googlesource.com/c/sdk/+/185500