### PR TITLE
Add adb power service check to for Android device health check

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -157,13 +157,8 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   Future<HealthCheckResult> adbPowerServiceCheck({ProcessManager processManager}) async {
     HealthCheckResult healthCheckResult;
     try {
-      final String result =
-          await eval('adb', <String>['shell', 'dumpsys', '-l', '|', 'grep', 'power\$'], processManager: processManager);
-      if (result.trim() == 'power') {
-        healthCheckResult = HealthCheckResult.success(kAdbPowerServiceCheckKey);
-      } else {
-        healthCheckResult = HealthCheckResult.failure(kAdbPowerServiceCheckKey, 'Can\'t find service: power');
-      }
+      await eval('adb', <String>['shell', 'dumpsys', 'power'], processManager: processManager);
+      healthCheckResult = HealthCheckResult.success(kAdbPowerServiceCheckKey);
     } on BuildFailedError catch (error) {
       healthCheckResult = HealthCheckResult.failure(kAdbPowerServiceCheckKey, error.toString());
     }

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -13,6 +13,7 @@ import 'dart:convert' show utf8;
 
 const String kAttachedDeviceHealthcheckKey = 'attached_device';
 const String kAttachedDeviceHealthcheckValue = 'No device is available';
+const String kAdbPowerServiceCheckKey = 'adb_power_service';
 const String kKeychainUnlockCheckKey = 'keychain_unlock';
 const String kUnlockLoginKeychain = '/usr/local/bin/unlock_login_keychain.sh';
 const String kCertCheckKey = 'codesigning_cert';

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.2"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   build:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.3"
   cli_util:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.4"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.2"
+    version: "0.6.3"
   logging:
     dependency: "direct main"
     description:
@@ -182,14 +182,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.2"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -238,14 +238,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.3"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0"
   platform:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety.2"
+    version: "1.5.0-nullsafety.3"
   process:
     dependency: "direct main"
     description:
@@ -329,14 +329,14 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.4"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety.2"
+    version: "0.10.10-nullsafety.3"
   source_span:
     dependency: transitive
     description:
@@ -350,56 +350,56 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.5"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.3"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.7"
+    version: "1.16.0-nullsafety.18"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.4"
+    version: "0.2.19-nullsafety.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.7"
+    version: "0.3.12-nullsafety.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.5"
   vm_service:
     dependency: transitive
     description:
@@ -436,4 +436,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <=2.12.0-276.0.dev"
+  dart: ">=2.12.0-0.0 <3.0.0"

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 
 import 'package:device_doctor/src/android_device.dart';
 import 'package:device_doctor/src/device.dart';
+import 'package:device_doctor/src/health.dart';
 import 'package:device_doctor/src/utils.dart';
 
 import 'utils.dart';
@@ -97,6 +98,75 @@ void main() {
         'product_board': 'mno'
       };
       expect(deviceProperties, equals(expectedProperties));
+    });
+  });
+
+  group('AndroidDeviceHealthCheck', () {
+    AndroidDeviceDiscovery deviceDiscovery;
+    MockProcessManager processManager;
+    Process process;
+    String output;
+
+    setUp(() {
+      deviceDiscovery = AndroidDeviceDiscovery('/tmp/output');
+      processManager = MockProcessManager();
+    });
+
+    test('returns success when adb power service is available', () async {
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      output = 'power';
+
+      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
+
+      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, true);
+      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
+    });
+
+    test('returns failure when adb power service is not available - no power match', () async {
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      output = 'abc';
+
+      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
+
+      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, false);
+      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
+      expect(healthCheckResult.details, 'Can\'t find service: power');
+    });
+
+    test('returns failure when adb power service is not available - no exact power match', () async {
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      output = 'abc power def';
+
+      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
+
+      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, false);
+      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
+      expect(healthCheckResult.details, 'Can\'t find service: power');
+    });
+
+    test('returns failure when adb returns none 0 code', () async {
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+              workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      process = FakeProcess(1);
+
+      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, false);
+      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
+      expect(healthCheckResult.details, 'Executable adb failed with exit code 1.');
     });
   });
 }

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -105,7 +105,6 @@ void main() {
     AndroidDeviceDiscovery deviceDiscovery;
     MockProcessManager processManager;
     Process process;
-    String output;
 
     setUp(() {
       deviceDiscovery = AndroidDeviceDiscovery('/tmp/output');
@@ -113,51 +112,19 @@ void main() {
     });
 
     test('returns success when adb power service is available', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
-      output = 'power';
-
-      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
+      process = FakeProcess(0);
 
       HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
       expect(healthCheckResult.succeeded, true);
       expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
     });
 
-    test('returns failure when adb power service is not available - no power match', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(process));
-
-      output = 'abc';
-
-      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
-
-      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
-      expect(healthCheckResult.succeeded, false);
-      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
-      expect(healthCheckResult.details, 'Can\'t find service: power');
-    });
-
-    test('returns failure when adb power service is not available - no exact power match', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
-              workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(process));
-
-      output = 'abc power def';
-
-      process = FakeProcess(0, out: <List<int>>[utf8.encode(output)]);
-
-      HealthCheckResult healthCheckResult = await deviceDiscovery.adbPowerServiceCheck(processManager: processManager);
-      expect(healthCheckResult.succeeded, false);
-      expect(healthCheckResult.name, kAdbPowerServiceCheckKey);
-      expect(healthCheckResult.details, 'Can\'t find service: power');
-    });
-
     test('returns failure when adb returns none 0 code', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', '-l', '|', 'grep', 'power\$'],
+      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -112,8 +112,8 @@ void main() {
     });
 
     test('returns success when adb power service is available', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power'],
-              workingDirectory: anyNamed('workingDirectory')))
+      when(processManager
+              .start(<dynamic>['adb', 'shell', 'dumpsys', 'power'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
       process = FakeProcess(0);
@@ -124,8 +124,8 @@ void main() {
     });
 
     test('returns failure when adb returns none 0 code', () async {
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power'],
-              workingDirectory: anyNamed('workingDirectory')))
+      when(processManager
+              .start(<dynamic>['adb', 'shell', 'dumpsys', 'power'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
       process = FakeProcess(1);


### PR DESCRIPTION
This adds adb power service health check for android device: make sure the power service is available before reserving/running tests.

Related: https://github.com/flutter/flutter/issues/76130