### PR TITLE
[app_dart] Reland scheduler service

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:cocoon_service/src/service/scheduler.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
@@ -21,6 +20,7 @@ import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
 import '../service/datastore.dart';
 import '../service/github_service.dart';
+import '../service/scheduler.dart';
 
 /// Queries GitHub for the list of recent commits according to different branches,
 /// and creates corresponding rows in the cloud datastore and the BigQuery for any commits

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -50,7 +50,12 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     final GithubService githubService = await config.createGithubService(slug.owner, slug.name);
     final DatastoreService datastore = datastoreProvider(config.db);
 
-    final Scheduler scheduler = Scheduler(config: config, datastore: datastore, httpClient: httpClientProvider(), gitHubBackoffCalculator: gitHubBackoffCalculator, log: log);
+    final Scheduler scheduler = Scheduler(
+        config: config,
+        datastore: datastore,
+        httpClient: httpClientProvider(),
+        gitHubBackoffCalculator: gitHubBackoffCalculator,
+        log: log);
 
     for (String branch in await config.flutterBranches) {
       final List<Commit> lastProcessedCommit = await datastore.queryRecentCommits(limit: 1, branch: branch).toList();
@@ -71,12 +76,12 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
 
       final List<Commit> recentCommits = await _getRecentCommits(commits, datastore, branch);
       await scheduler.addCommits(recentCommits);
-
     }
     return Body.empty;
   }
 
-  Future<List<Commit>> _getRecentCommits(List<RepositoryCommit> commits, DatastoreService datastore, String branch) async {
+  Future<List<Commit>> _getRecentCommits(
+      List<RepositoryCommit> commits, DatastoreService datastore, String branch) async {
     final List<Commit> recentCommits = <Commit>[];
     for (RepositoryCommit commit in commits) {
       final String id = 'flutter/flutter/$branch/${commit.sha}';

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:cocoon_service/src/service/scheduler.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
-import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
 import 'package:truncate/truncate.dart';
 
@@ -16,7 +15,6 @@ import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../foundation/utils.dart';
 import '../model/appengine/commit.dart';
-import '../model/appengine/task.dart';
 import '../model/devicelab/manifest.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -67,6 +67,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
       List<RepositoryCommit> commits;
       try {
         commits = await githubService.listCommits(slug, branch, lastCommitTimestampMills);
+        log.debug('Retrieved ${commits.length} commits from GitHub');
       } on GitHubError catch (error) {
         log.error('$error');
         continue;

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -3,16 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
-import 'package:cocoon_service/src/service/luci.dart';
+import 'package:cocoon_service/src/service/scheduler.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
 import 'package:truncate/truncate.dart';
-import 'package:yaml/yaml.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../foundation/providers.dart';
@@ -24,7 +21,6 @@ import '../model/devicelab/manifest.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
-import '../request_handling/exceptions.dart';
 import '../service/datastore.dart';
 import '../service/github_service.dart';
 
@@ -39,24 +35,22 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     AuthenticationProvider authenticationProvider, {
     @visibleForTesting this.datastoreProvider = DatastoreService.defaultProvider,
     @visibleForTesting this.httpClientProvider = Providers.freshHttpClient,
-    @visibleForTesting this.branchHttpClientProvider = Providers.freshHttpClient,
     @visibleForTesting this.gitHubBackoffCalculator = twoSecondLinearBackoff,
   })  : assert(datastoreProvider != null),
         assert(httpClientProvider != null),
-        assert(branchHttpClientProvider != null),
-        assert(gitHubBackoffCalculator != null),
         super(config: config, authenticationProvider: authenticationProvider);
 
   final DatastoreServiceProvider datastoreProvider;
-  final HttpClientProvider httpClientProvider;
-  final HttpClientProvider branchHttpClientProvider;
   final GitHubBackoffCalculator gitHubBackoffCalculator;
+  final HttpClientProvider httpClientProvider;
 
   @override
   Future<Body> get() async {
     final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
     final GithubService githubService = await config.createGithubService(slug.owner, slug.name);
     final DatastoreService datastore = datastoreProvider(config.db);
+
+    final Scheduler scheduler = Scheduler(config: config, datastore: datastore, httpClient: httpClientProvider(), gitHubBackoffCalculator: gitHubBackoffCalculator, log: log);
 
     for (String branch in await config.flutterBranches) {
       final List<Commit> lastProcessedCommit = await datastore.queryRecentCommits(limit: 1, branch: branch).toList();
@@ -75,186 +69,31 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
         continue;
       }
 
-      final List<Commit> newCommits = await _getNewCommits(commits, datastore, branch);
+      final List<Commit> recentCommits = await _getRecentCommits(commits, datastore, branch);
+      await scheduler.addCommits(recentCommits);
 
-      if (newCommits.isEmpty) {
-        // Nothing to do.
-        continue;
-      }
-      log.debug('Found ${newCommits.length} new commits for branch $branch on GitHub');
-
-      // Save [Commit] to BigQuery and create [Task] in Datastore.
-      await _saveData(newCommits, datastore);
     }
     return Body.empty;
   }
 
-  Future<void> _saveData(
-    List<Commit> newCommits,
-    DatastoreService datastore,
-  ) async {
-    const String projectId = 'flutter-dashboard';
-    const String dataset = 'cocoon';
-    const String table = 'Checklist';
-
-    final TabledataResourceApi tabledataResourceApi = await config.createTabledataResourceApi();
-    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
-
-    for (Commit commit in newCommits) {
-      /// Consolidate [commits] together
-      ///
-      /// Prepare for bigquery [insertAll]
-      tableDataInsertAllRequestRows.add(<String, Object>{
-        'json': <String, Object>{
-          'ID': commit.id,
-          'CreateTimestamp': commit.timestamp,
-          'FlutterRepositoryPath': commit.repository,
-          'CommitSha': commit.sha,
-          'CommitAuthorLogin': commit.author,
-          'CommitAuthorAvatarURL': commit.authorAvatarUrl,
-          'CommitMessage': commit.message,
-          'Branch': commit.branch,
-        },
-      });
-
-      final List<Task> tasks = await _createTasks(
-        commitKey: commit.key,
-        sha: commit.sha,
-        createTimestamp: DateTime.now().millisecondsSinceEpoch,
-      );
-
-      try {
-        await datastore.withTransaction<void>((Transaction transaction) async {
-          transaction.queueMutations(inserts: <Commit>[commit]);
-          transaction.queueMutations(inserts: tasks);
-          await transaction.commit();
-          log.debug('Committed ${tasks.length} new tasks for commit ${commit.sha}');
-        });
-      } catch (error) {
-        log.error('Failed to add commit ${commit.sha}: $error');
-      }
-    }
-
-    /// Final [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest rows =
-        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
-
-    /// Insert [commits] to [BigQuery]
-    try {
-      await tabledataResourceApi.insertAll(rows, projectId, dataset, table);
-    } on ApiRequestError {
-      log.warning('Failed to add commits to BigQuery: $ApiRequestError');
-    }
-  }
-
-  Future<List<Commit>> _getNewCommits(List<RepositoryCommit> commits, DatastoreService datastore, String branch) async {
-    final List<Commit> newCommits = <Commit>[];
+  Future<List<Commit>> _getRecentCommits(List<RepositoryCommit> commits, DatastoreService datastore, String branch) async {
+    final List<Commit> recentCommits = <Commit>[];
     for (RepositoryCommit commit in commits) {
       final String id = 'flutter/flutter/$branch/${commit.sha}';
       final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
-
-      if (await datastore.db.lookupValue<Commit>(key, orElse: () => null) == null) {
-        newCommits.add(Commit(
-          key: key,
-          timestamp: commit.commit.committer.date.millisecondsSinceEpoch,
-          repository: 'flutter/flutter',
-          sha: commit.sha,
-          author: commit.author.login,
-          authorAvatarUrl: commit.author.avatarUrl,
-          // The field has a size of 1500 we need to ensure the commit message
-          // is at most 1500 chars long.
-          message: truncate(commit.commit.message, 1490, omission: '...'),
-          branch: branch,
-        ));
-      } else {
-        // Once we've found a commit that's already been recorded, we stop looking.
-        break;
-      }
-    }
-    return newCommits;
-  }
-
-  Future<List<Task>> _createTasks({
-    @required Key<String> commitKey,
-    @required String sha,
-    @required int createTimestamp,
-  }) async {
-    Task newTask(
-      String name,
-      String stageName,
-      List<String> requiredCapabilities,
-      bool isFlaky,
-      int timeoutInMinutes,
-    ) {
-      return Task(
-        key: commitKey.append(Task),
-        commitKey: commitKey,
-        createTimestamp: createTimestamp,
-        startTimestamp: 0,
-        endTimestamp: 0,
-        name: name,
-        attempts: 0,
-        isFlaky: isFlaky,
-        timeoutInMinutes: timeoutInMinutes,
-        requiredCapabilities: requiredCapabilities,
-        stageName: stageName,
-        status: Task.statusNew,
-      );
-    }
-
-    final List<Task> tasks = <Task>[];
-    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
-    for (LuciBuilder builder in prodBuilders) {
-      // These built-in tasks are not listed in the manifest.
-      tasks.add(Task.chromebot(commitKey: commitKey, createTimestamp: createTimestamp, builder: builder));
-    }
-
-    final YamlMap yaml = await _loadDevicelabManifest(sha);
-    final Manifest manifest = Manifest.fromJson(yaml);
-    manifest.tasks.forEach((String taskName, ManifestTask info) {
-      tasks.add(newTask(
-        taskName,
-        info.stage,
-        info.requiredAgentCapabilities,
-        info.isFlaky,
-        info.timeoutInMinutes,
+      recentCommits.add(Commit(
+        key: key,
+        timestamp: commit.commit.committer.date.millisecondsSinceEpoch,
+        repository: 'flutter/flutter',
+        sha: commit.sha,
+        author: commit.author.login,
+        authorAvatarUrl: commit.author.avatarUrl,
+        // The field has a size of 1500 we need to ensure the commit message
+        // is at most 1500 chars long.
+        message: truncate(commit.commit.message, 1490, omission: '...'),
+        branch: branch,
       ));
-    });
-
-    return tasks;
-  }
-
-  Future<YamlMap> _loadDevicelabManifest(String sha) async {
-    final String path = '/flutter/flutter/$sha/dev/devicelab/manifest.yaml';
-    final Uri url = Uri.https('raw.githubusercontent.com', path);
-
-    final HttpClient client = httpClientProvider();
-    try {
-      for (int attempt = 0; attempt < 3; attempt++) {
-        final HttpClientRequest clientRequest = await client.getUrl(url);
-
-        try {
-          final HttpClientResponse clientResponse = await clientRequest.close();
-          final int status = clientResponse.statusCode;
-
-          if (status == HttpStatus.ok) {
-            final String content = await utf8.decoder.bind(clientResponse).join();
-            return loadYaml(content) as YamlMap;
-          } else {
-            log.warning('Attempt to download manifest.yaml failed (HTTP $status)');
-          }
-        } catch (error, stackTrace) {
-          log.error('Attempt to download manifest.yaml failed:\n$error\n$stackTrace');
-        }
-
-        await Future<void>.delayed(gitHubBackoffCalculator(attempt));
-      }
-    } finally {
-      client.close(force: true);
     }
-
-    log.error('GitHub not responding; giving up');
-    response.headers.set(HttpHeaders.retryAfterHeader, '120');
-    throw const HttpStatusException(HttpStatus.serviceUnavailable, 'GitHub not responding');
+    return recentCommits;
   }
 }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -55,7 +55,7 @@ class Scheduler {
     log.debug('Found ${newCommits.length} new commits on GitHub');
     for (Commit commit in newCommits) {
       await _addCommit(commit);
-    } 
+    }
   }
 
   Future<void> _addCommit(Commit commit) async {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -25,7 +25,7 @@ import 'datastore.dart';
 /// Scheduler responsibilties include:
 ///   1. Tracking commits in Cocoon
 ///   2. Ensuring commits are validated (via scheduling tasks against commits)
-///   3. Retry mechanisms for taskss
+///   3. Retry mechanisms for tasks
 class Scheduler {
   Scheduler({
     @required this.config,
@@ -48,8 +48,6 @@ class Scheduler {
   ///   * Write it to datastore
   ///   * Schedule tasks listed in its scheduler config
   /// Otherwise, ignore it.
-  ///
-  /// [commits] is assumed to be sorted in descending order by merged timestamp.
   Future<void> addCommits(List<Commit> commits) async {
     final List<Commit> newCommits = await _getNewCommits(commits);
     log.debug('Found ${newCommits.length} new commits on GitHub');
@@ -78,7 +76,6 @@ class Scheduler {
     final List<Commit> newCommits = <Commit>[];
     // Ensure commits are sorted from newest to oldest
     commits.sort((Commit a, Commit b) => a.timestamp.compareTo(b.timestamp));
-    print(commits);
     for (Commit commit in commits) {
       if (await datastore.db.lookupValue<Commit>(commit.key, orElse: () => null) == null) {
         newCommits.add(commit);
@@ -143,7 +140,7 @@ class Scheduler {
         log.debug('Committed ${tasks.length} new tasks for commit ${commit.sha}');
       });
     } catch (error) {
-      log.error('Failed to add commit ${commit.sha}: $error');
+      log.error('Failed to commit tasks for ${commit.sha}: $error');
     }
 
     return tasks;

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -1,0 +1,224 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:gcloud/db.dart';
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:meta/meta.dart';
+import 'package:yaml/yaml.dart';
+
+import '../datastore/cocoon_config.dart';
+import '../foundation/utils.dart';
+import '../model/appengine/commit.dart';
+import '../model/appengine/task.dart';
+import '../model/devicelab/manifest.dart';
+import '../request_handling/exceptions.dart';
+import '../service/luci.dart';
+import 'datastore.dart';
+
+/// Scheduler service to validate all commits to supported Flutter repositories.
+///
+/// Scheduler responsibilties include:
+///   1. Tracking commits in Cocoon
+///   2. Ensuring commits are validated (via scheduling tasks against commits)
+///   3. Retry mechanisms for taskss
+class Scheduler {
+  Scheduler({
+    @required this.config,
+    @required this.datastore,
+    this.gitHubBackoffCalculator = twoSecondLinearBackoff,
+    this.httpClient,
+    this.log,
+  })  : assert(datastore != null),
+        assert(gitHubBackoffCalculator != null);
+
+  final Config config;
+  final DatastoreService datastore;
+  final HttpClient httpClient;
+  final GitHubBackoffCalculator gitHubBackoffCalculator;
+  final Logging log;
+
+  /// Ensure [commits] exist in Cocoon.
+  ///
+  /// If [Commit] does not exist in Datastore:
+  ///   * Write it to datastore
+  ///   * Schedule tasks listed in its scheduler config
+  /// Otherwise, ignore it.
+  ///
+  /// [commits] is assumed to be sorted in descending order by merged timestamp.
+  Future<void> addCommits(List<Commit> commits) async {
+    final List<Commit> newCommits = await _getNewCommits(commits);
+    log.debug('Found ${newCommits.length} new commits on GitHub');
+    for (Commit commit in newCommits) {
+      await _addCommit(commit);
+    } 
+  }
+
+  Future<void> _addCommit(Commit commit) async {
+    try {
+      await datastore.withTransaction<void>((Transaction transaction) async {
+        transaction.queueMutations(inserts: <Commit>[commit]);
+        await transaction.commit();
+        log.debug('Committed commit ${commit.sha}');
+      });
+      await _scheduleTasks(commit);
+    } catch (error) {
+      log.error('Failed to add commit ${commit.sha}: $error');
+    }
+
+    await _uploadToBigQuery(commit);
+  }
+
+  /// Return subset of [commits] not stored in Datastore.
+  Future<List<Commit>> _getNewCommits(List<Commit> commits) async {
+    final List<Commit> newCommits = <Commit>[];
+    // Ensure commits are sorted from newest to oldest
+    commits.sort((Commit a, Commit b) => a.timestamp.compareTo(b.timestamp));
+    print(commits);
+    for (Commit commit in commits) {
+      if (await datastore.db.lookupValue<Commit>(commit.key, orElse: () => null) == null) {
+        newCommits.add(commit);
+      } else {
+        // Once we've found a commit that's already been recorded, we stop looking.
+        break;
+      }
+    }
+
+    // Reverses commits to be in order of oldest to newest.
+    return newCommits;
+  }
+
+  /// Create [Tasks] specified in [commit] scheduler config.
+  Future<List<Task>> _scheduleTasks(Commit commit) async {
+    Task newTask(
+      String name,
+      String stageName,
+      List<String> requiredCapabilities,
+      bool isFlaky,
+      int timeoutInMinutes,
+    ) {
+      return Task(
+        key: commit.key.append(Task),
+        commitKey: commit.key,
+        createTimestamp: commit.timestamp,
+        startTimestamp: 0,
+        endTimestamp: 0,
+        name: name,
+        attempts: 0,
+        isFlaky: isFlaky,
+        timeoutInMinutes: timeoutInMinutes,
+        requiredCapabilities: requiredCapabilities,
+        stageName: stageName,
+        status: Task.statusNew,
+      );
+    }
+
+    final List<Task> tasks = <Task>[];
+    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
+    for (LuciBuilder builder in prodBuilders) {
+      // These built-in tasks are not listed in the manifest.
+      tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));
+    }
+
+    final YamlMap yaml = await loadDevicelabManifest(commit);
+    final Manifest manifest = Manifest.fromJson(yaml);
+    manifest.tasks.forEach((String taskName, ManifestTask info) {
+      tasks.add(newTask(
+        taskName,
+        info.stage,
+        info.requiredAgentCapabilities,
+        info.isFlaky,
+        info.timeoutInMinutes,
+      ));
+    });
+
+    try {
+      await datastore.withTransaction<void>((Transaction transaction) async {
+        transaction.queueMutations(inserts: tasks);
+        await transaction.commit();
+        log.debug('Committed ${tasks.length} new tasks for commit ${commit.sha}');
+      });
+    } catch (error) {
+      log.error('Failed to add commit ${commit.sha}: $error');
+    }
+
+    return tasks;
+  }
+
+  /// Load in memory the Cocoon Agent DeviceLab scheduler config.
+  ///
+  // TODO(chillers): Remove when DeviceLab has migrated to LUCI. https://github.com/flutter/flutter/projects/151
+  @visibleForTesting
+  Future<YamlMap> loadDevicelabManifest(Commit commit) async {
+    final String path = '/flutter/flutter/${commit.sha}/dev/devicelab/manifest.yaml';
+    final Uri url = Uri.https('raw.githubusercontent.com', path);
+
+    try {
+      for (int attempt = 0; attempt < 3; attempt++) {
+        final HttpClientRequest clientRequest = await httpClient.getUrl(url);
+
+        try {
+          final HttpClientResponse clientResponse = await clientRequest.close();
+          final int status = clientResponse.statusCode;
+
+          if (status == HttpStatus.ok) {
+            final String content = await utf8.decoder.bind(clientResponse).join();
+            return loadYaml(content) as YamlMap;
+          } else {
+            log.warning('Attempt to download manifest.yaml failed (HTTP $status)');
+          }
+        } catch (error, stackTrace) {
+          log.error('Attempt to download manifest.yaml failed:\n$error\n$stackTrace');
+        }
+
+        await Future<void>.delayed(gitHubBackoffCalculator(attempt));
+      }
+    } finally {
+      httpClient.close(force: true);
+    }
+
+    log.error('GitHub not responding; giving up');
+    throw HttpStatusException(HttpStatus.serviceUnavailable, 'Failed to load $path from GitHub');
+  }
+
+  /// Push [Commit] to BigQuery as part of the infra metrics dashboards.
+  Future<void> _uploadToBigQuery(Commit commit) async {
+    const String projectId = 'flutter-dashboard';
+    const String dataset = 'cocoon';
+    const String table = 'Checklist';
+
+    final TabledataResourceApi tabledataResourceApi = await config.createTabledataResourceApi();
+    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
+
+    /// Consolidate [commits] together
+    ///
+    /// Prepare for bigquery [insertAll]
+    tableDataInsertAllRequestRows.add(<String, Object>{
+      'json': <String, Object>{
+        'ID': commit.id,
+        'CreateTimestamp': commit.timestamp,
+        'FlutterRepositoryPath': commit.repository,
+        'CommitSha': commit.sha,
+        'CommitAuthorLogin': commit.author,
+        'CommitAuthorAvatarURL': commit.authorAvatarUrl,
+        'CommitMessage': commit.message,
+        'Branch': commit.branch,
+      },
+    });
+
+    /// Final [rows] to be inserted to [BigQuery]
+    final TableDataInsertAllRequest rows =
+        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
+
+    /// Insert [commits] to [BigQuery]
+    try {
+      await tabledataResourceApi.insertAll(rows, projectId, dataset, table);
+    } on ApiRequestError {
+      log.warning('Failed to add commits to BigQuery: $ApiRequestError');
+    }
+  }
+}

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -74,8 +74,8 @@ class Scheduler {
   /// Return subset of [commits] not stored in Datastore.
   Future<List<Commit>> _getNewCommits(List<Commit> commits) async {
     final List<Commit> newCommits = <Commit>[];
-    // Ensure commits are sorted from newest to oldest
-    commits.sort((Commit a, Commit b) => a.timestamp.compareTo(b.timestamp));
+    // Ensure commits are sorted from newest to oldest (descending order)
+    commits.sort((Commit a, Commit b) => b.timestamp.compareTo(a.timestamp));
     for (Commit commit in commits) {
       if (await datastore.db.lookupValue<Commit>(commit.key, orElse: () => null) == null) {
         newCommits.add(commit);

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -134,9 +134,10 @@ void main() {
       expect(db.values.values.whereType<Commit>().length, 4);
       expect(db.values.values.whereType<Task>().length, 0);
       httpClient.request.response.body = singleTaskManifestYaml;
+      // Commits 7, 8, 9 will get added and scheduled to the tree
       final Body body = await tester.get<Body>(handler);
-      expect(db.values.values.whereType<Commit>().length, 6);
-      expect(db.values.values.whereType<Task>().length, 10);
+      expect(db.values.values.whereType<Commit>().length, 7);
+      expect(db.values.values.whereType<Task>().length, 15);
       expect(await body.serialize().toList(), isEmpty);
     });
 
@@ -185,8 +186,8 @@ void main() {
       final Body body = await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 3);
       expect(db.values.values.whereType<Task>().length, 10);
-      expect(db.values.values.whereType<Commit>().map<String>(toSha), <String>['1', '2', '4']);
-      expect(db.values.values.whereType<Commit>().map<int>(toTimestamp), <int>[1, 2, 4]);
+      expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
+      expect(db.values.values.whereType<Commit>().map<int>(toTimestamp), containsAll(<int>[1, 2, 4]));
       expect(await body.serialize().toList(), isEmpty);
     });
   });

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -46,20 +46,23 @@ void main() {
       httpClient = FakeHttpClient();
       httpClient.request.response.body = singleDeviceLabTaskManifestYaml;
 
-      scheduler = Scheduler(config: config, datastore: DatastoreService(db, 2), httpClient: httpClient, log: FakeLogging());
+      scheduler =
+          Scheduler(config: config, datastore: DatastoreService(db, 2), httpClient: httpClient, log: FakeLogging());
     });
 
     List<Commit> createCommitList(List<String> shas) {
-      return List<Commit>.generate(shas.length, (int index) => Commit(
-        author: 'Username',
-        authorAvatarUrl: 'http://example.org/avatar.jpg',
-        branch: 'master',
-        key: db.emptyKey.append(Commit, id: 'flutter/flutter/master/${shas[index]}'),
-        message: 'commit message',
-        repository: 'flutter',
-        sha: shas[index],
-        timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index])).millisecondsSinceEpoch,
-      ));
+      return List<Commit>.generate(
+          shas.length,
+          (int index) => Commit(
+                author: 'Username',
+                authorAvatarUrl: 'http://example.org/avatar.jpg',
+                branch: 'master',
+                key: db.emptyKey.append(Commit, id: 'flutter/flutter/master/${shas[index]}'),
+                message: 'commit message',
+                repository: 'flutter',
+                sha: shas[index],
+                timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index])).millisecondsSinceEpoch,
+              ));
     }
 
     Commit shaToCommit(String sha, {String branch = 'master'}) {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1,0 +1,140 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:gcloud/db.dart' as gcloud_db;
+import 'package:googleapis/bigquery/v2.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/scheduler.dart';
+
+import '../src/datastore/fake_cocoon_config.dart';
+import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/fake_http.dart';
+import '../src/request_handling/fake_logging.dart';
+import '../src/utilities/mocks.dart';
+
+const String singleDeviceLabTaskManifestYaml = '''
+tasks:
+  linux_test:
+    stage: devicelab
+    required_agent_capabilities: ["linux/android"]
+''';
+
+void main() {
+  group('add commits', () {
+    FakeConfig config;
+    FakeDatastoreDB db;
+    FakeHttpClient httpClient;
+    Scheduler scheduler;
+
+    setUp(() {
+      final MockTabledataResourceApi tabledataResourceApi = MockTabledataResourceApi();
+      when(tabledataResourceApi.insertAll(any, any, any, any)).thenAnswer((_) {
+        return Future<TableDataInsertAllResponse>.value(null);
+      });
+
+      db = FakeDatastoreDB();
+      config = FakeConfig(tabledataResourceApi: tabledataResourceApi, dbValue: db);
+      httpClient = FakeHttpClient();
+      httpClient.request.response.body = singleDeviceLabTaskManifestYaml;
+
+      scheduler = Scheduler(config: config, datastore: DatastoreService(db, 2), httpClient: httpClient, log: FakeLogging());
+    });
+
+    List<Commit> createCommitList(List<String> shas) {
+      return List<Commit>.generate(shas.length, (int index) => Commit(
+        author: 'Username',
+        authorAvatarUrl: 'http://example.org/avatar.jpg',
+        branch: 'master',
+        key: db.emptyKey.append(Commit, id: 'flutter/flutter/master/${shas[index]}'),
+        message: 'commit message',
+        repository: 'flutter',
+        sha: shas[index],
+        timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index])).millisecondsSinceEpoch,
+      ));
+    }
+
+    Commit shaToCommit(String sha, {String branch = 'master'}) {
+      return Commit(
+          key: db.emptyKey.append(Commit, id: 'flutter/flutter/$branch/$sha'),
+          sha: sha,
+          branch: branch,
+          timestamp: int.parse(sha));
+    }
+
+    test('succeeds when GitHub returns no commits', () async {
+      await scheduler.addCommits(<Commit>[]);
+      expect(db.values, isEmpty);
+    });
+
+    test('inserts all relevant fields of the commit', () async {
+      config.flutterBranchesValue = <String>['master'];
+      expect(db.values.values.whereType<Commit>().length, 0);
+      await scheduler.addCommits(createCommitList(<String>['1']));
+      expect(db.values.values.whereType<Commit>().length, 1);
+      final Commit commit = db.values.values.whereType<Commit>().single;
+      expect(commit.repository, 'flutter');
+      expect(commit.branch, 'master');
+      expect(commit.sha, '1');
+      expect(commit.timestamp, 1);
+      expect(commit.author, 'Username');
+      expect(commit.authorAvatarUrl, 'http://example.org/avatar.jpg');
+      expect(commit.message, 'commit message');
+    });
+
+    test('skips commits for which transaction commit fails', () async {
+      config.flutterBranchesValue = <String>['master'];
+
+      // Existing commits should not be duplicated.
+      final Commit commit = shaToCommit('1');
+      db.values[commit.key] = commit;
+
+      db.onCommit = (List<gcloud_db.Model<dynamic>> inserts, List<gcloud_db.Key<dynamic>> deletes) {
+        if (inserts.whereType<Commit>().where((Commit commit) => commit.sha == '3').isNotEmpty) {
+          throw StateError('Commit failed');
+        }
+      };
+      // Commits are expect from newest to oldest timestamps
+      await scheduler.addCommits(createCommitList(<String>['2', '3', '4']));
+      expect(db.values.values.whereType<Commit>().length, 3);
+      // The 2 new commits are scheduled tasks, existing commit has none.
+      expect(db.values.values.whereType<Task>().length, 2 * 5);
+      expect(db.values.values.whereType<Commit>().map<String>(toSha), <String>['1', '2', '4']);
+      expect(db.values.values.whereType<Commit>().map<int>(toTimestamp), <int>[1, 2, 4]);
+    });
+
+    test('retries manifest download upon HTTP failure', () async {
+      int retry = 0;
+      httpClient.onIssueRequest = (FakeHttpClientRequest request) {
+        request.response.statusCode = retry == 0 ? HttpStatus.serviceUnavailable : HttpStatus.ok;
+        retry++;
+      };
+
+      config.flutterBranchesValue = <String>['master'];
+      await scheduler.loadDevicelabManifest(shaToCommit('123'));
+      expect(retry, 2);
+    });
+
+    test('gives up devicelab manifest download after 3 tries', () async {
+      int retry = 0;
+      httpClient.onIssueRequest = (FakeHttpClientRequest request) => retry++;
+
+      config.flutterBranchesValue = <String>['master'];
+      httpClient.request.response.statusCode = HttpStatus.serviceUnavailable;
+      await expectLater(scheduler.loadDevicelabManifest(shaToCommit('123')), throwsA(isA<HttpStatusException>()));
+      expect(retry, 3);
+    });
+  });
+}
+
+String toSha(Commit commit) => commit.sha;
+
+int toTimestamp(Commit commit) => commit.timestamp;

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -110,8 +110,9 @@ void main() {
       expect(db.values.values.whereType<Commit>().length, 3);
       // The 2 new commits are scheduled tasks, existing commit has none.
       expect(db.values.values.whereType<Task>().length, 2 * 5);
-      expect(db.values.values.whereType<Commit>().map<String>(toSha), <String>['1', '2', '4']);
-      expect(db.values.values.whereType<Commit>().map<int>(toTimestamp), <int>[1, 2, 4]);
+      // Check commits were added, but 3 was not
+      expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
+      expect(db.values.values.whereType<Commit>().map<String>(toSha), isNot(contains('3')));
     });
 
     test('retries manifest download upon HTTP failure', () async {

--- a/licenses/check_licenses.dart
+++ b/licenses/check_licenses.dart
@@ -37,7 +37,7 @@ Future<void> run(List<String> arguments) async {
 // TESTS
 String _generateLicense(String prefix) {
   assert(prefix != null);
-  return '${prefix}Copyright (2014|2015|2016|2017|2018|2019|2020) The Flutter Authors. All rights reserved.\n'
+  return '${prefix}Copyright (2014|2015|2016|2017|2018|2019|2020|2021) The Flutter Authors. All rights reserved.\n'
       '${prefix}Use of this source code is governed by a BSD-style license that can be\n'
       '${prefix}found in the LICENSE file.';
 }


### PR DESCRIPTION
See the last commit for the diff between https://github.com/flutter/cocoon/pull/1087

The issue appears to have been the age was backwards in the scheduler. It was only looking to add older commits that did not exist in Datastore. Instead, it should add newer commits that do not exist in Datastore. Simply, larger timestamp commits should get added to datastore.

# Issues

https://github.com/flutter/flutter/issues/76140

# Future work
* Trigger adding tasks from github webhooks
  * Remove the cron method
* Move retry logic into this service