### PR TITLE
Add developer mode health check for android device

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -167,12 +167,16 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   }
 
   @visibleForTesting
+  /// The health check for Android device developer mode.
+  /// 
+  /// Developer mode `on` is expected for a healthy Android device.
   Future<HealthCheckResult> developerModeCheck({ProcessManager processManager}) async {
     HealthCheckResult healthCheckResult;
     try {
       final String result = await eval(
           'adb', <String>['shell', 'settings', 'get', 'global', 'development_settings_enabled'],
           processManager: processManager);
+      // The output of `development_settings_enabled` is `1` when developer mode is on. 
       if (result == '1') {
         healthCheckResult = HealthCheckResult.success(kDeveloperModeCheckKey);
       } else {

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -97,6 +97,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       final List<HealthCheckResult> checks = <HealthCheckResult>[];
       checks.add(HealthCheckResult.success('device_access'));
       checks.add(await adbPowerServiceCheck(processManager: processManager));
+      checks.add(await developerModeCheck(processManager: processManager));
       results['android-device-${device.deviceId}'] = checks;
     }
     final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);
@@ -161,6 +162,24 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       healthCheckResult = HealthCheckResult.success(kAdbPowerServiceCheckKey);
     } on BuildFailedError catch (error) {
       healthCheckResult = HealthCheckResult.failure(kAdbPowerServiceCheckKey, error.toString());
+    }
+    return healthCheckResult;
+  }
+
+  @visibleForTesting
+  Future<HealthCheckResult> developerModeCheck({ProcessManager processManager}) async {
+    HealthCheckResult healthCheckResult;
+    try {
+      final String result = await eval(
+          'adb', <String>['shell', 'settings', 'get', 'global', 'development_settings_enabled'],
+          processManager: processManager);
+      if (result == '1') {
+        healthCheckResult = HealthCheckResult.success(kDeveloperModeCheckKey);
+      } else {
+        healthCheckResult = HealthCheckResult.failure(kDeveloperModeCheckKey, 'developer mode is off');
+      }
+    } on BuildFailedError catch (error) {
+      healthCheckResult = HealthCheckResult.failure(kDeveloperModeCheckKey, error.toString());
     }
     return healthCheckResult;
   }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -167,8 +167,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   }
 
   @visibleForTesting
+
   /// The health check for Android device developer mode.
-  /// 
+  ///
   /// Developer mode `on` is expected for a healthy Android device.
   Future<HealthCheckResult> developerModeCheck({ProcessManager processManager}) async {
     HealthCheckResult healthCheckResult;
@@ -176,7 +177,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       final String result = await eval(
           'adb', <String>['shell', 'settings', 'get', 'global', 'development_settings_enabled'],
           processManager: processManager);
-      // The output of `development_settings_enabled` is `1` when developer mode is on. 
+      // The output of `development_settings_enabled` is `1` when developer mode is on.
       if (result == '1') {
         healthCheckResult = HealthCheckResult.success(kDeveloperModeCheckKey);
       } else {

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -14,6 +14,7 @@ import 'dart:convert' show utf8;
 const String kAttachedDeviceHealthcheckKey = 'attached_device';
 const String kAttachedDeviceHealthcheckValue = 'No device is available';
 const String kAdbPowerServiceCheckKey = 'adb_power_service';
+const String kDeveloperModeCheckKey = 'developer_mode';
 const String kKeychainUnlockCheckKey = 'keychain_unlock';
 const String kUnlockLoginKeychain = '/usr/local/bin/unlock_login_keychain.sh';
 const String kCertCheckKey = 'codesigning_cert';

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.3"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.3"
+    version: "0.12.10"
   meta:
     dependency: "direct main"
     description:
@@ -238,7 +238,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety.3"
+    version: "1.5.0"
   process:
     dependency: "direct main"
     description:
@@ -329,77 +329,77 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.4"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety.3"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.18"
+    version: "1.16.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.7"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.16"
+    version: "0.3.13"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
This add Android device developer mode health check: make sure it is on before reserving tests.

Related: https://github.com/flutter/flutter/issues/76165