### PR TITLE
Add swarming user auto login check for Mac bots

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -13,6 +13,7 @@ import 'package:retry/retry.dart';
 import 'device.dart';
 import 'health.dart';
 import 'host_utils.dart';
+import 'mac.dart';
 import 'utils.dart';
 
 class AndroidDeviceDiscovery implements DeviceDiscovery {
@@ -98,6 +99,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       checks.add(HealthCheckResult.success('device_access'));
       checks.add(await adbPowerServiceCheck(processManager: processManager));
       checks.add(await developerModeCheck(processManager: processManager));
+      if (Platform.isMacOS) {
+        checks.add(await userAutoLoginCheck(processManager: processManager));
+      }
       results['android-device-${device.deviceId}'] = checks;
     }
     final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -96,7 +96,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     final Map<String, List<HealthCheckResult>> results = <String, List<HealthCheckResult>>{};
     for (AndroidDevice device in await discoverDevices(processManager: processManager)) {
       final List<HealthCheckResult> checks = <HealthCheckResult>[];
-      checks.add(HealthCheckResult.success('device_access'));
+      checks.add(HealthCheckResult.success(kDeviceAccessCheckKey));
       checks.add(await adbPowerServiceCheck(processManager: processManager));
       checks.add(await developerModeCheck(processManager: processManager));
       if (Platform.isMacOS) {

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -45,7 +45,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     final Map<String, List<HealthCheckResult>> results = <String, List<HealthCheckResult>>{};
     for (Device device in await discoverDevices()) {
       final List<HealthCheckResult> checks = <HealthCheckResult>[];
-      checks.add(HealthCheckResult.success('device_access'));
+      checks.add(HealthCheckResult.success(kDeviceAccessCheckKey));
       checks.add(await keychainUnlockCheck(processManager: processManager));
       checks.add(await certCheck(processManager: processManager));
       checks.add(await devicePairCheck(processManager: processManager));

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -10,6 +10,7 @@ import 'package:process/process.dart';
 
 import 'device.dart';
 import 'health.dart';
+import 'mac.dart';
 import 'utils.dart';
 
 /// IOS implementation of [DeviceDiscovery].
@@ -48,6 +49,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       checks.add(await keychainUnlockCheck(processManager: processManager));
       checks.add(await certCheck(processManager: processManager));
       checks.add(await devicePairCheck(processManager: processManager));
+      checks.add(await userAutoLoginCheck(processManager: processManager));
       results['ios-device-${device.deviceId}'] = checks;
     }
     final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);

--- a/device_doctor/lib/src/mac.dart
+++ b/device_doctor/lib/src/mac.dart
@@ -10,6 +10,9 @@ import 'health.dart';
 import 'utils.dart';
 
 /// The health check for Mac swarming user auto login.
+///
+/// The `swarming` user auto login is required for Flutter desktop tests which need to run
+/// GUI application on Mac.
 Future<HealthCheckResult> userAutoLoginCheck({ProcessManager processManager}) async {
   HealthCheckResult healthCheckResult;
   try {

--- a/device_doctor/lib/src/mac.dart
+++ b/device_doctor/lib/src/mac.dart
@@ -1,0 +1,30 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:process/process.dart';
+
+import 'health.dart';
+import 'utils.dart';
+
+/// The health check for Mac swarming user auto login.
+Future<HealthCheckResult> userAutoLoginCheck({ProcessManager processManager}) async {
+  HealthCheckResult healthCheckResult;
+  try {
+    final String user = await eval(
+        'defaults', <String>['read', '/Library/Preferences/com.apple.loginwindow', 'autoLoginUser'],
+        processManager: processManager);
+    // User `swarming` is expected setup for Mac bot auto login.
+    if (user == 'swarming') {
+      healthCheckResult = HealthCheckResult.success(kUserAutoLoginCheckKey);
+    } else {
+      healthCheckResult =
+          HealthCheckResult.failure(kUserAutoLoginCheckKey, 'swarming user is not setup for auto login');
+    }
+  } on BuildFailedError catch (error) {
+    healthCheckResult = HealthCheckResult.failure(kUserAutoLoginCheckKey, error.toString());
+  }
+  return healthCheckResult;
+}

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -16,6 +16,7 @@ const String kAttachedDeviceHealthcheckValue = 'No device is available';
 const String kAdbPowerServiceCheckKey = 'adb_power_service';
 const String kDeveloperModeCheckKey = 'developer_mode';
 const String kKeychainUnlockCheckKey = 'keychain_unlock';
+const String kUserAutoLoginCheckKey = 'swarming_user_auto_login';
 const String kUnlockLoginKeychain = '/usr/local/bin/unlock_login_keychain.sh';
 const String kCertCheckKey = 'codesigning_cert';
 const String kDevicePairCheckKey = 'device_pair';

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -11,6 +11,7 @@ import 'package:process/process.dart';
 
 import 'dart:convert' show utf8;
 
+const String kDeviceAccessCheckKey = 'device_access';
 const String kAttachedDeviceHealthcheckKey = 'attached_device';
 const String kAttachedDeviceHealthcheckValue = 'No device is available';
 const String kAdbPowerServiceCheckKey = 'adb_power_service';

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -52,11 +52,12 @@ void main() {
       Map<String, List<HealthCheckResult>> results = await deviceDiscovery.checkDevices(processManager: processManager);
       expect(results.keys.length, equals(1));
       expect(results.keys.toList()[0], 'ios-device-abcdefg');
-      expect(results['ios-device-abcdefg'].length, equals(4));
+      expect(results['ios-device-abcdefg'].length, equals(5));
       expect(results['ios-device-abcdefg'][0].succeeded, true);
       expect(results['ios-device-abcdefg'][1].succeeded, true);
       expect(results['ios-device-abcdefg'][2].succeeded, false);
       expect(results['ios-device-abcdefg'][3].succeeded, false);
+      expect(results['ios-device-abcdefg'][4].succeeded, false);
     });
   });
 

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -52,11 +52,16 @@ void main() {
       Map<String, List<HealthCheckResult>> results = await deviceDiscovery.checkDevices(processManager: processManager);
       expect(results.keys.length, equals(1));
       expect(results.keys.toList()[0], 'ios-device-abcdefg');
-      expect(results['ios-device-abcdefg'].length, equals(5));
+      expect(results['ios-device-abcdefg'].length, 5);
+      expect(results['ios-device-abcdefg'][0].name, kDeviceAccessCheckKey);
       expect(results['ios-device-abcdefg'][0].succeeded, true);
+      expect(results['ios-device-abcdefg'][1].name, kKeychainUnlockCheckKey);
       expect(results['ios-device-abcdefg'][1].succeeded, true);
+      expect(results['ios-device-abcdefg'][2].name, kCertCheckKey);
       expect(results['ios-device-abcdefg'][2].succeeded, false);
+      expect(results['ios-device-abcdefg'][3].name, kDevicePairCheckKey);
       expect(results['ios-device-abcdefg'][3].succeeded, false);
+      expect(results['ios-device-abcdefg'][4].name, kUserAutoLoginCheckKey);
       expect(results['ios-device-abcdefg'][4].succeeded, false);
     });
   });

--- a/device_doctor/test/src/mac_test.dart
+++ b/device_doctor/test/src/mac_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:device_doctor/src/health.dart';
+import 'package:device_doctor/src/mac.dart';
+import 'package:device_doctor/src/utils.dart';
+
+import 'utils.dart';
+
+void main() {
+  group('Mac - health checks', () {
+    MockProcessManager processManager;
+    Process process;
+    List<List<int>> output;
+
+    setUp(() {
+      processManager = MockProcessManager();
+    });
+
+    test('Swarming user auto login check - success', () async {
+      when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+      output = <List<int>>[utf8.encode('swarming')];
+      process = FakeProcess(0, out: output);
+      HealthCheckResult healthCheckResult = await userAutoLoginCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, true);
+    });
+
+    test('Swarming user auto login check - exception', () async {
+      when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+      process = FakeProcess(1);
+      HealthCheckResult healthCheckResult = await userAutoLoginCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, false);
+      expect(healthCheckResult.name, kUserAutoLoginCheckKey);
+      expect(healthCheckResult.details, 'Executable defaults failed with exit code 1.');
+    });
+
+    test('Swarming user auto login check - failure', () async {
+      when(processManager.start(any, workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+      output = <List<int>>[utf8.encode('test')];
+      process = FakeProcess(0, out: output);
+      HealthCheckResult healthCheckResult = await userAutoLoginCheck(processManager: processManager);
+      expect(healthCheckResult.succeeded, false);
+      expect(healthCheckResult.name, kUserAutoLoginCheckKey);
+      expect(healthCheckResult.details, 'swarming user is not setup for auto login');
+    });
+  });
+}


### PR DESCRIPTION
This adds health check for Mac bot swarming user auto login.
Though the check is on host level, we are adding it to device doctor tool to make it possible to quarantine bots when failing.

This is based on assumption that `swarming` user has been setup auto login for all Mac bots running devicelab tasks.

Related issue: https://github.com/flutter/flutter/issues/76091
