### PR TITLE
Remove closeIosDialog from cleanup for ios device

### DIFF
--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -129,7 +129,5 @@ class IosDevice implements Device {
   Future<void> recover() async {
     // Restarts the device first.
     await eval('idevicediagnostics', <String>['restart']);
-    // Close pop up dialogs if any.
-    await closeIosDialog(deviceId: deviceId);
   }
 }


### PR DESCRIPTION
This is to remove closeIosDialog functionality from device doctor cleanup for ios device.

Some context:

- close iOS dialog has been implemented in recipes
- if it fails to close IOS dialog from recipe, it will fail test rather than prevent picking up test. So we need to pre health check if iOS dialog is able to be closed before reserving a test to run. Namely quarantine the bot if the health check fails.
- Running closeIosDialog needs xcode available, but xcode is not ready when running device doctor health check
- device doctor clean up needs to be implemented from bot_config side to unblock issues (https://github.com/flutter/flutter/issues/76796#issuecomment-786425051).

Therefore here we are removing the closeIosDialog function from cleanup step to unblock the above issue.

A follow up is to add a corresponding health check (https://github.com/flutter/flutter/issues/76815).