### PR TITLE
Add uninstall appllcations to iOS device recovery

### DIFF
--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -210,6 +210,15 @@ void main() {
       expect(result, isFalse);
     });
 
+    test('list applications - failure', () async {
+      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+      process = FakeProcess(1);
+
+      final bool result = await device.uninstall_applications(processManager: processManager);
+      expect(result, isFalse);
+    });
+
     test('uninstall applications - no device is available', () async {
       when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));


### PR DESCRIPTION
Uninstall applications when task fails for iOS device tasks.

This is to prevent application installation failure caused by using different signing certificate from previous installed application.

Related issue: https://github.com/flutter/flutter/issues/76896