### PR TITLE
Add submit-queue check to the list of not related checks.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -253,6 +253,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     const Set<String> notInAuthorsControl = <String>{
       'flutter-build', // flutter repo
       'luci-engine', // engine repo
+      'submit-queue', // plugins repo
     };
 
     log.info('Validating name: $name, branch: $branch, status: $statuses');


### PR DESCRIPTION
This is to avoid the githubbot from removing the waiting for tree to go
green label.

Bug: https://github.com/flutter/flutter/issues/77401