### PR TITLE
[app_dart] Add description to pubspec.yaml

### DIFF
--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 name: cocoon_service
+description: AppEngine service for managing Flutter CI
 homepage: https://github.com/flutter/cocoon
 publish_to: none
 


### PR DESCRIPTION
This is required for other Dart packages to pull Cocoon as a remote dependency. Which comes up when deploying a microservice dependent on it.