### PR TITLE
[app_dart] Show flutter-build description on failures

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -73,7 +73,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
           final CreateStatus request = CreateStatus(buildStatus.githubStatus);
           request.targetUrl = 'https://flutter-dashboard.appspot.com/#/build';
           request.context = config.flutterBuild;
-          if (buildStatus.succeeded) {
+          if (!buildStatus.succeeded) {
             request.description = config.flutterBuildDescription;
           }
 


### PR DESCRIPTION
Fix it so this message is shown on failure.

![Screen Shot 2021-03-15 at 2 25 56 PM](https://user-images.githubusercontent.com/2148558/111223420-5dcb6280-859a-11eb-9132-d79ee61b97e4.png)

# Test
Skipped as there was no existing test for this, and it was a quick fix.