### PR TITLE
[app_dart] luciBuilders aggregates from all branches

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';

--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -94,12 +94,25 @@ class Config {
   ///
   /// If [branch] is not [defaultBranch], a release branch, it will pull from HEAD of [branch].
   /// Otherwise, it will pull from the [ref] or [prNumber].
-  Future<List<LuciBuilder>> luciBuilders(String bucket, String repo,
-      {String commitSha, int prNumber, String branch}) async {
+  Future<List<LuciBuilder>> luciBuilders(
+    String bucket,
+    String repo, {
+    String commitSha,
+    int prNumber,
+    String branch = kDefaultBranchName,
+  }) async {
     final GithubService githubService = await createGithubService('flutter', repo);
-    branch ??= defaultBranch;
-    // TODO(chillers): Add support for release branch try builds. https://github.com/flutter/flutter/issues/72466
-    final String ref = (branch != defaultBranch) ? commitSha : branch;
+    String ref;
+    if (prNumber != null) {
+      ref = kDefaultBranchName;
+    } else if (branch != kDefaultBranchName) {
+      ref = branch;
+    } else if (commitSha != null) {
+      ref = commitSha;
+    } else {
+      loggingService.warning('Failed to find place for builders, using default branch');
+      ref = kDefaultBranchName;
+    }
     return getLuciBuilders(
       githubService,
       httpClient,

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -93,11 +93,10 @@ Future<RepositorySlug> repoNameForBuilder(List<LuciBuilder> builders, String bui
 
 /// Returns LUCI builders based on [bucket] and [repo].
 ///
-/// For `try` case with [ref], builders are returned based on try_builders.json config file in
-/// the corresponding [ref], and also based on filtering changed files in [prNumber] via property
-/// [run_if] in each config.
-///
-/// For `prod` case, builders are returned based on prod_builders.json config file from `master`.
+/// Builder config is loaded from `$bucket_builders.json` at [ref] of [repo].
+/// 
+/// If [bucket] is try, [prNumber] is used to filter the builder list to only the affected
+/// builders based on the [run_if] config property.
 Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClientProvider luciHttpClientProvider,
     GitHubBackoffCalculator gitHubBackoffCalculator, Logging log, RepositorySlug slug, String bucket,
     {int prNumber, String ref = 'master'}) async {

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -93,14 +93,14 @@ Future<RepositorySlug> repoNameForBuilder(List<LuciBuilder> builders, String bui
 
 /// Returns LUCI builders based on [bucket] and [repo].
 ///
-/// For `try` case with [commitSha], builders are returned based on try_builders.json config file in
-/// the corresponding [commitSha], and also based on filtering changed files in [prNumber] via property
+/// For `try` case with [ref], builders are returned based on try_builders.json config file in
+/// the corresponding [ref], and also based on filtering changed files in [prNumber] via property
 /// [run_if] in each config.
 ///
 /// For `prod` case, builders are returned based on prod_builders.json config file from `master`.
 Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClientProvider luciHttpClientProvider,
     GitHubBackoffCalculator gitHubBackoffCalculator, Logging log, RepositorySlug slug, String bucket,
-    {int prNumber, String commitSha = 'master'}) async {
+    {int prNumber, String ref = 'master'}) async {
   const Map<String, String> repoFilePathPrefix = <String, String>{
     'flutter': 'dev',
     'engine': 'ci/dev',
@@ -108,7 +108,7 @@ Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClien
     'plugins': '.ci/dev',
     'packages': 'dev'
   };
-  final String filePath = '${slug.name}/$commitSha/${repoFilePathPrefix[slug.name]}/';
+  final String filePath = '${slug.name}/$ref/${repoFilePathPrefix[slug.name]}/';
   final String fileName = bucket == 'try' ? 'try_builders.json' : 'prod_builders.json';
   String builderContent =
       await remoteFileContent(luciHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/$filePath$fileName');
@@ -121,7 +121,7 @@ Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClien
       .where((LuciBuilder element) => element.enabled ?? true)
       .toList();
 
-  if (bucket == 'prod' || commitSha == 'master') {
+  if (bucket == 'prod' || ref == 'master') {
     return builders;
   }
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -119,7 +119,7 @@ Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClien
       .where((LuciBuilder element) => element.enabled ?? true)
       .toList();
 
-  if (bucket == 'prod' || ref == 'master') {
+  if (bucket == 'prod') {
     return builders;
   }
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -94,7 +94,7 @@ Future<RepositorySlug> repoNameForBuilder(List<LuciBuilder> builders, String bui
 /// Returns LUCI builders based on [bucket] and [repo].
 ///
 /// Builder config is loaded from `$bucket_builders.json` at [ref] of [repo].
-/// 
+///
 /// If [bucket] is try, [prNumber] is used to filter the builder list to only the affected
 /// builders based on the [run_if] config property.
 Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClientProvider luciHttpClientProvider,
@@ -112,8 +112,7 @@ Future<List<LuciBuilder>> getLuciBuilders(GithubService githubService, HttpClien
   String builderContent =
       await remoteFileContent(luciHttpClientProvider, log, gitHubBackoffCalculator, '/flutter/$filePath$fileName');
   builderContent ??= '{"builders":[]}';
-  Map<String, dynamic> builderMap;
-  builderMap = json.decode(builderContent) as Map<String, dynamic>;
+  final Map<String, dynamic> builderMap = json.decode(builderContent) as Map<String, dynamic>;
   final List<dynamic> builderList = builderMap['builders'] as List<dynamic>;
   final List<LuciBuilder> builders = builderList
       .map((dynamic builder) => LuciBuilder.fromJson(builder as Map<String, dynamic>))

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -59,6 +59,14 @@ class Commit extends Model<String> {
   @StringProperty(propertyName: 'FlutterRepositoryPath', required: true)
   String repository;
 
+  /// The GitHub repo name this commit is from.
+  String get repo => repository.split('/')[1];
+
+  /// The GitHub organization this commit is from.
+  ///
+  /// Every [Commit] in Cocoon is expected to be from flutter.
+  String get org => repository.split('/').first;
+
   /// The branch of the commit.
   @StringProperty(propertyName: 'Branch')
   String branch;

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -273,11 +273,7 @@ class LuciBuilder {
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
 
   /// Loads and returns the list of known builders from the Cocoon [config].
-  static Future<List<LuciBuilder>> getProdBuilders(
-    String repo,
-    Config config, {
-    String branch = 'master',
-  }) async {
+  static Future<List<LuciBuilder>> getProdBuilders(String repo, Config config) async {
     return await config.luciBuilders('prod', repo);
   }
 }

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -12,7 +12,6 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
-import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
 import '../model/luci/buildbucket.dart';
 import '../request_handling/api_request_handler.dart';

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -12,6 +12,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/cocoon_config.dart';
+import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
 import '../model/luci/buildbucket.dart';
 import '../request_handling/api_request_handler.dart';
@@ -273,8 +274,18 @@ class LuciBuilder {
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
 
   /// Loads and returns the list of known builders from the Cocoon [config].
-  static Future<List<LuciBuilder>> getProdBuilders(String repo, Config config) async {
-    return await config.luciBuilders('prod', repo);
+  static Future<List<LuciBuilder>> getProdBuilders(
+    String repo,
+    Config config, {
+    String branch,
+    String sha,
+  }) async {
+    return await config.luciBuilders(
+      'prod',
+      repo,
+      branch: branch,
+      commitSha: sha,
+    );
   }
 }
 

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -69,6 +69,7 @@ class LuciService {
     bool requireTaskName = false,
   }) async {
     assert(requireTaskName != null);
+
     final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(repo, config);
     final List<Build> builds = await getBuildsForBuilderList(builders);
 
@@ -272,7 +273,11 @@ class LuciBuilder {
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
 
   /// Loads and returns the list of known builders from the Cocoon [config].
-  static Future<List<LuciBuilder>> getProdBuilders(String repo, Config config) async {
+  static Future<List<LuciBuilder>> getProdBuilders(
+    String repo,
+    Config config, {
+    String branch = 'master',
+  }) async {
     return await config.luciBuilders('prod', repo);
   }
 }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -147,7 +147,7 @@ class Scheduler {
   }
 
   /// Create [Tasks] specified in [commit] scheduler config.
-  /// 
+  ///
   /// This is an aggregate of the devicelab manifest and prod_builders.json.
   Future<List<Task>> _getTasks(Commit commit) async {
     Task newTask(
@@ -174,7 +174,12 @@ class Scheduler {
     }
 
     final List<Task> tasks = <Task>[];
-    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
+    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders(
+      commit.repo,
+      config,
+      branch: commit.branch,
+      sha: commit.sha,
+    );
     for (LuciBuilder builder in prodBuilders) {
       // These built-in tasks are not listed in the manifest.
       tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -147,6 +147,8 @@ class Scheduler {
   }
 
   /// Create [Tasks] specified in [commit] scheduler config.
+  /// 
+  /// This is an aggregate of the devicelab manifest and prod_builders.json.
   Future<List<Task>> _getTasks(Commit commit) async {
     Task newTask(
       String name,

--- a/app_dart/test/datastore/cocoon_config_test.dart
+++ b/app_dart/test/datastore/cocoon_config_test.dart
@@ -7,8 +7,42 @@ import 'dart:typed_data';
 import 'package:test/test.dart';
 
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/service/luci.dart';
 
 import '../src/datastore/fake_datastore.dart';
+import '../src/request_handling/fake_http.dart';
+
+const String luciBuildersDefaultBranch = '''
+      {
+        "builders":[
+            {
+              "name":"Linux framework_tests",
+              "repo":"flutter",
+              "enabled":true
+            }, {
+              "name":"Linux build_aar_test",
+              "repo":"cocoon",
+              "enabled":false
+            }
+        ]
+      }
+      ''';
+
+const String luciBuildersReleaseBranch = '''
+      {
+        "builders":[
+            {
+              "name":"Linux Stable framework_tests",
+              "repo":"flutter",
+              "enabled":true
+            }, {
+              "name":"Linux stable build_aar_test",
+              "repo":"flutter",
+              "enabled":false
+            }
+        ]
+      }
+      ''';
 
 void main() {
   group('githubAppInstallations', () {
@@ -33,4 +67,37 @@ void main() {
       expect(installation['godofredoc/cocoon']['installation_id'], equals('123'));
     });
   });
+
+  group('luci builders', () {
+    FakeDatastoreDB datastore;
+    FakeHttpClient fakeHttpClient;
+    CacheService cacheService;
+    Config config;
+    setUp(() {
+      datastore = FakeDatastoreDB();
+      fakeHttpClient = FakeHttpClient();
+      cacheService = CacheService(inMemory: true);
+      cacheService.set(Config.configCacheName, 'flutterBranches',
+          Uint8List.fromList(<int>[...'master'.codeUnits, ...'release-abc'.codeUnits]));
+      config = Config(datastore, cacheService, httpClientProvider: () => fakeHttpClient);
+    });
+
+    test('gets all builds from default and release branches', () async {
+      fakeHttpClient.onIssueRequest = (FakeHttpClientRequest request) {
+        if (request.uri == Uri.https('github.com', 'flutter/master/dev/prod_builders.json')) {
+          return luciBuildersDefaultBranch;
+        } else {
+          return luciBuildersReleaseBranch;
+        }
+      };
+
+      final List<LuciBuilder> prodBuilders = await config.luciBuilders('prod', 'flutter');
+      expect(prodBuilders.length, 2);
+      expect(luciBuildersToNames(prodBuilders),
+          containsAll(<String>['Linux framework_tests', 'Linux Stable framework_tests']));
+    });
+  });
 }
+
+List<String> luciBuildersToNames(List<LuciBuilder> builders) =>
+    builders.map((LuciBuilder builder) => builder.name).toList();

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -254,7 +254,7 @@ class FakeConfig implements Config {
     String repo, {
     String commitSha = 'master',
     int prNumber,
-    String branch,
+    String branch = kDefaultBranchName,
   }) async {
     if (repo == 'flutter') {
       return <LuciBuilder>[
@@ -276,4 +276,10 @@ class FakeConfig implements Config {
 
   @override
   HttpClientProvider get httpClient => throw UnimplementedError();
+
+  @override
+  GithubService github;
+
+  @override
+  Logging logValue;
 }

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -270,6 +270,5 @@ class FakeConfig implements Config {
   String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 
   @override
-  // TODO: implement httpClient
   HttpClientProvider get httpClient => throw UnimplementedError();
 }

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -249,8 +249,13 @@ class FakeConfig implements Config {
   }
 
   @override
-  Future<List<LuciBuilder>> luciBuilders(String bucket, String repo,
-      {String commitSha = 'master', int prNumber}) async {
+  Future<List<LuciBuilder>> luciBuilders(
+    String bucket,
+    String repo, {
+    String commitSha = 'master',
+    int prNumber,
+    String branch,
+  }) async {
     if (repo == 'flutter') {
       return <LuciBuilder>[
         const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),

--- a/app_dart/test/src/datastore/fake_cocoon_config.dart
+++ b/app_dart/test/src/datastore/fake_cocoon_config.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/datastore/cocoon_config.dart';
+import 'package:cocoon_service/src/foundation/typedefs.dart';
 import 'package:cocoon_service/src/model/appengine/key_helper.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
@@ -267,4 +268,8 @@ class FakeConfig implements Config {
 
   @override
   String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
+
+  @override
+  // TODO: implement httpClient
+  HttpClientProvider get httpClient => throw UnimplementedError();
 }


### PR DESCRIPTION
This updates `config.luciBuilders` to aggregate all the `LuciBuilders` from the `flutterBranches`. This supports showing luci builders from release branches in the build dashboard. Previously it only grabbed for master / tip of tree.

The release branches still require updating the builders.json to include the release channel name (e.g. `Linux Stable`).

# Issues
https://github.com/flutter/flutter/issues/72466