### PR TITLE
[app_dart] Switch scheduler to httpClientProvider + cleanup

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -36,10 +36,9 @@ Future<String> remoteFileContent(HttpClientProvider branchHttpClientProvider, Lo
   try {
     // TODO(keyonghan): apply retry logic here to simply, https://github.com/flutter/flutter/issues/52427
     for (int attempt = 0; attempt < 3; attempt++) {
-      final HttpClientRequest clientRequest = await client.getUrl(url);
-
       try {
-        final HttpClientResponse clientResponse = await clientRequest.close();
+        final HttpClientRequest clientRequest = await client.getUrl(url).timeout(const Duration(seconds: 5));
+        final HttpClientResponse clientResponse = await clientRequest.close().timeout(const Duration(seconds: 5));
         final int status = clientResponse.statusCode;
 
         if (status == HttpStatus.ok) {

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -28,8 +28,14 @@ Duration twoSecondLinearBackoff(int attempt) {
   return const Duration(seconds: 2) * (attempt + 1);
 }
 
-Future<String> remoteFileContent(HttpClientProvider branchHttpClientProvider, Logging log,
-    GitHubBackoffCalculator gitHubBackoffCalculator, String filePath) async {
+/// Get content of [filePath] from GitHub CDN.
+Future<String> remoteFileContent(
+  HttpClientProvider branchHttpClientProvider,
+  Logging log,
+  GitHubBackoffCalculator gitHubBackoffCalculator,
+  String filePath, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
   final Uri url = Uri.https('raw.githubusercontent.com', filePath);
 
   final HttpClient client = branchHttpClientProvider();
@@ -37,8 +43,8 @@ Future<String> remoteFileContent(HttpClientProvider branchHttpClientProvider, Lo
     // TODO(keyonghan): apply retry logic here to simply, https://github.com/flutter/flutter/issues/52427
     for (int attempt = 0; attempt < 3; attempt++) {
       try {
-        final HttpClientRequest clientRequest = await client.getUrl(url).timeout(const Duration(seconds: 5));
-        final HttpClientResponse clientResponse = await clientRequest.close().timeout(const Duration(seconds: 5));
+        final HttpClientRequest clientRequest = await client.getUrl(url).timeout(timeout);
+        final HttpClientResponse clientResponse = await clientRequest.close().timeout(timeout);
         final int status = clientResponse.statusCode;
 
         if (status == HttpStatus.ok) {

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -39,7 +39,7 @@ class GithubWebhook extends RequestHandler<Body> {
             Scheduler(
               config: config,
               datastore: DatastoreService.defaultProvider(config.db),
-              httpClient: Providers.freshHttpClient(),
+              httpClientProvider: Providers.freshHttpClient,
             ),
         super(config: config);
 

--- a/app_dart/lib/src/request_handlers/refresh_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/refresh_github_commits.dart
@@ -51,7 +51,7 @@ class RefreshGithubCommits extends ApiRequestHandler<Body> {
     final Scheduler scheduler = Scheduler(
       config: config,
       datastore: datastore,
-      httpClient: httpClientProvider(),
+      httpClientProvider: httpClientProvider,
       gitHubBackoffCalculator: gitHubBackoffCalculator,
       log: log,
     );

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -204,10 +204,9 @@ class Scheduler {
 
     try {
       for (int attempt = 0; attempt < 3; attempt++) {
-        final HttpClientRequest clientRequest = await httpClient.getUrl(url);
-
         try {
-          final HttpClientResponse clientResponse = await clientRequest.close();
+          final HttpClientRequest clientRequest = await httpClient.getUrl(url);
+          final HttpClientResponse clientResponse = await clientRequest.close().timeout(const Duration(seconds: 5));
           final int status = clientResponse.statusCode;
 
           if (status == HttpStatus.ok) {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -56,8 +56,8 @@ void main() {
       httpClient = FakeHttpClient();
       httpClient.request.response.body = singleDeviceLabTaskManifestYaml;
 
-      scheduler =
-          Scheduler(config: config, datastore: DatastoreService(db, 2), httpClient: httpClient, log: FakeLogging());
+      scheduler = Scheduler(
+          config: config, datastore: DatastoreService(db, 2), httpClientProvider: () => httpClient, log: FakeLogging());
     });
 
     List<Commit> createCommitList(List<String> shas) {
@@ -178,8 +178,8 @@ void main() {
       httpClient = FakeHttpClient();
       httpClient.request.response.body = singleDeviceLabTaskManifestYaml;
 
-      scheduler =
-          Scheduler(config: config, datastore: DatastoreService(db, 2), httpClient: httpClient, log: FakeLogging());
+      scheduler = Scheduler(
+          config: config, datastore: DatastoreService(db, 2), httpClientProvider: () => httpClient, log: FakeLogging());
     });
 
     test('creates expected commit', () async {


### PR DESCRIPTION
- Scheduler needs to pass httpClientProvider instead of httpClient due to timeout issues where the client is closed
- Use common remote file utility for devicelab manifest
- Update remote file utility to catch all possible places where an error can occur
- Set timeout of get request on the remote file utility

# Issues

Fixes https://github.com/flutter/flutter/issues/78479