### PR TITLE
Add retries to the call of getCheckRun and updateCheckStatus

### DIFF
--- a/app_dart/lib/src/foundation/github_checks_util.dart
+++ b/app_dart/lib/src/foundation/github_checks_util.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:core';
+import 'dart:io';
 
 import 'package:cocoon_service/src/model/github/checks.dart';
 import 'package:github/github.dart' as github;
@@ -70,7 +71,7 @@ class GithubChecksUtil {
         detailsUrl: detailsUrl,
         output: output,
       );
-    }, retryIf: (Exception e) => e is github.GitHubError);
+    }, retryIf: (Exception e) => e is github.GitHubError || e is SocketException);
   }
 
   Future<github.CheckRun> getCheckRun(
@@ -91,7 +92,7 @@ class GithubChecksUtil {
         slug,
         checkRunId: id,
       );
-    }, retryIf: (Exception e) => e is github.GitHubError);
+    }, retryIf: (Exception e) => e is github.GitHubError || e is SocketException);
   }
 
   /// Sends a request to github checks api to create a new [CheckRun] associated

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -14,6 +14,7 @@ import 'package:github/github.dart';
 import 'package:googleapis/oauth2/v2.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 
 import '../datastore/cocoon_config.dart';
 import '../foundation/typedefs.dart';
@@ -96,15 +97,32 @@ class LuciStatusHandler extends RequestHandler<Body> {
         userData['repo_owner'] as String,
         userData['repo_name'] as String,
       );
-      await githubChecksService.updateCheckStatus(
-        buildPushMessage,
-        luciBuildService,
-        slug,
-      );
+      await _updateCheckStatus(buildPushMessage, slug);
     } else {
       log.error('This repo does not support checks API');
     }
     return Body.empty;
+  }
+
+  /// Updates check status with retries.
+  ///
+  /// The `githubChecksService.updateCheckStatus` has been hitting `SocketException` occasionally.
+  /// Retry logic is to mitigate this issue: https://github.com/flutter/flutter/issues/74611.
+  Future<void> _updateCheckStatus(BuildPushMessage buildPushMessage, RepositorySlug slug) async {
+    const RetryOptions r = RetryOptions(
+      maxAttempts: 3,
+      delayFactor: Duration(seconds: 2),
+    );
+    await r.retry(
+      () async {
+        await githubChecksService.updateCheckStatus(
+          buildPushMessage,
+          luciBuildService,
+          slug,
+        );
+      },
+      retryIf: (Exception e) => e is SocketException,
+    );
   }
 
   Future<bool> _authenticateRequest(HttpHeaders headers) async {

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -98,7 +98,6 @@ class GithubChecksService {
     LuciBuildService luciBuildService,
     github.RepositorySlug slug,
   ) async {
-    github.GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
     final push_message.Build build = buildPushMessage.build;
     if (buildPushMessage.userData.isEmpty) {
       return false;
@@ -114,7 +113,7 @@ class GithubChecksService {
       return false;
     }
     final github.CheckRun checkRun = await githubChecksUtil.getCheckRun(
-      gitHubClient,
+      config,
       slug,
       userData['check_run_id'] as int,
     );
@@ -130,7 +129,6 @@ class GithubChecksService {
           await luciBuildService.getTryBuildById(buildPushMessage.build.id, fields: 'id,builder,summaryMarkdown');
       output = github.CheckRunOutput(title: checkRun.name, summary: build.summaryMarkdown ?? 'Empty summaryMarkdown');
     }
-    gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
     await githubChecksUtil.updateCheckRun(
       config,
       slug,


### PR DESCRIPTION
This is to prevent errors when calling `/api/luci-status-handler` due to `GitHub Error` and `SocketException`.

Related issues: https://github.com/flutter/flutter/issues/78555, https://github.com/flutter/flutter/issues/78561