### PR TITLE
[app_dart] Fix webhook scheduled commit repository field

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -77,7 +77,6 @@ class Scheduler {
     }
 
     final String fullRepo = pr.base.repo.fullName;
-    final String repo = pr.base.repo.name;
     final String branch = pr.base.ref;
     final String sha = pr.mergeCommitSha;
 
@@ -90,7 +89,7 @@ class Scheduler {
       key: key,
       // The field has a max length of 1500 so ensure the commit message is not longer.
       message: truncate(pr.title, 1490, omission: '...'),
-      repository: repo,
+      repository: fullRepo,
       sha: sha,
       timestamp: pr.mergedAt.millisecondsSinceEpoch,
     );

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -246,7 +246,7 @@ void main() {
 PullRequest createPullRequest({
   int id = 789,
   String branch = 'master',
-  String repo = 'flutter/flutter',
+  String repo = 'flutter',
   String authorLogin = 'dash',
   String authorAvatar = 'dashatar',
   String title = 'example message',

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -69,7 +69,7 @@ void main() {
                 branch: 'master',
                 key: db.emptyKey.append(Commit, id: 'flutter/flutter/master/${shas[index]}'),
                 message: 'commit message',
-                repository: 'flutter',
+                repository: 'flutter/flutter',
                 sha: shas[index],
                 timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index])).millisecondsSinceEpoch,
               ));
@@ -86,7 +86,7 @@ void main() {
       await scheduler.addCommits(createCommitList(<String>['1']));
       expect(db.values.values.whereType<Commit>().length, 1);
       final Commit commit = db.values.values.whereType<Commit>().single;
-      expect(commit.repository, 'flutter');
+      expect(commit.repository, 'flutter/flutter');
       expect(commit.branch, 'master');
       expect(commit.sha, '1');
       expect(commit.timestamp, 1);
@@ -188,7 +188,7 @@ void main() {
 
       expect(db.values.values.whereType<Commit>().length, 1);
       final Commit commit = db.values.values.whereType<Commit>().single;
-      expect(commit.repository, 'flutter');
+      expect(commit.repository, 'flutter/flutter');
       expect(commit.branch, 'master');
       expect(commit.sha, 'abc');
       expect(commit.timestamp, 1);
@@ -232,7 +232,7 @@ void main() {
 
       expect(db.values.values.whereType<Commit>().length, 1);
       final Commit commit = db.values.values.whereType<Commit>().single;
-      expect(commit.repository, 'flutter');
+      expect(commit.repository, 'flutter/flutter');
       expect(commit.branch, '1.26');
       expect(commit.sha, 'abc');
       expect(commit.timestamp, 1);
@@ -246,7 +246,7 @@ void main() {
 PullRequest createPullRequest({
   int id = 789,
   String branch = 'master',
-  String repo = 'flutter',
+  String repo = 'flutter/flutter',
   String authorLogin = 'dash',
   String authorAvatar = 'dashatar',
   String title = 'example message',


### PR DESCRIPTION
Forked from https://github.com/flutter/cocoon/pull/1111 into a smaller PR. Commits scheduled via webhook are truncating the repo.

`Commit.repo` expects `$org/$repo` as the format. This is causing failures to load commit diffs from the build dashboard.