### PR TITLE
[app_dart] Configurable supported repos for scheduler

### DIFF
--- a/app_dart/lib/src/datastore/cocoon_config.dart
+++ b/app_dart/lib/src/datastore/cocoon_config.dart
@@ -55,6 +55,11 @@ class Config {
     'flutter/plugins',
   };
 
+  /// List of GitHub repositories that are supported by [Scheduler].
+  static const Set<String> schedulerSupportedRepos = <String>{
+    'flutter/flutter',
+  };
+
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -104,6 +104,11 @@ class Scheduler {
   }
 
   Future<void> _addCommit(Commit commit) async {
+    if (!Config.schedulerSupportedRepos.contains(commit.repository)) {
+      log.debug('Skipping ${commit.id} as repo is not supported');
+      return;
+    }
+
     final List<Task> tasks = await _getTasks(commit);
     try {
       await datastore.withTransaction<void>((Transaction transaction) async {
@@ -198,7 +203,7 @@ class Scheduler {
   // TODO(chillers): Remove when DeviceLab has migrated to LUCI. https://github.com/flutter/flutter/projects/151
   @visibleForTesting
   Future<YamlMap> loadDevicelabManifest(Commit commit) async {
-    final String path = '/flutter/flutter/${commit.sha}/dev/devicelab/manifest.yaml';
+    final String path = '/${commit.repository}/${commit.sha}/dev/devicelab/manifest.yaml';
     log.debug('Getting devicelab manifest content');
     final String content = await remoteFileContent(httpClientProvider, log, gitHubBackoffCalculator, path);
     if (content == null) {


### PR DESCRIPTION
Only `flutter/flutter` has prod tasks that are supported by `Scheduler`. The GitHub webhooks are trying to schedule commits against unsupported repos (like `flutter/engine`) which is causing an increase in failures.

This doesn't affect presubmit tasks. When the scheduler is more fleshed out, this will include both types of builds.