### PR TITLE
[cocoon] Add createCheckRun retry on SocketException

### DIFF
--- a/app_dart/lib/src/foundation/github_checks_util.dart
+++ b/app_dart/lib/src/foundation/github_checks_util.dart
@@ -114,7 +114,7 @@ class GithubChecksUtil {
         name,
         headSha,
       );
-    }, retryIf: (Exception e) => e is github.GitHubError);
+    }, retryIf: (Exception e) => e is github.GitHubError || e is SocketException);
   }
 
   Future<github.CheckRun> _createCheckRun(


### PR DESCRIPTION
This is to enable presubmit LUCI `createCheckRun` retry on `SocketException`. The retry logic has been there when hitting Github Error, and this is appending the SocketException as well.

Related issue: https://github.com/flutter/flutter/issues/74611