### PR TITLE
[app_flutter] Link favicon

### DIFF
--- a/app_flutter/lib/main.dart
+++ b/app_flutter/lib/main.dart
@@ -63,7 +63,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Dashboard',
+      title: 'Build Dashboard',
       theme: ThemeData(),
       darkTheme: ThemeData.dark(),
       initialRoute: '/',

--- a/app_flutter/web/index.html
+++ b/app_flutter/web/index.html
@@ -6,12 +6,22 @@ found in the LICENSE file. -->
 <head>
   <meta charset="UTF-8">
   <meta name="google-signin-client_id" content="308150028417-vlj9mqlm3gk1d03fb0efif1fu5nagdtt.apps.googleusercontent.com">
-  <title>app_flutter</title>
+  <title>Build Dashboard</title>
   <!-- This application normally gets displayed on a TV that is hard to reach.
   Refreshing this page once a day (in seconds) makes it so the TV stays relatively
   up to date without anyone have to get a ladder to use the TV as a computer.
   -->
   <meta http-equiv="refresh" content="86400">
+
+
+  <!-- iOS meta tags & icons -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="repository">
+  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" href="favicon.png"/>
 </head>
 <body>
   <script src="main.dart.js" type="application/javascript"></script>


### PR DESCRIPTION
The favicon broke when we removed the Angular Dart dashboard as the Flutter app relied on the Angular Dart dashboard to link the favicon. Add the favicon links, similar to how the repository dashboard already does it.

I ran this locally to verify the links are working.