### PR TITLE
Reduce cron for /api/refresh-github-commits

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -3,7 +3,7 @@
 cron:
 - description: refresh commits from GitHub
   url: /api/refresh-github-commits
-  schedule: every 1 minutes
+  schedule: every 15 minutes
 - description: refresh chromebot build status
   url: /api/refresh-chromebot-status
   schedule: every 3 minutes


### PR DESCRIPTION
Triaging the flutter-dashboard GCP logs shows all commits are being scheduled from the webhook trigger instead of this cron job. Reducing frequency to save some GitHub API quota.