### PR TITLE
Revert "[app_dart] Cache static files for 30 minutes"

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -176,12 +176,6 @@ For more options run:
 $ dart dev/deploy.dart --help
 ```
 
-##### Changes not propagated
-
-Cocoon caches static assets for 30 minutes. This will delay releases until the
-cache is reset. Breaking changes will require wiping the memorystore instance
-from the Google Cloud dashboard.
-
 ### Branching support for flutter repo
 
 Add targeted branches in `dev/branches.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -145,12 +145,7 @@ Future<void> main() async {
           return await request.response.redirect(Uri.parse(redirects[filePath]));
         }
 
-        await CacheRequestHandler<Body>(
-          cache: cache,
-          config: config,
-          delegate: StaticFileHandler(filePath, config: config),
-          ttl: const Duration(minutes: 30),
-        ).service(request);
+        await StaticFileHandler(filePath, config: config).service(request);
       }
     }, onAcceptingConnections: (InternetAddress address, int port) {
       final String host = address.isLoopback ? 'localhost' : address.host;


### PR DESCRIPTION
Reverts flutter/cocoon#1117

The MIME type isn't being saved, so everything is sent as plaintext. This is causing the dashboard to be unusable.