### PR TITLE
[app_dart] Pull *_builders from commit sha on PRs prs use commitSha for *_builders configs

### DIFF
--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -99,7 +99,8 @@ class Config {
   /// Returns list of LUCI builders supported in Cocoon.
   ///
   /// If [branch] is not [defaultBranch], a release branch, it will pull from HEAD of [branch].
-  /// Otherwise, it will pull from the [ref] or [prNumber].
+  /// If [commitSha] is passed, it will pull from that revision. Otherwise, it will pull from
+  /// HEAD of [defaultBranch].
   Future<List<LuciBuilder>> luciBuilders(
     String bucket,
     String repo, {
@@ -109,14 +110,13 @@ class Config {
   }) async {
     final GithubService githubService = await createGithubService('flutter', repo);
     String ref;
-    if (prNumber != null) {
-      ref = kDefaultBranchName;
-    } else if (branch != kDefaultBranchName) {
+    loggingService.debug('Pulling LUCI builders with sha: $commitSha, prNumber: $prNumber, branch: $branch');
+    if (branch != null && branch != kDefaultBranchName) {
       ref = branch;
     } else if (commitSha != null) {
       ref = commitSha;
     } else {
-      loggingService.warning('Failed to find place for builders, using default branch');
+      loggingService.warning('Failed to find place for builders, using $kDefaultBranchName');
       ref = kDefaultBranchName;
     }
     return getLuciBuilders(

--- a/app_dart/test/datastore/config_test.dart
+++ b/app_dart/test/datastore/config_test.dart
@@ -44,7 +44,7 @@ const String luciBuildersReleaseBranch = '''
         ]
       }''';
 
-const String luciTryBuildersDefaultBranch = '''
+const String luciTryBuildersAbc = '''
       {
         "builders":[
             {
@@ -133,16 +133,18 @@ void main() {
       expect(luciBuildersToNames(prodBuilders), <String>['Linux Stable framework_tests']);
     });
 
-    test('gets all try builds from default branch', () async {
+    test('gets all try builds from sha', () async {
       fakeHttpClient.onIssueRequest = (FakeHttpClientRequest request) {
-        if (request.uri == Uri.https('raw.githubusercontent.com', 'flutter/flutter/master/dev/try_builders.json')) {
-          request.response = FakeHttpClientResponse(body: luciTryBuildersDefaultBranch);
+        if (request.uri == Uri.https('raw.githubusercontent.com', 'flutter/flutter/abc/dev/try_builders.json')) {
+          request.response = FakeHttpClientResponse(body: luciTryBuildersAbc);
         }
       };
       final List<LuciBuilder> tryBuilders = await config.luciBuilders(
         'try',
         'flutter',
+        branch: null,
         prNumber: 12345,
+        commitSha: 'abc',
       );
       expect(luciBuildersToNames(tryBuilders), <String>['try test 1']);
     });


### PR DESCRIPTION
1. refresh-chromebot-statuses was setting a null branch (https://github.com/flutter/flutter/issues/78889)
  - I missed a null check
2. try builders pulled from HEAD of master instead of the PR sha (https://github.com/flutter/flutter/pull/78623#discussion_r599842246)
  - My assumption was these configs came from HEAD and not the PR

Added a debug statement to make it easier to know what information this is getting for future changes.