### PR TITLE
[scheduler] Add SchedulerConfig and validation tests

### DIFF
--- a/app_dart/bin/validate_scheduler_config.dart
+++ b/app_dart/bin/validate_scheduler_config.dart
@@ -1,0 +1,21 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+import 'package:cocoon_service/cocoon_service.dart';
+
+void main(List<String> args) {
+  final String configPath = args.first;
+  final File configFile = File(configPath);
+  if (!configFile.existsSync()) {
+    print('validate_scheduler_config.dart configPath');
+    exit(1);
+  }
+
+  final YamlMap configYaml = loadYaml(configFile.readAsStringSync()) as YamlMap;
+  print(loadSchedulerConfig(configYaml));
+}

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -43,3 +43,4 @@ export 'src/service/cache_service.dart';
 export 'src/service/github_checks_service.dart';
 export 'src/service/github_status_service.dart';
 export 'src/service/luci_build_service.dart';
+export 'src/service/scheduler.dart';

--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -1,0 +1,179 @@
+///
+//  Generated code. Do not modify.
+//  source: lib/src/model/proto/internal/scheduler.proto
+//
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class SchedulerConfig extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig', createEmptyInstance: create)
+    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM, subBuilder: Target.create)
+    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enabledBranches')
+    ..hasRequiredFields = false
+  ;
+
+  SchedulerConfig._() : super();
+  factory SchedulerConfig({
+    $core.Iterable<Target> targets,
+    $core.Iterable<$core.String> enabledBranches,
+  }) {
+    final _result = create();
+    if (targets != null) {
+      _result.targets.addAll(targets);
+    }
+    if (enabledBranches != null) {
+      _result.enabledBranches.addAll(enabledBranches);
+    }
+    return _result;
+  }
+  factory SchedulerConfig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  SchedulerConfig clone() => SchedulerConfig()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) => super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static SchedulerConfig create() => SchedulerConfig._();
+  SchedulerConfig createEmptyInstance() => create();
+  static $pb.PbList<SchedulerConfig> createRepeated() => $pb.PbList<SchedulerConfig>();
+  @$core.pragma('dart2js:noInline')
+  static SchedulerConfig getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
+  static SchedulerConfig _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<Target> get targets => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get enabledBranches => $_getList(1);
+}
+
+class Target extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dependencies')
+    ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bringup')
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3)
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed')
+    ..m<$core.String, $core.String>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties', entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipe')
+    ..hasRequiredFields = false
+  ;
+
+  Target._() : super();
+  factory Target({
+    $core.String name,
+    $core.Iterable<$core.String> dependencies,
+    $core.bool bringup,
+    $core.int timeout,
+    $core.String testbed,
+    $core.Map<$core.String, $core.String> properties,
+    $core.String recipe,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (dependencies != null) {
+      _result.dependencies.addAll(dependencies);
+    }
+    if (bringup != null) {
+      _result.bringup = bringup;
+    }
+    if (timeout != null) {
+      _result.timeout = timeout;
+    }
+    if (testbed != null) {
+      _result.testbed = testbed;
+    }
+    if (properties != null) {
+      _result.properties.addAll(properties);
+    }
+    if (recipe != null) {
+      _result.recipe = recipe;
+    }
+    return _result;
+  }
+  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Target clone() => Target()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Target copyWith(void Function(Target) updates) => super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static Target create() => Target._();
+  Target createEmptyInstance() => create();
+  static $pb.PbList<Target> createRepeated() => $pb.PbList<Target>();
+  @$core.pragma('dart2js:noInline')
+  static Target getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Target>(create);
+  static Target _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.String> get dependencies => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.bool get bringup => $_getBF(2);
+  @$pb.TagNumber(3)
+  set bringup($core.bool v) { $_setBool(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBringup() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBringup() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get timeout => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set timeout($core.int v) { $_setSignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasTimeout() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearTimeout() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get testbed => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set testbed($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTestbed() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTestbed() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.Map<$core.String, $core.String> get properties => $_getMap(5);
+
+  @$pb.TagNumber(7)
+  $core.String get recipe => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set recipe($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasRecipe() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearRecipe() => clearField(7);
+}
+

--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -10,11 +10,13 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SchedulerConfig extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig', createEmptyInstance: create)
-    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM, subBuilder: Target.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig',
+      createEmptyInstance: create)
+    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM,
+        subBuilder: Target.create)
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enabledBranches')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   SchedulerConfig._() : super();
   factory SchedulerConfig({
@@ -30,25 +32,28 @@ class SchedulerConfig extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SchedulerConfig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SchedulerConfig.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SchedulerConfig clone() => SchedulerConfig()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) => super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) =>
+      super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SchedulerConfig create() => SchedulerConfig._();
   SchedulerConfig createEmptyInstance() => create();
   static $pb.PbList<SchedulerConfig> createRepeated() => $pb.PbList<SchedulerConfig>();
   @$core.pragma('dart2js:noInline')
-  static SchedulerConfig getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
+  static SchedulerConfig getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
   static SchedulerConfig _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -59,16 +64,23 @@ class SchedulerConfig extends $pb.GeneratedMessage {
 }
 
 class Target extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target',
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dependencies')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bringup')
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3)
-    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed')
-    ..m<$core.String, $core.String>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties', entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
+    ..a<$core.int>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3,
+        defaultOrMaker: 30)
+    ..a<$core.String>(
+        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed', $pb.PbFieldType.OS,
+        defaultOrMaker: 'linux-vm')
+    ..m<$core.String, $core.String>(
+        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties',
+        entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipe')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   Target._() : super();
   factory Target({
@@ -104,18 +116,19 @@ class Target extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Target clone() => Target()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Target copyWith(void Function(Target) updates) => super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Target copyWith(void Function(Target) updates) =>
+      super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Target create() => Target._();
@@ -128,7 +141,10 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -140,25 +156,34 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get bringup => $_getBF(2);
   @$pb.TagNumber(3)
-  set bringup($core.bool v) { $_setBool(2, v); }
+  set bringup($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBringup() => $_has(2);
   @$pb.TagNumber(3)
   void clearBringup() => clearField(3);
 
   @$pb.TagNumber(4)
-  $core.int get timeout => $_getIZ(3);
+  $core.int get timeout => $_getI(3, 30);
   @$pb.TagNumber(4)
-  set timeout($core.int v) { $_setSignedInt32(3, v); }
+  set timeout($core.int v) {
+    $_setSignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasTimeout() => $_has(3);
   @$pb.TagNumber(4)
   void clearTimeout() => clearField(4);
 
   @$pb.TagNumber(5)
-  $core.String get testbed => $_getSZ(4);
+  $core.String get testbed => $_getS(4, 'linux-vm');
   @$pb.TagNumber(5)
-  set testbed($core.String v) { $_setString(4, v); }
+  set testbed($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTestbed() => $_has(4);
   @$pb.TagNumber(5)
@@ -170,10 +195,12 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get recipe => $_getSZ(6);
   @$pb.TagNumber(7)
-  set recipe($core.String v) { $_setString(6, v); }
+  set recipe($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasRecipe() => $_has(6);
   @$pb.TagNumber(7)
   void clearRecipe() => clearField(7);
 }
-

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -18,9 +18,9 @@ const Target$json = const {
   '2': const [
     const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
     const {'1': 'dependencies', '3': 2, '4': 3, '5': 9, '10': 'dependencies'},
-    const {'1': 'bringup', '3': 3, '4': 1, '5': 8, '10': 'bringup'},
-    const {'1': 'timeout', '3': 4, '4': 1, '5': 5, '10': 'timeout'},
-    const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '10': 'testbed'},
+    const {'1': 'bringup', '3': 3, '4': 1, '5': 8, '7': 'false', '10': 'bringup'},
+    const {'1': 'timeout', '3': 4, '4': 1, '5': 5, '7': '30', '10': 'timeout'},
+    const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '7': 'linux-vm', '10': 'testbed'},
     const {'1': 'properties', '3': 6, '4': 3, '5': 11, '6': '.Target.PropertiesEntry', '10': 'properties'},
     const {'1': 'recipe', '3': 7, '4': 1, '5': 9, '10': 'recipe'},
   ],
@@ -35,4 +35,3 @@ const Target_PropertiesEntry$json = const {
   ],
   '7': const {'7': true},
 };
-

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -1,0 +1,38 @@
+///
+//  Generated code. Do not modify.
+//  source: lib/src/model/proto/internal/scheduler.proto
+//
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+const SchedulerConfig$json = const {
+  '1': 'SchedulerConfig',
+  '2': const [
+    const {'1': 'targets', '3': 1, '4': 3, '5': 11, '6': '.Target', '10': 'targets'},
+    const {'1': 'enabled_branches', '3': 2, '4': 3, '5': 9, '10': 'enabledBranches'},
+  ],
+};
+
+const Target$json = const {
+  '1': 'Target',
+  '2': const [
+    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'dependencies', '3': 2, '4': 3, '5': 9, '10': 'dependencies'},
+    const {'1': 'bringup', '3': 3, '4': 1, '5': 8, '10': 'bringup'},
+    const {'1': 'timeout', '3': 4, '4': 1, '5': 5, '10': 'timeout'},
+    const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '10': 'testbed'},
+    const {'1': 'properties', '3': 6, '4': 3, '5': 11, '6': '.Target.PropertiesEntry', '10': 'properties'},
+    const {'1': 'recipe', '3': 7, '4': 1, '5': 9, '10': 'recipe'},
+  ],
+  '3': const [Target_PropertiesEntry$json],
+};
+
+const Target_PropertiesEntry$json = const {
+  '1': 'PropertiesEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -4,6 +4,13 @@
 
 syntax = "proto2";
 
+message SchedulerConfig {
+    // Targets to run from this config.
+    repeated Target targets = 1;
+    // Git branches to run these targets against.
+    repeated string enabled_branches = 2;
+}
+
 message Target {
     // Unique, human readable identifier.
     optional string name = 1;

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -1,0 +1,24 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto2";
+
+message Target {
+    // Unique, human readable identifier.
+    optional string name = 1;
+    // Names of other targets required to succeed before triggering this target.
+    repeated string dependencies = 2;
+    // Whether this target is stable and can be used to gate commits.
+    // Defaults to false which blocks builds.
+    optional bool bringup = 3;
+    // Number of minutes this target is allowed to run before being marked as failed.
+    optional int32 timeout = 4;
+    // Name of the testbed this target will run on.
+    // Defaults to a linux vm.
+    optional string testbed = 5;
+    // Properties to configure infrastructure tooling.
+    map<string, string> properties = 6;
+    // Name of the LUCI recipe to trigger.
+    optional string recipe = 7;
+}

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -18,12 +18,12 @@ message Target {
     repeated string dependencies = 2;
     // Whether this target is stable and can be used to gate commits.
     // Defaults to false which blocks builds.
-    optional bool bringup = 3;
+    optional bool bringup = 3 [default = false];
     // Number of minutes this target is allowed to run before being marked as failed.
-    optional int32 timeout = 4;
+    optional int32 timeout = 4 [default = 30];
     // Name of the testbed this target will run on.
     // Defaults to a linux vm.
-    optional string testbed = 5;
+    optional string testbed = 5 [default = 'linux-vm'];
     // Properties to configure infrastructure tooling.
     map<string, string> properties = 6;
     // Name of the LUCI recipe to trigger.

--- a/app_dart/lib/src/model/proto/protos.dart
+++ b/app_dart/lib/src/model/proto/protos.dart
@@ -7,5 +7,6 @@ export 'internal/build_status_response.pb.dart';
 export 'internal/commit.pb.dart';
 export 'internal/commit_status.pb.dart';
 export 'internal/key.pb.dart';
+export 'internal/scheduler.pb.dart';
 export 'internal/stage.pb.dart';
 export 'internal/task.pb.dart';

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -18,6 +18,7 @@ import '../foundation/utils.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
 import '../model/devicelab/manifest.dart';
+import '../model/proto/protos.dart' show SchedulerConfig, Target;
 import '../request_handling/exceptions.dart';
 import '../service/luci.dart';
 import 'datastore.dart';
@@ -254,5 +255,79 @@ class Scheduler {
     } on ApiRequestError {
       log.warning('Failed to add commits to BigQuery: $ApiRequestError');
     }
+  }
+}
+
+/// Load [yamlConfig] to [SchedulerConfig] and validate the dependency graph.
+SchedulerConfig loadSchedulerConfig(YamlMap yamlConfig) {
+  final SchedulerConfig config = SchedulerConfig();
+  config.mergeFromProto3Json(yamlConfig);
+  _validateSchedulerConfig(config);
+
+  return config;
+}
+
+void _validateSchedulerConfig(SchedulerConfig schedulerConfig) {
+  if (schedulerConfig.targets.isEmpty) {
+    throw const FormatException('Scheduler config must have at least 1 target');
+  }
+
+  if (schedulerConfig.enabledBranches.isEmpty) {
+    throw const FormatException('Scheduler config must have at least 1 enabled branch');
+  }
+
+  final Map<String, List<Target>> targetGraph = <String, List<Target>>{};
+  final List<String> exceptions = <String>[];
+  // Construct [targetGraph]
+  for (final Target target in schedulerConfig.targets) {
+    if (targetGraph.containsKey(target.name)) {
+      exceptions.add('ERROR: ${target.name} already exists in graph');
+    } else {
+      targetGraph[target.name] = <Target>[];
+      // Add edges
+      if (target.dependencies.isNotEmpty) {
+        if (target.dependencies.length != 1) {
+          exceptions.add('ERROR: ${target.name} has multiple dependencies which is not supported. Use only one dependency');
+        } else {
+          if (target.dependencies.first == target.name) {
+            exceptions.add('ERROR: ${target.name} cannot depend on itself');
+          } else if (targetGraph.containsKey(target.dependencies.first)) {
+            targetGraph[target.dependencies.first].add(target);
+          } else {
+            exceptions.add('ERROR: ${target.name} depends on ${target.dependencies.first} which does not exist');
+          }
+        }
+      }
+    }
+  }
+  _checkExceptions(exceptions);
+
+  // Check all root nodes create non-cyclic paths
+  final List<Target> rootTargets = schedulerConfig.targets.where((Target target) => target.dependencies.isEmpty).toList();
+  _searchForCycles(targetGraph, rootTargets, exceptions);
+  _checkExceptions(exceptions);
+
+  // Check if there was leaves in the graph that were not traversed.
+  if (targetGraph.keys.isNotEmpty) {
+    exceptions.addAll(targetGraph.keys.map((String targetName) => 'ERROR: Failed to find path for $targetName'));
+  }
+  _checkExceptions(exceptions);   
+}
+
+void _searchForCycles(Map<String, List<Target>> targetGraph, List<Target> targets, List<String> exceptions) {
+  for (final Target target in targets) {
+    if (targetGraph.containsKey(target.name)) {
+      final List<Target> dependencies = targetGraph.remove(target.name);
+      _searchForCycles(targetGraph, dependencies, exceptions);
+    } else {
+      exceptions.add('ERROR: Cycle found at ${target.name}. Targets can only have linear dependencies');
+    }
+  }
+}
+
+void _checkExceptions(List<String> exceptions) {
+  if (exceptions.isNotEmpty) {
+    final String fullException = exceptions.reduce((String exception, _) => exception + '\n');
+    throw FormatException(fullException);
   }
 }

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -250,6 +250,24 @@ void main() {
       expect(commit.message, 'example message');
     });
   });
+
+  group('scheduler config', () {
+    test('fails when there are cyclic targets', () {
+
+    });
+
+    test('fails when there are duplicate targets', () {
+
+    });
+
+    test('fails when there are multiple dependencies', () {
+
+    });
+
+    test('fails when dependency does not exist', () {
+
+    });
+  });
 }
 
 PullRequest createPullRequest({

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -340,7 +340,15 @@ targets:
     dependencies:
       - A
       ''') as YamlMap;
-      expect(() => loadSchedulerConfig(configWithCycle), throwsA(isA<FormatException>()));
+      expect(
+          () => loadSchedulerConfig(configWithCycle),
+          throwsA(
+            isA<FormatException>().having(
+              (FormatException e) => e.toString(),
+              'message',
+              contains('ERROR: A depends on B which does not exist'),
+            ),
+          ));
     });
 
     test('fails when there are duplicate targets', () {
@@ -351,11 +359,19 @@ targets:
   - name: A
   - name: A
       ''') as YamlMap;
-      expect(() => loadSchedulerConfig(configWithDuplicateTargets), throwsA(isA<FormatException>()));
+      expect(
+          () => loadSchedulerConfig(configWithDuplicateTargets),
+          throwsA(
+            isA<FormatException>().having(
+              (FormatException e) => e.toString(),
+              'message',
+              contains('ERROR: A already exists in graph'),
+            ),
+          ));
     });
 
     test('fails when there are multiple dependencies', () {
-      final YamlMap configWithDuplicateTargets = loadYaml('''
+      final YamlMap configWithMultipleDependencies = loadYaml('''
 enabled_branches:
   - master
 targets:
@@ -366,11 +382,19 @@ targets:
       - A
       - B
       ''') as YamlMap;
-      expect(() => loadSchedulerConfig(configWithDuplicateTargets), throwsA(isA<FormatException>()));
+      expect(
+          () => loadSchedulerConfig(configWithMultipleDependencies),
+          throwsA(
+            isA<FormatException>().having(
+              (FormatException e) => e.toString(),
+              'message',
+              contains('ERROR: C has multiple dependencies which is not supported. Use only one dependency'),
+            ),
+          ));
     });
 
     test('fails when dependency does not exist', () {
-      final YamlMap configWithDuplicateTargets = loadYaml('''
+      final YamlMap configWithMissingTarget = loadYaml('''
 enabled_branches:
   - master
 targets:
@@ -378,7 +402,15 @@ targets:
     dependencies:
       - B
       ''') as YamlMap;
-      expect(() => loadSchedulerConfig(configWithDuplicateTargets), throwsA(isA<FormatException>()));
+      expect(
+          () => loadSchedulerConfig(configWithMissingTarget),
+          throwsA(
+            isA<FormatException>().having(
+              (FormatException e) => e.toString(),
+              'message',
+              contains('ERROR: A depends on B which does not exist'),
+            ),
+          ));
     });
   });
 }

--- a/licenses/check_licenses.dart
+++ b/licenses/check_licenses.dart
@@ -112,6 +112,7 @@ Iterable<File> _allFiles(String workingDirectory, String extension, {@required i
       if (path.basename(entity.path).endsWith('g.dart')) continue;
       if (path.basename(entity.path).endsWith('pb.dart')) continue;
       if (path.basename(entity.path).endsWith('pbenum.dart')) continue;
+      if (path.basename(entity.path).endsWith('pbjson.dart')) continue;
       if (extension == null || path.extension(entity.path) == '.$extension') {
         matches += 1;
         yield entity;


### PR DESCRIPTION
Part of go/flutter-build-test-infra

This change is a no-op to Cocoon, and only adds models necessary for future changes.

* Create `SchedulerConfig` and `Target` protos
* Validate scheduler config from a yaml is valid
  * Ensure all dependencies exist
  * No duplicate targets
  * No cycles (the config should only create a tree)
* Add `bin/validate_scheduler_config.dart` for running tests against external configs

# Issues

https://github.com/flutter/flutter/issues/76140