### PR TITLE
use flutter_test instead of package:test

### DIFF
--- a/app_flutter/pubspec.yaml
+++ b/app_flutter/pubspec.yaml
@@ -35,7 +35,6 @@ dev_dependencies:
     sdk: flutter
   mockito: ^4.0.0
   path: ^1.6.4
-  test: ^1.6.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/app_flutter/test/logic/qualified_task_test.dart
+++ b/app_flutter/test/logic/qualified_task_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit, Task;
 

--- a/app_flutter/test/logic/task_grid_filter_test.dart
+++ b/app_flutter/test/logic/task_grid_filter_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:cocoon_service/protos.dart' show Commit, CommitStatus, Task;
 

--- a/app_flutter/test/service/appengine_cocoon_test.dart
+++ b/app_flutter/test/service/appengine_cocoon_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:http/http.dart' show Client, Request, Response;
 import 'package:http/testing.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:cocoon_service/protos.dart';
 

--- a/app_flutter/test/service/google_authentication_test.dart
+++ b/app_flutter/test/service/google_authentication_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:app_flutter/service/google_authentication.dart';
 

--- a/repo_dashboard/pubspec.yaml
+++ b/repo_dashboard/pubspec.yaml
@@ -35,7 +35,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.6.0
 
 dependency_overrides:
   # Override path_provider to pick up fixes for FFI changes.

--- a/repo_dashboard/test/build_status_service_test.dart
+++ b/repo_dashboard/test/build_status_service_test.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 
 import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:repository_dashboard/models/build_status.dart';
 import 'package:repository_dashboard/services/build_status_service.dart';

--- a/repo_dashboard/test/build_status_test.dart
+++ b/repo_dashboard/test/build_status_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'package:repository_dashboard/models/build_status.dart';
 

--- a/repo_dashboard/test/skia_autoroll_service_test.dart
+++ b/repo_dashboard/test/skia_autoroll_service_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
 

--- a/repo_dashboard/test/status_page_status_service_test.dart
+++ b/repo_dashboard/test/status_page_status_service_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
 


### PR DESCRIPTION
This makes it easier to version solve since flutter_test has fewer dependencies.

Blocking https://github.com/flutter/flutter/issues/77856

Should be safe as long as `flutter test` is being used to run unit tests, even if they are not flutter tests