### PR TITLE
[cocoon] Exclude null builds when calling buildbucket API

### DIFF
--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -202,6 +202,7 @@ class LuciService {
     final BatchResponse batchResponse = await buildBucketClient.batch(batchRequest);
     final Iterable<Build> builds = batchResponse.responses
         .map<SearchBuildsResponse>((Response response) => response.searchBuilds)
+        .where((SearchBuildsResponse response) => response.builds != null)
         .expand<Build>((SearchBuildsResponse response) => response.builds);
     return builds;
   }


### PR DESCRIPTION
When buildbucket API call returns empty builds, it fails `/api/refresh-chromebot-status` which refresh LUCI builds statuses to flutter dashboard.
This is to exclude the empty case.

https://github.com/flutter/flutter/issues/79380