### PR TITLE
[app_dart] Remove refresh github commits cron

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -1,9 +1,6 @@
 # Updates to this file must be pushed with:
 #   gcloud app deploy --project flutter-dashboard cron.yaml
 cron:
-- description: refresh commits from GitHub
-  url: /api/refresh-github-commits
-  schedule: every 15 minutes
 - description: refresh chromebot build status
   url: /api/refresh-chromebot-status
   schedule: every 3 minutes


### PR DESCRIPTION
Disable the cron job as it is causing issues with the webhook scheduler.

For the next week I'll look at if any commits are being dropped via https://plx.corp.google.com/scripts2/script_60._49462f_0000_2e53_920f_089e0832f92c

This endpoint can still be manually queried if there are outages

# Issues

https://github.com/flutter/flutter/issues/79408