### PR TITLE
[scheduler] Rename recipe field to builder

### DIFF
--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -10,11 +10,13 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SchedulerConfig extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig', createEmptyInstance: create)
-    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM, subBuilder: Target.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig',
+      createEmptyInstance: create)
+    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM,
+        subBuilder: Target.create)
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enabledBranches')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   SchedulerConfig._() : super();
   factory SchedulerConfig({
@@ -30,25 +32,28 @@ class SchedulerConfig extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SchedulerConfig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SchedulerConfig.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SchedulerConfig clone() => SchedulerConfig()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) => super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) =>
+      super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SchedulerConfig create() => SchedulerConfig._();
   SchedulerConfig createEmptyInstance() => create();
   static $pb.PbList<SchedulerConfig> createRepeated() => $pb.PbList<SchedulerConfig>();
   @$core.pragma('dart2js:noInline')
-  static SchedulerConfig getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
+  static SchedulerConfig getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
   static SchedulerConfig _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -59,16 +64,23 @@ class SchedulerConfig extends $pb.GeneratedMessage {
 }
 
 class Target extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target',
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dependencies')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bringup')
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3, defaultOrMaker: 30)
-    ..a<$core.String>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed', $pb.PbFieldType.OS, defaultOrMaker: 'linux-vm')
-    ..m<$core.String, $core.String>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties', entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
+    ..a<$core.int>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3,
+        defaultOrMaker: 30)
+    ..a<$core.String>(
+        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed', $pb.PbFieldType.OS,
+        defaultOrMaker: 'linux-vm')
+    ..m<$core.String, $core.String>(
+        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties',
+        entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'builder')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   Target._() : super();
   factory Target({
@@ -104,18 +116,19 @@ class Target extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Target clone() => Target()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Target copyWith(void Function(Target) updates) => super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Target copyWith(void Function(Target) updates) =>
+      super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Target create() => Target._();
@@ -128,7 +141,10 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -140,7 +156,10 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get bringup => $_getBF(2);
   @$pb.TagNumber(3)
-  set bringup($core.bool v) { $_setBool(2, v); }
+  set bringup($core.bool v) {
+    $_setBool(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBringup() => $_has(2);
   @$pb.TagNumber(3)
@@ -149,7 +168,10 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get timeout => $_getI(3, 30);
   @$pb.TagNumber(4)
-  set timeout($core.int v) { $_setSignedInt32(3, v); }
+  set timeout($core.int v) {
+    $_setSignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasTimeout() => $_has(3);
   @$pb.TagNumber(4)
@@ -158,7 +180,10 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get testbed => $_getS(4, 'linux-vm');
   @$pb.TagNumber(5)
-  set testbed($core.String v) { $_setString(4, v); }
+  set testbed($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTestbed() => $_has(4);
   @$pb.TagNumber(5)
@@ -170,10 +195,12 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get builder => $_getSZ(6);
   @$pb.TagNumber(7)
-  set builder($core.String v) { $_setString(6, v); }
+  set builder($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasBuilder() => $_has(6);
   @$pb.TagNumber(7)
   void clearBuilder() => clearField(7);
 }
-

--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -10,13 +10,11 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SchedulerConfig extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig',
-      createEmptyInstance: create)
-    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM,
-        subBuilder: Target.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig', createEmptyInstance: create)
+    ..pc<Target>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'targets', $pb.PbFieldType.PM, subBuilder: Target.create)
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enabledBranches')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   SchedulerConfig._() : super();
   factory SchedulerConfig({
@@ -32,28 +30,25 @@ class SchedulerConfig extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SchedulerConfig.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory SchedulerConfig.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SchedulerConfig.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SchedulerConfig clone() => SchedulerConfig()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) =>
-      super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SchedulerConfig copyWith(void Function(SchedulerConfig) updates) => super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SchedulerConfig create() => SchedulerConfig._();
   SchedulerConfig createEmptyInstance() => create();
   static $pb.PbList<SchedulerConfig> createRepeated() => $pb.PbList<SchedulerConfig>();
   @$core.pragma('dart2js:noInline')
-  static SchedulerConfig getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
+  static SchedulerConfig getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SchedulerConfig>(create);
   static SchedulerConfig _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -64,23 +59,16 @@ class SchedulerConfig extends $pb.GeneratedMessage {
 }
 
 class Target extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target',
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Target', createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dependencies')
     ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bringup')
-    ..a<$core.int>(
-        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3,
-        defaultOrMaker: 30)
-    ..a<$core.String>(
-        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed', $pb.PbFieldType.OS,
-        defaultOrMaker: 'linux-vm')
-    ..m<$core.String, $core.String>(
-        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties',
-        entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
-    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipe')
-    ..hasRequiredFields = false;
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeout', $pb.PbFieldType.O3, defaultOrMaker: 30)
+    ..a<$core.String>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'testbed', $pb.PbFieldType.OS, defaultOrMaker: 'linux-vm')
+    ..m<$core.String, $core.String>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties', entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'builder')
+    ..hasRequiredFields = false
+  ;
 
   Target._() : super();
   factory Target({
@@ -90,7 +78,7 @@ class Target extends $pb.GeneratedMessage {
     $core.int timeout,
     $core.String testbed,
     $core.Map<$core.String, $core.String> properties,
-    $core.String recipe,
+    $core.String builder,
   }) {
     final _result = create();
     if (name != null) {
@@ -111,24 +99,23 @@ class Target extends $pb.GeneratedMessage {
     if (properties != null) {
       _result.properties.addAll(properties);
     }
-    if (recipe != null) {
-      _result.recipe = recipe;
+    if (builder != null) {
+      _result.builder = builder;
     }
     return _result;
   }
-  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Target.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Target clone() => Target()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Target copyWith(void Function(Target) updates) =>
-      super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Target copyWith(void Function(Target) updates) => super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Target create() => Target._();
@@ -141,10 +128,7 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -156,10 +140,7 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get bringup => $_getBF(2);
   @$pb.TagNumber(3)
-  set bringup($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set bringup($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasBringup() => $_has(2);
   @$pb.TagNumber(3)
@@ -168,10 +149,7 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get timeout => $_getI(3, 30);
   @$pb.TagNumber(4)
-  set timeout($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set timeout($core.int v) { $_setSignedInt32(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasTimeout() => $_has(3);
   @$pb.TagNumber(4)
@@ -180,10 +158,7 @@ class Target extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get testbed => $_getS(4, 'linux-vm');
   @$pb.TagNumber(5)
-  set testbed($core.String v) {
-    $_setString(4, v);
-  }
-
+  set testbed($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasTestbed() => $_has(4);
   @$pb.TagNumber(5)
@@ -193,14 +168,12 @@ class Target extends $pb.GeneratedMessage {
   $core.Map<$core.String, $core.String> get properties => $_getMap(5);
 
   @$pb.TagNumber(7)
-  $core.String get recipe => $_getSZ(6);
+  $core.String get builder => $_getSZ(6);
   @$pb.TagNumber(7)
-  set recipe($core.String v) {
-    $_setString(6, v);
-  }
-
+  set builder($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
-  $core.bool hasRecipe() => $_has(6);
+  $core.bool hasBuilder() => $_has(6);
   @$pb.TagNumber(7)
-  void clearRecipe() => clearField(7);
+  void clearBuilder() => clearField(7);
 }
+

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -35,4 +35,3 @@ const Target_PropertiesEntry$json = const {
   ],
   '7': const {'7': true},
 };
-

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -22,7 +22,7 @@ const Target$json = const {
     const {'1': 'timeout', '3': 4, '4': 1, '5': 5, '7': '30', '10': 'timeout'},
     const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '7': 'linux-vm', '10': 'testbed'},
     const {'1': 'properties', '3': 6, '4': 3, '5': 11, '6': '.Target.PropertiesEntry', '10': 'properties'},
-    const {'1': 'recipe', '3': 7, '4': 1, '5': 9, '10': 'recipe'},
+    const {'1': 'builder', '3': 7, '4': 1, '5': 9, '10': 'builder'},
   ],
   '3': const [Target_PropertiesEntry$json],
 };
@@ -35,3 +35,4 @@ const Target_PropertiesEntry$json = const {
   ],
   '7': const {'7': true},
 };
+

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -4,6 +4,7 @@
 
 syntax = "proto2";
 
+// Next ID: 3
 message SchedulerConfig {
     // Targets to run from this config.
     repeated Target targets = 1;
@@ -11,6 +12,7 @@ message SchedulerConfig {
     repeated string enabled_branches = 2;
 }
 
+// Next ID: 8
 message Target {
     // Unique, human readable identifier.
     optional string name = 1;
@@ -26,6 +28,6 @@ message Target {
     optional string testbed = 5 [default = 'linux-vm'];
     // Properties to configure infrastructure tooling.
     map<string, string> properties = 6;
-    // Name of the LUCI recipe to trigger.
-    optional string recipe = 7;
+    // Name of the LUCI builder to trigger.
+    optional string builder = 7;
 }

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -260,7 +260,7 @@ enabled_branches:
   - master
 targets:
   - name: A
-    recipe: test_recipe
+    builder: builderA
     properties:
       test: abc
       ''') as YamlMap;
@@ -273,7 +273,7 @@ targets:
       expect(target.properties, <String, String>{
         'test': 'abc',
       });
-      expect(target.recipe, 'test_recipe');
+      expect(target.builder, 'builderA');
       expect(target.testbed, 'linux-vm');
       expect(target.timeout, 30);
     });


### PR DESCRIPTION
This config isn't being used yet. It's non-trivial to spawn a swarming task to run a recipe in Flutter LUCI infrastructure.

Instead, we'll start by triggering the existing builders from Cocoon.