### PR TITLE
[app_dart] Update engine build status to use config value

### DIFF
--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -240,8 +240,8 @@ class Config {
   String get flutterBuild => 'flutter-build';
 
   // Repository status description for github status.
-  String get flutterBuildDescription => 'Flutter build is currently broken. Please do not merge this '
-      'PR unless it contains a fix to the broken build.';
+  String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
+      'PR unless it contains a fix for the tree.';
 
   RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
 

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -84,8 +84,7 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
         request.targetUrl = 'https://ci.chromium.org/p/flutter/g/engine/console';
         request.context = 'luci-engine';
         if (status != GithubBuildStatusUpdate.statusSuccess) {
-          request.description = 'Flutter build is currently broken. Please do not merge this '
-              'PR unless it contains a fix to the broken build.';
+          request.description = config.flutterBuildDescription;
         }
 
         try {


### PR DESCRIPTION
Quick fix to unify the framework and engine tree failure status messages (they are identical)