### PR TITLE
[app_dart] Create FakeScheduler service + fix empty manifest crash

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -46,10 +46,7 @@ Future<void> main() async {
     );
 
     /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
-    final Scheduler scheduler = Scheduler(
-      cache: cache,
-      config: config,
-    );
+    final Scheduler scheduler = Scheduler(config: config);
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
       '/api/append-log': AppendLog(config, authProvider),

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -70,6 +70,7 @@ Future<void> main() async {
         buildBucketClient: buildBucketClient,
         luciBuildService: luciBuildService,
         githubChecksService: githubChecksService,
+        scheduler: scheduler,
       ),
       '/api/luci-status-handler': LuciStatusHandler(
         config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -19,6 +19,7 @@ Future<void> main() async {
     final CacheService cache = CacheService(inMemory: inMemoryCache);
 
     final Config config = Config(dbService, cache);
+    final DatastoreService datastore = DatastoreService.defaultProvider(dbService);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);
     final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config);
     final BuildBucketClient buildBucketClient = BuildBucketClient(
@@ -43,6 +44,13 @@ Future<void> main() async {
     /// Github checks api service used to provide luci test execution status on the Github UI.
     final GithubChecksService githubChecksService = GithubChecksService(
       config,
+    );
+
+    /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
+    final Scheduler scheduler = Scheduler(
+      cache: cache,
+      config: config,
+      datastore: datastore,
     );
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
@@ -74,7 +82,11 @@ Future<void> main() async {
       '/api/push-gold-status-to-github': PushGoldStatusToGithub(config, authProvider),
       '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(config, authProvider, luciBuildService),
       '/api/refresh-chromebot-status': RefreshChromebotStatus(config, authProvider, luciBuildService),
-      '/api/refresh-github-commits': RefreshGithubCommits(config, authProvider),
+      '/api/refresh-github-commits': RefreshGithubCommits(
+        config,
+        authProvider,
+        scheduler: scheduler,
+      ),
       '/api/reserve-task': ReserveTask(config, authProvider),
       '/api/reset-devicelab-task': ResetDevicelabTask(
         config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -19,7 +19,6 @@ Future<void> main() async {
     final CacheService cache = CacheService(inMemory: inMemoryCache);
 
     final Config config = Config(dbService, cache);
-    final DatastoreService datastore = DatastoreService.defaultProvider(dbService);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);
     final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config);
     final BuildBucketClient buildBucketClient = BuildBucketClient(

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -50,7 +50,6 @@ Future<void> main() async {
     final Scheduler scheduler = Scheduler(
       cache: cache,
       config: config,
-      datastore: datastore,
     );
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -40,6 +40,7 @@ export 'src/request_handling/swarming_authentication.dart';
 export 'src/service/access_token_provider.dart';
 export 'src/service/buildbucket.dart';
 export 'src/service/cache_service.dart';
+export 'src/service/datastore.dart';
 export 'src/service/github_checks_service.dart';
 export 'src/service/github_status_service.dart';
 export 'src/service/luci_build_service.dart';

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -40,7 +40,6 @@ export 'src/request_handling/swarming_authentication.dart';
 export 'src/service/access_token_provider.dart';
 export 'src/service/buildbucket.dart';
 export 'src/service/cache_service.dart';
-export 'src/service/datastore.dart';
 export 'src/service/github_checks_service.dart';
 export 'src/service/github_status_service.dart';
 export 'src/service/luci_build_service.dart';

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -27,9 +27,13 @@ final RegExp kEngineTestRegExp = RegExp(r'tests?\.(dart|java|mm|m|cc)$');
 
 @immutable
 class GithubWebhook extends RequestHandler<Body> {
-  const GithubWebhook(Config config,
-      {@required this.buildBucketClient, @required this.scheduler, this.luciBuildService, this.githubChecksService,})
-      : assert(buildBucketClient != null),
+  const GithubWebhook(
+    Config config, {
+    @required this.buildBucketClient,
+    @required this.scheduler,
+    this.luciBuildService,
+    this.githubChecksService,
+  })  : assert(buildBucketClient != null),
         super(config: config);
 
   /// A client for querying and scheduling LUCI Builds.

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -11,13 +11,11 @@ import 'package:github/hooks.dart';
 import 'package:meta/meta.dart';
 
 import '../datastore/config.dart';
-import '../foundation/providers.dart';
 import '../model/github/checks.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
 import '../request_handling/request_handler.dart';
 import '../service/buildbucket.dart';
-import '../service/datastore.dart';
 import '../service/github_checks_service.dart';
 import '../service/luci_build_service.dart';
 import '../service/scheduler.dart';
@@ -29,18 +27,9 @@ final RegExp kEngineTestRegExp = RegExp(r'tests?\.(dart|java|mm|m|cc)$');
 
 @immutable
 class GithubWebhook extends RequestHandler<Body> {
-  GithubWebhook(Config config,
-      {@required this.buildBucketClient,
-      @visibleForTesting Scheduler schedulerValue,
-      this.luciBuildService,
-      this.githubChecksService})
+  const GithubWebhook(Config config,
+      {@required this.buildBucketClient, @required this.scheduler, this.luciBuildService, this.githubChecksService,})
       : assert(buildBucketClient != null),
-        scheduler = schedulerValue ??
-            Scheduler(
-              config: config,
-              datastore: DatastoreService.defaultProvider(config.db),
-              httpClientProvider: Providers.freshHttpClient,
-            ),
         super(config: config);
 
   /// A client for querying and scheduling LUCI Builds.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -20,7 +20,6 @@ import '../model/appengine/task.dart';
 import '../model/devicelab/manifest.dart';
 import '../model/proto/protos.dart' show SchedulerConfig, Target;
 import '../request_handling/exceptions.dart';
-import 'cache_service.dart';
 import 'datastore.dart';
 import 'luci.dart';
 
@@ -32,7 +31,6 @@ import 'luci.dart';
 ///   3. Retry mechanisms for tasks
 class Scheduler {
   Scheduler({
-    @required this.cache,
     @required this.config,
     this.datastoreProvider = DatastoreService.defaultProvider,
     this.gitHubBackoffCalculator = twoSecondLinearBackoff,
@@ -41,7 +39,6 @@ class Scheduler {
   })  : assert(datastoreProvider != null),
         assert(gitHubBackoffCalculator != null);
 
-  final CacheService cache;
   final Config config;
   final DatastoreServiceProvider datastoreProvider;
   final HttpClientProvider httpClientProvider;
@@ -49,9 +46,6 @@ class Scheduler {
 
   DatastoreService datastore;
   Logging log;
-
-  /// Subcache key to store [SchedulerConfig] for quicker retrievals.
-  static const String schedulerSubcacheName = 'scheduler';
 
   /// Sets the appengine [log] used by this class to log debug and error
   /// messages. This method has to be called before any other method in this

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -14,6 +14,7 @@ import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 
 import 'package:crypto/crypto.dart';
+import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -58,17 +59,18 @@ void main() {
       githubService = FakeGithubService();
       serviceAccountInfo = const ServiceAccountInfo(email: serviceAccountEmail);
       request = FakeHttpRequest();
+      db = FakeDatastoreDB();
       config = FakeConfig(
+        dbValue: db,
         deviceLabServiceAccountValue: serviceAccountInfo,
         githubService: githubService,
         tabledataResourceApi: MockTabledataResourceApi(),
       );
-      db = FakeDatastoreDB();
       gitHubClient = MockGitHub();
       issuesService = MockIssuesService();
       pullRequestsService = MockPullRequestsService();
       mockBuildBucketClient = MockBuildBucketClient();
-      scheduler = FakeScheduler(config: config, datastore: DatastoreService(db, 5));
+      scheduler = FakeScheduler(config: config);
       tester = RequestHandlerTester(request: request);
       serviceAccountInfo = await config.deviceLabServiceAccount;
 

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -14,7 +14,6 @@ import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 
 import 'package:crypto/crypto.dart';
-import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -84,7 +84,7 @@ void main() {
       db = FakeDatastoreDB();
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi, githubService: githubService, dbValue: db);
       auth = FakeAuthenticationProvider();
-      scheduler = FakeScheduler(datastore: DatastoreService(config.db, 5), config: config);
+      scheduler = FakeScheduler(config: config);
       tester = ApiRequestHandlerTester();
       handler = RefreshGithubCommits(
         config,

--- a/app_dart/test/request_handlers/refresh_github_commits_test.dart
+++ b/app_dart/test/request_handlers/refresh_github_commits_test.dart
@@ -19,8 +19,8 @@ import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
-import '../src/request_handling/fake_http.dart';
 import '../src/service/fake_github_service.dart';
+import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 
 const String singleTaskManifestYaml = '''
@@ -35,7 +35,7 @@ void main() {
     FakeConfig config;
     FakeAuthenticationProvider auth;
     FakeDatastoreDB db;
-    FakeHttpClient httpClient;
+    FakeScheduler scheduler;
     ApiRequestHandlerTester tester;
     RefreshGithubCommits handler;
 
@@ -84,14 +84,13 @@ void main() {
       db = FakeDatastoreDB();
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi, githubService: githubService, dbValue: db);
       auth = FakeAuthenticationProvider();
-      httpClient = FakeHttpClient();
+      scheduler = FakeScheduler(datastore: DatastoreService(config.db, 5), config: config);
       tester = ApiRequestHandlerTester();
       handler = RefreshGithubCommits(
         config,
         auth,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        httpClientProvider: () => httpClient,
-        gitHubBackoffCalculator: (int attempt) => Duration.zero,
+        scheduler: scheduler,
       );
 
       githubService.listCommitsBranch = (String branch, int hours) {
@@ -115,7 +114,7 @@ void main() {
       config.flutterBranchesValue = <String>['flutter-1.1-candidate.1', 'master'];
 
       expect(db.values.values.whereType<Commit>().length, 0);
-      httpClient.request.response.body = singleTaskManifestYaml;
+      scheduler.devicelabManifest = singleTaskManifestYaml;
       await tester.get<Body>(handler);
       final Commit commit = db.values.values.whereType<Commit>().first;
       expect(db.values.values.whereType<Commit>().length, 2);
@@ -133,7 +132,7 @@ void main() {
 
       expect(db.values.values.whereType<Commit>().length, 4);
       expect(db.values.values.whereType<Task>().length, 0);
-      httpClient.request.response.body = singleTaskManifestYaml;
+      scheduler.devicelabManifest = singleTaskManifestYaml;
       // Commits 7, 8, 9 will get added and scheduled to the tree
       final Body body = await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 7);
@@ -146,7 +145,7 @@ void main() {
       config.flutterBranchesValue = <String>['flutter-0.0-candidate.0'];
 
       expect(db.values.values.whereType<Commit>().length, 0);
-      httpClient.request.response.body = singleTaskManifestYaml;
+      scheduler.devicelabManifest = singleTaskManifestYaml;
       await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 1);
     });
@@ -155,7 +154,7 @@ void main() {
       githubCommits = <String>['1'];
       config.flutterBranchesValue = <String>['master'];
       expect(db.values.values.whereType<Commit>().length, 0);
-      httpClient.request.response.body = singleTaskManifestYaml;
+      scheduler.devicelabManifest = singleTaskManifestYaml;
       await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 1);
       final Commit commit = db.values.values.whereType<Commit>().single;
@@ -182,7 +181,7 @@ void main() {
           throw StateError('Commit failed');
         }
       };
-      httpClient.request.response.body = singleTaskManifestYaml;
+      scheduler.devicelabManifest = singleTaskManifestYaml;
       final Body body = await tester.get<Body>(handler);
       expect(db.values.values.whereType<Commit>().length, 3);
       expect(db.values.values.whereType<Task>().length, 10);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -16,7 +16,6 @@ import 'package:cocoon_service/protos.dart' show SchedulerConfig, Target;
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/service/cache_service.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 
@@ -38,7 +37,6 @@ tasks:
 ''';
 
 void main() {
-  CacheService cache;
   FakeConfig config;
   FakeDatastoreDB db;
   FakeHttpClient httpClient;
@@ -60,7 +58,6 @@ void main() {
         return Future<TableDataInsertAllResponse>.value(null);
       });
 
-      cache = CacheService(inMemory: true);
       db = FakeDatastoreDB();
       config = FakeConfig(tabledataResourceApi: tabledataResourceApi, dbValue: db);
       httpClient = FakeHttpClient(onIssueRequest: (FakeHttpClientRequest request) {
@@ -72,7 +69,6 @@ void main() {
       });
 
       scheduler = Scheduler(
-        cache: cache,
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
         httpClientProvider: () => httpClient,
@@ -212,7 +208,6 @@ void main() {
         return Future<TableDataInsertAllResponse>.value(null);
       });
 
-      cache = CacheService(inMemory: true);
       db = FakeDatastoreDB();
       config = FakeConfig(
         tabledataResourceApi: tabledataResourceApi,
@@ -227,7 +222,6 @@ void main() {
         }
       });
       scheduler = Scheduler(
-        cache: cache,
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
         httpClientProvider: () => httpClient,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:gcloud/db.dart' as gcloud_db;
+import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:mockito/mockito.dart';
@@ -73,7 +74,7 @@ void main() {
       scheduler = Scheduler(
         cache: cache,
         config: config,
-        datastore: DatastoreService(db, 2),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
         httpClientProvider: () => httpClient,
         log: FakeLogging(),
       );
@@ -228,7 +229,7 @@ void main() {
       scheduler = Scheduler(
         cache: cache,
         config: config,
-        datastore: DatastoreService(db, 2),
+        datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
         httpClientProvider: () => httpClient,
         log: FakeLogging(),
       );

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -116,7 +116,6 @@ void main() {
       expect(db.values.values.whereType<Commit>().length, 1);
     });
 
-
     test('inserts all relevant fields of the commit', () async {
       config.flutterBranchesValue = <String>['master'];
       expect(db.values.values.whereType<Commit>().length, 0);

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -8,7 +8,6 @@ import 'package:cocoon_service/src/datastore/config.dart';
 import 'package:cocoon_service/src/model/proto/internal/scheduler.pb.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/service/cache_service.dart';
-import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 
 import '../request_handling/fake_logging.dart';
@@ -18,11 +17,9 @@ class FakeScheduler extends Scheduler {
   FakeScheduler({
     this.schedulerConfig,
     this.devicelabManifest = 'tasks:',
-    DatastoreService datastore,
     Config config,
   }) : super(
           config: config,
-          datastore: datastore,
           cache: CacheService(inMemory: true),
           log: FakeLogging(),
         );

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -17,7 +17,7 @@ import '../request_handling/fake_logging.dart';
 class FakeScheduler extends Scheduler {
   FakeScheduler({
     this.schedulerConfig,
-    this.devicelabManifest = '',
+    this.devicelabManifest = 'tasks:',
     DatastoreService datastore,
     Config config,
   }) : super(
@@ -32,9 +32,6 @@ class FakeScheduler extends Scheduler {
 
   /// String contents of [Manifest] for legacy devicelab tasks.
   String devicelabManifest;
-
-  @override
-  Future<SchedulerConfig> getSchedulerConfig(Commit commit) async => schedulerConfig ?? SchedulerConfig.getDefault();
 
   @override
   Future<YamlMap> loadDevicelabManifest(Commit commit) async => await loadYaml(devicelabManifest) as YamlMap;

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -7,7 +7,6 @@ import 'package:yaml/yaml.dart';
 import 'package:cocoon_service/src/datastore/config.dart';
 import 'package:cocoon_service/src/model/proto/internal/scheduler.pb.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
-import 'package:cocoon_service/src/service/cache_service.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 
 import '../request_handling/fake_logging.dart';
@@ -20,7 +19,6 @@ class FakeScheduler extends Scheduler {
     Config config,
   }) : super(
           config: config,
-          cache: CacheService(inMemory: true),
           log: FakeLogging(),
         );
 

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -1,0 +1,41 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+import 'package:cocoon_service/src/datastore/config.dart';
+import 'package:cocoon_service/src/model/proto/internal/scheduler.pb.dart';
+import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/service/cache_service.dart';
+import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/scheduler.dart';
+
+import '../request_handling/fake_logging.dart';
+
+/// Fake for [Scheduler] to use for tests that rely on it.
+class FakeScheduler extends Scheduler {
+  FakeScheduler({
+    this.schedulerConfig,
+    this.devicelabManifest = '',
+    DatastoreService datastore,
+    Config config,
+  }) : super(
+          config: config,
+          datastore: datastore,
+          cache: CacheService(inMemory: true),
+          log: FakeLogging(),
+        );
+
+  /// [SchedulerConfig] value to be injected on [getSchedulerConfig].
+  SchedulerConfig schedulerConfig;
+
+  /// String contents of [Manifest] for legacy devicelab tasks.
+  String devicelabManifest;
+
+  @override
+  Future<SchedulerConfig> getSchedulerConfig(Commit commit) async => schedulerConfig ?? SchedulerConfig.getDefault();
+
+  @override
+  Future<YamlMap> loadDevicelabManifest(Commit commit) async => await loadYaml(devicelabManifest) as YamlMap;
+}

--- a/app_dart/test/src/utilities/mocks.dart
+++ b/app_dart/test/src/utilities/mocks.dart
@@ -11,7 +11,6 @@ import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
 import 'package:cocoon_service/src/service/luci.dart';
 import 'package:cocoon_service/src/service/reservation_provider.dart';
-import 'package:cocoon_service/src/service/scheduler.dart';
 import 'package:cocoon_service/src/service/task_provider.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
@@ -27,8 +26,6 @@ class MockRepositoriesService extends Mock implements RepositoriesService {}
 class MockTabledataResourceApi extends Mock implements TabledataResourceApi {}
 
 class MockAccessTokenService extends Mock implements AccessTokenService {}
-
-class MockScheduler extends Mock implements Scheduler {}
 
 class MockTaskService extends Mock implements TaskService {}
 


### PR DESCRIPTION
This is to make it easier to write tests that depend on `Scheduler` but do not care about its implementation.

While implementing this, I noticed an issue where empty devicelab manifests would cause crashes, so I fixed it. Added a regression test.

## Issues
Fixes https://github.com/flutter/flutter/issues/79679
https://github.com/flutter/flutter/issues/76140