### PR TITLE
Skip reboot for 32 bit phone when recovering device

### DIFF
--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -14,6 +14,11 @@ import 'health.dart';
 import 'mac.dart';
 import 'utils.dart';
 
+/// Identifiers for devices that should never be rebooted.
+final Set<String> noRebootForbidList = <String>{
+  '822ef7958bba573829d85eef4df6cbdd86593730', // 32bit iPhone requires manual intervention on reboot.
+};
+
 /// IOS implementation of [DeviceDiscovery].
 ///
 /// Discovers available ios devices and chooses one to work with.
@@ -137,6 +142,9 @@ class IosDevice implements Device {
   Future<bool> restart_device({ProcessManager processManager}) async {
     processManager ??= LocalProcessManager();
     try {
+      if (noRebootForbidList.contains(deviceId)) {
+        return true;
+      }
       await eval('idevicediagnostics', <String>['restart'], processManager: processManager);
     } on BuildFailedError catch (error) {
       logger.severe('device restart fails: $error');

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -15,7 +15,7 @@ import 'mac.dart';
 import 'utils.dart';
 
 /// Identifiers for devices that should never be rebooted.
-final Set<String> noRebootForbidList = <String>{
+final Set<String> noRebootList = <String>{
   '822ef7958bba573829d85eef4df6cbdd86593730', // 32bit iPhone requires manual intervention on reboot.
 };
 
@@ -142,7 +142,7 @@ class IosDevice implements Device {
   Future<bool> restart_device({ProcessManager processManager}) async {
     processManager ??= LocalProcessManager();
     try {
-      if (noRebootForbidList.contains(deviceId)) {
+      if (noRebootList.contains(deviceId)) {
         return true;
       }
       await eval('idevicediagnostics', <String>['restart'], processManager: processManager);

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.0-nullsafety.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.0-nullsafety.2"
   build:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.0-nullsafety.2"
   cli_util:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.0-nullsafety.4"
   convert:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.3-nullsafety.2"
   logging:
     dependency: "direct main"
     description:
@@ -182,14 +182,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.10-nullsafety.2"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.5"
   mime:
     dependency: transitive
     description:
@@ -238,14 +238,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.0-nullsafety.2"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.0-nullsafety.2"
   platform:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.0-nullsafety.2"
   process:
     dependency: "direct main"
     description:
@@ -329,77 +329,77 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.0-nullsafety.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.10-nullsafety.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.0-nullsafety.5"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.0-nullsafety.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.0-nullsafety.2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.0-nullsafety.2"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.3"
+    version: "1.16.0-nullsafety.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.2.19-nullsafety.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.13"
+    version: "0.3.12-nullsafety.7"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.0-nullsafety.4"
   vm_service:
     dependency: transitive
     description:
@@ -436,4 +436,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.10.0-78 <2.11.0"

--- a/device_doctor/pubspec.yaml
+++ b/device_doctor/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Dart tool to check device healthiness and implement recovery mech
 version: 1.0.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   args: ^1.5.2

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -210,6 +210,12 @@ void main() {
       expect(result, isFalse);
     });
 
+    test('device restart - skip 32 bit phone', () async {
+      device = IosDevice(deviceId: '822ef7958bba573829d85eef4df6cbdd86593730');
+      final bool result = await device.restart_device(processManager: processManager);
+      expect(result, isTrue);
+    });
+
     test('list applications - failure', () async {
       when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));


### PR DESCRIPTION
Device recovery of device_doctor tool reboots the device. However ios32 phone needs manual intervention when rebooting.
This PR skips reboot for the 32 phone.

Related issue: https://github.com/flutter/flutter/issues/79316