### PR TITLE
[scheduler] Add scheduler field to target

### DIFF
--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -80,6 +80,9 @@ class Target extends $pb.GeneratedMessage {
         6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties',
         entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'builder')
+    ..a<$core.String>(
+        8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'scheduler', $pb.PbFieldType.OS,
+        defaultOrMaker: 'cocoon')
     ..hasRequiredFields = false;
 
   Target._() : super();
@@ -91,6 +94,7 @@ class Target extends $pb.GeneratedMessage {
     $core.String testbed,
     $core.Map<$core.String, $core.String> properties,
     $core.String builder,
+    $core.String scheduler,
   }) {
     final _result = create();
     if (name != null) {
@@ -113,6 +117,9 @@ class Target extends $pb.GeneratedMessage {
     }
     if (builder != null) {
       _result.builder = builder;
+    }
+    if (scheduler != null) {
+      _result.scheduler = scheduler;
     }
     return _result;
   }
@@ -203,4 +210,16 @@ class Target extends $pb.GeneratedMessage {
   $core.bool hasBuilder() => $_has(6);
   @$pb.TagNumber(7)
   void clearBuilder() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get scheduler => $_getS(7, 'cocoon');
+  @$pb.TagNumber(8)
+  set scheduler($core.String v) {
+    $_setString(7, v);
+  }
+
+  @$pb.TagNumber(8)
+  $core.bool hasScheduler() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearScheduler() => clearField(8);
 }

--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -9,6 +9,10 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
+import 'scheduler.pbenum.dart';
+
+export 'scheduler.pbenum.dart';
+
 class SchedulerConfig extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SchedulerConfig',
@@ -80,9 +84,9 @@ class Target extends $pb.GeneratedMessage {
         6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'properties',
         entryClassName: 'Target.PropertiesEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS)
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'builder')
-    ..a<$core.String>(
-        8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'scheduler', $pb.PbFieldType.OS,
-        defaultOrMaker: 'cocoon')
+    ..e<SchedulerSystem>(
+        8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'scheduler', $pb.PbFieldType.OE,
+        defaultOrMaker: SchedulerSystem.cocoon, valueOf: SchedulerSystem.valueOf, enumValues: SchedulerSystem.values)
     ..hasRequiredFields = false;
 
   Target._() : super();
@@ -94,7 +98,7 @@ class Target extends $pb.GeneratedMessage {
     $core.String testbed,
     $core.Map<$core.String, $core.String> properties,
     $core.String builder,
-    $core.String scheduler,
+    SchedulerSystem scheduler,
   }) {
     final _result = create();
     if (name != null) {
@@ -212,10 +216,10 @@ class Target extends $pb.GeneratedMessage {
   void clearBuilder() => clearField(7);
 
   @$pb.TagNumber(8)
-  $core.String get scheduler => $_getS(7, 'cocoon');
+  SchedulerSystem get scheduler => $_getN(7);
   @$pb.TagNumber(8)
-  set scheduler($core.String v) {
-    $_setString(7, v);
+  set scheduler(SchedulerSystem v) {
+    setField(8, v);
   }
 
   @$pb.TagNumber(8)

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
@@ -1,0 +1,27 @@
+///
+//  Generated code. Do not modify.
+//  source: lib/src/model/proto/internal/scheduler.proto
+//
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+// ignore_for_file: UNDEFINED_SHOWN_NAME
+import 'dart:core' as $core;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class SchedulerSystem extends $pb.ProtobufEnum {
+  static const SchedulerSystem cocoon =
+      SchedulerSystem._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'cocoon');
+  static const SchedulerSystem luci =
+      SchedulerSystem._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'luci');
+
+  static const $core.List<SchedulerSystem> values = <SchedulerSystem>[
+    cocoon,
+    luci,
+  ];
+
+  static final $core.Map<$core.int, SchedulerSystem> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static SchedulerSystem valueOf($core.int value) => _byValue[value];
+
+  const SchedulerSystem._($core.int v, $core.String n) : super(v, n);
+}

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
@@ -10,6 +10,8 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class SchedulerSystem extends $pb.ProtobufEnum {
+  const SchedulerSystem._($core.int v, $core.String n) : super(v, n);
+
   static const SchedulerSystem cocoon =
       SchedulerSystem._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'cocoon');
   static const SchedulerSystem luci =
@@ -22,6 +24,4 @@ class SchedulerSystem extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, SchedulerSystem> _byValue = $pb.ProtobufEnum.initByValue(values);
   static SchedulerSystem valueOf($core.int value) => _byValue[value];
-
-  const SchedulerSystem._($core.int v, $core.String n) : super(v, n);
 }

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -23,6 +23,7 @@ const Target$json = const {
     const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '7': 'linux-vm', '10': 'testbed'},
     const {'1': 'properties', '3': 6, '4': 3, '5': 11, '6': '.Target.PropertiesEntry', '10': 'properties'},
     const {'1': 'builder', '3': 7, '4': 1, '5': 9, '10': 'builder'},
+    const {'1': 'scheduler', '3': 8, '4': 1, '5': 9, '7': 'cocoon', '10': 'scheduler'},
   ],
   '3': const [Target_PropertiesEntry$json],
 };

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -5,6 +5,14 @@
 // @dart = 2.7
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
+const SchedulerSystem$json = const {
+  '1': 'SchedulerSystem',
+  '2': const [
+    const {'1': 'cocoon', '2': 1},
+    const {'1': 'luci', '2': 2},
+  ],
+};
+
 const SchedulerConfig$json = const {
   '1': 'SchedulerConfig',
   '2': const [
@@ -23,7 +31,7 @@ const Target$json = const {
     const {'1': 'testbed', '3': 5, '4': 1, '5': 9, '7': 'linux-vm', '10': 'testbed'},
     const {'1': 'properties', '3': 6, '4': 3, '5': 11, '6': '.Target.PropertiesEntry', '10': 'properties'},
     const {'1': 'builder', '3': 7, '4': 1, '5': 9, '10': 'builder'},
-    const {'1': 'scheduler', '3': 8, '4': 1, '5': 9, '7': 'cocoon', '10': 'scheduler'},
+    const {'1': 'scheduler', '3': 8, '4': 1, '5': 14, '6': '.SchedulerSystem', '7': 'cocoon', '10': 'scheduler'},
   ],
   '3': const [Target_PropertiesEntry$json],
 };

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -31,6 +31,16 @@ message Target {
     // Name of the LUCI builder to trigger.
     optional string builder = 7;
     // Name of the scheduler to trigger this target.
-    // Defaults to being triggered by cocoon. Supports 'cocoon', 'luci'.
-    optional string scheduler = 8 [default = 'cocoon'];
+    // Defaults to being triggered by cocoon.
+    optional SchedulerSystem scheduler = 8 [default = cocoon];
 }
+
+// Schedulers supported in SchedulerConfig.
+// Next ID: 2
+enum SchedulerSystem {
+    // Cocoon will handle all actions for the target (initial trigger, retries).
+    cocoon = 1;
+    // LUCI triggers the build when mirrored to GoB. Cocoon triggers retries.
+    luci = 2;
+  }
+  

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -30,4 +30,7 @@ message Target {
     map<string, string> properties = 6;
     // Name of the LUCI builder to trigger.
     optional string builder = 7;
+    // Name of the scheduler to trigger this target.
+    // Defaults to being triggered by cocoon. Supports 'cocoon', 'luci'.
+    optional string scheduler = 8 [default = 'cocoon'];
 }

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -36,7 +36,7 @@ message Target {
 }
 
 // Schedulers supported in SchedulerConfig.
-// Next ID: 2
+// Next ID: 3
 enum SchedulerSystem {
     // Cocoon will handle all actions for the target (initial trigger, retries).
     cocoon = 1;

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -269,6 +269,9 @@ void _validateSchedulerConfig(SchedulerConfig schedulerConfig) {
     throw const FormatException('Scheduler config must have at least 1 enabled branch');
   }
 
+  /// List of supported schedulers that can trigger targets. Non-cocoon schedulers
+  /// do not have initial triggers done by [Scheduler].
+  final List<String> supportedSchedulers = <String>['cocoon', 'luci'];
   final Map<String, List<Target>> targetGraph = <String, List<Target>>{};
   final List<String> exceptions = <String>[];
   // Construct [targetGraph]. With a one scan approach, cycles in the graph
@@ -278,6 +281,9 @@ void _validateSchedulerConfig(SchedulerConfig schedulerConfig) {
       exceptions.add('ERROR: ${target.name} already exists in graph');
     } else {
       targetGraph[target.name] = <Target>[];
+      if (!supportedSchedulers.contains(target.scheduler)) {
+        exceptions.add('ERROR: ${target.name} specifies scheduler=${target.scheduler} which is not supported');
+      }
       // Add edges
       if (target.dependencies.isNotEmpty) {
         if (target.dependencies.length != 1) {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -269,9 +269,6 @@ void _validateSchedulerConfig(SchedulerConfig schedulerConfig) {
     throw const FormatException('Scheduler config must have at least 1 enabled branch');
   }
 
-  /// List of supported schedulers that can trigger targets. Non-cocoon schedulers
-  /// do not have initial triggers done by [Scheduler].
-  final List<String> supportedSchedulers = <String>['cocoon', 'luci'];
   final Map<String, List<Target>> targetGraph = <String, List<Target>>{};
   final List<String> exceptions = <String>[];
   // Construct [targetGraph]. With a one scan approach, cycles in the graph
@@ -281,9 +278,6 @@ void _validateSchedulerConfig(SchedulerConfig schedulerConfig) {
       exceptions.add('ERROR: ${target.name} already exists in graph');
     } else {
       targetGraph[target.name] = <Target>[];
-      if (!supportedSchedulers.contains(target.scheduler)) {
-        exceptions.add('ERROR: ${target.name} specifies scheduler=${target.scheduler} which is not supported');
-      }
       // Add edges
       if (target.dependencies.isNotEmpty) {
         if (target.dependencies.length != 1) {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -10,7 +10,7 @@ import 'package:googleapis/bigquery/v2.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import 'package:cocoon_service/protos.dart' show SchedulerConfig, Target;
+import 'package:cocoon_service/protos.dart' show SchedulerConfig, SchedulerSystem, Target;
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
@@ -274,7 +274,7 @@ targets:
         'test': 'abc',
       });
       expect(target.builder, 'builderA');
-      expect(target.scheduler, 'cocoon');
+      expect(target.scheduler, SchedulerSystem.cocoon);
       expect(target.testbed, 'linux-vm');
       expect(target.timeout, 30);
     });
@@ -287,15 +287,7 @@ targets:
   - name: A
     scheduler: dashatar
       ''') as YamlMap;
-      expect(
-          () => loadSchedulerConfig(targetWithNonexistentScheduler),
-          throwsA(
-            isA<FormatException>().having(
-              (FormatException e) => e.toString(),
-              'message',
-              contains('ERROR: A specifies scheduler=dashatar which is not supported'),
-            ),
-          ));
+      expect(() => loadSchedulerConfig(targetWithNonexistentScheduler), throwsA(isA<FormatException>()));
     });
 
     test('constructs graph with dependency chain', () {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -274,8 +274,28 @@ targets:
         'test': 'abc',
       });
       expect(target.builder, 'builderA');
+      expect(target.scheduler, 'cocoon');
       expect(target.testbed, 'linux-vm');
       expect(target.timeout, 30);
+    });
+
+    test('throws exception when non-existent scheduler is given', () {
+      final YamlMap targetWithNonexistentScheduler = loadYaml('''
+enabled_branches:
+  - master
+targets:
+  - name: A
+    scheduler: dashatar
+      ''') as YamlMap;
+      expect(
+          () => loadSchedulerConfig(targetWithNonexistentScheduler),
+          throwsA(
+            isA<FormatException>().having(
+              (FormatException e) => e.toString(),
+              'message',
+              contains('ERROR: A specifies scheduler=dashatar which is not supported'),
+            ),
+          ));
     });
 
     test('constructs graph with dependency chain', () {


### PR DESCRIPTION
This allows for specifying a customer scheduler in the target. This will allow us to consolidate all the existing configs under `.ci.yaml` and make migrations simpler.

When this and https://github.com/flutter/cocoon/pull/1139 land, I'll follow up with a PR to download `.ci.yaml` and add the plumbing to add targets as tasks.

https://github.com/flutter/flutter/issues/76140