### PR TITLE
Allow request API requests from internal accounts.

### DIFF
--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -103,7 +103,6 @@ class AuthenticationProvider {
   /// unauthenticated.
   Future<AuthenticatedContext> authenticate(HttpRequest request) async {
     final String agentId = request.headers.value('Agent-ID');
-    final String authorization = request.headers.value('Authorization');
     final bool isCron = request.headers.value('X-Appengine-Cron') == 'true';
     final String idTokenFromCookie = request.cookies
         .where((Cookie cookie) => cookie.name == 'X-Flutter-IdToken')

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -50,6 +50,9 @@ import 'exceptions.dart';
 ///     as a user account. The [RequestContext.agent] field will be null
 ///     (unless the request _also_ contained the aforementioned headers).
 ///
+///     @google.com accounts can call APIs using curl and gcloud.
+///     E.g. curl '<api_url>' -H "X-Flutter-IdToken: $(gcloud auth print-identity-token)"
+///
 ///     User accounts are only authorized if the user is either a "@google.com"
 ///     account or is an [AllowedAccount] in Cocoon's Datastore.
 ///

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -201,7 +201,7 @@ void main() {
       });
 
       test('fails if token verification yields forged token', () async {
-        verifyTokenResponse.body = '{"aud": "forgery"}';
+        verifyTokenResponse.body = '{"aud": "forgery", "email": "abc@abc.com"}';
         config.oauthClientIdValue = 'expected-client-id';
         await expectLater(auth.authenticateIdToken('abc123', clientContext: clientContext, log: log),
             throwsA(isA<Unauthenticated>()));
@@ -210,6 +210,15 @@ void main() {
         expect(log.records.single.level, LogLevel.WARNING);
         expect(log.records.single.message, contains('forgery'));
         expect(log.records.single.message, contains('expected-client-id'));
+      });
+
+      test('allows different aud for gcloud tokens with google accounts', () async {
+        verifyTokenResponse.body = '{"aud": "different", "email": "abc@google.com"}';
+        config.oauthClientIdValue = 'expected-client-id';
+        await expectLater(auth.authenticateIdToken('abc123', clientContext: clientContext, log: log),
+            throwsA(isA<Unauthenticated>()));
+        expect(httpClient.requestCount, 1);
+        expect(log.records, hasLength(0));
       });
 
       test('succeeds for google.com auth user', () async {


### PR DESCRIPTION
There are several APIs that are called manually by gardeners. This
change allows to use gcloud auth to authenticate curl requests.

Bug: https://github.com/flutter/flutter/issues/43123