### PR TITLE
[app_dart] Differentiate 404s from other HTTP exceptions on GitHub files

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -46,7 +46,10 @@ Future<void> main() async {
     );
 
     /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
-    final Scheduler scheduler = Scheduler(config: config);
+    final Scheduler scheduler = Scheduler(
+      cache: cache,
+      config: config,
+    );
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
       '/api/append-log': AppendLog(config, authProvider),

--- a/app_dart/bin/validate_scheduler_config.dart
+++ b/app_dart/bin/validate_scheduler_config.dart
@@ -17,5 +17,5 @@ void main(List<String> args) {
   }
 
   final YamlMap configYaml = loadYaml(configFile.readAsStringSync()) as YamlMap;
-  print(loadSchedulerConfig(configYaml));
+  print(schedulerConfigFromYaml(configYaml));
 }

--- a/app_dart/integration_test/validate_all_ci_configs_test.dart
+++ b/app_dart/integration_test/validate_all_ci_configs_test.dart
@@ -22,19 +22,14 @@ const List<String> configFiles = <String>[
 Future<void> main() async {
   for (final String configFile in configFiles) {
     test('validate config file of $configFile', () async {
-      final String configContent = await remoteFileContent(
-        () => io.HttpClient(),
-        TestLogging.instance,
-        twoSecondLinearBackoff,
+      final String configContent = await githubFileContent(
         configFile,
+        httpClientProvider: () => io.HttpClient(),
+        log: TestLogging.instance,
       );
-      if (configContent == null) {
-        fail('Failed to download file: https://raw.githubusercontent.com/$configFile');
-      }
-
       final YamlMap configYaml = loadYaml(configContent) as YamlMap;
       try {
-        loadSchedulerConfig(configYaml);
+        schedulerConfigFromYaml(configYaml);
       } on FormatException catch (e) {
         fail(e.message);
       }

--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -73,7 +73,7 @@ class Config {
     final Uint8List cacheValue = await _cache.getOrCreate(
       configCacheName,
       'flutterBranches',
-      createFn: () => getBranches(Providers.freshHttpClient, loggingService, twoSecondLinearBackoff),
+      createFn: () => getBranches(Providers.freshHttpClient, loggingService),
       ttl: configCacheTtl,
     );
 
@@ -84,8 +84,8 @@ class Config {
   Future<List<LuciBuilder>> luciBuilders(String bucket, String repo,
       {String commitSha = 'master', int prNumber}) async {
     final GithubService githubService = await createGithubService('flutter', repo);
-    return await getLuciBuilders(githubService, Providers.freshHttpClient, twoSecondLinearBackoff, loggingService,
-        RepositorySlug('flutter', repo), bucket,
+    return await getLuciBuilders(
+        githubService, Providers.freshHttpClient, loggingService, RepositorySlug('flutter', repo), bucket,
         prNumber: prNumber, commitSha: commitSha);
   }
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -75,7 +75,7 @@ FutureOr<String> getUrl(
       throw HttpException('HTTP $status: $url');
     }
   } finally {
-    client.close();
+    client.close(force: true);
   }
 }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -208,6 +208,9 @@ class Scheduler {
       ));
     });
 
+    final SchedulerConfig schedulerConfig = await getSchedulerConfig(commit);
+    log.debug('Loaded scheduler config $schedulerConfig');
+
     return tasks;
   }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -240,6 +240,10 @@ class Scheduler {
         retryOptions: retryOptions,
       );
     } on NotFoundException {
+      log.debug('Failed to find $ciPath');
+      return SchedulerConfig.getDefault().writeToBuffer();
+    } on HttpException catch (_, e) {
+      log.warning('githubFileContent failed to get $ciPath: $e');
       return SchedulerConfig.getDefault().writeToBuffer();
     }
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
@@ -266,11 +270,13 @@ class Scheduler {
         log: log,
         retryOptions: retryOptions,
       );
+      return loadYaml(content) as YamlMap;
     } on NotFoundException {
       return loadYaml('tasks:') as YamlMap;
+    } on HttpException catch (_, e) {
+      log.error('githubFileContent failed to get $path: $e');
+      rethrow;
     }
-
-    return loadYaml(content) as YamlMap;
   }
 
   /// Push [Commit] to BigQuery as part of the infra metrics dashboards.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 import 'package:truncate/truncate.dart';
 import 'package:yaml/yaml.dart';
 
@@ -20,6 +22,7 @@ import '../model/appengine/task.dart';
 import '../model/devicelab/manifest.dart';
 import '../model/proto/protos.dart' show SchedulerConfig, Target;
 import '../request_handling/exceptions.dart';
+import 'cache_service.dart';
 import 'datastore.dart';
 import 'luci.dart';
 
@@ -31,6 +34,7 @@ import 'luci.dart';
 ///   3. Retry mechanisms for tasks
 class Scheduler {
   Scheduler({
+    @required this.cache,
     @required this.config,
     this.datastoreProvider = DatastoreService.defaultProvider,
     this.gitHubBackoffCalculator = twoSecondLinearBackoff,
@@ -39,6 +43,7 @@ class Scheduler {
   })  : assert(datastoreProvider != null),
         assert(gitHubBackoffCalculator != null);
 
+  final CacheService cache;
   final Config config;
   final DatastoreServiceProvider datastoreProvider;
   final HttpClientProvider httpClientProvider;
@@ -46,6 +51,9 @@ class Scheduler {
 
   DatastoreService datastore;
   Logging log;
+
+  /// Name of the subcache to store scheduler related values in redis.
+  static const String subcacheName = 'scheduler';
 
   /// Sets the appengine [log] used by this class to log debug and error
   /// messages. This method has to be called before any other method in this
@@ -203,17 +211,62 @@ class Scheduler {
     return tasks;
   }
 
+  /// Load in memory the `.ci.yaml`.
+  Future<SchedulerConfig> getSchedulerConfig(Commit commit, {RetryOptions retryOptions}) async {
+    final String ciPath = '${commit.repository}/${commit.sha}/.ci.yaml';
+    final Uint8List configBytes = await cache.getOrCreate(subcacheName, ciPath,
+        createFn: () => _downloadSchedulerConfig(
+              ciPath,
+              retryOptions: retryOptions,
+            ),
+        ttl: const Duration(hours: 1));
+    return SchedulerConfig.fromBuffer(configBytes);
+  }
+
+  /// Get `.ci.yaml` from GitHub, and store the bytes in redis for future retrieval.
+  ///
+  /// If GitHub returns [HttpStatus.notFound], an empty config will be inserted assuming
+  /// that commit does not support the scheduler config file.
+  Future<Uint8List> _downloadSchedulerConfig(String ciPath, {RetryOptions retryOptions}) async {
+    String configContent;
+    try {
+      configContent = await githubFileContent(
+        ciPath,
+        httpClientProvider: httpClientProvider,
+        log: log,
+        retryOptions: retryOptions,
+      );
+    } on NotFoundException {
+      return SchedulerConfig.getDefault().writeToBuffer();
+    }
+    final YamlMap configYaml = loadYaml(configContent) as YamlMap;
+    return schedulerConfigFromYaml(configYaml).writeToBuffer();
+  }
+
   /// Load in memory the Cocoon Agent DeviceLab scheduler config.
+  ///
+  /// If GitHub returns [HttpStatus.notFound], an empty manifest is returned.
   ///
   // TODO(chillers): Remove when DeviceLab has migrated to LUCI. https://github.com/flutter/flutter/projects/151
   @visibleForTesting
-  Future<YamlMap> loadDevicelabManifest(Commit commit) async {
-    final String path = '/${commit.repository}/${commit.sha}/dev/devicelab/manifest.yaml';
+  Future<YamlMap> loadDevicelabManifest(
+    Commit commit, {
+    RetryOptions retryOptions,
+  }) async {
+    final String path = '${commit.repository}/${commit.sha}/dev/devicelab/manifest.yaml';
     log.debug('Getting devicelab manifest content');
-    final String content = await remoteFileContent(httpClientProvider, log, gitHubBackoffCalculator, path);
-    if (content == null) {
-      throw HttpStatusException(HttpStatus.serviceUnavailable, 'Failed to load $path from GitHub');
+    String content;
+    try {
+      content = await githubFileContent(
+        path,
+        httpClientProvider: httpClientProvider,
+        log: log,
+        retryOptions: retryOptions,
+      );
+    } on NotFoundException {
+      return loadYaml('tasks:') as YamlMap;
     }
+
     return loadYaml(content) as YamlMap;
   }
 
@@ -256,7 +309,7 @@ class Scheduler {
 }
 
 /// Load [yamlConfig] to [SchedulerConfig] and validate the dependency graph.
-SchedulerConfig loadSchedulerConfig(YamlMap yamlConfig) {
+SchedulerConfig schedulerConfigFromYaml(YamlMap yamlConfig) {
   final SchedulerConfig config = SchedulerConfig();
   config.mergeFromProto3Json(yamlConfig);
   _validateSchedulerConfig(config);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -144,7 +144,6 @@ void main() {
       expect(db.values.values.whereType<Commit>().length, 1);
     });
 
-
     test('inserts all relevant fields of the commit', () async {
       config.flutterBranchesValue = <String>['master'];
       expect(db.values.values.whereType<Commit>().length, 0);

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:retry/retry.dart';
 import 'package:yaml/yaml.dart';
 
 import 'package:cocoon_service/src/datastore/config.dart';
 import 'package:cocoon_service/src/model/proto/internal/scheduler.pb.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/service/cache_service.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 
 import '../request_handling/fake_logging.dart';
@@ -18,6 +20,7 @@ class FakeScheduler extends Scheduler {
     this.devicelabManifest = 'tasks:',
     Config config,
   }) : super(
+          cache: CacheService(inMemory: true),
           config: config,
           log: FakeLogging(),
         );
@@ -29,5 +32,9 @@ class FakeScheduler extends Scheduler {
   String devicelabManifest;
 
   @override
-  Future<YamlMap> loadDevicelabManifest(Commit commit) async => await loadYaml(devicelabManifest) as YamlMap;
+  Future<SchedulerConfig> getSchedulerConfig(Commit commit, {RetryOptions retryOptions}) async => schedulerConfig;
+
+  @override
+  Future<YamlMap> loadDevicelabManifest(Commit commit, {RetryOptions retryOptions}) async =>
+      await loadYaml(devicelabManifest) as YamlMap;
 }


### PR DESCRIPTION
* Refactor `remoteFileContent` to `githubFileContent`
  - Only return response content if file was a 200 response
  - Throw NotFoundException on 404s
  - Throw HttpException on remaining exceptions
  - Allows for customized responses where it may be okay if a config file does not exist, otherwise it should be a hard failure
* If DeviceLab `manifest.yaml` 404s, return default response
* Retrieve `.ci.yaml` and store it in cache for future use

## Issues
https://github.com/flutter/flutter/issues/76140