### PR TITLE
Prevent failures on empty status list.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -50,7 +50,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         log.error('_checkPRs error in $repo: $e');
       }
     }
-
     return Body.empty;
   }
 
@@ -209,18 +208,21 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
           );
 
       final String sha = commit['oid'] as String;
-      final List<Map<String, dynamic>> statuses =
-          (commit['status']['contexts'] as List<dynamic>).cast<Map<String, dynamic>>();
+      List<Map<String, dynamic>> statuses;
+      if (commit['status'] != null && (commit['status']['contexts'] as List<dynamic>).isNotEmpty) {
+        statuses = (commit['status']['contexts'] as List<dynamic>).cast<Map<String, dynamic>>();
+      }
+      statuses = statuses ?? <Map<String, dynamic>>[];
       List<Map<String, dynamic>> checkRuns;
       if (commit['checkSuites']['nodes'] != null && (commit['checkSuites']['nodes'] as List<dynamic>).isNotEmpty) {
         checkRuns =
             (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
       }
       checkRuns = checkRuns ?? <Map<String, dynamic>>[];
-      final Set<String> failingStatuses = <String>{};
+      final Set<String> failures = <String>{};
       final bool ciSuccessful = await _checkStatuses(
         sha,
-        failingStatuses,
+        failures,
         statuses,
         checkRuns,
         name,
@@ -230,12 +232,13 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       list.add(_AutoMergeQueryResult(
         graphQLId: id,
         ciSuccessful: ciSuccessful,
-        failingStatuses: failingStatuses,
+        failures: failures,
         hasApprovedReview: hasApproval,
         changeRequestAuthors: changeRequestAuthors,
         number: number,
         sha: sha,
         labelId: labelId,
+        emptyValidations: checkRuns.isEmpty || statuses.isEmpty,
       ));
     }
     return list;
@@ -363,15 +366,16 @@ class _AutoMergeQueryResult {
     @required this.hasApprovedReview,
     @required this.changeRequestAuthors,
     @required this.ciSuccessful,
-    @required this.failingStatuses,
+    @required this.failures,
     @required this.number,
     @required this.sha,
     @required this.labelId,
+    @required this.emptyValidations,
   })  : assert(graphQLId != null),
         assert(hasApprovedReview != null),
         assert(changeRequestAuthors != null),
         assert(ciSuccessful != null),
-        assert(failingStatuses != null),
+        assert(failures != null),
         assert(number != null),
         assert(sha != null),
         assert(labelId != null);
@@ -388,8 +392,8 @@ class _AutoMergeQueryResult {
   /// Whether CI has run successfully on the pull request.
   final bool ciSuccessful;
 
-  /// A set of status names that have failed.
-  final Set<String> failingStatuses;
+  /// A set of status/check names that have failed.
+  final Set<String> failures;
 
   /// The pull request number.
   final int number;
@@ -400,13 +404,15 @@ class _AutoMergeQueryResult {
   /// The GitHub GraphQL ID of the waiting label.
   final String labelId;
 
+  /// Whether the commit has empty validations or not.
+  final bool emptyValidations;
+
   /// Whether it is sane to automatically merge this PR.
-  bool get shouldMerge => ciSuccessful && failingStatuses.isEmpty && hasApprovedReview && changeRequestAuthors.isEmpty;
+  bool get shouldMerge => ciSuccessful && failures.isEmpty && hasApprovedReview && changeRequestAuthors.isEmpty && !emptyValidations;
 
   /// Whether the auto-merge label should be removed from this PR.
-  bool get shouldRemoveLabel => !hasApprovedReview || changeRequestAuthors.isNotEmpty || failingStatuses.isNotEmpty;
+  bool get shouldRemoveLabel => !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyValidations;
 
-  /// An appropriate message to leave when removing the label.
   String get removalMessage {
     if (!shouldRemoveLabel) {
       return '';
@@ -424,9 +430,14 @@ class _AutoMergeQueryResult {
       buffer.writeln('- This pull request has changes requested by @$author. Please '
           'resolve those before re-applying the label.');
     }
-    for (String status in failingStatuses) {
+    for (String status in failures) {
       buffer.writeln('- The status or check suite $status has failed. Please fix the '
           'issues identified (or deflake) before re-applying this label.');
+    }
+    if (emptyValidations) {
+      buffer.writeln('- This commit has empty status or empty checks. Please'
+          ' check the Google CLA status is present and Flutter Dashboard'
+          ' application has multiple checks.');
     }
     return buffer.toString();
   }
@@ -440,6 +451,7 @@ class _AutoMergeQueryResult {
         'hasApprovedReview: $hasApprovedReview, '
         'changeRequestAuthors: $changeRequestAuthors, '
         'labelId: $labelId, '
+        'emptyValidations: $emptyValidations, '
         'shouldMerge: $shouldMerge}';
   }
 }

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -408,10 +408,12 @@ class _AutoMergeQueryResult {
   final bool emptyValidations;
 
   /// Whether it is sane to automatically merge this PR.
-  bool get shouldMerge => ciSuccessful && failures.isEmpty && hasApprovedReview && changeRequestAuthors.isEmpty && !emptyValidations;
+  bool get shouldMerge =>
+      ciSuccessful && failures.isEmpty && hasApprovedReview && changeRequestAuthors.isEmpty && !emptyValidations;
 
   /// Whether the auto-merge label should be removed from this PR.
-  bool get shouldRemoveLabel => !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyValidations;
+  bool get shouldRemoveLabel =>
+      !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyValidations;
 
   String get removalMessage {
     if (!shouldRemoveLabel) {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -46,7 +46,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     for (String repo in supportedRepos) {
       try {
         await _checkPRs('flutter', repo, log, client);
-      } on Exception catch (_, e) {
+      } catch (e) {
         log.error('_checkPRs error in $repo: $e');
       }
     }
@@ -209,16 +209,18 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 
       final String sha = commit['oid'] as String;
       List<Map<String, dynamic>> statuses;
-      if (commit['status'] != null && (commit['status']['contexts'] as List<dynamic>).isNotEmpty) {
+      if (commit['status'] != null &&
+          commit['status']['contexts'] != null &&
+          (commit['status']['contexts'] as List<dynamic>).isNotEmpty) {
         statuses = (commit['status']['contexts'] as List<dynamic>).cast<Map<String, dynamic>>();
       }
-      statuses = statuses ?? <Map<String, dynamic>>[];
+      statuses ??= <Map<String, dynamic>>[];
       List<Map<String, dynamic>> checkRuns;
       if (commit['checkSuites']['nodes'] != null && (commit['checkSuites']['nodes'] as List<dynamic>).isNotEmpty) {
         checkRuns =
             (commit['checkSuites']['nodes']?.first['checkRuns']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
       }
-      checkRuns = checkRuns ?? <Map<String, dynamic>>[];
+      checkRuns ??= <Map<String, dynamic>>[];
       final Set<String> failures = <String>{};
       final bool ciSuccessful = await _checkStatuses(
         sha,

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -40,6 +40,7 @@ class FakeConfig implements Config {
     this.loggingServiceValue,
     this.tabledataResourceApi,
     this.githubService,
+    this.githubGraphQLClient,
     this.cirrusGraphQLClient,
     this.metricsDestination,
     this.taskLogServiceAccountValue,


### PR DESCRIPTION
Increases resilience and improves the waiting for tree to go green
workflows in the following ways:

* Process the label per repo independently of failures in other repos.
* Remove label and update PR if it does not have any checks and any
  statuses.
* Do not raise an exception when graphql returns an empry list.

Bug: https://github.com/flutter/flutter/issues/79974