### PR TITLE
[app_dart] Lower log warning to debug in auth flow

### DIFF
--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -178,7 +178,7 @@ class AuthenticationProvider {
         /// Google Auth API returns a message in the response body explaining why
         /// the request failed. Such as "Invalid Token".
         final String body = await utf8.decodeStream(verifyTokenResponse);
-        log.warning('Token verification failed: ${verifyTokenResponse.statusCode}; $body');
+        log.debug('Token verification failed: ${verifyTokenResponse.statusCode}; $body');
         throw const Unauthenticated('Invalid ID token');
       }
 

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -176,7 +176,7 @@ void main() {
         expect(result.agent, isNull);
         expect(result.clientContext, same(clientContext));
 
-        // check log for debug statement and warning
+        // check log for debug statement
         expect(log.records, hasLength(2));
         expect(log.records.first.message, contains('Token verification failed: 401; Invalid token: bad-cookie'));
       });
@@ -188,7 +188,6 @@ void main() {
             throwsA(isA<Unauthenticated>()));
         expect(httpClient.requestCount, 1);
         expect(log.records, hasLength(1));
-        expect(log.records.single.level, LogLevel.WARNING);
         expect(log.records.single.message, contains('Invalid token: abc123'));
       });
 
@@ -207,7 +206,6 @@ void main() {
             throwsA(isA<Unauthenticated>()));
         expect(httpClient.requestCount, 1);
         expect(log.records, hasLength(1));
-        expect(log.records.single.level, LogLevel.WARNING);
         expect(log.records.single.message, contains('forgery'));
         expect(log.records.single.message, contains('expected-client-id'));
       });

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:appengine/appengine.dart';
 import 'package:cocoon_service/src/model/appengine/agent.dart';
 import 'package:cocoon_service/src/model/appengine/allowed_account.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';


### PR DESCRIPTION
This path is frequently reached where the cookie is out of date due to the Flutter app rarely using cookies. Lowering this to a debug statement to reduce noise in the logs.