### PR TITLE
[app_dart] Refactor repo references to RepositorySlug

### DIFF
--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -299,8 +299,7 @@ class Config {
   }
 
   Future<GitHub> createGitHubClient(RepositorySlug slug) async {
-    String githubToken;
-    githubToken = await generateGithubToken(slug);
+    final String githubToken = await generateGithubToken(slug);
     return GitHub(auth: Authentication.withToken(githubToken));
   }
 
@@ -339,6 +338,13 @@ class Config {
   Future<bigquery.TabledataResourceApi> createTabledataResourceApi() async {
     final AccessClientProvider accessClientProvider = AccessClientProvider(await deviceLabServiceAccount);
     return await BigqueryService(accessClientProvider).defaultTabledata();
+  }
+
+  /// Default GitHub service when the repository does not matter.
+  ///
+  /// Internally uses the framework repo for OAuth.
+  Future<GithubService> createDefaultGitHubService() async {
+    return createGithubService(flutterSlug);
   }
 
   Future<GithubService> createGithubService(RepositorySlug slug) async {

--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -39,28 +39,21 @@ class Config {
   final CacheService _cache;
 
   /// List of Github presubmit supported repos.
-  static const Set<String> supportedRepos = <String>{
-    'engine',
-    'flutter',
-    'cocoon',
-    'packages',
-    'plugins',
-  };
-
-  /// List of Github presubmit supported repos.
   ///
   /// This adds support for the `waiting for tree to go green label` to the repo.
-  static const Set<String> checksSupportedRepos = <String>{
-    'flutter/cocoon',
-    'flutter/engine',
-    'flutter/flutter',
-    'flutter/packages',
-    'flutter/plugins',
+  ///
+  /// Relies on the GitHub Checks API being enabled for this repo.
+  static Set<RepositorySlug> supportedRepos = <RepositorySlug>{
+    RepositorySlug('flutter', 'cocoon'),
+    RepositorySlug('flutter', 'engine'),
+    RepositorySlug('flutter', 'flutter'),
+    RepositorySlug('flutter', 'packages'),
+    RepositorySlug('flutter', 'plugins'),
   };
 
   /// List of GitHub repositories that are supported by [Scheduler].
-  static const Set<String> schedulerSupportedRepos = <String>{
-    'flutter/flutter',
+  static Set<RepositorySlug> schedulerSupportedRepos = <RepositorySlug>{
+    RepositorySlug('flutter', 'flutter'),
   };
 
   /// Memorystore subcache name to store [CocoonConfig] values in.
@@ -83,11 +76,10 @@ class Config {
   }
 
   // Returns LUCI builders.
-  Future<List<LuciBuilder>> luciBuilders(String bucket, String repo,
+  Future<List<LuciBuilder>> luciBuilders(String bucket, RepositorySlug slug,
       {String commitSha = 'master', int prNumber}) async {
-    final GithubService githubService = await createGithubService('flutter', repo);
-    return await getLuciBuilders(
-        githubService, Providers.freshHttpClient, loggingService, RepositorySlug('flutter', repo), bucket,
+    final GithubService githubService = await createGithubService(slug);
+    return await getLuciBuilders(githubService, Providers.freshHttpClient, loggingService, slug, bucket,
         prNumber: prNumber, commitSha: commitSha);
   }
 
@@ -253,6 +245,7 @@ class Config {
   String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
 
+  RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
   RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
@@ -291,9 +284,9 @@ class Config {
     return signedToken.toString();
   }
 
-  Future<String> generateGithubToken(String owner, String repository) async {
+  Future<String> generateGithubToken(RepositorySlug slug) async {
     final Map<String, dynamic> appInstallations = await githubAppInstallations;
-    final String appInstallation = appInstallations['$owner/$repository']['installation_id'] as String;
+    final String appInstallation = appInstallations['${slug.fullName}']['installation_id'] as String;
     final String jsonWebToken = await generateJsonWebToken();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jsonWebToken',
@@ -305,9 +298,9 @@ class Config {
     return jsonBody['token'] as String;
   }
 
-  Future<GitHub> createGitHubClient(String owner, String repository) async {
+  Future<GitHub> createGitHubClient(RepositorySlug slug) async {
     String githubToken;
-    githubToken = await generateGithubToken(owner, repository);
+    githubToken = await generateGithubToken(slug);
     return GitHub(auth: Authentication.withToken(githubToken));
   }
 
@@ -348,8 +341,8 @@ class Config {
     return await BigqueryService(accessClientProvider).defaultTabledata();
   }
 
-  Future<GithubService> createGithubService(String owner, String repository) async {
-    final GitHub github = await createGitHubClient(owner, repository);
+  Future<GithubService> createGithubService(RepositorySlug slug) async {
+    final GitHub github = await createGitHubClient(slug);
     return GithubService(github);
   }
 
@@ -365,11 +358,7 @@ class Config {
     );
   }
 
-  bool githubPresubmitSupportedRepo(String repositoryName) {
-    return supportedRepos.contains(repositoryName);
-  }
-
-  bool isChecksSupportedRepo(RepositorySlug slug) {
-    return checksSupportedRepos.contains('${slug.owner}/${slug.name}');
+  bool githubPresubmitSupportedRepo(RepositorySlug slug) {
+    return supportedRepos.contains(slug);
   }
 }

--- a/app_dart/lib/src/foundation/github_checks_util.dart
+++ b/app_dart/lib/src/foundation/github_checks_util.dart
@@ -59,10 +59,7 @@ class GithubChecksUtil {
       delayFactor: Duration(seconds: 2),
     );
     return r.retry(() async {
-      final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(
-        slug.owner,
-        slug.name,
-      );
+      final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(slug);
       await gitHubClient.checks.checkRuns.updateCheckRun(
         slug,
         checkRun,
@@ -84,10 +81,7 @@ class GithubChecksUtil {
       delayFactor: Duration(seconds: 2),
     );
     return r.retry(() async {
-      final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(
-        slug.owner,
-        slug.name,
-      );
+      final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(slug);
       return await gitHubClient.checks.checkRuns.getCheckRun(
         slug,
         checkRunId: id,
@@ -123,10 +117,7 @@ class GithubChecksUtil {
     String name,
     String headSha,
   ) async {
-    final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(
-      slug.owner,
-      slug.name,
-    );
+    final github.GitHub gitHubClient = await cocoonConfig.createGitHubClient(slug);
     return gitHubClient.checks.checkRuns.createCheckRun(
       slug,
       name: name,

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
+import 'package:github/github.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import 'key_converter.dart';
@@ -62,6 +63,8 @@ class Commit extends Model<String> {
   /// The branch of the commit.
   @StringProperty(propertyName: 'Branch')
   String branch;
+
+  RepositorySlug get slug => RepositorySlug(repository.split('/').first, repository.split('/').last);
 
   @override
   String toString() {

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -54,7 +54,7 @@ class Commit extends Model<String> {
   @StringProperty(propertyName: 'Commit.Message', required: false)
   String message;
 
-  /// The repository on which the commit was made.
+  /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
   @StringProperty(propertyName: 'FlutterRepositoryPath', required: true)
@@ -64,6 +64,7 @@ class Commit extends Model<String> {
   @StringProperty(propertyName: 'Branch')
   String branch;
 
+  /// [RepositorySlug] of where this commit exists.
   RepositorySlug get slug => RepositorySlug(repository.split('/').first, repository.split('/').last);
 
   @override

--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -29,7 +29,7 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final GithubService githubService = await config.createGithubService('flutter', 'flutter');
+    final GithubService githubService = await config.createGithubService(config.flutterSlug);
     final Map<String, dynamic> quotaUsage = (await githubService.getRateLimit()).toJson();
     quotaUsage['timestamp'] = DateTime.now().toIso8601String();
 

--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -29,7 +29,7 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final GithubService githubService = await config.createGithubService(config.flutterSlug);
+    final GithubService githubService = await config.createDefaultGitHubService();
     final Map<String, dynamic> quotaUsage = (await githubService.getRateLimit()).toJson();
     quotaUsage['timestamp'] = DateTime.now().toIso8601String();
 

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -143,10 +143,8 @@ class GithubWebhook extends RequestHandler<Body> {
     // The mergeable flag may be null. False indicates there's a merge conflict,
     // null indicates unknown. Err on the side of allowing the job to run.
     if (pr.mergeable == false) {
-      final GitHub gitHubClient = await config.createGitHubClient(
-        slug.owner,
-        slug.name,
-      );
+      final RepositorySlug slug = pullRequestEvent.repository.slug();
+      final GitHub gitHubClient = await config.createGitHubClient(slug);
       final String body = config.mergeConflictPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, slug, body)) {
         await gitHubClient.issues.createComment(slug, pr.number, body);
@@ -168,7 +166,7 @@ class GithubWebhook extends RequestHandler<Body> {
     final RepositorySlug slug = pullRequestEvent.repository.slug();
     final String repo = pr.base.repo.fullName.toLowerCase();
     if (kNeedsCheckLabelsAndTests.contains(repo)) {
-      final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+      final GitHub gitHubClient = await config.createGitHubClient(slug);
       try {
         await _validateRefs(gitHubClient, pr);
         if (repo == 'flutter/flutter') {

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -49,8 +49,8 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     final Logging log = loggingProvider();
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusServiceProvider(datastore);
-    final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-    final GithubService githubService = await config.createGithubService(slug.owner, slug.name);
+    final RepositorySlug slug = config.flutterSlug;
+    final GithubService githubService = await config.createGithubService(slug);
 
     if (authContext.clientContext.isDevelopmentEnvironment) {
       // Don't push GitHub status from the local dev server.

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -51,8 +51,9 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     }
     luciBuildService.setLogger(log);
 
+    final RepositorySlug slug = config.engineSlug;
     final LuciService luciService = luciServiceProvider(this);
-    final Map<LuciBuilder, List<LuciTask>> luciTasks = await luciService.getRecentTasks(repo: 'engine');
+    final Map<LuciBuilder, List<LuciTask>> luciTasks = await luciService.getRecentTasks(slug: slug);
 
     String status = GithubBuildStatusUpdate.statusSuccess;
     for (List<LuciTask> tasks in luciTasks.values) {
@@ -71,9 +72,8 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     };
     await insertBigquery(bigqueryTableName, bigqueryData, await config.createTabledataResourceApi(), log);
 
-    final RepositorySlug slug = RepositorySlug('flutter', 'engine');
     final DatastoreService datastore = datastoreProvider(config.db);
-    final GitHub github = await config.createGitHubClient(slug.owner, slug.name);
+    final GitHub github = await config.createGitHubClient(slug);
     final List<GithubBuildStatusUpdate> updates = <GithubBuildStatusUpdate>[];
     await for (PullRequest pr in github.pullRequests.list(slug)) {
       final GithubBuildStatusUpdate update = await datastore.queryLastStatusUpdate(slug, pr);

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -48,8 +48,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       return Body.empty;
     }
 
-    final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
-    final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+    final RepositorySlug slug = config.flutterSlug;
+    final GitHub gitHubClient = await config.createGitHubClient(slug);
     final List<GithubGoldStatusUpdate> statusUpdates = <GithubGoldStatusUpdate>[];
     log.debug('Beginning Gold checks...');
     await for (PullRequest pr in gitHubClient.pullRequests.list(slug)) {

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -54,7 +54,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     final LuciService luciService = luciServiceProvider(this);
     final DatastoreService datastore = datastoreProvider(config.db);
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks = await luciService.getBranchRecentTasks(
-      repo: 'flutter',
+      slug: config.flutterSlug,
       requireTaskName: true,
     );
 

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -66,7 +66,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     });
     String builder = task.builderName;
     if (builder == null) {
-      final List<LuciBuilder> builders = await config.luciBuilders('prod', 'flutter');
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', commit.slug);
       builder = builders
           .where((LuciBuilder builder) => builder.taskName == task.name)
           .map((LuciBuilder builder) => builder.name)

--- a/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
@@ -37,10 +37,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
   Future<Body> get() async {
     final DatastoreService datastore = datastoreProvider(config.db);
 
-    for (String repository in Config.schedulerSupportedRepos) {
-      final String owner = repository.split('/').first;
-      final String repo = repository.split('/').last;
-      final RepositorySlug slug = RepositorySlug(owner, repo);
+    for (RepositorySlug slug in Config.schedulerSupportedRepos) {
       await _vacuumRepository(slug, datastore: datastore);
     }
 
@@ -48,7 +45,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
   }
 
   Future<void> _vacuumRepository(RepositorySlug slug, {DatastoreService datastore}) async {
-    final GithubService githubService = await config.createGithubService(slug.owner, slug.name);
+    final GithubService githubService = await config.createGithubService(slug);
     for (String branch in await config.getSupportedBranches(slug)) {
       final List<Commit> commits =
           await _vacuumBranch(slug, branch, datastore: datastore, githubService: githubService);

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -41,7 +41,7 @@ class GithubChecksService {
   ///   https://docs.github.com/en/rest/reference/checks#rerequest-a-check-suite
   Future<void> handleCheckSuite(CheckSuiteEvent checkSuiteEvent, LuciBuildService luciBuilderService) async {
     final github.RepositorySlug slug = checkSuiteEvent.repository.slug();
-    final github.GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+    final github.GitHub gitHubClient = await config.createGitHubClient(slug);
     final github.PullRequest pullRequest = checkSuiteEvent.checkSuite.pullRequests[0];
     final int pullRequestNumber = pullRequest.number;
     final String commitSha = checkSuiteEvent.checkSuite.headSha;

--- a/app_dart/lib/src/service/github_status_service.dart
+++ b/app_dart/lib/src/service/github_status_service.dart
@@ -27,10 +27,9 @@ class GithubStatusService {
     String commitSha,
     RepositorySlug slug,
   ) async {
-    final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+    final GitHub gitHubClient = await config.createGitHubClient(slug);
     final Map<String, bb.Build> builds = await luciBuildService.tryBuildsForRepositoryAndPr(slug, prNumber, commitSha);
-    final List<LuciBuilder> builders =
-        await config.luciBuilders('try', slug.name, commitSha: commitSha, prNumber: prNumber);
+    final List<LuciBuilder> builders = await config.luciBuilders('try', slug, commitSha: commitSha, prNumber: prNumber);
     final List<String> builderNames = builders.map((LuciBuilder entry) => entry.name).toList();
     for (bb.Build build in builds.values) {
       // LUCI configuration contain more builders than the ones we would like to run.
@@ -54,10 +53,10 @@ class GithubStatusService {
     @required RepositorySlug slug,
   }) async {
     // No builderName configuration, nothing to do here.
-    if (await repoNameForBuilder(await config.luciBuilders('try', slug.name), builderName) == null) {
+    if (await repoNameForBuilder(await config.luciBuilders('try', slug), builderName) == null) {
       return false;
     }
-    final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+    final GitHub gitHubClient = await config.createGitHubClient(slug);
     // GitHub "only" allows setting a status for a context/ref pair 1000 times.
     // We should avoid unnecessarily setting a pending status, e.g. if we get
     // started and pending messages close together.
@@ -96,10 +95,10 @@ class GithubStatusService {
     @required RepositorySlug slug,
   }) async {
     // No builderName configuration, nothing to do here.
-    if (await repoNameForBuilder(await config.luciBuilders('try', slug.name), builderName) == null) {
+    if (await repoNameForBuilder(await config.luciBuilders('try', slug), builderName) == null) {
       return false;
     }
-    final GitHub gitHubClient = await config.createGitHubClient(slug.owner, slug.name);
+    final GitHub gitHubClient = await config.createGitHubClient(slug);
     final CreateStatus status = statusForResult(result)
       ..context = builderName
       ..description = 'Flutter LUCI Build: $builderName'

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:github/github.dart';
 import 'package:retry/retry.dart';
 
 import 'package:appengine/appengine.dart';
@@ -65,11 +66,11 @@ class LuciService {
   ///
   /// The list of known LUCI builders is specified in [LuciBuilder.all].
   Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>> getBranchRecentTasks({
-    String repo,
+    RepositorySlug slug,
     bool requireTaskName = false,
   }) async {
     assert(requireTaskName != null);
-    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(repo, config);
+    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(slug, config);
     final List<Build> builds = await getBuildsForBuilderList(builders);
 
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> results =
@@ -140,11 +141,11 @@ class LuciService {
   ///
   /// The list of known LUCI builders is specified in [LuciBuilder.all].
   Future<Map<LuciBuilder, List<LuciTask>>> getRecentTasks({
-    String repo,
+    RepositorySlug slug,
     bool requireTaskName = false,
   }) async {
     assert(requireTaskName != null);
-    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(repo, config);
+    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(slug, config);
     final List<Build> builds = await getBuildsForBuilderList(builders);
 
     final Map<LuciBuilder, List<LuciTask>> results = <LuciBuilder, List<LuciTask>>{};
@@ -273,8 +274,8 @@ class LuciBuilder {
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
 
   /// Loads and returns the list of known builders from the Cocoon [config].
-  static Future<List<LuciBuilder>> getProdBuilders(String repo, Config config) async {
-    return await config.luciBuilders('prod', repo);
+  static Future<List<LuciBuilder>> getProdBuilders(RepositorySlug slug, Config config) async {
+    return await config.luciBuilders('prod', slug);
   }
 }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -123,7 +123,7 @@ class Scheduler {
   }
 
   Future<void> _addCommit(Commit commit) async {
-    if (!Config.schedulerSupportedRepos.contains(commit.repository)) {
+    if (!Config.schedulerSupportedRepos.contains(commit.slug)) {
       log.debug('Skipping ${commit.id} as repo is not supported');
       return;
     }
@@ -194,7 +194,7 @@ class Scheduler {
     }
 
     final List<Task> tasks = <Task>[];
-    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders('flutter', config);
+    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders(commit.slug, config);
     for (LuciBuilder builder in prodBuilders) {
       // These built-in tasks are not listed in the manifest.
       tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -82,7 +82,7 @@ void main() {
       });
       await tester.get(handler);
       expect(log.records.length, 1);
-      expect(log.records[0].message, '_checkPRs error in cocoon: null: Undefined location');
+      expect(log.records[0].message, '_checkPRs error in flutter/cocoon: null: Undefined location');
     });
   });
   group('check for waiting pull requests', () {
@@ -270,7 +270,6 @@ void main() {
       await tester.get(handler);
 
       _verifyQueries();
-
       githubGraphQLClient.verifyMutations(<MutationOptions>[]);
     });
 

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -81,6 +81,13 @@ void main() {
 
       when(gitHubClient.issues).thenReturn(issuesService);
       when(gitHubClient.pullRequests).thenReturn(pullRequestsService);
+      when(mockGithubChecksUtil.createCheckRun(any, any, any, any)).thenAnswer((_) async {
+        return CheckRun.fromJson(const <String, dynamic>{
+          'id': 1,
+          'started_at': '2020-05-10T02:49:31Z',
+          'check_suite': <String, dynamic>{'id': 2}
+        });
+      });
 
       config.wrongHeadBranchPullRequestMessageValue = 'wrongHeadBranchPullRequestMessage';
       config.wrongBaseBranchPullRequestMessageValue = 'wrongBaseBranchPullRequestMessage';
@@ -927,13 +934,6 @@ void main() {
       });
 
       Future<void> _testActions(String action, {bool never = false}) async {
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any)).thenAnswer((_) async {
-          return CheckRun.fromJson(const <String, dynamic>{
-            'id': 1,
-            'started_at': '2020-05-10T02:49:31Z',
-            'check_suite': <String, dynamic>{'id': 2}
-          });
-        });
         when(issuesService.listLabelsByIssue(any, issueNumber)).thenAnswer((_) {
           return Stream<IssueLabel>.fromIterable(<IssueLabel>[
             IssueLabel()..name = 'Random Label',

--- a/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
@@ -105,14 +105,14 @@ void main() {
       config.db.values[status.key] = status;
 
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders('engine', config),
+        await LuciBuilder.getProdBuilders(config.engineSlug, config),
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
               commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusFailed, buildNumber: 1, builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(repo: 'engine')).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -130,7 +130,7 @@ void main() {
       config.db.values[status.key] = status;
 
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders('engine', config),
+        await LuciBuilder.getProdBuilders(config.engineSlug, config),
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -141,7 +141,7 @@ void main() {
               builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(repo: 'engine')).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -159,7 +159,7 @@ void main() {
       config.db.values[status.key] = status;
 
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders('engine', config),
+        await LuciBuilder.getProdBuilders(config.engineSlug, config),
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -170,7 +170,7 @@ void main() {
               builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(repo: 'engine')).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -189,7 +189,7 @@ void main() {
       config.db.values[status.key] = status;
 
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders('engine', config),
+        await LuciBuilder.getProdBuilders(config.engineSlug, config),
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -212,7 +212,7 @@ void main() {
               builderName: 'efg'),
         ],
       );
-      when(mockLuciService.getRecentTasks(repo: 'engine')).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -231,7 +231,7 @@ void main() {
       config.db.values[status.key] = status;
 
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders('engine', config),
+        await LuciBuilder.getProdBuilders(config.engineSlug, config),
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -242,7 +242,7 @@ void main() {
               builderName: 'abc'),
         ],
       );
-      when(mockLuciService.getRecentTasks(repo: 'engine')).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -63,7 +63,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -75,7 +75,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -100,7 +100,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -112,7 +112,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -129,7 +129,7 @@ void main() {
         config.db.values[task.key] = task;
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -141,7 +141,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -159,7 +159,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -171,7 +171,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -191,7 +191,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -203,7 +203,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -222,7 +222,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -234,7 +234,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -253,7 +253,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -271,7 +271,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -290,7 +290,7 @@ void main() {
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -304,7 +304,7 @@ void main() {
                     });
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> testLuciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders('flutter', config),
+                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'test'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -317,7 +317,7 @@ void main() {
                       ],
                     });
         luciTasks.addAll(testLuciTasks);
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -349,8 +349,9 @@ void main() {
         config.db.values[task.key] = task;
 
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                <LuciBuilder>[const LuciBuilder(name: 'Mac abc', repo: 'flutter', taskName: 'def', flaky: false)],
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(<LuciBuilder>[
+          LuciBuilder(name: 'Mac abc', repo: config.flutterSlug.name, taskName: 'def', flaky: false)
+        ],
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -362,7 +363,7 @@ void main() {
                             builderName: 'Mac abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(repo: 'flutter', requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });

--- a/app_dart/test/request_handlers/reset_devicelab_task_test.dart
+++ b/app_dart/test/request_handlers/reset_devicelab_task_test.dart
@@ -37,7 +37,9 @@ void main() {
 
     test('disables attempts increase when resetting devicelab task', () async {
       final Commit commit = Commit(
-          key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'));
+        key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8'),
+        repository: 'flutter/flutter',
+      );
       final Task task = Task(
           key: commit.key.append(Task, id: 4590522719010816), commitKey: commit.key, attempts: 0, status: 'Failed');
       config.db.values[task.key] = task;

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -76,6 +76,7 @@ void main() {
           Commit,
           id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8',
         ),
+        repository: 'flutter/flutter',
         sha: '7d03371610c07953a5def50d500045941de516b8',
       );
     });

--- a/app_dart/test/request_handlers/reset_try_task_test.dart
+++ b/app_dart/test/request_handlers/reset_try_task_test.dart
@@ -5,6 +5,8 @@
 import 'package:cocoon_service/src/request_handlers/reset_try_task.dart';
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:github/github.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
@@ -12,23 +14,29 @@ import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/service/fake_scheduler.dart';
+import '../src/utilities/mocks.dart';
 
 void main() {
   group('ResetTryTask', () {
+    ApiRequestHandlerTester tester;
     FakeClientContext clientContext;
     ResetTryTask handler;
     FakeConfig config;
     FakeScheduler fakeScheduler;
     FakeAuthenticatedContext authContext;
-    ApiRequestHandlerTester tester;
+    MockGithubChecksUtil mockGithubChecksUtil;
 
     setUp(() {
       clientContext = FakeClientContext();
       clientContext.isDevelopmentEnvironment = false;
       authContext = FakeAuthenticatedContext(clientContext: clientContext);
       config = FakeConfig();
+      mockGithubChecksUtil = MockGithubChecksUtil();
       tester = ApiRequestHandlerTester(context: authContext);
-      fakeScheduler = FakeScheduler(config: config);
+      fakeScheduler = FakeScheduler(
+        config: config,
+        githubChecksUtil: mockGithubChecksUtil,
+      );
       handler = ResetTryTask(
         config,
         FakeAuthenticationProvider(clientContext: clientContext),
@@ -59,6 +67,13 @@ void main() {
     });
 
     test('Trigger builds if all parameters are correct', () async {
+      when(mockGithubChecksUtil.createCheckRun(any, config.flutterSlug, any, any)).thenAnswer((_) async {
+        return CheckRun.fromJson(const <String, dynamic>{
+          'id': 1,
+          'started_at': '2020-05-10T02:49:31Z',
+          'check_suite': <String, dynamic>{'id': 2}
+        });
+      });
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
         'commitSha': 'commitAbc',
         'repo': 'flutter',

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -59,7 +59,7 @@ void main() {
     });
 
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTaskBranchMap =
-        await service.getBranchRecentTasks(repo: 'flutter');
+        await service.getBranchRecentTasks(slug: config.flutterSlug);
     // There's no branch logic so there is only one entry
     expect(luciTaskBranchMap.keys.length, 1);
     final Map<String, List<LuciTask>> luciTaskMap = luciTaskBranchMap.values.first;

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -45,7 +45,6 @@ class FakeConfig implements Config {
     this.metricsDestination,
     this.taskLogServiceAccountValue,
     this.rollerAccountsValue,
-    this.flutterSlugValue,
     this.flutterBuildValue,
     this.flutterBuildDescriptionValue,
     this.flutterBranchesValue,
@@ -88,7 +87,6 @@ class FakeConfig implements Config {
   String waitingForTreeToGoGreenLabelNameValue;
   ServiceAccountCredentials taskLogServiceAccountValue;
   Set<String> rollerAccountsValue;
-  RepositorySlug flutterSlugValue;
   List<String> flutterBranchesValue;
   int maxRecordsValue;
   String flutterGoldPendingValue;
@@ -102,7 +100,7 @@ class FakeConfig implements Config {
   List<String> supportedBranchesValue;
 
   @override
-  Future<GitHub> createGitHubClient(String owner, String repository) async => githubClient;
+  Future<GitHub> createGitHubClient(RepositorySlug slug) async => githubClient;
 
   @override
   Future<GraphQLClient> createGitHubGraphQLClient() async => githubGraphQLClient;
@@ -114,7 +112,7 @@ class FakeConfig implements Config {
   Future<TabledataResourceApi> createTabledataResourceApi() async => tabledataResourceApi;
 
   @override
-  Future<GithubService> createGithubService(String owner, String repository) async => githubService;
+  Future<GithubService> createGithubService(RepositorySlug slug) async => githubService;
 
   @override
   Future<FlutterDestination> createMetricsDestination() async => metricsDestination;
@@ -210,7 +208,7 @@ class FakeConfig implements Config {
   String get waitingForTreeToGoGreenLabelName => waitingForTreeToGoGreenLabelNameValue;
 
   @override
-  RepositorySlug get flutterSlug => flutterSlugValue;
+  RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
 
   @override
   Future<ServiceAccountCredentials> get taskLogServiceAccount async => taskLogServiceAccountValue;
@@ -219,12 +217,17 @@ class FakeConfig implements Config {
   Set<String> get rollerAccounts => rollerAccountsValue;
 
   @override
-  bool githubPresubmitSupportedRepo(String repositoryName) {
-    return <String>['flutter', 'engine', 'cocoon', 'packages'].contains(repositoryName);
+  bool githubPresubmitSupportedRepo(RepositorySlug slug) {
+    return <RepositorySlug>[
+      RepositorySlug('flutter', 'flutter'),
+      RepositorySlug('flutter', 'engine'),
+      RepositorySlug('flutter', 'cocoon'),
+      RepositorySlug('flutter', 'packages'),
+    ].contains(slug);
   }
 
   @override
-  Future<String> generateGithubToken(String user, String repository) {
+  Future<String> generateGithubToken(RepositorySlug slug) {
     throw UnimplementedError();
   }
 
@@ -246,23 +249,18 @@ class FakeConfig implements Config {
   Future<String> get githubPublicKey => throw UnimplementedError();
 
   @override
-  bool isChecksSupportedRepo(RepositorySlug slug) {
-    return '${slug.owner}/${slug.name}' == 'flutter/cocoon';
-  }
-
-  @override
-  Future<List<LuciBuilder>> luciBuilders(String bucket, String repo,
+  Future<List<LuciBuilder>> luciBuilders(String bucket, RepositorySlug slug,
       {String commitSha = 'master', int prNumber}) async {
-    if (repo == 'flutter') {
+    if (slug.name == 'flutter') {
       return <LuciBuilder>[
         const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),
         const LuciBuilder(name: 'Mac', repo: 'flutter', taskName: 'mac_bot', flaky: false),
         const LuciBuilder(name: 'Windows', repo: 'flutter', taskName: 'windows_bot', flaky: false),
         const LuciBuilder(name: 'Linux Coverage', repo: 'flutter', taskName: 'coverage_bot', flaky: true)
       ];
-    } else if (repo == 'cocoon') {
+    } else if (slug.name == 'cocoon') {
       return <LuciBuilder>[const LuciBuilder(name: 'Cocoon', repo: 'cocoon', taskName: 'cocoon_bot', flaky: true)];
-    } else if (repo == 'engine') {
+    } else if (slug.name == 'engine') {
       return <LuciBuilder>[const LuciBuilder(name: 'Linux', repo: 'engine', taskName: 'coverage_bot', flaky: true)];
     }
     return <LuciBuilder>[];
@@ -273,4 +271,7 @@ class FakeConfig implements Config {
 
   @override
   Future<List<String>> getSupportedBranches(RepositorySlug slug) async => supportedBranchesValue;
+
+  @override
+  RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
 }

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -274,4 +274,7 @@ class FakeConfig implements Config {
 
   @override
   RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
+
+  @override
+  Future<GithubService> createDefaultGitHubService() async => githubService;
 }


### PR DESCRIPTION
This makes use of GitHub repositories consistent across Cocoon. Previously, some references were only the name of the repositories, others were `$owner/$name`, and lastly some were `RepositorySlug`. This switches everything to `RepositorySlug`.

Fixes https://github.com/flutter/flutter/issues/80531