### PR TITLE
Prevent retries on tasks already scheduled or running.

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -76,10 +76,14 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final Iterable<Build> currentBuilds = await luciBuildService.getProdBuilds(slug, commit.sha, builder, repo);
     final List<Status> noReschedule = <Status>[Status.started, Status.scheduled, Status.success];
     final Build build = currentBuilds.firstWhere(
-      (Build element) => noReschedule.contains(element.status),
+      (Build element) {
+        log.info('Found build status: ${element.status} inNoReschedule ${noReschedule.contains(element.status)}');
+        return noReschedule.contains(element.status);
+      },
       orElse: () => null,
     );
-    log.info('Owner: $owner, Repo: $repo, Builder: $builder, CommitSha: ${commit.sha}, CurrentBuild: $build');
+    log.info(
+        'Owner: $owner, Repo: $repo, Builder: $builder, CommitSha: ${commit.sha}, CurrentBuild: $build, CurrentBuild: $currentBuilds');
 
     if (build != null) {
       throw const ConflictException();

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -82,8 +82,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
       },
       orElse: () => null,
     );
-    log.info(
-        'Owner: $owner, Repo: $repo, Builder: $builder, CommitSha: ${commit.sha}, CurrentBuild: $build, CurrentBuild: $currentBuilds');
+    log.info('Owner: $owner, Repo: $repo, Builder: $builder, CommitSha: ${commit.sha}, Build: $build');
 
     if (build != null) {
       throw const ConflictException();

--- a/app_dart/lib/src/request_handling/exceptions.dart
+++ b/app_dart/lib/src/request_handling/exceptions.dart
@@ -41,7 +41,8 @@ class MethodNotAllowed extends HttpStatusException {
 
 /// Exception that will trigger an HTTP 409 conflict.
 class ConflictException extends HttpStatusException {
-  const ConflictException([String message = 'Request conflict with server state']) : super(HttpStatus.conflict, message);
+  const ConflictException([String message = 'Request conflict with server state'])
+      : super(HttpStatus.conflict, message);
 }
 
 /// Exception that will trigger an HTTP 500 internal server error.

--- a/app_dart/lib/src/request_handling/exceptions.dart
+++ b/app_dart/lib/src/request_handling/exceptions.dart
@@ -39,6 +39,11 @@ class MethodNotAllowed extends HttpStatusException {
   const MethodNotAllowed(String method) : super(HttpStatus.methodNotAllowed, 'Unsupported method: $method');
 }
 
+/// Exception that will trigger an HTTP 409 conflict.
+class ConflictException extends HttpStatusException {
+  const ConflictException([String message = 'Request conflict with server state']) : super(HttpStatus.conflict, message);
+}
+
 /// Exception that will trigger an HTTP 500 internal server error.
 class InternalServerError extends HttpStatusException {
   const InternalServerError([String message = 'Internal server error'])

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -91,12 +91,9 @@ class LuciBuildService {
               bucket: bucket,
               builder: builderName,
             ),
-            tags: <String, List<String>>{
-              'buildset': <String>['sha/git/$commitSha'],
-              'user_agent': const <String>['flutter-cocoon'],
-            },
+            tags: tags,
           ),
-          fields: 'builds.*.id,builds.*.builder,builds.*.tags',
+          fields: 'builds.*.id,builds.*.builder,builds.*.tags,builds.*.status',
         ),
       ),
     ]));

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -59,7 +59,7 @@ class LuciBuildService {
     return getBuilds(slug, commitSha, builderName, 'try', tags);
   }
 
-  /// Returns an Iterable of try BuildBucket build for a given Github [slug], [commitSha],
+  /// Returns an Iterable of prod BuildBucket build for a given Github [slug], [commitSha],
   /// [builderName] and [repo].
   Future<Iterable<Build>> getProdBuilds(
     github.RepositorySlug slug,
@@ -73,8 +73,8 @@ class LuciBuildService {
     return getBuilds(slug, commitSha, builderName, 'prod', tags);
   }
 
-  /// Returns a BuildBucket build for a given Github [slug], [commitSha],
-  /// [builderName] and [bucket].
+  /// Returns an iterable of BuildBucket builds for a given Github [slug], [commitSha],
+  /// [builderName], [bucket] and [tags].
   Future<Iterable<Build>> getBuilds(
     github.RepositorySlug slug,
     String commitSha,

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -16,6 +16,34 @@ import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/utilities/mocks.dart';
 
+const Build startedBuild = Build(
+  id: 999,
+  builderId: BuilderId(
+    project: 'flutter',
+    bucket: 'prod',
+    builder: 'Mac',
+  ),
+  status: Status.started,
+);
+const Build scheduledBuild = Build(
+  id: 999,
+  builderId: BuilderId(
+    project: 'flutter',
+    bucket: 'prod',
+    builder: 'Mac',
+  ),
+  status: Status.scheduled,
+);
+const Build succeededBuild = Build(
+  id: 999,
+  builderId: BuilderId(
+    project: 'flutter',
+    bucket: 'prod',
+    builder: 'Mac',
+  ),
+  status: Status.success,
+);
+
 void main() {
   group('ResetProdTask', () {
     FakeClientContext clientContext;
@@ -25,9 +53,6 @@ void main() {
     FakeAuthenticatedContext authContext;
     ApiRequestHandlerTester tester;
     Commit commit;
-    Build startedBuild;
-    Build scheduledBuild;
-    Build succeededBuild;
 
     setUp(() {
       final FakeDatastoreDB datastoreDB = FakeDatastoreDB();
@@ -52,33 +77,6 @@ void main() {
           id: 'flutter/flutter/7d03371610c07953a5def50d500045941de516b8',
         ),
         sha: '7d03371610c07953a5def50d500045941de516b8',
-      );
-      startedBuild = const Build(
-        id: 999,
-        builderId: BuilderId(
-          project: 'flutter',
-          bucket: 'prod',
-          builder: 'Mac',
-        ),
-        status: Status.started,
-      );
-      scheduledBuild = const Build(
-        id: 999,
-        builderId: BuilderId(
-          project: 'flutter',
-          bucket: 'prod',
-          builder: 'Mac',
-        ),
-        status: Status.scheduled,
-      );
-      succeededBuild = const Build(
-        id: 999,
-        builderId: BuilderId(
-          project: 'flutter',
-          bucket: 'prod',
-          builder: 'Mac',
-        ),
-        status: Status.success,
       );
     });
     test('Schedule new task', () async {
@@ -199,7 +197,7 @@ void main() {
       expect(() => tester.post(handler), throwsA(isA<ConflictException>()));
     });
 
-    test('Fails if task already succeded', () async {
+    test('Fails if task already succeeded', () async {
       final Task task = Task(
           key: commit.key.append(Task, id: 4590522719010816),
           commitKey: commit.key,

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -91,8 +91,10 @@ void main() {
       );
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[];
+      });
       await tester.post(handler);
-
       expect(
         verify(mockLuciBuildService.rescheduleProdBuild(
           commitSha: captureAnyNamed('commitSha'),
@@ -112,6 +114,9 @@ void main() {
           builderName: 'Windows');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[];
+      });
       await tester.post(handler);
       expect(
         verify(mockLuciBuildService.rescheduleProdBuild(
@@ -133,6 +138,9 @@ void main() {
           status: 'Failed');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[];
+      });
       await tester.post(handler);
       expect(
         verify(mockLuciBuildService.rescheduleProdBuild(
@@ -170,8 +178,8 @@ void main() {
           builderName: 'Windows');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
-      when(mockLuciBuildService.getBuild(any, any, any, any)).thenAnswer((_) async {
-        return scheduledBuild;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[scheduledBuild];
       });
       expect(() => tester.post(handler), throwsA(isA<ConflictException>()));
     });
@@ -185,8 +193,8 @@ void main() {
           builderName: 'Windows');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
-      when(mockLuciBuildService.getBuild(any, any, any, any)).thenAnswer((_) async {
-        return startedBuild;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[startedBuild];
       });
       expect(() => tester.post(handler), throwsA(isA<ConflictException>()));
     });
@@ -200,13 +208,13 @@ void main() {
           builderName: 'Windows');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
-      when(mockLuciBuildService.getBuild(any, any, any, any)).thenAnswer((_) async {
-        return succeededBuild;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[succeededBuild];
       });
       expect(() => tester.post(handler), throwsA(isA<ConflictException>()));
     });
 
-    test('Reschedules if build is null', () async {
+    test('Reschedules if build is empty', () async {
       Task task = Task(
           key: commit.key.append(Task, id: 4590522719010816),
           commitKey: commit.key,
@@ -215,8 +223,8 @@ void main() {
           builderName: 'Windows');
       config.db.values[task.key] = task;
       config.db.values[commit.key] = commit;
-      when(mockLuciBuildService.getBuild(any, any, any, any)).thenAnswer((_) async {
-        return null;
+      when(mockLuciBuildService.getProdBuilds(any, any, any, any)).thenAnswer((_) async {
+        return <Build>[];
       });
       await tester.post(handler);
       expect(

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -100,7 +100,7 @@ void main() {
       );
       expect(build, isNull);
     });
-  test('Existing try build', () async {
+    test('Existing try build', () async {
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -72,13 +72,12 @@ void main() {
           ],
         );
       });
-      final Build build = await service.getBuild(
+      final Iterable<Build> builds = await service.getTryBuilds(
         slug,
         'commit123',
         'abcd',
-        'try',
       );
-      expect(build, macBuild);
+      expect(builds.first, macBuild);
     });
     test('Existing prod build', () async {
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
@@ -92,13 +91,13 @@ void main() {
           ],
         );
       });
-      final Build build = await service.getBuild(
+      final Iterable<Build> builds = await service.getProdBuilds(
         slug,
         'commit123',
         'abcd',
-        'prod',
+        'flutter',
       );
-      expect(build, isNull);
+      expect(builds, isEmpty);
     });
     test('Existing try build', () async {
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
@@ -112,13 +111,12 @@ void main() {
           ],
         );
       });
-      final Build build = await service.getBuild(
+      final Iterable<Build> builds = await service.getTryBuilds(
         slug,
         'commit123',
         'abcd',
-        'try',
       );
-      expect(build, linuxBuild);
+      expect(builds.first, linuxBuild);
     });
   });
   group('buildsForRepositoryAndPr', () {

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -164,6 +164,9 @@ class AppEngineCocoonService implements CocoonService {
         },
         body: jsonEncode(<String, String>{
           'Key': task.key.child.name,
+          // This prepares this api to support different repos.
+          'Owner': 'flutter',
+          'Repo': 'flutter',
         }));
 
     return response.statusCode == HttpStatus.ok;


### PR DESCRIPTION
When a task has failed and the dashboard latency is high multiple people
can retry the same build multiple times wasting resources and preventing
tasks with lower priority from running.

Bug: https://github.com/flutter/flutter/issues/80918