### PR TITLE
Remove agent health update cron job.

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -4,9 +4,6 @@ cron:
 - description: refresh chromebot build status
   url: /api/refresh-chromebot-status
   schedule: every 3 minutes
-- description: clean up stale datastore records
-  url: /api/vacuum-clean
-  schedule: every 1 hours
 - description: retrieve missing commits
   url: /api/vacuum-github-commits
   schedule: every 1 hours
@@ -22,9 +19,6 @@ cron:
 - description: check for mergeable commits waiting for the tree to go green
   url: /api/check-waiting-pull-requests
   schedule: every 5 minutes
-- description: insert agent health status to bigquery
-  url: /api/update-agent-health-history
-  schedule: every 1 minutes
 - description: push github rate limit history to bigquery
   url: /api/public/github-rate-limit-status
   schedule: every 1 minutes


### PR DESCRIPTION
Agents have been deprecated and this job is generating errors, disable the cron job.