### PR TITLE
Replaced accentColor with colorScheme.secondary

### DIFF
--- a/repo_dashboard/lib/repository.dart
+++ b/repo_dashboard/lib/repository.dart
@@ -154,7 +154,7 @@ class _RepositoryDashboardWidgetState extends State<_RepositoryDashboardWidget> 
                   subtitle1: headline.copyWith(fontWeight: FontWeight.normal),
                   headline5: headline,
                 ),
-            dividerColor: Theme.of(context).accentColor,
+            dividerColor: Theme.of(context).colorScheme.secondary,
             iconTheme: IconTheme.of(context).copyWith(size: 30.0)),
         child: ListTileTheme(
           contentPadding: const EdgeInsets.only(bottom: 46.0),


### PR DESCRIPTION
Replaced Theme accentColor dependency with colorScheme.secondary because the accentColor theme properties are going to be deprecated. See https://github.com/flutter/flutter/pull/81336