### PR TITLE
[scheduler] Add .ci.yaml presubmit scheduling

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -32,13 +32,6 @@ Future<void> main() async {
       serviceAccountInfo,
     );
 
-    /// Github status service to update the state of the build
-    /// in the Github UI.
-    final GithubStatusService githubStatusService = GithubStatusService(
-      config,
-      luciBuildService,
-    );
-
     /// Github checks api service used to provide luci test execution status on the Github UI.
     final GithubChecksService githubChecksService = GithubChecksService(
       config,
@@ -48,7 +41,15 @@ Future<void> main() async {
     final Scheduler scheduler = Scheduler(
       cache: cache,
       config: config,
+      githubChecksService: githubChecksService,
       luciBuildService: luciBuildService,
+    );
+
+    /// Github status service to update the state of the build
+    /// in the Github UI.
+    final GithubStatusService githubStatusService = GithubStatusService(
+      config,
+      scheduler,
     );
 
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -45,13 +45,6 @@ Future<void> main() async {
       luciBuildService: luciBuildService,
     );
 
-    /// Github status service to update the state of the build
-    /// in the Github UI.
-    final GithubStatusService githubStatusService = GithubStatusService(
-      config,
-      scheduler,
-    );
-
     final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
       '/api/check-waiting-pull-requests': CheckForWaitingPullRequests(config, authProvider),
       '/api/flush-cache': FlushCache(
@@ -73,7 +66,6 @@ Future<void> main() async {
         config,
         buildBucketClient,
         luciBuildService,
-        githubStatusService,
         githubChecksService,
       ),
       '/api/push-build-status-to-github': PushBuildStatusToGithub(config, authProvider),

--- a/app_dart/lib/src/datastore/config.dart
+++ b/app_dart/lib/src/datastore/config.dart
@@ -76,11 +76,10 @@ class Config {
   }
 
   // Returns LUCI builders.
-  Future<List<LuciBuilder>> luciBuilders(String bucket, RepositorySlug slug,
-      {String commitSha = 'master', int prNumber}) async {
+  Future<List<LuciBuilder>> luciBuilders(String bucket, RepositorySlug slug, {String commitSha = 'master'}) async {
     final GithubService githubService = await createGithubService(slug);
     return await getLuciBuilders(githubService, Providers.freshHttpClient, loggingService, slug, bucket,
-        prNumber: prNumber, commitSha: commitSha);
+        commitSha: commitSha);
   }
 
   Future<String> _getSingleValue(String id) async {

--- a/app_dart/lib/src/foundation/github_checks_util.dart
+++ b/app_dart/lib/src/foundation/github_checks_util.dart
@@ -5,11 +5,11 @@
 import 'dart:core';
 import 'dart:io';
 
-import 'package:cocoon_service/src/model/github/checks.dart';
 import 'package:github/github.dart' as github;
 import 'package:retry/retry.dart';
 
 import '../datastore/config.dart';
+import '../model/github/checks.dart';
 
 /// Wrapper class for github checkrun service. This is used to simplify
 /// mocking during testing because some of the subclasses are private.

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -118,11 +118,10 @@ Future<RepositorySlug> repoNameForBuilder(List<LuciBuilder> builders, String bui
   return RepositorySlug('flutter', repoName);
 }
 
-/// Returns LUCI builders based on [bucket] and [repo].
+/// Returns LUCI builders based on [bucket] and [slug].
 ///
 /// For `try` case with [commitSha], builders are returned based on try_builders.json config file in
-/// the corresponding [commitSha], and also based on filtering changed files in [prNumber] via property
-/// [run_if] in each config.
+/// the corresponding [commitSha].
 ///
 /// For `prod` case, builders are returned based on prod_builders.json config file from `master`.
 Future<List<LuciBuilder>> getLuciBuilders(

--- a/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pb.dart
@@ -1,6 +1,6 @@
 ///
 //  Generated code. Do not modify.
-//  source: scheduler.proto
+//  source: lib/src/model/proto/internal/scheduler.proto
 //
 // @dart = 2.7
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
@@ -49,8 +49,7 @@ class SchedulerConfig extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   SchedulerConfig copyWith(void Function(SchedulerConfig) updates) =>
-      super.copyWith((message) => updates(message as SchedulerConfig))
-          as SchedulerConfig; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SchedulerConfig)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SchedulerConfig create() => SchedulerConfig._();
@@ -91,6 +90,7 @@ class Target extends $pb.GeneratedMessage {
     ..a<$core.bool>(
         10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'postsubmit', $pb.PbFieldType.OB,
         defaultOrMaker: true)
+    ..pPS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'runIf')
     ..hasRequiredFields = false;
 
   Target._() : super();
@@ -105,6 +105,7 @@ class Target extends $pb.GeneratedMessage {
     SchedulerSystem scheduler,
     $core.bool presubmit,
     $core.bool postsubmit,
+    $core.Iterable<$core.String> runIf,
   }) {
     final _result = create();
     if (name != null) {
@@ -137,6 +138,9 @@ class Target extends $pb.GeneratedMessage {
     if (postsubmit != null) {
       _result.postsubmit = postsubmit;
     }
+    if (runIf != null) {
+      _result.runIf.addAll(runIf);
+    }
     return _result;
   }
   factory Target.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
@@ -151,7 +155,7 @@ class Target extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Target copyWith(void Function(Target) updates) =>
-      super.copyWith((message) => updates(message as Target)) as Target; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Target)); // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Target create() => Target._();
@@ -262,4 +266,7 @@ class Target extends $pb.GeneratedMessage {
   $core.bool hasPostsubmit() => $_has(9);
   @$pb.TagNumber(10)
   void clearPostsubmit() => clearField(10);
+
+  @$pb.TagNumber(11)
+  $core.List<$core.String> get runIf => $_getList(10);
 }

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
@@ -1,6 +1,6 @@
 ///
 //  Generated code. Do not modify.
-//  source: scheduler.proto
+//  source: lib/src/model/proto/internal/scheduler.proto
 //
 // @dart = 2.7
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -1,15 +1,10 @@
 ///
 //  Generated code. Do not modify.
-//  source: scheduler.proto
+//  source: lib/src/model/proto/internal/scheduler.proto
 //
 // @dart = 2.7
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
-import 'dart:core' as $core;
-import 'dart:convert' as $convert;
-import 'dart:typed_data' as $typed_data;
-
-@$core.Deprecated('Use schedulerSystemDescriptor instead')
 const SchedulerSystem$json = const {
   '1': 'SchedulerSystem',
   '2': const [
@@ -18,10 +13,6 @@ const SchedulerSystem$json = const {
   ],
 };
 
-/// Descriptor for `SchedulerSystem`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List schedulerSystemDescriptor =
-    $convert.base64Decode('Cg9TY2hlZHVsZXJTeXN0ZW0SCgoGY29jb29uEAESCAoEbHVjaRAC');
-@$core.Deprecated('Use schedulerConfigDescriptor instead')
 const SchedulerConfig$json = const {
   '1': 'SchedulerConfig',
   '2': const [
@@ -30,10 +21,6 @@ const SchedulerConfig$json = const {
   ],
 };
 
-/// Descriptor for `SchedulerConfig`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List schedulerConfigDescriptor = $convert.base64Decode(
-    'Cg9TY2hlZHVsZXJDb25maWcSIQoHdGFyZ2V0cxgBIAMoCzIHLlRhcmdldFIHdGFyZ2V0cxIpChBlbmFibGVkX2JyYW5jaGVzGAIgAygJUg9lbmFibGVkQnJhbmNoZXM=');
-@$core.Deprecated('Use targetDescriptor instead')
 const Target$json = const {
   '1': 'Target',
   '2': const [
@@ -47,11 +34,11 @@ const Target$json = const {
     const {'1': 'scheduler', '3': 8, '4': 1, '5': 14, '6': '.SchedulerSystem', '7': 'cocoon', '10': 'scheduler'},
     const {'1': 'presubmit', '3': 9, '4': 1, '5': 8, '7': 'true', '10': 'presubmit'},
     const {'1': 'postsubmit', '3': 10, '4': 1, '5': 8, '7': 'true', '10': 'postsubmit'},
+    const {'1': 'run_if', '3': 11, '4': 3, '5': 9, '10': 'runIf'},
   ],
   '3': const [Target_PropertiesEntry$json],
 };
 
-@$core.Deprecated('Use targetDescriptor instead')
 const Target_PropertiesEntry$json = const {
   '1': 'PropertiesEntry',
   '2': const [
@@ -60,7 +47,3 @@ const Target_PropertiesEntry$json = const {
   ],
   '7': const {'7': true},
 };
-
-/// Descriptor for `Target`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List targetDescriptor = $convert.base64Decode(
-    'CgZUYXJnZXQSEgoEbmFtZRgBIAEoCVIEbmFtZRIiCgxkZXBlbmRlbmNpZXMYAiADKAlSDGRlcGVuZGVuY2llcxIfCgdicmluZ3VwGAMgASgIOgVmYWxzZVIHYnJpbmd1cBIcCgd0aW1lb3V0GAQgASgFOgIzMFIHdGltZW91dBIiCgd0ZXN0YmVkGAUgASgJOghsaW51eC12bVIHdGVzdGJlZBI3Cgpwcm9wZXJ0aWVzGAYgAygLMhcuVGFyZ2V0LlByb3BlcnRpZXNFbnRyeVIKcHJvcGVydGllcxIYCgdidWlsZGVyGAcgASgJUgdidWlsZGVyEjYKCXNjaGVkdWxlchgIIAEoDjIQLlNjaGVkdWxlclN5c3RlbToGY29jb29uUglzY2hlZHVsZXISIgoJcHJlc3VibWl0GAkgASgIOgR0cnVlUglwcmVzdWJtaXQSJAoKcG9zdHN1Ym1pdBgKIAEoCDoEdHJ1ZVIKcG9zdHN1Ym1pdBo9Cg9Qcm9wZXJ0aWVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -12,7 +12,7 @@ message SchedulerConfig {
     repeated string enabled_branches = 2;
 }
 
-// Next ID: 11
+// Next ID: 12
 message Target {
     // Unique, human readable identifier.
     optional string name = 1;
@@ -37,6 +37,9 @@ message Target {
     optional bool presubmit = 9 [default = true];
     // Whether target should run post-submit.
     optional bool postsubmit = 10 [default = true];
+    // List of paths that trigger this target in presubmit when there is a diff.
+    // If no paths are given, it will always run.
+    repeated string run_if = 11;
 }
 
 // Schedulers supported in SchedulerConfig.

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:cocoon_service/src/foundation/providers.dart';
 import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
-import 'package:cocoon_service/src/service/github_status_service.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/oauth2/v2.dart';
@@ -48,7 +47,6 @@ class LuciStatusHandler extends RequestHandler<Body> {
     Config config,
     this.buildBucketClient,
     this.luciBuildService,
-    this.githubStatusService,
     this.githubChecksService, {
     LoggingProvider loggingProvider,
   })  : assert(buildBucketClient != null),
@@ -58,7 +56,6 @@ class LuciStatusHandler extends RequestHandler<Body> {
   final BuildBucketClient buildBucketClient;
   final LoggingProvider loggingProvider;
   final LuciBuildService luciBuildService;
-  final GithubStatusService githubStatusService;
   final GithubChecksService githubChecksService;
 
   @override

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -286,9 +286,10 @@ class LuciBuilder {
   /// Serializes this object to a JSON primitive.
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
 
-  /// Loads and returns the list of known builders from the Cocoon [config].
-  static Future<List<LuciBuilder>> getProdBuilders(RepositorySlug slug, Config config) async {
-    return await config.luciBuilders('prod', slug);
+  /// Loads and returns the list of known builders from the Cocoon [config] for [commitSha].
+  static Future<List<LuciBuilder>> getProdBuilders(RepositorySlug slug, Config config,
+      {String commitSha = 'master'}) async {
+    return await config.luciBuilders('prod', slug, commitSha: commitSha);
   }
 }
 

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -15,6 +15,7 @@ import 'package:meta/meta.dart';
 import '../datastore/config.dart';
 import '../model/appengine/task.dart';
 import '../model/luci/buildbucket.dart';
+import '../model/proto/internal/scheduler.pb.dart';
 import '../request_handling/api_request_handler.dart';
 
 import 'buildbucket.dart';
@@ -244,7 +245,19 @@ class LuciBuilder {
   }) : assert(name != null);
 
   /// Create a new [LuciBuilder] object from its JSON representation.
+  // TODO(chillers): Remove once *_builder.json is removed. https://github.com/flutter/flutter/issues/76140
   factory LuciBuilder.fromJson(Map<String, dynamic> json) => _$LuciBuilderFromJson(json);
+
+  /// Create a new [LuciBuilder] from a [Target].
+  factory LuciBuilder.fromTarget(Target target, RepositorySlug slug) {
+    return LuciBuilder(
+      name: target.builder,
+      repo: slug.name,
+      runIf: target.runIf,
+      taskName: target.name,
+      flaky: target.bringup,
+    );
+  }
 
   /// The name of this builder.
   @JsonKey(required: true, disallowNullValue: true)

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -172,7 +172,8 @@ class Scheduler {
   /// Create [Tasks] specified in [commit] scheduler config.
   Future<List<Task>> _getTasks(Commit commit) async {
     final List<Task> tasks = <Task>[];
-    final List<LuciBuilder> prodBuilders = await LuciBuilder.getProdBuilders(commit.slug, config);
+    final List<LuciBuilder> prodBuilders =
+        await LuciBuilder.getProdBuilders(commit.slug, config, commitSha: commit.sha);
     for (LuciBuilder builder in prodBuilders) {
       tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));
     }
@@ -298,7 +299,7 @@ class Scheduler {
     }
   }
 
-  /// Get an agreggate of LUCI presubmit builders from .ci.yaml and try_builders.json.
+  /// Get an aggregate of LUCI presubmit builders from .ci.yaml and try_builders.json.
   Future<List<LuciBuilder>> getPresubmitBuilders({@required Commit commit, int prNumber}) async {
     // Get try_builders.json builders
     final List<LuciBuilder> builders = await config.luciBuilders(

--- a/app_dart/test/request_handlers/luci_status_test.dart
+++ b/app_dart/test/request_handlers/luci_status_test.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/service/github_status_service.dart';
 import 'package:http/testing.dart' as http_test;
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
@@ -22,7 +21,6 @@ import '../src/request_handling/fake_logging.dart';
 import '../src/request_handling/request_handler_tester.dart';
 import '../src/service/fake_buildbucket.dart';
 import '../src/service/fake_luci_build_service.dart';
-import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 import '../src/utilities/push_message.dart';
 
@@ -36,30 +34,22 @@ void main() {
   LuciStatusHandler handler;
   FakeBuildBucketClient buildbucket;
   FakeConfig config;
-  FakeScheduler scheduler;
   MockGitHub mockGitHubClient;
   FakeHttpRequest request;
   RequestHandlerTester tester;
   MockRepositoriesService mockRepositoriesService;
   final FakeLogging log = FakeLogging();
-  GithubStatusService githubStatusService;
   MockGithubChecksService mockGithubChecksService;
 
   setUp(() async {
     config = FakeConfig();
     buildbucket = FakeBuildBucketClient();
-    scheduler = FakeScheduler(config: config, buildbucket: buildbucket);
 
-    githubStatusService = GithubStatusService(
-      config,
-      scheduler,
-    );
     mockGithubChecksService = MockGithubChecksService();
     handler = LuciStatusHandler(
       config,
       buildbucket,
       FakeLuciBuildService(config),
-      githubStatusService,
       mockGithubChecksService,
       loggingProvider: () => log,
     );

--- a/app_dart/test/request_handlers/luci_status_test.dart
+++ b/app_dart/test/request_handlers/luci_status_test.dart
@@ -10,7 +10,6 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/service_account_info.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/github_status_service.dart';
-import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:http/testing.dart' as http_test;
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
@@ -21,6 +20,9 @@ import '../src/datastore/fake_config.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/fake_logging.dart';
 import '../src/request_handling/request_handler_tester.dart';
+import '../src/service/fake_buildbucket.dart';
+import '../src/service/fake_luci_build_service.dart';
+import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 import '../src/utilities/push_message.dart';
 
@@ -32,38 +34,31 @@ void main() {
   const String deviceLabEmail = 'flutter-devicelab@flutter-dashboard.iam.gserviceaccount.com';
 
   LuciStatusHandler handler;
+  FakeBuildBucketClient buildbucket;
   FakeConfig config;
+  FakeScheduler scheduler;
   MockGitHub mockGitHubClient;
   FakeHttpRequest request;
   RequestHandlerTester tester;
   MockRepositoriesService mockRepositoriesService;
-  MockBuildBucketClient buildBucketClient;
   final FakeLogging log = FakeLogging();
-  const String serviceAccountEmail = 'test@test';
-  LuciBuildService luciBuildService;
-  ServiceAccountInfo serviceAccountInfo;
   GithubStatusService githubStatusService;
   MockGithubChecksService mockGithubChecksService;
 
   setUp(() async {
-    serviceAccountInfo = const ServiceAccountInfo(email: serviceAccountEmail);
-    config = FakeConfig(deviceLabServiceAccountValue: serviceAccountInfo);
-    buildBucketClient = MockBuildBucketClient();
-    serviceAccountInfo = await config.deviceLabServiceAccount;
-    luciBuildService = LuciBuildService(
-      config,
-      buildBucketClient,
-      serviceAccountInfo,
-    );
+    config = FakeConfig();
+    buildbucket = FakeBuildBucketClient();
+    scheduler = FakeScheduler(config: config, buildbucket: buildbucket);
+
     githubStatusService = GithubStatusService(
       config,
-      luciBuildService,
+      scheduler,
     );
     mockGithubChecksService = MockGithubChecksService();
     handler = LuciStatusHandler(
       config,
-      buildBucketClient,
-      luciBuildService,
+      buildbucket,
+      FakeLuciBuildService(config),
       githubStatusService,
       mockGithubChecksService,
       loggingProvider: () => log,

--- a/app_dart/test/request_handlers/reset_try_task_test.dart
+++ b/app_dart/test/request_handlers/reset_try_task_test.dart
@@ -13,6 +13,7 @@ import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
+import '../src/service/fake_github_service.dart';
 import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 
@@ -30,7 +31,7 @@ void main() {
       clientContext = FakeClientContext();
       clientContext.isDevelopmentEnvironment = false;
       authContext = FakeAuthenticatedContext(clientContext: clientContext);
-      config = FakeConfig();
+      config = FakeConfig(githubService: FakeGithubService());
       mockGithubChecksUtil = MockGithubChecksUtil();
       tester = ApiRequestHandlerTester(context: authContext);
       fakeScheduler = FakeScheduler(

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:cocoon_service/src/model/github/checks.dart';
-import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/service/github_checks_service.dart';
 import 'package:cocoon_service/src/service/luci.dart';
@@ -30,16 +29,6 @@ void main() {
   GithubChecksService githubChecksService;
   github.CheckRun checkRun;
   RepositorySlug slug;
-
-  const Build linuxBuild = Build(
-    id: 998,
-    builderId: BuilderId(
-      project: 'flutter',
-      bucket: 'prod',
-      builder: 'Linux Cocoon',
-    ),
-    status: Status.failure,
-  );
 
   setUp(() {
     mockGithubService = MockGithubService();

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -394,7 +394,8 @@ void main() {
           ],
         );
       });
-      final List<Build> result = await service.failedBuilds(slug, 1, 'abc', <LuciBuilder>[const LuciBuilder(name: 'Linux', flaky: false, repo: 'flutter')]);
+      final List<Build> result = await service
+          .failedBuilds(slug, 1, 'abc', <LuciBuilder>[const LuciBuilder(name: 'Linux', flaky: false, repo: 'flutter')]);
       expect(result, hasLength(1));
     });
   });

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -58,6 +58,7 @@ class FakeConfig implements Config {
     this.flutterGoldDraftChangeValue,
     this.flutterGoldStalePRValue,
     this.supportedBranchesValue,
+    this.luciBuildersValue,
     FakeDatastoreDB dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -98,6 +99,7 @@ class FakeConfig implements Config {
   String flutterGoldDraftChangeValue;
   String flutterGoldStalePRValue;
   List<String> supportedBranchesValue;
+  List<LuciBuilder> luciBuildersValue;
 
   @override
   Future<GitHub> createGitHubClient(RepositorySlug slug) async => githubClient;
@@ -251,6 +253,9 @@ class FakeConfig implements Config {
   @override
   Future<List<LuciBuilder>> luciBuilders(String bucket, RepositorySlug slug,
       {String commitSha = 'master', int prNumber}) async {
+    if (luciBuildersValue != null) {
+      return luciBuildersValue;
+    }
     if (slug.name == 'flutter') {
       return <LuciBuilder>[
         const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:retry/retry.dart';
 
 import 'package:cocoon_service/src/datastore/config.dart';
@@ -10,6 +11,7 @@ import 'package:cocoon_service/src/model/proto/internal/scheduler.pb.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/cache_service.dart';
+import 'package:cocoon_service/src/service/github_checks_service.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 
 import '../request_handling/fake_logging.dart';
@@ -19,20 +21,29 @@ import 'fake_luci_build_service.dart';
 class FakeScheduler extends Scheduler {
   FakeScheduler({
     this.schedulerConfig,
+    LuciBuildService luciBuildService,
     BuildBucketClient buildbucket,
     Config config,
     GithubChecksUtil githubChecksUtil,
   }) : super(
           cache: CacheService(inMemory: true),
           config: config,
-          luciBuildService: FakeLuciBuildService(config, buildbucket: buildbucket, githubChecksUtil: githubChecksUtil),
+          githubChecksService: GithubChecksService(config, githubChecksUtil: githubChecksUtil),
+          luciBuildService: luciBuildService ??
+              FakeLuciBuildService(config, buildbucket: buildbucket, githubChecksUtil: githubChecksUtil),
         ) {
     setLogger(FakeLogging());
   }
+
+  final SchedulerConfig _defaultConfig = SchedulerConfig(
+    enabledBranches: <String>['master'],
+    targets: <Target>[],
+  );
 
   /// [SchedulerConfig] value to be injected on [getSchedulerConfig].
   SchedulerConfig schedulerConfig;
 
   @override
-  Future<SchedulerConfig> getSchedulerConfig(Commit commit, {RetryOptions retryOptions}) async => schedulerConfig;
+  Future<SchedulerConfig> getSchedulerConfig(Commit commit, {RetryOptions retryOptions}) async =>
+      schedulerConfig ?? _defaultConfig;
 }

--- a/app_dart/test/src/utilities/mocks.dart
+++ b/app_dart/test/src/utilities/mocks.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/src/foundation/github_checks_util.dart';
 import 'package:cocoon_service/src/service/access_token_provider.dart';
 import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
+import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:cocoon_service/src/service/luci.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
@@ -18,6 +19,8 @@ import 'package:mockito/mockito.dart';
 import '../request_handling/fake_http.dart';
 
 class MockGitHub extends Mock implements GitHub {}
+
+class MockGithubService extends Mock implements GithubService {}
 
 class MockRepositoriesService extends Mock implements RepositoriesService {}
 


### PR DESCRIPTION
1. Add `run_if` to `Target` (maintain compatibility with try_builders.json)
2. Some refactoring to pass `List<LuciBuilder>` from scheduler to LuciBuildService for triggering presubmit runs
 - The scheduler concats try_builders.json and .ci.yaml presubmit targets

# Issues
Closes https://github.com/flutter/flutter/issues/77858 - Scheduler supports presubmit triggers
https://github.com/flutter/flutter/issues/76140 - Create Scheduler service
Fixes https://github.com/flutter/flutter/issues/80084 - prod_builders.json does not mark tasks flaky immediately