### PR TITLE
Fix duplicates tasknames get status list

### DIFF
--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -10,7 +10,6 @@ import '../model/appengine/commit.dart';
 import '../model/appengine/github_build_status_update.dart';
 import '../model/appengine/stage.dart';
 import '../model/appengine/task.dart';
-
 import 'datastore.dart';
 
 /// Function signature for a [BuildStatusService] provider.
@@ -83,6 +82,11 @@ class BuildStatusService {
               tasksInProgress[task.name] = false;
             } else if (_isFailed(task) || _isRerunning(task)) {
               failedTasks.add(task.name);
+
+              /// This task no longer needs to be checked to see if its causing
+              /// the build status to fail since its been
+              /// added to the failedTasks list.
+              tasksInProgress[task.name] = false;
             }
           }
         }

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -113,6 +113,14 @@ void main() {
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
+      test('ensure failed task do not have duplicates when last consecutive commits contains red tasks', () async {
+        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
+        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFailed);
+
+        final BuildStatus status = await buildStatusService.calculateCumulativeStatus();
+        expect(status, BuildStatus.failure(const <String>['task2']));
+      });
+
       test('ignores failures on flaky commits', () async {
         db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
         db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFlakyFailed);


### PR DESCRIPTION
If there are failures for a task in the consecutive latest commits, we will duplicate the task name in the list of failed tasks being returned.

Ensure that we only return a task name once in the list of failing tasks.

Bug:https://github.com/flutter/flutter/issues/81402
Test:app_dart/dart test