### PR TITLE
[app_dart] Set logger in vacuum github commits

### DIFF
--- a/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
@@ -36,6 +36,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
   @override
   Future<Body> get() async {
     final DatastoreService datastore = datastoreProvider(config.db);
+    scheduler.setLogger(log);
 
     for (RepositorySlug slug in Config.schedulerSupportedRepos) {
       await _vacuumRepository(slug, datastore: datastore);


### PR DESCRIPTION
This is causing some errors when we do want to add a commit from the cron method as the scheduler logger is null