### PR TITLE
Make api/get-status repository aware

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -106,6 +106,22 @@ Future<void> main() async {
         authProvider,
         scheduler: scheduler,
       ),
+
+      /// Returns status of the tree.
+      ///
+      /// Returns serialized proto with enum representing the
+      /// status of the tree and list of offending tasks.
+      ///
+      /// GET: /api/public/build-status
+      ///
+      /// Parameters:
+      ///   branch: (string in query) default: 'master'. Name of the repo branch.
+      ///
+      /// Response: Status 200 OK
+      ///  {
+      ///    1: 2,
+      ///    2: [ "win_tool_tests_commands", "win_build_test", "win_module_test"]
+      ///   }
       '/api/public/build-status': CacheRequestHandler<Body>(
         cache: cache,
         config: config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -82,6 +82,24 @@ Future<void> main() async {
         authProvider,
         scheduler,
       ),
+
+      /// Updates cocoon task status.
+      ///
+      /// This API updates task status in datastore.
+      ///
+      /// POST: /api-update-status
+      ///
+      /// Parameters:
+      ///   CommitBranch: (string in body). Branch of commit.
+      ///   CommitSha: (string in body). Sha of commit.
+      ///   BuilderName: (string in body). Name of the luci builder.
+      ///   NewStatus: (string in body) required. Status of the task.
+      ///   ResultData: (string in body) optional. Benchmark data.
+      ///   BenchmarkScoreKeys: (string in body) optional. Benchmark data.
+      ///
+      /// Response: Status 200 OK
+      ///
+      /// Requires authentication: Status: 401 Unauthorized
       '/api/update-task-status': UpdateTaskStatus(config, swarmingAuthProvider),
       '/api/vacuum-github-commits': VacuumGithubCommits(
         config,
@@ -94,11 +112,72 @@ Future<void> main() async {
         delegate: GetBuildStatus(config),
         ttl: const Duration(seconds: 15),
       ),
+
+      /// Returns task results for commits.
+      ///
+      /// Returns result details about each task in each checklist for every commit.
+      ///
+      /// GET: /api/public/get-status
+      ///
+      /// Parameters:
+      ///   branch: (string in query) default: 'master'. Name of the repo branch.
+      ///   lastCommitKey: (string in query) optional. Encoded commit key for the last commit to return resutls.
+      ///
+      /// Response: Status: 200 OK
+      ///   {"Statuses":[
+      ///     {"Checklist":{
+      ///        "Key":"ah..jgM",
+      ///        "Checklist":{"FlutterRepositoryPath":"flutter/flutter",
+      ///        "CreateTimestamp":1620134239000,
+      ///        "Commit":{"Sha":"7f1d1414cc5f0b0317272ced49a9c0b44e5c3af8",
+      ///        "Message":"Revert \"Migrate to ChannelBuffers.push\"",
+      ///        "Author":{"Login":"renyou","avatar_url":"https://avatars.githubusercontent.com/u/666474?v=4"}},"Branch":"master"}},
+      ///        "Stages":[{"Name":"chromebot",
+      ///          "Tasks":[
+      ///            {"Task":{
+      ///            "ChecklistKey":"ahF..jgM",
+      ///            "CreateTimestamp":1620134239000,
+      ///            "StartTimestamp":0,
+      ///            "EndTimestamp":1620136203757,
+      ///            "Name":"linux_cubic_bezier_perf__e2e_summary",
+      ///            "Attempts":1,
+      ///            "Flaky":false,
+      ///            "TimeoutInMinutes":0,
+      ///            "Reason":"",
+      ///            "BuildNumber":null,
+      ///            "BuildNumberList":"1279",
+      ///            "BuilderName":"Linux cubic_bezier_perf__e2e_summary",
+      ///            "luciBucket":"luci.flutter.prod",
+      ///            "RequiredCapabilities":["can-update-github"],
+      ///            "ReservedForAgentID":"",
+      ///            "StageName":"chromebot",
+      ///            "Status":"Succeeded"
+      ///            },
+      ///          ],
+      ///          "Status": "InProgress",
+      ///        ]},
+      ///       },
+      ///     }
       '/api/public/get-status': CacheRequestHandler<Body>(
         cache: cache,
         config: config,
         delegate: GetStatus(config),
       ),
+
+      /// Return supported branches.
+      ///
+      /// Returns branches that are supported by the dashboard
+      /// for the default repo.
+      ///
+      /// GET: /api/public/get-branches
+      ///
+      /// Response: Status 200 OK
+      /// {Branches: [
+      ///   "flutter-1.26-candidate.17",
+      ///   "flutter-2.2-candidate.10",
+      ///   "master"
+      ///   ]
+      /// }
       '/api/public/get-branches': CacheRequestHandler<Body>(
         cache: cache,
         config: config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -136,7 +136,8 @@ Future<void> main() async {
       /// GET: /api/public/get-status
       ///
       /// Parameters:
-      ///   branch: (string in query) default: 'master'. Name of the repo branch.
+      ///   branch: (string in query) default: 'master'. Name of the branch to filter on.
+      ///   repo: (string in query) default: 'flutter/flutter'. Name of repo to filter on.
       ///   lastCommitKey: (string in query) optional. Encoded commit key for the last commit to return resutls.
       ///
       /// Response: Status: 200 OK

--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -27,13 +27,15 @@ class GetBuildStatus extends RequestHandler<Body> {
   final BuildStatusServiceProvider buildStatusProvider;
 
   static const String branchParam = 'branch';
+  static const String repoParam = 'repo';
 
   @override
   Future<Body> get() async {
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusProvider(datastore);
     final String branch = request.uri.queryParameters[branchParam] ?? 'master';
-    final BuildStatus status = await buildStatusService.calculateCumulativeStatus(branch: branch);
+    final String repo = request.uri.queryParameters[repoParam] ?? 'flutter/flutter';
+    final BuildStatus status = await buildStatusService.calculateCumulativeStatus(branch: branch, repo: repo);
     final BuildStatusResponse response = BuildStatusResponse()
       ..buildStatus = status.succeeded ? EnumBuildStatus.success : EnumBuildStatus.failure
       ..failingTasks.addAll(status.failedTasks);

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -29,11 +29,13 @@ class GetStatus extends RequestHandler<Body> {
 
   static const String lastCommitKeyParam = 'lastCommitKey';
   static const String branchParam = 'branch';
+  static const String repoParam = 'repo';
 
   @override
   Future<Body> get() async {
     final String encodedLastCommitKey = request.uri.queryParameters[lastCommitKeyParam];
     final String branch = request.uri.queryParameters[branchParam] ?? 'master';
+    final String repo = request.uri.queryParameters[repoParam] ?? 'flutter/flutter';
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusProvider(datastore);
     final KeyHelper keyHelper = config.keyHelper;
@@ -41,7 +43,7 @@ class GetStatus extends RequestHandler<Body> {
     final int lastCommitTimestamp = await _obtainTimestamp(encodedLastCommitKey, keyHelper, datastore);
 
     final List<SerializableCommitStatus> statuses = await buildStatusService
-        .retrieveCommitStatus(limit: commitNumber, timestamp: lastCommitTimestamp, branch: branch)
+        .retrieveCommitStatus(limit: commitNumber, timestamp: lastCommitTimestamp, branch: branch, repo: repo)
         .map<SerializableCommitStatus>(
             (CommitStatus status) => SerializableCommitStatus(status, keyHelper.encode(status.commit.key)))
         .toList();

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -49,10 +49,11 @@ class BuildStatusService {
   /// the latest commit status, so it does not impact the build status.
   /// Task B fails because its last known status was to be failing, even though
   /// there is currently a newer version that is in progress.
-  Future<BuildStatus> calculateCumulativeStatus({String branch}) async {
+  Future<BuildStatus> calculateCumulativeStatus({String branch, String repo}) async {
     final List<CommitStatus> statuses = await retrieveCommitStatus(
       limit: numberOfCommitsToReferenceForTreeStatus,
       branch: branch,
+      repo: repo,
     ).toList();
     if (statuses.isEmpty) {
       return BuildStatus.failure();

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -114,9 +114,9 @@ class BuildStatusService {
   ///
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
-  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp, String branch}) async* {
+  Stream<CommitStatus> retrieveCommitStatus({int limit, int timestamp, String branch, String repo}) async* {
     await for (Commit commit
-        in datastoreService.queryRecentCommits(limit: limit, timestamp: timestamp, branch: branch)) {
+        in datastoreService.queryRecentCommits(limit: limit, timestamp: timestamp, branch: branch, repo: repo)) {
       final List<Stage> stages = await datastoreService.queryTasksGroupedByStage(commit);
       yield CommitStatus(commit, stages);
     }

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -8,8 +8,8 @@ import 'dart:math';
 import 'package:gcloud/datastore.dart' as gcloud_datastore;
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
-import 'package:meta/meta.dart';
 import 'package:grpc/grpc.dart';
+import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 
 import '../model/appengine/commit.dart';
@@ -84,11 +84,12 @@ class DatastoreService {
   /// The [limit] argument specifies the maximum number of commits to retrieve.
   ///
   /// The returned commits will be ordered by most recent [Commit.timestamp].
-  Stream<Commit> queryRecentCommits({int limit = 100, int timestamp, String branch}) {
+  Stream<Commit> queryRecentCommits(
+      {int limit = 100, int timestamp, String branch = 'master', String repo = 'flutter/flutter'}) {
     timestamp ??= DateTime.now().millisecondsSinceEpoch;
-    branch ??= 'master';
     final Query<Commit> query = db.query<Commit>()
       ..limit(limit)
+      ..filter('repository =', repo)
       ..filter('branch =', branch)
       ..order('-timestamp')
       ..filter('timestamp <', timestamp);
@@ -96,10 +97,11 @@ class DatastoreService {
   }
 
   // Queries for recent commits without considering branches.
-  Stream<Commit> queryRecentCommitsNoBranch({int limit = 100, int timestamp}) {
+  Stream<Commit> queryRecentCommitsNoBranch({int limit = 100, int timestamp, String repo='flutter/flutter'}) {
     timestamp ??= DateTime.now().millisecondsSinceEpoch;
     final Query<Commit> query = db.query<Commit>()
       ..limit(limit)
+      ..filter('repository =', repo)
       ..order('-timestamp')
       ..filter('timestamp <', timestamp);
     return query.run();

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -97,7 +97,7 @@ class DatastoreService {
   }
 
   // Queries for recent commits without considering branches.
-  Stream<Commit> queryRecentCommitsNoBranch({int limit = 100, int timestamp, String repo='flutter/flutter'}) {
+  Stream<Commit> queryRecentCommitsNoBranch({int limit = 100, int timestamp, String repo = 'flutter/flutter'}) {
     timestamp ??= DateTime.now().millisecondsSinceEpoch;
     final Query<Commit> query = db.query<Commit>()
       ..limit(limit)

--- a/app_dart/test/service/datastore_test.dart
+++ b/app_dart/test/service/datastore_test.dart
@@ -7,9 +7,9 @@ import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/datastore.dart' as gcloud_datastore;
 import 'package:gcloud/db.dart';
-import 'package:test/test.dart';
 import 'package:grpc/grpc.dart';
 import 'package:retry/retry.dart';
+import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
@@ -48,8 +48,11 @@ void main() {
 
       test('QueryRecentCommits', () async {
         for (String branch in <String>['master', 'release']) {
-          final Commit commit =
-              Commit(key: config.db.emptyKey.append(Commit, id: 'abc_$branch'), sha: 'abc_$branch', branch: branch);
+          final Commit commit = Commit(
+              key: config.db.emptyKey.append(Commit, id: 'abc_$branch'),
+              sha: 'abc_$branch',
+              branch: branch,
+              repository: 'flutter/flutter');
           config.db.values[commit.key] = commit;
         }
         // Defaults to master
@@ -61,13 +64,17 @@ void main() {
         expect(commits, hasLength(1));
         expect(commits[0].branch, equals('release'));
       });
+
       test('QueryRecentCommitsNoBranch', () async {
         // Empty results
         List<Commit> commits = await datastoreService.queryRecentCommits().toList();
         expect(commits, isEmpty);
         for (String branch in <String>['master', 'release']) {
-          final Commit commit =
-              Commit(key: config.db.emptyKey.append(Commit, id: 'abc_$branch'), sha: 'abc_$branch', branch: branch);
+          final Commit commit = Commit(
+              key: config.db.emptyKey.append(Commit, id: 'abc_$branch'),
+              sha: 'abc_$branch',
+              branch: branch,
+              repository: 'flutter/flutter');
           config.db.values[commit.key] = commit;
         }
         // Results from two branches
@@ -75,8 +82,96 @@ void main() {
         expect(commits, hasLength(2));
       });
 
+      test('QueryRecentCommitsNoBranch - repository filtering', () async {
+        // Empty results
+        List<Commit> commits = await datastoreService.queryRecentCommitsNoBranch().toList();
+        expect(commits, isEmpty);
+        for (String repo in <String>['flutter/flutter', 'flutter/engine']) {
+          final Commit commit =
+              Commit(key: config.db.emptyKey.append(Commit, id: 'abc_$repo'), sha: 'abc_$repo', repository: repo);
+          config.db.values[commit.key] = commit;
+        }
+        // Defaults to flutter/flutter
+        commits = await datastoreService.queryRecentCommitsNoBranch().toList();
+        expect(commits, hasLength(1));
+        expect(commits[0].repository, equals('flutter/flutter'));
+        // Explicit repo
+        commits = await datastoreService.queryRecentCommitsNoBranch(repo: 'flutter/engine').toList();
+        expect(commits, hasLength(1));
+        expect(commits[0].repository, equals('flutter/engine'));
+        // Invalid repo
+        commits = await datastoreService.queryRecentCommitsNoBranch(repo: 'flutter/DNE').toList();
+        expect(commits, hasLength(0));
+      });
+
+      test('QueryRecentCommits - repository and branch filter', () async {
+        // Empty results
+        List<Commit> commits = await datastoreService.queryRecentCommits().toList();
+        expect(commits, isEmpty);
+        for (String repo in <String>['flutter/flutter', 'flutter/engine']) {
+          for (String branch in <String>['master', 'release']) {
+            final Commit commit = Commit(
+                key: config.db.emptyKey.append(Commit, id: 'abc_${repo}_${branch}'),
+                sha: 'abc_${repo}_${branch}',
+                repository: repo,
+                branch: branch);
+            config.db.values[commit.key] = commit;
+          }
+        }
+        // Defaults to flutter/flutter and master
+        commits = await datastoreService.queryRecentCommits().toList();
+        expect(commits, hasLength(1));
+        expect(commits[0].repository, equals('flutter/flutter'));
+        expect(commits[0].branch, equals('master'));
+        // Explicit branch and repo
+        commits = await datastoreService.queryRecentCommits(repo: 'flutter/engine', branch: 'release').toList();
+        expect(commits, hasLength(1));
+        expect(commits[0].repository, equals('flutter/engine'));
+        expect(commits[0].branch, equals('release'));
+        // Invalid repo
+        commits = await datastoreService.queryRecentCommits(repo: 'flutter/DNE').toList();
+        expect(commits, hasLength(0));
+        // Invalid branch
+        commits = await datastoreService.queryRecentCommits(branch: 'branchDNE').toList();
+        expect(commits, hasLength(0));
+        // Valid repo, invalid branch
+        commits = await datastoreService.queryRecentCommits(repo: 'flutter/flutter', branch: 'branchDNE').toList();
+        expect(commits, hasLength(0));
+        // Invalid repo, valid branch
+        commits = await datastoreService.queryRecentCommits(repo: 'flutter/DNE', branch: 'master').toList();
+        expect(commits, hasLength(0));
+      });
+
+      test('QueryRecentCommitsNoBranch - repository and branch filter', () async {
+        // Empty results
+        List<Commit> commits = await datastoreService.queryRecentCommitsNoBranch().toList();
+        expect(commits, isEmpty);
+        for (String repo in <String>['flutter/flutter', 'flutter/engine']) {
+          for (String branch in <String>['master', 'release']) {
+            final Commit commit = Commit(
+                key: config.db.emptyKey.append(Commit, id: 'abc_${repo}_${branch}'),
+                sha: 'abc_${repo}_${branch}',
+                repository: repo,
+                branch: branch);
+            config.db.values[commit.key] = commit;
+          }
+        }
+        // Defaults to flutter/flutter from all branches
+        commits = await datastoreService.queryRecentCommitsNoBranch().toList();
+        expect(commits, hasLength(2));
+        expect(commits[0].repository, equals('flutter/flutter'));
+        // Explicit repo
+        commits = await datastoreService.queryRecentCommitsNoBranch(repo: 'flutter/engine').toList();
+        expect(commits, hasLength(2));
+        expect(commits[0].repository, equals('flutter/engine'));
+        // Invalid repo
+        commits = await datastoreService.queryRecentCommitsNoBranch(repo: 'flutter/DNE').toList();
+        expect(commits, hasLength(0));
+      });
+
       test('QueryRecentTasksNoBranch - release branch', () async {
-        final Commit commit = Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), branch: 'release');
+        final Commit commit =
+            Commit(key: config.db.emptyKey.append(Commit, id: 'abc'), branch: 'release', repository: 'flutter/flutter');
         config.db.values[commit.key] = commit;
         final Task task = Task(
             key: commit.key.append(Task, id: 123),

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -168,11 +168,13 @@ class FakeQuery<T extends Model<dynamic>> implements Query<T> {
   Stream<T> run() {
     Iterable<T> resultsView = results;
 
-    // This considers only the special case when there exists [branch] or [pr] filter.
+    // This considers only the special case when there exists [branch], [repository] or [pr] filter.
     for (FakeFilterSpec filter in filters) {
       final String filterString = filter.filterString;
       final Object value = filter.comparisonObject;
-      if (filterString.contains('branch =') || filterString.contains('head =')) {
+      if (filterString.contains('branch =') ||
+          filterString.contains('head =') ||
+          filterString.contains('repository =')) {
         resultsView = resultsView.where((T result) => result.toString().contains(value.toString()));
       }
     }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -23,7 +23,7 @@ class FakeBuildStatusService implements BuildStatusService {
   }
 
   @override
-  Stream<CommitStatus> retrieveCommitStatus({int limit = 100, int timestamp, String branch}) {
+  Stream<CommitStatus> retrieveCommitStatus({int limit = 100, int timestamp, String branch, String repo}) {
     if (commitStatuses == null) {
       throw AssertionError();
     }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -15,7 +15,7 @@ class FakeBuildStatusService implements BuildStatusService {
   List<CommitStatus> commitStatuses;
 
   @override
-  Future<BuildStatus> calculateCumulativeStatus({String branch}) async {
+  Future<BuildStatus> calculateCumulativeStatus({String branch, String repo}) async {
     if (cumulativeStatus == null) {
       throw AssertionError();
     }


### PR DESCRIPTION
We now filter on an (optional) repo query parameter when returning list of commits from datastore.

Due to constraints in datatstore querying, application of filtering by repo will now reject any values that do not match the expected repo name, so if data rows contain any empty/null values for the repository, they will also be filtered out.

TEST=app_dart/dart test