### PR TITLE
Add lint: prefer relative imports

### DIFF
--- a/app_dart/analysis_options.yaml
+++ b/app_dart/analysis_options.yaml
@@ -153,6 +153,7 @@ linter:
     - prefer_iterable_whereType
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables

--- a/app_dart/lib/src/model/google/grpc.dart
+++ b/app_dart/lib/src/model/google/grpc.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:json_annotation/json_annotation.dart';
+
+import '../../request_handling/body.dart';
 
 part 'grpc.g.dart';
 

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:github/github.dart';
 import 'package:graphql/client.dart';
 import 'package:meta/meta.dart';
@@ -15,6 +14,7 @@ import '../foundation/typedefs.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
 import '../service/config.dart';
 import 'check_for_waiting_pull_requests_queries.dart';
 import 'refresh_cirrus_status.dart';

--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -4,14 +4,14 @@
 
 import 'dart:async';
 
-import 'package:cocoon_service/protos.dart' show BuildStatusResponse, EnumBuildStatus;
-import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:meta/meta.dart';
 
+import '../../protos.dart' show BuildStatusResponse, EnumBuildStatus;
 import '../request_handling/body.dart';
 import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
 import '../service/config.dart';
+import '../service/datastore.dart';
 
 @immutable
 class GetBuildStatus extends RequestHandler<Body> {

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -5,22 +5,22 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:cocoon_service/src/foundation/providers.dart';
-import 'package:cocoon_service/src/service/buildbucket.dart';
-import 'package:cocoon_service/src/service/github_checks_service.dart';
-import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/oauth2/v2.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
+import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../model/appengine/service_account_info.dart';
 import '../model/luci/push_message.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
 import '../request_handling/request_handler.dart';
+import '../service/buildbucket.dart';
 import '../service/config.dart';
+import '../service/github_checks_service.dart';
+import '../service/luci_build_service.dart';
 
 /// An endpoint for listening to LUCI status updates for scheduled builds.
 ///

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:github/github.dart';
 import 'package:graphql/client.dart';
 import 'package:meta/meta.dart';
@@ -18,6 +17,7 @@ import '../model/appengine/github_gold_status_update.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
 import '../service/config.dart';
 import '../service/datastore.dart';
 

--- a/app_dart/lib/src/request_handlers/query_github_graphql.dart
+++ b/app_dart/lib/src/request_handlers/query_github_graphql.dart
@@ -6,14 +6,14 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:graphql/client.dart';
 import 'package:meta/meta.dart';
 
+import '../../cocoon_service.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
 import '../service/config.dart';
 
 /// Runs an authenticated Github GraphQl query returning the query result as json.

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -5,23 +5,23 @@
 import 'dart:async';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/model/appengine/commit.dart';
-import 'package:cocoon_service/src/model/appengine/task.dart';
-import 'package:cocoon_service/src/model/luci/buildbucket.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/service/luci.dart';
-import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
+import '../../cocoon_service.dart';
+import '../model/appengine/commit.dart';
 import '../model/appengine/key_helper.dart';
+import '../model/appengine/task.dart';
+import '../model/luci/buildbucket.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
 import '../service/config.dart';
 import '../service/datastore.dart';
+import '../service/luci.dart';
+import '../service/luci_build_service.dart';
 
 /// Triggers prod builds based on a task key. This handler is used to trigger
 /// LUCI builds that didn't run or failed.

--- a/app_dart/lib/src/request_handlers/reset_try_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_try_task.dart
@@ -4,14 +4,14 @@
 
 import 'dart:async';
 
-import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
+import '../../cocoon_service.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/exceptions.dart';
 import '../service/config.dart';
 import '../service/scheduler.dart';
 

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -7,11 +7,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/cocoon_service.dart';
 import 'package:dbcrypt/dbcrypt.dart';
 import 'package:gcloud/db.dart';
 import 'package:meta/meta.dart';
 
+import '../../cocoon_service.dart';
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../model/appengine/allowed_account.dart';

--- a/app_dart/lib/src/request_handling/static_file_handler.dart
+++ b/app_dart/lib/src/request_handling/static_file_handler.dart
@@ -6,13 +6,13 @@ import 'dart:async';
 import 'dart:io' show ContentType, HttpResponse;
 import 'dart:typed_data';
 
-import 'package:cocoon_service/cocoon_service.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:mime/mime.dart';
 import 'package:path/path.dart' as path;
 
+import '../../cocoon_service.dart';
 import 'exceptions.dart';
 
 /// A class based on [RequestHandler] for serving static files.

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -7,12 +7,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/model/google/token_info.dart';
 import 'package:meta/meta.dart';
 
+import '../../cocoon_service.dart';
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
+import '../model/google/token_info.dart';
 import 'exceptions.dart';
 
 /// Class capable of authenticating [HttpRequest]s for infra endpoints.

--- a/app_dart/lib/src/service/github_status_service.dart
+++ b/app_dart/lib/src/service/github_status_service.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../foundation/utils.dart';
+import '../model/appengine/commit.dart';
 import '../model/luci/push_message.dart';
 import 'config.dart';
 import 'luci.dart';

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -5,17 +5,17 @@
 import 'dart:convert';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/src/foundation/github_checks_util.dart';
-import 'package:cocoon_service/src/model/github/checks.dart';
-import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:github/github.dart' as github;
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 
 import '../../cocoon_service.dart';
+import '../foundation/github_checks_util.dart';
 import '../model/appengine/service_account_info.dart';
+import '../model/github/checks.dart';
 import '../model/luci/buildbucket.dart';
 import '../model/luci/push_message.dart' as push_message;
+import '../request_handling/exceptions.dart';
 import 'buildbucket.dart';
 import 'luci.dart';
 

--- a/app_flutter/analysis_options.yaml
+++ b/app_flutter/analysis_options.yaml
@@ -140,7 +140,7 @@ linter:
     - prefer_iterable_whereType
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
-    # - prefer_relative_imports # not yet tested
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables

--- a/app_flutter/lib/service/appengine_cocoon.dart
+++ b/app_flutter/lib/service/appengine_cocoon.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:app_flutter/logic/qualified_task.dart';
 import 'package:cocoon_service/protos.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;

--- a/app_flutter/lib/widgets/commit_author_avatar.dart
+++ b/app_flutter/lib/widgets/commit_author_avatar.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:app_flutter/widgets/web_image.dart';
 import 'package:cocoon_service/protos.dart' show Commit;
 import 'package:flutter/material.dart';
+
+import 'web_image.dart';
 
 /// Shows the appropriate avatar for a [Commit]'s author.
 ///


### PR DESCRIPTION
This is a recreation of https://github.com/flutter/cocoon/pull/1211 as I had a git hiccup

This lint is now supported, and we can add it to be enforced.

Added and updated `app_dart` and `app_flutter`.