### PR TITLE
[scheduler] Update prod tasks listed in ci.yaml

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -70,8 +70,18 @@ Future<void> main() async {
       ),
       '/api/push-build-status-to-github': PushBuildStatusToGithub(config, authProvider),
       '/api/push-gold-status-to-github': PushGoldStatusToGithub(config, authProvider),
-      '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(config, authProvider, luciBuildService),
-      '/api/refresh-chromebot-status': RefreshChromebotStatus(config, authProvider, luciBuildService),
+      '/api/push-engine-build-status-to-github': PushEngineStatusToGithub(
+        config,
+        authProvider,
+        luciBuildService,
+        scheduler: scheduler,
+      ),
+      '/api/refresh-chromebot-status': RefreshChromebotStatus(
+        config,
+        authProvider,
+        luciBuildService,
+        scheduler: scheduler,
+      ),
       '/api/reset-prod-task': ResetProdTask(
         config,
         authProvider,

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -65,7 +65,7 @@ class Commit extends Model<String> {
   String branch;
 
   /// [RepositorySlug] of where this commit exists.
-  RepositorySlug get slug => RepositorySlug(repository.split('/').first, repository.split('/').last);
+  RepositorySlug get slug => RepositorySlug.full(repository);
 
   @override
   String toString() {

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:cocoon_scheduler/scheduler.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
@@ -11,7 +12,6 @@ import '../foundation/utils.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/github_build_status_update.dart';
 import '../model/appengine/task.dart';
-import '../model/proto/internal/scheduler.pb.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';

--- a/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_engine_status_to_github.dart
@@ -59,9 +59,8 @@ class PushEngineStatusToGithub extends ApiRequestHandler<Body> {
     final RepositorySlug slug = config.engineSlug;
     final Commit engineTipOfTreeCommit = Commit(sha: config.defaultBranch, repository: slug.fullName);
     final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(engineTipOfTreeCommit);
-    final List<Target> postsubmitTargets = scheduler.getPostSubmitTargets(engineTipOfTreeCommit, schedulerConfig);
     final List<LuciBuilder> postsubmitBuilders =
-        postsubmitTargets.map((Target target) => LuciBuilder.fromTarget(target, engineTipOfTreeCommit.slug)).toList();
+        await scheduler.getPostSubmitBuilders(engineTipOfTreeCommit, schedulerConfig);
     final LuciService luciService = luciServiceProvider(this);
     final Map<LuciBuilder, List<LuciTask>> luciTasks = await luciService.getRecentTasks(builders: postsubmitBuilders);
 

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -28,7 +28,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     Config config,
     AuthenticationProvider authenticationProvider,
     this.luciBuildService, {
-    this.scheduler,
+    @required this.scheduler,
     @visibleForTesting LuciServiceProvider luciServiceProvider,
     @visibleForTesting DatastoreServiceProvider datastoreProvider,
     @visibleForTesting this.branchHttpClientProvider = Providers.freshHttpClient,

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -60,9 +60,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     final DatastoreService datastore = datastoreProvider(config.db);
     final Commit latestCommit = await datastore.queryRecentCommits(limit: 1).single;
     final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(latestCommit);
-    final List<Target> postsubmitTargets = scheduler.getPostSubmitTargets(latestCommit, schedulerConfig);
-    final List<LuciBuilder> postsubmitBuilders =
-        postsubmitTargets.map((Target target) => LuciBuilder.fromTarget(target, latestCommit.slug)).toList();
+    final List<LuciBuilder> postsubmitBuilders = await scheduler.getPostSubmitBuilders(latestCommit, schedulerConfig);
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks = await luciService.getBranchRecentTasks(
       builders: postsubmitBuilders,
       requireTaskName: true,

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -9,7 +9,9 @@ import 'package:meta/meta.dart';
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
 import '../foundation/utils.dart';
+import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
+import '../model/proto/internal/scheduler.pb.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
@@ -18,6 +20,7 @@ import '../service/config.dart';
 import '../service/datastore.dart';
 import '../service/luci.dart';
 import '../service/luci_build_service.dart';
+import '../service/scheduler.dart';
 
 @immutable
 class RefreshChromebotStatus extends ApiRequestHandler<Body> {
@@ -25,6 +28,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     Config config,
     AuthenticationProvider authenticationProvider,
     this.luciBuildService, {
+    this.scheduler,
     @visibleForTesting LuciServiceProvider luciServiceProvider,
     @visibleForTesting DatastoreServiceProvider datastoreProvider,
     @visibleForTesting this.branchHttpClientProvider = Providers.freshHttpClient,
@@ -40,6 +44,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
   final DatastoreServiceProvider datastoreProvider;
   final HttpClientProvider branchHttpClientProvider;
   final GitHubBackoffCalculator gitHubBackoffCalculator;
+  final Scheduler scheduler;
 
   static LuciService _createLuciService(ApiRequestHandler<dynamic> handler) {
     return LuciService(
@@ -53,8 +58,13 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
   Future<Body> get() async {
     final LuciService luciService = luciServiceProvider(this);
     final DatastoreService datastore = datastoreProvider(config.db);
+    final Commit latestCommit = await datastore.queryRecentCommits(limit: 1).single;
+    final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(latestCommit);
+    final List<Target> postsubmitTargets = scheduler.getPostSubmitTargets(latestCommit, schedulerConfig);
+    final List<LuciBuilder> postsubmitBuilders =
+        postsubmitTargets.map((Target target) => LuciBuilder.fromTarget(target, latestCommit.slug)).toList();
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks = await luciService.getBranchRecentTasks(
-      slug: config.flutterSlug,
+      builders: postsubmitBuilders,
       requireTaskName: true,
     );
 

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -65,11 +65,10 @@ class LuciService {
   ///
   /// The list of known LUCI builders is specified in [LuciBuilder.all].
   Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>> getBranchRecentTasks({
-    RepositorySlug slug,
+    @required List<LuciBuilder> builders,
     bool requireTaskName = false,
   }) async {
     assert(requireTaskName != null);
-    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(slug, config);
     final List<Build> builds = await getBuildsForBuilderList(builders);
 
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> results =
@@ -140,11 +139,10 @@ class LuciService {
   ///
   /// The list of known LUCI builders is specified in [LuciBuilder.all].
   Future<Map<LuciBuilder, List<LuciTask>>> getRecentTasks({
-    RepositorySlug slug,
+    @required List<LuciBuilder> builders,
     bool requireTaskName = false,
   }) async {
     assert(requireTaskName != null);
-    final List<LuciBuilder> builders = await LuciBuilder.getProdBuilders(slug, config);
     final List<Build> builds = await getBuildsForBuilderList(builders);
 
     final Map<LuciBuilder, List<LuciTask>> results = <LuciBuilder, List<LuciTask>>{};
@@ -283,12 +281,6 @@ class LuciBuilder {
 
   /// Serializes this object to a JSON primitive.
   Map<String, dynamic> toJson() => _$LuciBuilderToJson(this);
-
-  /// Loads and returns the list of known builders from the Cocoon [config] for [commitSha].
-  static Future<List<LuciBuilder>> getProdBuilders(RepositorySlug slug, Config config,
-      {String commitSha = 'master'}) async {
-    return await config.luciBuilders('prod', slug, commitSha: commitSha);
-  }
 }
 
 @immutable

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -76,9 +76,9 @@ class LuciService {
     for (Build build in builds) {
       final String commit = build.input?.gitilesCommit?.hash ?? 'unknown';
       final String ref = build.input?.gitilesCommit?.ref ?? 'unknown';
-      final LuciBuilder builder = builders.singleWhere((LuciBuilder builder) {
+      final LuciBuilder builder = builders.where((LuciBuilder builder) {
         return builder.name == build.builderId.builder;
-      });
+      }).first;
       final String branch = ref == 'unknown' ? 'unknown' : ref.split('/')[2];
       final BranchLuciBuilder branchLuciBuilder = BranchLuciBuilder(
         luciBuilder: builder,
@@ -149,9 +149,9 @@ class LuciService {
     for (Build build in builds) {
       final String commit = build.input?.gitilesCommit?.hash ?? 'unknown';
       final String ref = build.input?.gitilesCommit?.ref ?? 'unknown';
-      final LuciBuilder builder = builders.singleWhere((LuciBuilder builder) {
+      final LuciBuilder builder = builders.where((LuciBuilder builder) {
         return builder.name == build.builderId.builder;
-      });
+      }).first;
       results[builder] ??= <LuciTask>[];
       results[builder].add(LuciTask(
         commitSha: commit,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -172,8 +172,8 @@ class Scheduler {
   /// Create [Tasks] specified in [commit] scheduler config.
   Future<List<Task>> _getTasks(Commit commit) async {
     final List<Task> tasks = <Task>[];
-    final List<LuciBuilder> prodBuilders =
-        await LuciBuilder.getProdBuilders(commit.slug, config, commitSha: commit.sha);
+    final List<LuciBuilder> prodBuilders = await config.luciBuilders('prod', commit.slug, commitSha: commit.sha);
+    ;
     for (LuciBuilder builder in prodBuilders) {
       tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));
     }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -221,12 +221,12 @@ class Scheduler {
   ///
   /// Get an aggregate of LUCI presubmit builders from .ci.yaml and prod_builders.json.
   Future<List<LuciBuilder>> getPostSubmitBuilders(Commit commit, SchedulerConfig schedulerConfig) async {
-    // Filter targets to only those run in postsubmit.
+    // 1. Get prod_builders.json builders
+    final List<LuciBuilder> postsubmitBuilders = await config.luciBuilders('prod', commit.slug, commitSha: commit.sha);
+    // 2. Get ci.yaml builders (filter to only those that are relevant)
     final List<Target> postsubmitTargets = schedulerConfig.targets.where((Target target) => target.postsubmit).toList();
     final List<Target> filteredTargets = _filterEnabledTargets(commit, schedulerConfig, postsubmitTargets);
-    final List<LuciBuilder> postsubmitBuilders =
-        filteredTargets.map((Target target) => LuciBuilder.fromTarget(target, commit.slug)).toList();
-    postsubmitBuilders.addAll(await config.luciBuilders('prod', commit.slug, commitSha: commit.sha));
+    postsubmitBuilders.addAll(filteredTargets.map((Target target) => LuciBuilder.fromTarget(target, commit.slug)));
     return postsubmitBuilders;
   }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -173,7 +173,6 @@ class Scheduler {
   Future<List<Task>> _getTasks(Commit commit) async {
     final List<Task> tasks = <Task>[];
     final List<LuciBuilder> prodBuilders = await config.luciBuilders('prod', commit.slug, commitSha: commit.sha);
-    ;
     for (LuciBuilder builder in prodBuilders) {
       tasks.add(Task.chromebot(commitKey: commit.key, createTimestamp: commit.timestamp, builder: builder));
     }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -217,6 +217,19 @@ class Scheduler {
     return _filterEnabledTargets(commit, config, postsubmitTargets);
   }
 
+  /// Get all [LuciBuilder] run on postsubmit for [Commit].
+  ///
+  /// Get an aggregate of LUCI presubmit builders from .ci.yaml and prod_builders.json.
+  Future<List<LuciBuilder>> getPostSubmitBuilders(Commit commit, SchedulerConfig schedulerConfig) async {
+    // Filter targets to only those run in postsubmit.
+    final List<Target> postsubmitTargets = schedulerConfig.targets.where((Target target) => target.postsubmit).toList();
+    final List<Target> filteredTargets = _filterEnabledTargets(commit, schedulerConfig, postsubmitTargets);
+    final List<LuciBuilder> postsubmitBuilders =
+        filteredTargets.map((Target target) => LuciBuilder.fromTarget(target, commit.slug)).toList();
+    postsubmitBuilders.addAll(await config.luciBuilders('prod', commit.slug, commitSha: commit.sha));
+    return postsubmitBuilders;
+  }
+
   /// Get all targets run on presubmit for [Commit].
   ///
   /// Filter [SchedulerConfig] to only the targets expected to run for the branch,

--- a/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_engine_status_to_github_test.dart
@@ -19,6 +19,7 @@ import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/service/fake_github_service.dart';
+import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
@@ -83,6 +84,7 @@ void main() {
         mockLuciBuildService,
         luciServiceProvider: (_) => mockLuciService,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
+        scheduler: FakeScheduler(config: config),
       );
 
       when(github.pullRequests).thenReturn(pullRequestsService);
@@ -102,16 +104,16 @@ void main() {
 
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
       config.db.values[status.key] = status;
-
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', config.engineSlug);
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders(config.engineSlug, config),
+        builders,
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
               commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusFailed, buildNumber: 1, builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -127,9 +129,9 @@ void main() {
 
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
       config.db.values[status.key] = status;
-
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', config.engineSlug);
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders(config.engineSlug, config),
+        builders,
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -140,7 +142,7 @@ void main() {
               builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -157,8 +159,9 @@ void main() {
 
       config.db.values[status.key] = status;
 
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', config.engineSlug);
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders(config.engineSlug, config),
+        builders,
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -169,7 +172,7 @@ void main() {
               builderName: 'abc')
         ],
       );
-      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -186,9 +189,9 @@ void main() {
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_test_1']));
 
       config.db.values[status.key] = status;
-
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', config.engineSlug);
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders(config.engineSlug, config),
+        builders,
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -211,7 +214,7 @@ void main() {
               builderName: 'efg'),
         ],
       );
-      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 
@@ -228,9 +231,9 @@ void main() {
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
 
       config.db.values[status.key] = status;
-
+      final List<LuciBuilder> builders = await config.luciBuilders('prod', config.engineSlug);
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        await LuciBuilder.getProdBuilders(config.engineSlug, config),
+        builders,
         key: (dynamic builder) => builder as LuciBuilder,
         value: (dynamic builder) => <LuciTask>[
           const LuciTask(
@@ -241,7 +244,7 @@ void main() {
               builderName: 'abc'),
         ],
       );
-      when(mockLuciService.getRecentTasks(slug: config.engineSlug)).thenAnswer((Invocation invocation) {
+      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
         return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
       });
 

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -63,24 +63,6 @@ void main() {
 
     group('without builder rerun', () {
       setUp(() {
-        branchHttpClient = FakeHttpClient();
-        tabledataResourceApi = FakeTabledataResourceApi();
-        config = FakeConfig(tabledataResourceApi: tabledataResourceApi);
-        config.flutterBranchesValue = <String>[config.defaultBranch];
-        tester = ApiRequestHandlerTester();
-        mockLuciService = MockLuciService();
-        mockLuciBuildService = MockLuciBuildService();
-        scheduler = FakeScheduler(config: config);
-        handler = RefreshChromebotStatus(
-          config,
-          FakeAuthenticationProvider(),
-          mockLuciBuildService,
-          luciServiceProvider: (_) => mockLuciService,
-          datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-          branchHttpClientProvider: () => branchHttpClient,
-          gitHubBackoffCalculator: (int attempt) => Duration.zero,
-          scheduler: scheduler,
-        );
         when(mockLuciBuildService.checkRerunBuilder(
                 commitSha: anyNamed('commitSha'), luciTask: anyNamed('luciTask'), retries: anyNamed('retries')))
             .thenAnswer((_) => Future<bool>.value(false));

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -288,7 +288,11 @@ void main() {
         final Commit commit = Commit(
             key: config.db.emptyKey.append(Commit, id: 'abc'), sha: 'abc', repository: config.flutterSlug.fullName);
         final Task task = Task(
-            key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
+            key: commit.key.append(Task, id: 123),
+            commitKey: commit.key,
+            builderName: 'Linux A',
+            status: Task.statusNew,
+            buildNumberList: '1');
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
         scheduler.schedulerConfig = oneTargetConfig;
@@ -301,17 +305,12 @@ void main() {
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
                         const LuciTask(
-                            commitSha: 'abc',
-                            ref: 'refs/heads/master',
-                            status: Task.statusSucceeded,
-                            buildNumber: 2,
-                            builderName: 'abc'),
-                        const LuciTask(
-                            commitSha: 'abc',
-                            ref: 'refs/heads/master',
-                            status: Task.statusFailed,
-                            buildNumber: 1,
-                            builderName: 'abc')
+                          commitSha: 'abc',
+                          ref: 'refs/heads/master',
+                          status: Task.statusSucceeded,
+                          buildNumber: 2,
+                          builderName: 'Linux A',
+                        ),
                       ],
                     });
         when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
@@ -322,7 +321,7 @@ void main() {
         expect(task.status, Task.statusNew);
         await tester.get(handler);
         expect(task.status, Task.statusSucceeded);
-        expect(task.buildNumberList, '1,2');
+        expect(task.buildNumberList, '2');
       });
 
       test('update task status for non master branch', () async {

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -17,6 +17,7 @@ import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
+import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
@@ -44,6 +45,7 @@ void main() {
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         branchHttpClientProvider: () => branchHttpClient,
         gitHubBackoffCalculator: (int attempt) => Duration.zero,
+        scheduler: FakeScheduler(config: config),
       );
     });
 
@@ -60,9 +62,9 @@ void main() {
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
 
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -74,7 +76,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -97,9 +99,9 @@ void main() {
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
 
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -111,7 +113,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -126,9 +128,9 @@ void main() {
         final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -140,7 +142,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -155,10 +157,9 @@ void main() {
         final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -170,7 +171,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -187,10 +188,9 @@ void main() {
         final Task task = Task(key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew);
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -202,7 +202,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -218,10 +218,9 @@ void main() {
             key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -233,7 +232,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -249,10 +248,9 @@ void main() {
             key: commit.key.append(Task, id: 123), commitKey: commit.key, status: Task.statusNew, buildNumberList: '1');
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'abc': <LuciTask>[
@@ -270,7 +268,7 @@ void main() {
                             builderName: 'abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -286,10 +284,9 @@ void main() {
         final Task task = Task(key: commit.key.append(Task, id: 456), commitKey: commit.key, status: Task.statusNew);
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -302,8 +299,7 @@ void main() {
                       ],
                     });
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> testLuciTasks =
-            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(
-                await LuciBuilder.getProdBuilders(config.flutterSlug, config),
+            Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(builders,
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder, branch: 'test'),
                 value: (dynamic builder) => <String, List<LuciTask>>{
                       'def': <LuciTask>[
@@ -316,7 +312,7 @@ void main() {
                       ],
                     });
         luciTasks.addAll(testLuciTasks);
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });
@@ -346,7 +342,7 @@ void main() {
             builderName: 'Mac abc');
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-
+        final List<LuciBuilder> builders = await config.luciBuilders('prod', config.flutterSlug);
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(<LuciBuilder>[
           LuciBuilder(name: 'Mac abc', repo: config.flutterSlug.name, taskName: 'def', flaky: false)
@@ -362,7 +358,7 @@ void main() {
                             builderName: 'Mac abc')
                       ],
                     });
-        when(mockLuciService.getBranchRecentTasks(slug: config.flutterSlug, requireTaskName: true))
+        when(mockLuciService.getBranchRecentTasks(builders: anyNamed('builders'), requireTaskName: true))
             .thenAnswer((Invocation invocation) {
           return Future<Map<BranchLuciBuilder, Map<String, List<LuciTask>>>>.value(luciTasks);
         });

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -59,7 +59,9 @@ void main() {
     });
 
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTaskBranchMap =
-        await service.getBranchRecentTasks(slug: config.flutterSlug);
+        await service.getBranchRecentTasks(builders: <LuciBuilder>[
+      const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),
+    ]);
     // There's no branch logic so there is only one entry
     expect(luciTaskBranchMap.keys.length, 1);
     final Map<String, List<LuciTask>> luciTaskMap = luciTaskBranchMap.values.first;

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:cocoon_scheduler/scheduler.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_github;
@@ -378,6 +379,16 @@ targets:
         expect(retriedBuildRequests.length, 1);
         final ScheduleBuildRequest retryRequest = retriedBuildRequests.first as ScheduleBuildRequest;
         expect(retryRequest.builderId.builder, 'Linux A');
+      });
+    });
+
+    group('postsubmit', () {
+      test('adds both prod_builders and .ci.yaml builds', () async {
+        final Commit commit = Commit(repository: config.flutterSlug.fullName);
+        final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(commit);
+        final List<LuciBuilder> postsubmitBuilders = await scheduler.getPostSubmitBuilders(commit, schedulerConfig);
+        expect(postsubmitBuilders.map((LuciBuilder builder) => builder.name).toList(),
+            <String>['Linux A', 'Linux', 'Mac', 'Windows', 'Linux Coverage']);
       });
     });
   });

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -388,7 +388,7 @@ targets:
         final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(commit);
         final List<LuciBuilder> postsubmitBuilders = await scheduler.getPostSubmitBuilders(commit, schedulerConfig);
         expect(postsubmitBuilders.map((LuciBuilder builder) => builder.name).toList(),
-            <String>['Linux A', 'Linux', 'Mac', 'Windows', 'Linux Coverage']);
+            <String>['Linux', 'Mac', 'Windows', 'Linux Coverage', 'Linux A']);
       });
     });
   });

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -107,7 +107,10 @@ class FakeDatastoreDB implements DatastoreDB {
 
   @override
   FakeQuery<T> query<T extends Model<dynamic>>({Partition partition, Key<dynamic> ancestorKey}) {
-    final List<T> results = values.values.whereType<T>().toList();
+    List<T> results = values.values.whereType<T>().toList();
+    if (ancestorKey != null) {
+      results = results.where((T entity) => entity?.parentKey == ancestorKey).toList();
+    }
     return FakeQuery<T>._(this, results);
   }
 

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -46,3 +46,15 @@ class FakeScheduler extends Scheduler {
   Future<SchedulerConfig> getSchedulerConfig(Commit commit, {RetryOptions retryOptions}) async =>
       schedulerConfig ?? _defaultConfig;
 }
+
+SchedulerConfig oneTargetConfig = SchedulerConfig(enabledBranches: <String>[
+  'master'
+], targets: <Target>[
+  Target(
+    bringup: false,
+    name: 'Linux A',
+    builder: 'Linux A',
+    presubmit: true,
+    postsubmit: true,
+  ),
+]);


### PR DESCRIPTION
Recreation of https://github.com/flutter/cocoon/pull/1210 due to some git hiccups

- Explicitly pass postsubmit builders in `LuciService.getRecentTasks`
  - Update `/api/refresh-chromebot-status` to get postsubmit builders from `Scheduler`
  - Update engine tree status to get postsubmit builders from `Scheduler`

# Tests
Add test to refresh-chromebot-status to check builders in ci.yaml are used to update status

# Issues
https://github.com/flutter/flutter/issues/76140