### PR TITLE
Add AppEngine readiness check.

### DIFF
--- a/app_dart/app.yaml
+++ b/app_dart/app.yaml
@@ -7,11 +7,12 @@ env: flex
 service: default
 
 readiness_check:
+  path: "/readiness_check"
   check_interval_sec: 20
-  timeout_sec: 10
-  failure_threshold: 3
+  timeout_sec: 20
+  failure_threshold: 10
   success_threshold: 2
-  app_start_timeout_sec: 500
+  app_start_timeout_sec: 600
 
 resources:
   memory_gb: 4.0

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -111,6 +111,8 @@ Future<void> main() async {
         ttl: const Duration(minutes: 1),
         delegate: GithubRateLimitStatus(config),
       ),
+      /// Handler for AppEngine to identify when dart server is ready to serve requests.
+      '/readiness_check': ReadinessCheck(),
     };
 
     return await runAppEngine((HttpRequest request) async {

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -111,6 +111,7 @@ Future<void> main() async {
         ttl: const Duration(minutes: 1),
         delegate: GithubRateLimitStatus(config),
       ),
+
       /// Handler for AppEngine to identify when dart server is ready to serve requests.
       '/readiness_check': ReadinessCheck(),
     };

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -17,6 +17,7 @@ export 'src/request_handlers/push_build_status_to_github.dart';
 export 'src/request_handlers/push_engine_status_to_github.dart';
 export 'src/request_handlers/push_gold_status_to_github.dart';
 export 'src/request_handlers/query_github_graphql.dart';
+export 'src/request_handlers/readiness_check.dart';
 export 'src/request_handlers/refresh_chromebot_status.dart';
 export 'src/request_handlers/reset_prod_task.dart';
 export 'src/request_handlers/reset_try_task.dart';

--- a/app_dart/lib/src/request_handlers/readiness_check.dart
+++ b/app_dart/lib/src/request_handlers/readiness_check.dart
@@ -1,0 +1,16 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'package:meta/meta.dart';
+import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
+
+@immutable
+class ReadinessCheck extends RequestHandler<Body> {
+  @override
+  Future<Body> get() async {
+    return Body.empty;
+  }
+}


### PR DESCRIPTION
This is to ensure the dart server is ready to serve requests before
marking the VM as ready.

Bug: https://github.com/flutter/flutter/issues/79464