### PR TITLE
Reduce injected latency for cocoon repo to 10 mins.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -24,6 +24,11 @@ import 'refresh_cirrus_status.dart';
 /// goes green.
 const int _kMergeCountPerCycle = 2;
 
+/// Injected latency per repository. Engine and Flutter use an injected latency of 1h meaning
+/// that the bot skips any commits younger than 1h. However 1h is too long for some repositories
+/// whose builds are faster. Use this constant to override the default 1h latency for a given repository.
+const Map<String, Duration> _kInjectedLatencies = <String, Duration>{'cocoon': Duration(minutes: 10)};
+
 @immutable
 class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
   const CheckForWaitingPullRequests(
@@ -187,7 +192,8 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       // Use the committedDate if pushedDate is null (commitedDate cannot be null).
       final DateTime utcDate =
           DateTime.parse(commit['pushedDate'] as String ?? commit['committedDate'] as String).toUtc();
-      if (utcDate.add(const Duration(hours: 1)).isAfter(DateTime.now().toUtc())) {
+      final Duration injectedDuration = _kInjectedLatencies[name] ?? const Duration(hours: 1);
+      if (utcDate.add(injectedDuration).isAfter(DateTime.now().toUtc())) {
         continue;
       }
       final String author = pullRequest['author']['login'] as String;


### PR DESCRIPTION
This is will allow the waiting for tree to go green bot to submit commit
older than 10 mins.

Bug: https://github.com/flutter/flutter/issues/81072