### PR TITLE
[scheduler] ci.yaml check run

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -359,6 +359,7 @@ class Scheduler {
         conclusion: github.CheckRunConclusion.success,
       );
     } else {
+      log.info('Marking PR #$prNumber ci.yaml validation as failed');
       // Failure when validating ci.yaml
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -345,6 +345,7 @@ class Scheduler {
         commitSha: commitSha,
       );
     } catch (e) {
+      log.info(e.toString());
       exception = e;
     }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -333,21 +333,23 @@ class Scheduler {
     );
     dynamic exception;
     final Commit presubmitCommit = Commit(branch: branch, repository: slug.fullName, sha: commitSha);
+    List<LuciBuilder> presubmitBuilders = <LuciBuilder>[];
     try {
-      final List<LuciBuilder> presubmitBuilders = await getPresubmitBuilders(
+      presubmitBuilders = await getPresubmitBuilders(
         commit: presubmitCommit,
         prNumber: prNumber,
       );
-      await luciBuildService.scheduleTryBuilds(
-        builders: presubmitBuilders,
-        slug: slug,
-        prNumber: prNumber,
-        commitSha: commitSha,
-      );
-    } catch (e) {
+    } on FormatException catch (e) {
       log.info(e.toString());
       exception = e;
     }
+
+    await luciBuildService.scheduleTryBuilds(
+      builders: presubmitBuilders,
+      slug: slug,
+      prNumber: prNumber,
+      commitSha: commitSha,
+    );
 
     // Update validate ci.yaml check
     if (exception == null) {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -333,23 +333,21 @@ class Scheduler {
     );
     dynamic exception;
     final Commit presubmitCommit = Commit(branch: branch, repository: slug.fullName, sha: commitSha);
-    List<LuciBuilder> presubmitBuilders = <LuciBuilder>[];
     try {
-      presubmitBuilders = await getPresubmitBuilders(
+      final List<LuciBuilder> presubmitBuilders = await getPresubmitBuilders(
         commit: presubmitCommit,
         prNumber: prNumber,
+      );
+      await luciBuildService.scheduleTryBuilds(
+        builders: presubmitBuilders,
+        slug: slug,
+        prNumber: prNumber,
+        commitSha: commitSha,
       );
     } on FormatException catch (e) {
       log.info(e.toString());
       exception = e;
     }
-
-    await luciBuildService.scheduleTryBuilds(
-      builders: presubmitBuilders,
-      slug: slug,
-      prNumber: prNumber,
-      commitSha: commitSha,
-    );
 
     // Update validate ci.yaml check
     if (exception == null) {

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -904,35 +904,6 @@ void main() {
         request.headers.set('X-GitHub-Event', 'pull_request');
       });
 
-      test('Exception is raised when no builders available', () async {
-        when(issuesService.listLabelsByIssue(any, issueNumber)).thenAnswer((_) {
-          return Stream<IssueLabel>.fromIterable(<IssueLabel>[
-            IssueLabel()..name = 'Random Label',
-          ]);
-        });
-
-        fakeBuildBucketClient.batchResponse = Future<BatchResponse>.value(
-          const BatchResponse(
-            responses: <Response>[
-              Response(
-                searchBuilds: SearchBuildsResponse(
-                  builds: <Build>[],
-                ),
-              ),
-            ],
-          ),
-        );
-
-        request.body = jsonTemplate('synchronize', issueNumber, kDefaultBranchName,
-            repoFullName: 'flutter/packages', repoName: 'packages');
-        final Uint8List body = utf8.encode(request.body) as Uint8List;
-        final Uint8List key = utf8.encode(keyString) as Uint8List;
-        final String hmac = getHmac(body, key);
-        request.headers.set('X-Hub-Signature', 'sha1=$hmac');
-
-        expect(tester.post(webhook), throwsA(isA<InternalServerError>()));
-      });
-
       Future<void> _testActions(String action, {bool never = false}) async {
         when(issuesService.listLabelsByIssue(any, issueNumber)).thenAnswer((_) {
           return Stream<IssueLabel>.fromIterable(<IssueLabel>[

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -326,7 +326,77 @@ targets:
           commitSha: 'abc',
         );
         expect(verify(mockGithubChecksUtil.createCheckRun(any, any, captureAny, 'abc')).captured,
-            <dynamic>['Linux', 'Mac', 'Windows', 'Linux Coverage', 'Linux A']);
+            <dynamic>['ci.yaml validation', 'Linux', 'Mac', 'Windows', 'Linux Coverage', 'Linux A']);
+      });
+
+      test('ci.yaml validation passes with default config', () async {
+        await scheduler.triggerPresubmitTargets(
+          branch: config.defaultBranch,
+          prNumber: 42,
+          slug: config.flutterSlug,
+          commitSha: 'abc',
+        );
+        expect(
+            verify(mockGithubChecksUtil.updateCheckRun(any, any, any,
+                    status: captureAnyNamed('status'),
+                    conclusion: captureAnyNamed('conclusion'),
+                    output: anyNamed('output')))
+                .captured,
+            <dynamic>[CheckRunStatus.completed, CheckRunConclusion.success]);
+      });
+
+      test('ci.yaml validation fails with empty config', () async {
+        httpClient = FakeHttpClient(onIssueRequest: (FakeHttpClientRequest request) {
+          if (request.uri.path.contains('.ci.yaml')) {
+            httpClient.request.response.body = '';
+          } else {
+            throw Exception('Failed to find ${request.uri.path}');
+          }
+        });
+        await scheduler.triggerPresubmitTargets(
+          branch: config.defaultBranch,
+          prNumber: 42,
+          slug: config.flutterSlug,
+          commitSha: 'abc',
+        );
+        expect(
+            verify(mockGithubChecksUtil.updateCheckRun(any, any, any,
+                    status: captureAnyNamed('status'),
+                    conclusion: captureAnyNamed('conclusion'),
+                    output: anyNamed('output')))
+                .captured,
+            <dynamic>[CheckRunStatus.completed, CheckRunConclusion.failure]);
+      });
+
+      test('ci.yaml validation fails with config with unknown dependencies', () async {
+        httpClient = FakeHttpClient(onIssueRequest: (FakeHttpClientRequest request) {
+          if (request.uri.path.contains('.ci.yaml')) {
+            httpClient.request.response.body = '''
+enabled_branches:
+  - master
+targets:
+  - name: A
+    builder: Linux A
+    dependencies:
+      - B
+          ''';
+          } else {
+            throw Exception('Failed to find ${request.uri.path}');
+          }
+        });
+        await scheduler.triggerPresubmitTargets(
+          branch: config.defaultBranch,
+          prNumber: 42,
+          slug: config.flutterSlug,
+          commitSha: 'abc',
+        );
+        expect(
+            verify(mockGithubChecksUtil.updateCheckRun(any, any, any,
+                    status: anyNamed('status'), conclusion: anyNamed('conclusion'), output: captureAnyNamed('output')))
+                .captured
+                .first
+                .text,
+            'FormatException: ERROR: A depends on B which does not exist');
       });
 
       test('retries only triggers failed builds only', () async {


### PR DESCRIPTION
This adds a check to all Cocoon scheduled presubmits that validates the ci.yaml + validates all builds were scheduled.

If `.ci.yaml` does not exist, it will pass as it uses an empty `SchedulerConfig`.

## Issues

https://github.com/flutter/flutter/issues/82303