### PR TITLE
Refactor [reset_prod_task] cocoon config keyHelper reference

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
@@ -48,8 +47,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
   Future<Body> post() async {
     final DatastoreService datastore = datastoreProvider(config.db);
     final String encodedKey = requestData[taskKeyParam] as String ?? '';
-    final ClientContext clientContext = authContext.clientContext;
-    final KeyHelper keyHelper = KeyHelper(applicationContext: clientContext.applicationContext);
+    final KeyHelper keyHelper = config.keyHelper;
     final String owner = requestData[ownerParam] as String ?? 'flutter';
     final String repo = requestData[repoParam] as String ?? 'flutter';
     String commitSha = requestData[commitShaParam] as String ?? '';

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -228,7 +228,6 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 30;
 
-  // TODO(keyonghan): update all existing APIs to use this reference, https://github.com/flutter/flutter/issues/48987.
   KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
 
   String get defaultBranch => kDefaultBranchName;

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -49,6 +49,7 @@ void main() {
     FakeClientContext clientContext;
     ResetProdTask handler;
     FakeConfig config;
+    FakeKeyHelper keyHelper;
     MockLuciBuildService mockLuciBuildService;
     FakeAuthenticatedContext authContext;
     ApiRequestHandlerTester tester;
@@ -56,9 +57,10 @@ void main() {
 
     setUp(() {
       final FakeDatastoreDB datastoreDB = FakeDatastoreDB();
-      config = FakeConfig(dbValue: datastoreDB);
       clientContext = FakeClientContext();
       clientContext.isDevelopmentEnvironment = false;
+      keyHelper = FakeKeyHelper(applicationContext: clientContext.applicationContext);
+      config = FakeConfig(dbValue: datastoreDB, keyHelperValue: keyHelper);
       authContext = FakeAuthenticatedContext(clientContext: clientContext);
       tester = ApiRequestHandlerTester(context: authContext);
       mockLuciBuildService = MockLuciBuildService();


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/48987

This PR makes `reset_prod_task.dart` use the keyHelper defined in the cocoon config.