### PR TITLE
Append triaging wiki link to Github check run summary

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -15,6 +15,11 @@ import 'config.dart';
 import 'luci_build_service.dart';
 import 'scheduler.dart';
 
+const String kGithubSummary = '''
+**[Triaging a LUCI build failure](https://github.com/flutter/flutter/wiki/Triaging-a-LUCI-build-failure)**
+
+''';
+
 /// Controls triggering builds and updating their status in the Github UI.
 class GithubChecksService {
   GithubChecksService(this.config, {GithubChecksUtil githubChecksUtil})
@@ -104,7 +109,7 @@ class GithubChecksService {
     if (status == github.CheckRunStatus.completed && failedStatesSet.contains(conclusion)) {
       final Build build =
           await luciBuildService.getTryBuildById(buildPushMessage.build.id, fields: 'id,builder,summaryMarkdown');
-      output = github.CheckRunOutput(title: checkRun.name, summary: build.summaryMarkdown ?? 'Empty summaryMarkdown');
+      output = github.CheckRunOutput(title: checkRun.name, summary: getGithubSummary(build.summaryMarkdown));
     }
     await githubChecksUtil.updateCheckRun(
       config,
@@ -116,6 +121,12 @@ class GithubChecksService {
       output: output,
     );
     return true;
+  }
+
+  /// Appends triage wiki page to `summaryMarkdown` from LUCI build so that people can easily
+  /// reference from github check run page.
+  String getGithubSummary(String summary) {
+    return kGithubSummary + (summary ?? 'Empty summaryMarkdown');
   }
 
   /// Transforms a [push_message.Result] to a [github.CheckRunConclusion].

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -103,6 +103,19 @@ void main() {
           <github.CheckRun>[checkRun]);
     });
   });
+
+  group('getGithubSummary', () {
+    test('nonempty summaryMarkdown', () async {
+      const String summaryMarkdown = 'test';
+      const String expectedSummary = '$kGithubSummary$summaryMarkdown';
+      expect(githubChecksService.getGithubSummary(summaryMarkdown), expectedSummary);
+    });
+
+    test('empty summaryMarkdown', () async {
+      const String expectedSummary = '${kGithubSummary}Empty summaryMarkdown';
+      expect(githubChecksService.getGithubSummary(null), expectedSummary);
+    });
+  });
 }
 
 String buildPushMessageJsonTemplate(String jsonUserData) => '''{


### PR DESCRIPTION
This adds the triaging [wiki page](https://github.com/flutter/flutter/wiki/Triaging-a-LUCI-build-failure) to the check run summary, to make it easy for people to reference. This should be more helpful for people new to the Flutter Infra/LUCI.

Related issue: https://github.com/flutter/flutter/issues/64208#issuecomment-841470687

<img width="996" alt="Screen Shot 2021-06-04 at 4 56 25 PM" src="https://user-images.githubusercontent.com/54558023/120873245-38754180-c556-11eb-9e80-ad82478dd05e.png">


