### PR TITLE
Update flutter status name.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -262,7 +262,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 
     // The status checks that are not related to changes in this PR.
     const Set<String> notInAuthorsControl = <String>{
-      'flutter-build', // flutter repo
+      'luci-flutter', // flutter repo
       'luci-engine', // engine repo
       'submit-queue', // plugins repo
     };

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -966,8 +966,8 @@ class StatusHelper {
 
   static const StatusHelper cirrusSuccess = StatusHelper('Cirrus CI', 'SUCCESS');
   static const StatusHelper cirrusFailure = StatusHelper('Cirrus CI', 'FAILURE');
-  static const StatusHelper flutterBuildSuccess = StatusHelper('flutter-build', 'SUCCESS');
-  static const StatusHelper flutterBuildFailure = StatusHelper('flutter-build', 'FAILURE');
+  static const StatusHelper flutterBuildSuccess = StatusHelper('luci-flutter', 'SUCCESS');
+  static const StatusHelper flutterBuildFailure = StatusHelper('luci-flutter', 'FAILURE');
   static const StatusHelper otherStatusFailure = StatusHelper('other status', 'FAILURE');
   static const StatusHelper luciEngineBuildSuccess = StatusHelper('luci-engine', 'SUCCESS');
   static const StatusHelper luciEngineBuildFailure = StatusHelper('luci-engine', 'FAILURE');


### PR DESCRIPTION
The status name was changed to make it consistent with the name used in
the engine and the the "waiting for tree to go green" was failing to
submit the PR instead of waiting for the tree to become green.

Bug: https://github.com/flutter/flutter/issues/84835