### PR TITLE
Add auto retry tag when build is auto triggered by cocoon

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -502,7 +502,7 @@ class LuciBuildService {
       log.info('Rerun builder: ${luciTask.builderName} for commit ${commit.sha}');
       final Map<String, List<String>> tags = <String, List<String>>{
         'triggered_by': <String>['cocoon'],
-        'trigger_type': <String>['auto'],
+        'trigger_type': <String>['retry'],
       };
       await rescheduleProdBuild(
         commitSha: commit.sha,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -500,10 +500,15 @@ class LuciBuildService {
   }) async {
     if (await _shouldRerunBuilder(luciTask, retries, commit, datastore)) {
       log.info('Rerun builder: ${luciTask.builderName} for commit ${commit.sha}');
+      final Map<String, List<String>> tags = <String, List<String>>{
+        'triggered_by': <String>['cocoon'],
+        'trigger_type': <String>['auto'],
+      };
       await rescheduleProdBuild(
         commitSha: commit.sha,
         builderName: luciTask.builderName,
         repo: repo,
+        tags: tags,
       );
       return true;
     }


### PR DESCRIPTION
Auto retry logic has been implemented for TOT failures, but there is no way to distinguish the auto-retried build from others. This PR adds auto trigger tags.

Issue: https://github.com/flutter/flutter/issues/85179