### PR TITLE
[app_dart] Add google_internal target support

### DIFF
--- a/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbenum.dart
@@ -14,10 +14,13 @@ class SchedulerSystem extends $pb.ProtobufEnum {
       SchedulerSystem._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'cocoon');
   static const SchedulerSystem luci =
       SchedulerSystem._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'luci');
+  static const SchedulerSystem google_internal =
+      SchedulerSystem._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'google_internal');
 
   static const $core.List<SchedulerSystem> values = <SchedulerSystem>[
     cocoon,
     luci,
+    google_internal,
   ];
 
   static final $core.Map<$core.int, SchedulerSystem> _byValue = $pb.ProtobufEnum.initByValue(values);

--- a/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
+++ b/app_dart/lib/src/model/proto/internal/scheduler.pbjson.dart
@@ -15,12 +15,13 @@ const SchedulerSystem$json = const {
   '2': const [
     const {'1': 'cocoon', '2': 1},
     const {'1': 'luci', '2': 2},
+    const {'1': 'google_internal', '2': 3},
   ],
 };
 
 /// Descriptor for `SchedulerSystem`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List schedulerSystemDescriptor =
-    $convert.base64Decode('Cg9TY2hlZHVsZXJTeXN0ZW0SCgoGY29jb29uEAESCAoEbHVjaRAC');
+    $convert.base64Decode('Cg9TY2hlZHVsZXJTeXN0ZW0SCgoGY29jb29uEAESCAoEbHVjaRACEhMKD2dvb2dsZV9pbnRlcm5hbBAD');
 @$core.Deprecated('Use schedulerConfigDescriptor instead')
 const SchedulerConfig$json = const {
   '1': 'SchedulerConfig',

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -50,10 +50,12 @@ message Target {
 }
 
 // Schedulers supported in SchedulerConfig.
-// Next ID: 3
+// Next ID: 4
 enum SchedulerSystem {
     // Cocoon will handle all actions for the target (initial trigger, retries).
     cocoon = 1;
     // LUCI triggers the build when mirrored to GoB. Cocoon triggers retries.
     luci = 2;
+    // Google internally uses Flutter, and validates if tip-of-tree causes breakages.
+    google_internal = 3;
 }

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -22,7 +22,7 @@ import '../service/datastore.dart';
 /// This handler requires (1) task identifier and (2) task status information.
 ///
 /// 1. Tasks are identified by:
-///  [gitBranchParam], [gitShaParam], [builderNameParam] (LUCI bots)
+///  [gitBranchParam], [gitShaParam], [builderNameParam]
 ///
 /// 2. Task status information
 ///  A. Required: [newStatusParam], either [Task.statusSucceeded] or [Task.statusFailed].
@@ -126,7 +126,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final List<Task> tasks = <Task>[];
     log.debug('Searching for task with builderName=$builderName');
     for (Task task in initialTasks) {
-      if (task.builderName == builderName) {
+      if (task.builderName == builderName || task.name == builderName) {
         tasks.add(task);
       }
     }

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -301,7 +301,7 @@ void main() {
             buildNumberList: '1');
         config.db.values[commit.key] = commit;
         config.db.values[task.key] = task;
-        scheduler.schedulerConfig = oneTargetConfig;
+        scheduler.schedulerConfig = exampleConfig;
         final List<Target> targets = scheduler.getPostSubmitTargets(commit, await scheduler.getSchedulerConfig(commit));
         final List<LuciBuilder> builders =
             targets.map((Target target) => LuciBuilder.fromTarget(target, commit.slug)).toList();

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -38,12 +38,18 @@ targets:
     builder: Linux A
     postsubmit: true
     presubmit: true
+    scheduler: luci
   - name: B
     builder: Linux B
     enabled_branches:
       - stable
     postsubmit: true
     presubmit: true
+    scheduler: luci
+  - name: Google Internal Roll
+    postsubmit: true
+    presubmit: false
+    scheduler: google_internal
 ''';
 
 void main() {
@@ -165,7 +171,7 @@ void main() {
         await scheduler.addCommits(createCommitList(<String>['2', '3', '4']));
         expect(db.values.values.whereType<Commit>().length, 3);
         // The 2 new commits are scheduled tasks, existing commit has none.
-        expect(db.values.values.whereType<Task>().length, 2 * 5);
+        expect(db.values.values.whereType<Task>().length, 2 * 6);
         // Check commits were added, but 3 was not
         expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
         expect(db.values.values.whereType<Commit>().map<String>(toSha), isNot(contains('3')));
@@ -187,7 +193,7 @@ void main() {
         await scheduler.addCommits(createCommitList(<String>['2', '3', '4']));
         expect(db.values.values.whereType<Commit>().length, 3);
         // The 2 new commits are scheduled tasks, existing commit has none.
-        expect(db.values.values.whereType<Task>().length, 2 * 5);
+        expect(db.values.values.whereType<Task>().length, 2 * 6);
         // Check commits were added, but 3 was not
         expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
         expect(db.values.values.whereType<Commit>().map<String>(toSha), isNot(contains('3')));
@@ -215,7 +221,7 @@ void main() {
         await scheduler.addPullRequest(mergedPr);
 
         expect(db.values.values.whereType<Commit>().length, 1);
-        expect(db.values.values.whereType<Task>().length, 5);
+        expect(db.values.values.whereType<Task>().length, 6);
       });
 
       test('does not schedule tasks against non-merged PRs', () async {
@@ -296,13 +302,21 @@ targets:
   - name: A
     builder: Linux A
     presubmit: true
+    scheduler: luci
   - name: B
     builder: Linux B
+    scheduler: luci
     enabled_branches:
       - stable
     presubmit: true
   - name: C
     builder: Linux C
+    scheduler: luci
+    enabled_branches:
+      - master
+    presubmit: true
+  - name: Google-internal roll
+    scheduler: google_internal
     enabled_branches:
       - master
     presubmit: true

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -47,14 +47,23 @@ class FakeScheduler extends Scheduler {
       schedulerConfig ?? _defaultConfig;
 }
 
-SchedulerConfig oneTargetConfig = SchedulerConfig(enabledBranches: <String>[
+SchedulerConfig exampleConfig = SchedulerConfig(enabledBranches: <String>[
   'master'
 ], targets: <Target>[
   Target(
     bringup: false,
     name: 'Linux A',
     builder: 'Linux A',
+    scheduler: SchedulerSystem.luci,
     presubmit: true,
     postsubmit: true,
+  ),
+  Target(
+    bringup: false,
+    name: 'Google Internal Roll',
+    builder: 'Google Internal Roll',
+    presubmit: false,
+    postsubmit: true,
+    scheduler: SchedulerSystem.google_internal,
   ),
 ]);


### PR DESCRIPTION
Adds initial plumbing to ingest target from `.ci.yaml`

```yaml
# .ci.yaml
- name: Google Internal Roll
   # Breakages in the Google roll usually require patches, not reverts. Including as FYI.
   bringup: true
   presubmit: false
   scheduler: google_internal
```

Using `/api/update-task-status` this target can be updated via FRoB

# Issues

https://github.com/flutter/flutter/issues/79658