### PR TITLE
Apply 'needs tests' label to any PR that needs tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -22,6 +22,7 @@ import '../service/scheduler.dart';
 const Set<String> kNeedsCheckLabelsAndTests = <String>{'flutter/flutter', 'flutter/engine'};
 
 final RegExp kEngineTestRegExp = RegExp(r'tests?\.(dart|java|mm|m|cc)$');
+final List<String> kNeedsTestsLabels = <String>['needs tests'];
 
 @immutable
 class GithubWebhook extends RequestHandler<Body> {
@@ -315,6 +316,7 @@ class GithubWebhook extends RequestHandler<Body> {
       final String body = config.missingTestsPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, slug, body)) {
         await gitHubClient.issues.createComment(slug, pr.number, body);
+        await gitHubClient.issues.addLabelsToIssue(slug, pr.number, kNeedsTestsLabels);
       }
     }
   }

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -513,7 +513,7 @@ void main() {
       ));
     });
 
-    test('Engine labels PRs, comment if no tests', () async {
+    test('Engine labels PRs, comment and labels if no tests', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
       request.body = jsonTemplate(
@@ -553,6 +553,12 @@ void main() {
         slug,
         issueNumber,
         argThat(contains(config.missingTestsPullRequestMessageValue)),
+      )).called(1);
+
+      verify(issuesService.addLabelsToIssue(
+        slug,
+        issueNumber,
+        <String>['needs tests'],
       )).called(1);
     });
 


### PR DESCRIPTION
This adds a `needs tests` label to any PR that doesn't appear to have tests. This allows us to more easily track PRs that were landed without tests.