### PR TITLE
Add TestRunFlaky property for task

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -30,7 +30,7 @@ class Task extends Model<int> {
     this.name,
     this.attempts = 0,
     this.isFlaky = false,
-    this.isTestRunFlaky = false,
+    this.isTestFlaky = false,
     this.timeoutInMinutes,
     this.reason = '',
     this.requiredCapabilities,
@@ -170,21 +170,26 @@ class Task extends Model<int> {
   @JsonKey(name: 'Attempts')
   int attempts;
 
-  /// Whether this task has been marked flaky by the devicelab manifest.
+  /// Whether this task has been marked flaky by .ci.yaml.
   ///
   /// See also:
   ///
-  ///  * <https://github.com/flutter/flutter/blob/master/dev/devicelab/manifest.yaml>
+  ///  * <https://github.com/flutter/flutter/blob/master/.ci.yaml>
+  ///
+  /// A flaky (`bringup: true`) task will not block the tree.
   @BoolProperty(propertyName: 'Flaky')
   @JsonKey(name: 'Flaky')
   bool isFlaky;
 
-  /// Whether the test run of this task is flaky.
+  /// Whether the test execution of this task shows flake.
   ///
   /// Test runner supports rerun, and this flag tracks if a flake happens.
-  @BoolProperty(propertyName: 'TestRunFlaky')
-  @JsonKey(name: 'TestRunFlaky')
-  bool isTestRunFlaky;
+  ///
+  /// See also:
+  ///  * <https://github.com/flutter/flutter/blob/master/dev/devicelab/lib/framework/runner.dart>
+  @BoolProperty(propertyName: 'TestFlaky')
+  @JsonKey(name: 'TestFlaky')
+  bool isTestFlaky;
 
   /// The timeout of the task, or zero if the task has no timeout.
   @IntProperty(propertyName: 'TimeoutInMinutes', required: true)
@@ -278,7 +283,7 @@ class Task extends Model<int> {
       ..write(', name: $name')
       ..write(', attempts: $attempts')
       ..write(', isFlaky: $isFlaky')
-      ..write(', isTestRunFlaky: $isTestRunFlaky')
+      ..write(', isTestRunFlaky: $isTestFlaky')
       ..write(', timeoutInMinutes: $timeoutInMinutes')
       ..write(', reason: $reason')
       ..write(', requiredCapabilities: $requiredCapabilities')

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -30,6 +30,7 @@ class Task extends Model<int> {
     this.name,
     this.attempts = 0,
     this.isFlaky = false,
+    this.isTestRunFlaky = false,
     this.timeoutInMinutes,
     this.reason = '',
     this.requiredCapabilities,
@@ -178,6 +179,13 @@ class Task extends Model<int> {
   @JsonKey(name: 'Flaky')
   bool isFlaky;
 
+  /// Whether the test run of this task is flaky.
+  ///
+  /// Test runner supports rerun, and this flag tracks if a flake happens.
+  @BoolProperty(propertyName: 'TestRunFlaky')
+  @JsonKey(name: 'TestRunFlaky')
+  bool isTestRunFlaky;
+
   /// The timeout of the task, or zero if the task has no timeout.
   @IntProperty(propertyName: 'TimeoutInMinutes', required: true)
   @JsonKey(name: 'TimeoutInMinutes')
@@ -270,6 +278,7 @@ class Task extends Model<int> {
       ..write(', name: $name')
       ..write(', attempts: $attempts')
       ..write(', isFlaky: $isFlaky')
+      ..write(', isTestRunFlaky: $isTestRunFlaky')
       ..write(', timeoutInMinutes: $timeoutInMinutes')
       ..write(', reason: $reason')
       ..write(', requiredCapabilities: $requiredCapabilities')

--- a/app_dart/lib/src/model/appengine/task.g.dart
+++ b/app_dart/lib/src/model/appengine/task.g.dart
@@ -16,7 +16,7 @@ Map<String, dynamic> _$TaskToJson(Task instance) => <String, dynamic>{
       'Name': instance.name,
       'Attempts': instance.attempts,
       'Flaky': instance.isFlaky,
-      'TestRunFlaky': instance.isTestRunFlaky,
+      'TestFlaky': instance.isTestFlaky,
       'TimeoutInMinutes': instance.timeoutInMinutes,
       'Reason': instance.reason,
       'BuildNumber': instance.buildNumber,

--- a/app_dart/lib/src/model/appengine/task.g.dart
+++ b/app_dart/lib/src/model/appengine/task.g.dart
@@ -16,6 +16,7 @@ Map<String, dynamic> _$TaskToJson(Task instance) => <String, dynamic>{
       'Name': instance.name,
       'Attempts': instance.attempts,
       'Flaky': instance.isFlaky,
+      'TestRunFlaky': instance.isTestRunFlaky,
       'TimeoutInMinutes': instance.timeoutInMinutes,
       'Reason': instance.reason,
       'BuildNumber': instance.buildNumber,

--- a/app_dart/lib/src/model/luci/buildbucket.g.dart
+++ b/app_dart/lib/src/model/luci/buildbucket.g.dart
@@ -279,9 +279,7 @@ ScheduleBuildRequest _$ScheduleBuildRequestFromJson(Map<String, dynamic> json) {
     experimental: _$enumDecodeNullable(_$TrinaryEnumMap, json['experimental']),
     gitilesCommit:
         json['gitilesCommit'] == null ? null : GitilesCommit.fromJson(json['gitilesCommit'] as Map<String, dynamic>),
-    properties: (json['properties'] as Map<String, dynamic>)?.map(
-      (k, e) => MapEntry(k, e as String),
-    ),
+    properties: json['properties'] as Map<String, dynamic>,
     dimensions: (json['dimensions'] as List)
         ?.map((e) => e == null ? null : RequestedDimension.fromJson(e as Map<String, dynamic>))
         ?.toList(),


### PR DESCRIPTION
This is to mark test, which has rerun from test runner side, as flaky if any.

Existing logic counts a test as flaky if multiple runs exist for the whole build. With https://github.com/flutter/flutter/pull/86394, a test can be flaky even if there is only one build run but there are multiple reruns from the test runner. This PR adds a task property to hold that flaky flag.

One TODO is update this property when task finishes if any flake exists from test runner side.

Related: https://github.com/flutter/flutter/issues/86324