### PR TITLE
Add a logging line to github webook scheduling tasks for mergeable PRs

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -141,6 +141,9 @@ class GithubWebhook extends RequestHandler<Body> {
     final PullRequest pr = pullRequestEvent.pullRequest;
     final RepositorySlug slug = pullRequestEvent.repository.slug();
 
+    log.info(
+        'Scheduling tasks if mergeable(${pr.mergeable}): owner=${slug.owner} repo=${slug.name} and pr=${pr.number}');
+
     // The mergeable flag may be null. False indicates there's a merge conflict,
     // null indicates unknown. Err on the side of allowing the job to run.
     if (pr.mergeable == false) {


### PR DESCRIPTION
Add a log line to help with debugging missing task scheduling for certain PRs (https://github.com/flutter/flutter/issues/86383)