### PR TITLE
[app_dart] Don't push tree status to release branches, fix LUCI console link

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -89,7 +89,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   Future<void> _updatePRs(RepositorySlug slug, String status, DatastoreService datastore) async {
     final GitHub github = await config.createGitHubClient(slug);
     final List<GithubBuildStatusUpdate> updates = <GithubBuildStatusUpdate>[];
-    await for (PullRequest pr in github.pullRequests.list(slug)) {
+    await for (PullRequest pr in github.pullRequests.list(slug, base: config.defaultBranch)) {
       final GithubBuildStatusUpdate update = await datastore.queryLastStatusUpdate(slug, pr);
       if (update.status != status) {
         log.debug('Updating status of ${slug.fullName}#${pr.number} from ${update.status} to $status');

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -94,7 +94,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       if (update.status != status) {
         log.debug('Updating status of ${slug.fullName}#${pr.number} from ${update.status} to $status');
         final CreateStatus request = CreateStatus(status);
-        request.targetUrl = 'https://ci.chromium.org/p/flutter/g/engine/console';
+        request.targetUrl = 'https://ci.chromium.org/p/flutter/g/${slug.name}/console';
         request.context = 'luci-${slug.name}';
         if (status != GithubBuildStatusUpdate.statusSuccess) {
           request.description = config.flutterBuildDescription;

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -90,7 +90,7 @@ void main() {
       when(github.pullRequests).thenReturn(pullRequestsService);
       when(github.issues).thenReturn(issuesService);
       when(github.repositories).thenReturn(repositoriesService);
-      when(pullRequestsService.list(any)).thenAnswer((Invocation _) {
+      when(pullRequestsService.list(any, base: config.defaultBranch)).thenAnswer((Invocation _) {
         return Stream<PullRequest>.fromIterable(prsFromGitHub);
       });
       when(repositoriesService.createStatus(any, any, any)).thenAnswer(


### PR DESCRIPTION
While doing the beta release, I noticed we unnecessarily push tree status to the release branches.

I manually ran and verified querying base with master returns pull requests using the HTTP API.