### PR TITLE
Rebase update_existing_flaky_issue with TOT

### DIFF
--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -8,6 +8,7 @@ import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart';
 
+import '../foundation/utils.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/1301 was merged after https://github.com/flutter/cocoon/pull/1302, but not rebased. This causes test failure due to missing related changes.

Example: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20test_ownership/1/overview