### PR TITLE
Fix golden tests after change in scrolling

### DIFF
--- a/app_flutter/lib/service/dev_cocoon.dart
+++ b/app_flutter/lib/service/dev_cocoon.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:fixnum/fixnum.dart';
@@ -14,6 +15,31 @@ import '../model/key.pb.dart';
 import '../model/task.pb.dart';
 import 'cocoon.dart';
 
+class _PausedCommitStatus {
+  _PausedCommitStatus(CocoonResponse<List<CommitStatus>> status)
+    : _completer = Completer<CocoonResponse<List<CommitStatus>>>(),
+      assert(status != null),
+      _pausedStatus = status;
+
+  Completer<CocoonResponse<List<CommitStatus>>> _completer;
+  CocoonResponse<List<CommitStatus>> _pausedStatus;
+
+  Future<CocoonResponse<List<CommitStatus>>> get future => _completer.future;
+
+  void update(CocoonResponse<List<CommitStatus>> newStatus) {
+    assert(_completer != null);
+    assert(_pausedStatus != null);
+    _pausedStatus = newStatus;
+  }
+
+  void complete() {
+    assert(_completer != null && _pausedStatus != null);
+    _completer.complete(_pausedStatus);
+    _completer = null;
+    _pausedStatus = null;
+  }
+}
+
 /// [CocoonService] for local development purposes.
 ///
 /// This creates fake data that mimicks what production will send.
@@ -24,12 +50,38 @@ class DevelopmentCocoonService implements CocoonService {
 
   final DateTime now;
 
+  _PausedCommitStatus _pausedStatus;
+  bool _paused = false;
+  bool get paused => _paused;
+  set paused(bool pause) {
+    if (_paused == pause) {
+      return;
+    }
+    assert(_paused || _pausedStatus == null);
+    if (_pausedStatus != null) {
+      _pausedStatus.complete();
+      _pausedStatus = null;
+    }
+    _paused = pause;
+  }
+
   @override
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
     CommitStatus lastCommitStatus,
     String branch,
   }) async {
-    return CocoonResponse<List<CommitStatus>>.data(_createFakeCommitStatuses(lastCommitStatus));
+    final CocoonResponse<List<CommitStatus>> data =
+        CocoonResponse<List<CommitStatus>>.data(_createFakeCommitStatuses(lastCommitStatus));
+    if (!_paused) {
+      return data;
+    }
+
+    if (_pausedStatus == null) {
+      _pausedStatus = _PausedCommitStatus(data);
+    } else {
+      _pausedStatus.update(data);
+    }
+    return _pausedStatus.future;
   }
 
   @override

--- a/app_flutter/lib/service/dev_cocoon.dart
+++ b/app_flutter/lib/service/dev_cocoon.dart
@@ -17,9 +17,9 @@ import 'cocoon.dart';
 
 class _PausedCommitStatus {
   _PausedCommitStatus(CocoonResponse<List<CommitStatus>> status)
-    : _completer = Completer<CocoonResponse<List<CommitStatus>>>(),
-      assert(status != null),
-      _pausedStatus = status;
+      : _completer = Completer<CocoonResponse<List<CommitStatus>>>(),
+        assert(status != null),
+        _pausedStatus = status;
 
   Completer<CocoonResponse<List<CommitStatus>>> _completer;
   CocoonResponse<List<CommitStatus>> _pausedStatus;

--- a/app_flutter/test/widgets/task_grid_test.dart
+++ b/app_flutter/test/widgets/task_grid_test.dart
@@ -43,8 +43,9 @@ void main() {
 
   testWidgets('TaskGridContainer with DevelopmentCocoonService', (WidgetTester tester) async {
     await precacheTaskIcons(tester);
+    final DevelopmentCocoonService service = DevelopmentCocoonService(DateTime.utc(2020));
     final BuildState buildState = BuildState(
-      cocoonService: DevelopmentCocoonService(DateTime.utc(2020)),
+      cocoonService: service,
       authService: MockGoogleSignInService(),
     );
     void listener1() {}
@@ -75,14 +76,20 @@ void main() {
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.origin.png');
 
     // Check if the LOADING... indicator appears.
+    service.paused = true;
     await tester.drag(find.byType(TaskGrid), const Offset(0.0, -5000.0));
     await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_y.png');
+    service.paused = false;
+    await tester.pumpAndSettle();
 
     // Check the right edge after the data comes in.
+    service.paused = true;
     await tester.drag(find.byType(TaskGrid), const Offset(-5000.0, 0.0));
     await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_x.png');
+    service.paused = false;
+    await tester.pumpAndSettle();
 
     await tester.pumpWidget(Container());
     buildState.dispose();
@@ -90,8 +97,9 @@ void main() {
 
   testWidgets('TaskGridContainer with DevelopmentCocoonService - dark', (WidgetTester tester) async {
     await precacheTaskIcons(tester);
+    final DevelopmentCocoonService service = DevelopmentCocoonService(DateTime.utc(2020));
     final BuildState buildState = BuildState(
-      cocoonService: DevelopmentCocoonService(DateTime.utc(2020)),
+      cocoonService: service,
       authService: MockGoogleSignInService(),
     );
     void listener1() {}
@@ -123,14 +131,20 @@ void main() {
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.origin.dark.png');
 
     // Check if the LOADING... indicator appears.
+    service.paused = true;
     await tester.drag(find.byType(TaskGrid), const Offset(0.0, -5000.0));
     await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_y.dark.png');
+    service.paused = false;
+    await tester.pumpAndSettle();
 
     // Check the right edge after the data comes in.
+    service.paused = true;
     await tester.drag(find.byType(TaskGrid), const Offset(-5000.0, 0.0));
     await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_x.dark.png');
+    service.paused = false;
+    await tester.pumpAndSettle();
 
     await tester.pumpWidget(Container());
     buildState.dispose();

--- a/app_flutter/test/widgets/task_grid_test.dart
+++ b/app_flutter/test/widgets/task_grid_test.dart
@@ -76,12 +76,12 @@ void main() {
 
     // Check if the LOADING... indicator appears.
     await tester.drag(find.byType(TaskGrid), const Offset(0.0, -5000.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_y.png');
 
     // Check the right edge after the data comes in.
     await tester.drag(find.byType(TaskGrid), const Offset(-5000.0, 0.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_x.png');
 
     await tester.pumpWidget(Container());
@@ -124,12 +124,12 @@ void main() {
 
     // Check if the LOADING... indicator appears.
     await tester.drag(find.byType(TaskGrid), const Offset(0.0, -5000.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_y.dark.png');
 
     // Check the right edge after the data comes in.
     await tester.drag(find.byType(TaskGrid), const Offset(-5000.0, 0.0));
-    await tester.pump();
+    await tester.pumpAndSettle();
     await expectGoldenMatches(find.byType(TaskGrid), 'task_grid_test.dev.scroll_x.dark.png');
 
     await tester.pumpWidget(Container());


### PR DESCRIPTION
A recent change in scrolling has led to an assertion failure in our scrolling golden tests. Apparently you need to use pumpAndSettle() to avoid the assertion.

I've verified the above solution, but I'm starting this PR off with an empty commit to verify that the current tree cannot pass its own tests. When it fails, I'll push a second commit with the fixes to verify that it passes.

~Note that this points out another issue with the tests here - the tests that failed were attempting to see the "LOADING..." banner after a scroll (as per the comments on the tests themselves), and I'm guessing that is why they used pump() rather than pumpAndSettle() because they needed to get the screen capture before the new data came in. As far as I can tell, that never happened and the golden files for those tests never had the "LOADING..." banner in the first place. I believe that something will need to be done with the data generator for the tests so that you can pause it, scroll, pumpAndSettle, see the banner, then resume the data source...~
So, it looks like the single pump() used to be testing the LOADING... banner by getting a redraw before new data came in, but it was hard to see because everything was white on white. Switching to pumpAndSettle() meant that the banner row was showing up as valid data now. So, I implemented explicit pausing of the testing cocoon data source so that the "LOADING" banner would still show up.