### PR TITLE
[cocoon device doctor] Kill android process before running tasks

### DIFF
--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -30,7 +30,7 @@ String _output;
 /// For `recovery`, it will do cleanup, reboot, etc. to try bringing device back to a working state.
 ///
 /// For `prepare`, it will prepare the device before running tasks, like kill running processes, etc.
-/// 
+///
 /// For `properties`, it will return device properties/dimensions, like manufacture, base_buildid, etc.
 ///
 /// Usage:

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -12,7 +12,7 @@ const String actionFlag = 'action';
 const String deviceOSFlag = 'device-os';
 const String helpFlag = 'help';
 const String outputFlag = 'output';
-const List<String> supportedOptions = <String>['healthcheck', 'recovery', 'properties'];
+const List<String> supportedOptions = <String>['healthcheck', 'prepare', 'recovery', 'properties'];
 const List<String> supportedDeviceOS = <String>['ios', 'android'];
 const String defaultOutputPath = '.output';
 
@@ -22,13 +22,15 @@ String _action;
 String _deviceOS;
 String _output;
 
-/// Manage `healthcheck`, `recovery`, and `properties` for devices.
+/// Manage `healthcheck`, `prepare, `recovery`, and `properties` for devices.
 ///
 /// For `healthcheck`, if no device is found or any health check fails an stderr will be logged,
 /// and an exception will be thrown.
 ///
 /// For `recovery`, it will do cleanup, reboot, etc. to try bringing device back to a working state.
 ///
+/// For `prepare`, it will prepare the device before running tasks, like kill running processes, etc.
+/// 
 /// For `properties`, it will return device properties/dimensions, like manufacture, base_buildid, etc.
 ///
 /// Usage:
@@ -63,6 +65,9 @@ Future<void> main(List<String> args) async {
   switch (_action) {
     case 'healthcheck':
       await deviceDiscovery.checkDevices();
+      break;
+    case 'prepare':
+      await deviceDiscovery.prepareDevices();
       break;
     case 'recovery':
       await deviceDiscovery.recoverDevices();

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -245,8 +245,8 @@ class AndroidDevice implements Device {
     // Example result:
     //
     // Proc # 0: fore  T/A/T  trm: 0 4544:com.google.android.googlequicksearchbox/u0a66 (top-activity)
-    final RegExp processRegExp = RegExp(' 0 [0-9]+:(?<process>.+)/');
-    final List<String> processes = results.map((e) => processRegExp.firstMatch(e).namedGroup('process')).toList();
+    final List<String> processes =
+        results.map((result) => result.substring(result.lastIndexOf(':') + 1, result.lastIndexOf('/'))).toList();
     try {
       for (String process in processes) {
         await eval('adb', <String>['shell', 'am', 'force-stop', process], processManager: processManager);

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -203,6 +203,13 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     }
     return healthCheckResult;
   }
+
+  @override
+  Future<void> prepareDevices() async {
+    for (Device device in await discoverDevices()) {
+      await device.prepare();
+    }
+  }
 }
 
 class AndroidDevice implements Device {
@@ -214,5 +221,41 @@ class AndroidDevice implements Device {
   @override
   Future<void> recover() async {
     await eval('adb', <String>['-s', deviceId, 'reboot'], canFail: false);
+  }
+
+  @override
+  Future<void> prepare() async {
+    await killProcesses();
+  }
+
+  /// Kill top running process if existing.
+  @visibleForTesting
+  Future<bool> killProcesses({ProcessManager processManager}) async {
+    processManager ??= LocalProcessManager();
+    String result;
+    result = await eval('adb', <String>['shell', 'dumpsys', 'activity', '|', 'grep', 'top-activity'],
+        canFail: true, processManager: processManager);
+
+    // Skip uninstalling process when no device is available or no application exists.
+    if (result == 'adb: no devices/emulators found' || result == null || result.isEmpty) {
+      stdout.write('no process is running');
+      return true;
+    }
+    final List<String> results = result.trim().split('\n');
+    // Example result:
+    //
+    // Proc # 0: fore  T/A/T  trm: 0 4544:com.google.android.googlequicksearchbox/u0a66 (top-activity)
+    final RegExp processRegExp = RegExp(' 0 [0-9]+:(?<process>.+)/');
+    final List<String> processes = results.map((e) => processRegExp.firstMatch(e).namedGroup('process')).toList();
+    try {
+      for (String process in processes) {
+        await eval('adb', <String>['shell', 'am', 'force-stop', process], processManager: processManager);
+        stdout.write('adb stop process: $process');
+      }
+    } on BuildFailedError catch (error) {
+      stderr.write('uninstall applications fails: $error');
+      return false;
+    }
+    return true;
   }
 }

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -36,6 +36,9 @@ abstract class DeviceDiscovery {
 
   /// Recovers the device.
   Future<void> recoverDevices();
+
+  /// Prepares the device.
+  Future<void> prepareDevices();
 }
 
 /// A proxy for one specific phone device.
@@ -45,4 +48,7 @@ abstract class Device {
 
   /// Recovers the device back to a healthy state.
   Future<void> recover();
+
+  /// Prepares the device before running tasks.
+  Future<void> prepare();
 }

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -122,6 +122,13 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     }
     return healthCheckResult;
   }
+
+  @override
+  Future<void> prepareDevices() async {
+    for (Device device in await discoverDevices()) {
+      await device.prepare();
+    }
+  }
 }
 
 /// iOS device.
@@ -135,6 +142,11 @@ class IosDevice implements Device {
   Future<void> recover() async {
     await uninstall_applications();
     await restart_device();
+  }
+
+  @override
+  Future<void> prepare() async {
+    return;
   }
 
   /// Restart iOS device.

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -205,7 +205,9 @@ void main() {
       when(processManager.start(<dynamic>['adb', 'shell', 'am', 'force-stop', 'com.google.android.apps.nexuslauncher'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(killProcess));
-      output = <List<int>>[utf8.encode('Proc #27: fg     T/ /TOP  LCM  t: 0 0:com.google.android.apps.nexuslauncher/u0a199 (top-activity)')];
+      output = <List<int>>[
+        utf8.encode('Proc #27: fg     T/ /TOP  LCM  t: 0 0:com.google.android.apps.nexuslauncher/u0a199 (top-activity)')
+      ];
       listProcess = FakeProcess(0, out: output);
       killProcess = FakeProcess(0);
 
@@ -234,7 +236,9 @@ void main() {
       when(processManager.start(<dynamic>['adb', 'shell', 'am', 'force-stop', 'com.google.android.apps.nexuslauncher'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(killProcess));
-      output = <List<int>>[utf8.encode('Proc #27: fg     T/ /TOP  LCM  t: 0 0:com.google.android.apps.nexuslauncher/u0a199 (top-activity)')];
+      output = <List<int>>[
+        utf8.encode('Proc #27: fg     T/ /TOP  LCM  t: 0 0:com.google.android.apps.nexuslauncher/u0a199 (top-activity)')
+      ];
       listProcess = FakeProcess(0, out: output);
       killProcess = FakeProcess(1);
 


### PR DESCRIPTION
This PR adds a support for a new action `prepare`, which prepares the phone before running a task. One feature added here for android device is: clean up the top activity in android devices.

Related: https://github.com/flutter/flutter/issues/83938



