### PR TITLE
Redirect traffic only after the deployment is successful.

### DIFF
--- a/cloud_build/deploy.sh
+++ b/cloud_build/deploy.sh
@@ -9,4 +9,5 @@ cp -r scheduler app_dart/build/
 pushd app_dart > /dev/null
 set -e
 gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
+gcloud app services set-traffic default --splits version-$2=1 --quiet
 popd > /dev/null


### PR DESCRIPTION
This is to address the problems with the backend not being available
during the deployment process.

Bug: https://github.com/flutter/flutter/issues/87222