### PR TITLE
[scheduler] Don't run bringup presubmit targets

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -241,7 +241,8 @@ class Scheduler {
   /// and that do not have any dependencies.
   List<Target> getPreSubmitTargets(Commit commit, SchedulerConfig config) {
     // Filter targets to only those run in presubmit.
-    final Iterable<Target> presubmitTargets = config.targets.where((Target target) => target.presubmit);
+    final Iterable<Target> presubmitTargets =
+        config.targets.where((Target target) => target.presubmit && !target.bringup);
 
     return _filterEnabledTargets(commit, config, presubmitTargets.toList());
   }

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -310,6 +310,10 @@ targets:
     enabled_branches:
       - master
     presubmit: true
+  - name: Linux D
+    scheduler: luci
+    bringup: true
+    presubmit: true
   - name: Google-internal roll
     scheduler: google_internal
     enabled_branches:


### PR DESCRIPTION
This is necessary for adding new presubmit targets in the .ci.yaml

The expectation is developers add a target that is in bringup, and wait for it to soak. Once prod is green, they can remove bringup to enable the presubmit.

Currently, this doesn't work as the ci.yaml change can't be landed as the builder doesn't exist yet.