### PR TITLE
Skip AndroidDeviceKillProcesses no running processes

### DIFF
--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -227,7 +227,7 @@ void main() {
 
       final bool result = await device.killProcesses(processManager: processManager);
       expect(result, true);
-    });
+    }, skip: 'https://github.com/flutter/flutter/issues/88008');
 
     test('fails to kill running processes', () async {
       when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'activity', '|', 'grep', 'top-activity'],


### PR DESCRIPTION
This test is flaking ~25% of the time.

https://github.com/flutter/flutter/issues/88008