### PR TITLE
Updates status calculation to pass if any success.

### DIFF
--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -65,7 +65,7 @@ class BuildStatusService {
       return BuildStatus.failure();
     }
 
-    final List<String> failedTasks = <String>[];
+    final Set<String> failedTasks = <String>{};
     for (CommitStatus status in statuses) {
       for (Stage stage in status.stages) {
         for (Task task in stage.tasks) {
@@ -82,19 +82,17 @@ class BuildStatusService {
               /// This task no longer needs to be checked to see if it causing
               /// the build status to fail.
               tasksInProgress[task.name] = false;
+              if (failedTasks.contains(task.name)) {
+                failedTasks.remove(task.name);
+              }
             } else if (_isFailed(task) || _isRerunning(task)) {
               failedTasks.add(task.name);
-
-              /// This task no longer needs to be checked to see if its causing
-              /// the build status to fail since its been
-              /// added to the failedTasks list.
-              tasksInProgress[task.name] = false;
             }
           }
         }
       }
     }
-    return failedTasks.isNotEmpty ? BuildStatus.failure(failedTasks) : BuildStatus.success();
+    return failedTasks.isNotEmpty ? BuildStatus.failure(failedTasks.toList()) : BuildStatus.success();
   }
 
   /// Creates a map of the tasks that need to be checked for the build status.

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -106,13 +106,6 @@ void main() {
         expect(status, BuildStatus.success());
       });
 
-      test('returns failure if last commit contains any red tasks', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
-        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFailed);
-        final BuildStatus status = await buildStatusService.calculateCumulativeStatus();
-        expect(status, BuildStatus.failure(const <String>['task2']));
-      });
-
       test('ensure failed task do not have duplicates when last consecutive commits contains red tasks', () async {
         db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
         db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFailed);
@@ -143,26 +136,6 @@ void main() {
         int row = 0;
         db.addOnQuery<Task>((Iterable<Task> results) {
           return row++ == 0 ? middleTaskInProgress : middleTaskFailed;
-        });
-        final BuildStatus status = await buildStatusService.calculateCumulativeStatus();
-        expect(status, BuildStatus.failure(const <String>['task2']));
-      });
-
-      test('returns failure when green but a task is rerunning', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskRerunning : allGreen;
-        });
-        final BuildStatus status = await buildStatusService.calculateCumulativeStatus();
-        expect(status, BuildStatus.failure(const <String>['task2']));
-      });
-
-      test('returns failure when a task has an infra failure', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskInfraFailure : allGreen;
         });
         final BuildStatus status = await buildStatusService.calculateCumulativeStatus();
         expect(status, BuildStatus.failure(const <String>['task2']));


### PR DESCRIPTION
Retry logic in flutter dashboard does not allow to retry if there was at
least a successful execution and the logic to paint the task-commit in
the grid was using the signal of the last task. This PR updates the
logic to calculate the grid status to make it consistent with the retry
logic.

Bug: https://github.com/flutter/flutter/issues/88197