### PR TITLE
[app_dart] Add FRoB account to swarming auth

### DIFF
--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -107,7 +107,13 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
         throw InternalServerError('Invalid JSON: "$tokenJson"');
       }
 
+      // Update is from Flutter LUCI builds
       if (token.email == config.luciProdAccount) {
+        return AuthenticatedContext(clientContext: clientContext);
+      }
+
+      if (token.email == config.frobAccount) {
+        log.debug('Authenticating as FRoB request');
         return AuthenticatedContext(clientContext: clientContext);
       }
 

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -221,6 +221,9 @@ class Config {
   /// Post submit service account email used by LUCI swarming tasks.
   String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 
+  /// Internal Google service account used to surface FRoB results.
+  String get frobAccount => 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
+
   int get maxTaskRetries => 2;
 
   /// Max retries for Luci builder with infra failure.

--- a/app_dart/test/request_handling/swarming_authentication_test.dart
+++ b/app_dart/test/request_handling/swarming_authentication_test.dart
@@ -54,7 +54,7 @@ void main() {
         );
       });
 
-      test('auth succeeds with expected service account', () async {
+      test('auth succeeds with flutter luci service account', () async {
         httpClient = FakeHttpClient(
             onIssueRequest: (FakeHttpClientRequest request) => verifyTokenResponse
               ..statusCode = HttpStatus.ok
@@ -68,7 +68,26 @@ void main() {
           loggingProvider: () => log,
         );
 
-        request.headers.add(SwarmingAuthenticationProvider.kSwarmingTokenHeader, 'unauthenticated token');
+        request.headers.add(SwarmingAuthenticationProvider.kSwarmingTokenHeader, 'token');
+
+        final AuthenticatedContext result = await auth.authenticate(request);
+        expect(result.clientContext, same(clientContext));
+      });
+
+      test('auth succeeds with frob service account', () async {
+        httpClient = FakeHttpClient(
+            onIssueRequest: (FakeHttpClientRequest request) => verifyTokenResponse
+              ..statusCode = HttpStatus.ok
+              ..body = '{"email": "${config.frobAccount}"}');
+
+        verifyTokenResponse = httpClient.request.response;
+        auth = SwarmingAuthenticationProvider(
+          config,
+          clientContextProvider: () => clientContext,
+          httpClientProvider: () => httpClient,
+          loggingProvider: () => log,
+        );
+        request.headers.add(SwarmingAuthenticationProvider.kSwarmingTokenHeader, 'token');
 
         final AuthenticatedContext result = await auth.authenticate(request);
         expect(result.clientContext, same(clientContext));

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -292,4 +292,7 @@ class FakeConfig implements Config {
 
   @override
   Future<GithubService> createDefaultGitHubService() async => githubService;
+
+  @override
+  String get frobAccount => 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
 }


### PR DESCRIPTION
This enables the FRoB team to POST to `/api/update-task-status` by putting their service account token in the header `Service-Account-Token`.

https://github.com/flutter/flutter/issues/79658