### PR TITLE
Prepare to remove devicelab service account.

### DIFF
--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -117,7 +117,10 @@ class LuciStatusHandler extends RequestHandler<Body> {
     if (info.expiresIn == null || info.expiresIn < 1) {
       return false;
     }
-    final ServiceAccountInfo devicelabServiceAccount = await config.deviceLabServiceAccount;
-    return info.email == devicelabServiceAccount.email;
+    final Set<String> allowedServiceAccounts = <String>{
+      'flutter-devicelab@flutter-dashboard.iam.gserviceaccount.com',
+      'flutter-dashboard@appspot.gserviceaccount.com'
+    };
+    return allowedServiceAccounts.contains(info.email);
   }
 }

--- a/app_dart/lib/src/request_handlers/luci_status.dart
+++ b/app_dart/lib/src/request_handlers/luci_status.dart
@@ -12,7 +12,6 @@ import 'package:meta/meta.dart';
 
 import '../foundation/providers.dart';
 import '../foundation/typedefs.dart';
-import '../model/appengine/service_account_info.dart';
 import '../model/luci/push_message.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';


### PR DESCRIPTION
As the pubsub messages are coming from the same project as the appengine
instance there is no reason to use an additional service account. This
PR removes the dependency on the devicelab service account.