### PR TITLE
Prepare search requests considering realm when calling builderbucket API

### DIFF
--- a/app_dart/lib/src/model/luci/buildbucket.dart
+++ b/app_dart/lib/src/model/luci/buildbucket.dart
@@ -12,9 +12,9 @@ import '../google/grpc.dart';
 part 'buildbucket.g.dart';
 
 // The classes in this file are based on protos found in:
-// https://chromium.googlesource.com/infra/luci/luci-go/+/master/buildbucket/proto/build.proto
-// https://chromium.googlesource.com/infra/luci/luci-go/+/master/buildbucket/proto/common.proto
-// https://chromium.googlesource.com/infra/luci/luci-go/+/master/buildbucket/proto/rpc.proto
+// https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/main/buildbucket/proto/build.proto
+// https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/main/buildbucket/proto/common.proto
+// https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/main/buildbucket/proto/builds_service.proto#381
 //
 // The `fromJson` methods in this class are static rather than factories so that
 // they can be passed as arguments to other functions looking for a parser.

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -47,6 +47,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       buildBucketClient: BuildBucketClient(),
       config: handler.config,
       clientContext: handler.authContext.clientContext,
+      log: handler.config.loggingService,
     );
   }
 

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -51,6 +51,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
       buildBucketClient: BuildBucketClient(),
       config: handler.config,
       clientContext: handler.authContext.clientContext,
+      log: handler.config.loggingService,
     );
   }
 

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -180,7 +180,7 @@ class LuciService {
     // Log error of any response if existing.
     // Any response code other than 200 suggests there is an error.
     // https://cloud.google.com/apis/design/errors#handling_errors
-    if (batchResponse.responses.any((Response response) => response.error.code != 200)) {
+    if (batchResponse.responses.any((Response response) => response.error != null && response.error.code != 200)) {
       final String responseError = batchResponse.responses
           .map<String>((Response response) {
             if (response.error.code == null) {

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -132,4 +132,24 @@ void main() {
       <LuciBuilder>[const LuciBuilder(name: 'Linux5', repo: 'flutter', flaky: false)]
     ]);
   });
+
+  test('prepare search requests', () async {
+    final FakeConfig config = FakeConfig(githubService: FakeGithubService());
+    final FakeClientContext clientContext = FakeClientContext();
+    final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
+    final LuciService service =
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+    final List<LuciBuilder> luciBuilders = <LuciBuilder>[
+      const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),
+    ];
+
+    final List<Request> searchRequests = service.prepareSearchRequests('flutter', true, luciBuilders);
+    expect(searchRequests.length, 2);
+    expect(searchRequests[0].searchBuilds.predicate.tags, <String, List<String>>{
+      'scheduler_job_id': <String>['flutter/Linux']
+    });
+    expect(searchRequests[1].searchBuilds.predicate.tags, <String, List<String>>{
+      'scheduler_job_id': <String>['flutter/prod-Linux']
+    });
+  });
 }

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -60,6 +60,7 @@ void main() {
         responses: <Response>[
           Response(
             searchBuilds: SearchBuildsResponse(builds: builds),
+            error: const GrpcStatus(code: 200, message: null, details: null)
           ),
         ],
       );
@@ -104,6 +105,7 @@ void main() {
         responses: <Response>[
           Response(
             searchBuilds: SearchBuildsResponse(builds: builds),
+            error: const GrpcStatus(code: 200, message: null, details: null)
           ),
         ],
       );

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/model/google/grpc.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/service/luci.dart';
 import 'package:mockito/mockito.dart';
@@ -10,12 +11,18 @@ import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_logging.dart';
 import '../src/service/fake_github_service.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
   BranchLuciBuilder branchLuciBuilder1;
   BranchLuciBuilder branchLuciBuilder2;
+  FakeLogging log;
+
+  setUp(() {
+    log = FakeLogging();
+  });
 
   test('validates effectiveness of class BranchLuciBuilder as a map key', () async {
     branchLuciBuilder1 = const BranchLuciBuilder(
@@ -34,7 +41,7 @@ void main() {
     final FakeClientContext clientContext = FakeClientContext();
     final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
     final LuciService service =
-        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext, log: log);
     final List<Build> builds = List<Build>.generate(
       luciStatusToTaskStatus.keys.length,
       (int index) => Build(
@@ -77,7 +84,7 @@ void main() {
     final FakeClientContext clientContext = FakeClientContext();
     final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
     final LuciService service =
-        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext, log: log);
     const LuciBuilder builder = LuciBuilder(name: 'Linux', repo: 'flutter', flaky: false);
     final List<Build> builds = List<Build>.generate(
       luciStatusToTaskStatus.keys.length,
@@ -105,12 +112,48 @@ void main() {
     expect(resultBuilds, builds);
   });
 
+  test('log error when response fails', () async {
+    final FakeConfig config = FakeConfig(githubService: FakeGithubService());
+    final FakeClientContext clientContext = FakeClientContext();
+    final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
+    final LuciService service =
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext, log: log);
+    const LuciBuilder builder = LuciBuilder(name: 'Linux', repo: 'flutter', flaky: false);
+    final List<Build> builds = List<Build>.generate(
+      luciStatusToTaskStatus.keys.length,
+      (int index) => Build(
+        id: index,
+        number: index,
+        builderId: const BuilderId(
+          project: 'flutter',
+          bucket: 'prod',
+          builder: 'Linux',
+        ),
+        status: luciStatusToTaskStatus.keys.toList()[index],
+      ),
+    );
+    when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+      return BatchResponse(
+        responses: <Response>[
+          Response(
+            searchBuilds: SearchBuildsResponse(builds: builds),
+            error: const GrpcStatus(code: 400, message: 'test', details: 'test error'),
+          ),
+        ],
+      );
+    });
+    await service.getBuildsForBuilderList(<LuciBuilder>[builder], repo: 'flutter');
+    expect(log.records.length, 1);
+    expect(log.records[0].level.name, 'Error');
+    expect(log.records[0].message, 'Failed search request response: [Response #400: test, test error]');
+  });
+
   test('luci getPartialBuildersList handles non-uniform batches', () async {
     final FakeConfig config = FakeConfig(githubService: FakeGithubService());
     final FakeClientContext clientContext = FakeClientContext();
     final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
     final LuciService service =
-        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext, log: log);
     const List<LuciBuilder> builders = <LuciBuilder>[
       LuciBuilder(name: 'Linux1', repo: 'flutter', flaky: false),
       LuciBuilder(name: 'Linux2', repo: 'flutter', flaky: false),
@@ -138,7 +181,7 @@ void main() {
     final FakeClientContext clientContext = FakeClientContext();
     final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
     final LuciService service =
-        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext);
+        LuciService(buildBucketClient: mockBuildBucketClient, config: config, clientContext: clientContext, log: log);
     final List<LuciBuilder> luciBuilders = <LuciBuilder>[
       const LuciBuilder(name: 'Linux', repo: 'flutter', taskName: 'linux_bot', flaky: false),
     ];

--- a/app_dart/test/service/luci_test.dart
+++ b/app_dart/test/service/luci_test.dart
@@ -59,9 +59,8 @@ void main() {
       return BatchResponse(
         responses: <Response>[
           Response(
-            searchBuilds: SearchBuildsResponse(builds: builds),
-            error: const GrpcStatus(code: 200, message: null, details: null)
-          ),
+              searchBuilds: SearchBuildsResponse(builds: builds),
+              error: const GrpcStatus(code: 200, message: null, details: null)),
         ],
       );
     });
@@ -104,9 +103,8 @@ void main() {
       return BatchResponse(
         responses: <Response>[
           Response(
-            searchBuilds: SearchBuildsResponse(builds: builds),
-            error: const GrpcStatus(code: 200, message: null, details: null)
-          ),
+              searchBuilds: SearchBuildsResponse(builds: builds),
+              error: const GrpcStatus(code: 200, message: null, details: null)),
         ],
       );
     });


### PR DESCRIPTION
The `staging` suffix was removed in https://flutter-review.googlesource.com/c/infra/+/17400 for staging builders, and same builder name exists in both staging and prod pools. This results in `realm` appended to `scheduler_job_id`:
<img width="700" alt="Screen Shot 2021-09-02 at 11 19 43 AM" src="https://user-images.githubusercontent.com/54558023/131896340-d120cb77-66d6-43b1-aebd-e10736e4b8e0.png">

Cocoon has been querying without specifying the `realm`, and miss those builds.

This PR adds the missing `realm` case.