### PR TITLE
Enable workflow to mirror master branch to main.

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,19 @@
+# Mirror master to main branches in the cocoon repository.
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    name: Mirror master branch to main branch
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: google/mirror-branch-action@v1.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: 'main'


### PR DESCRIPTION
We will mirror master branch to main. This will enable us to start moving some processes to main branch in preparation to deprecate master.