### PR TITLE
Pin the workflow dependency to a commit.

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Mirror action step
       id: mirror
-      uses: google/mirror-branch-action@v1.0
+      uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'master'


### PR DESCRIPTION
This is to follow the best practices on workflows security.