### PR TITLE
Grant explicit write permissions.

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,5 +1,4 @@
 # Mirror master to main branches in the cocoon repository.
-
 on:
   push:
     branches:
@@ -7,9 +6,12 @@ on:
 
 jobs:
   mirror_job:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Mirror master branch to main branch
     steps:
+<<<<<<< HEAD
     - name: Mirror action step
       id: mirror
       uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
@@ -17,3 +19,11 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'master'
         dest: 'main'
+=======
+      - name: Mirror action step
+        id: mirror
+        uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          source: 'master'
+>>>>>>> c455f1a7 (Grant explicit write permissions.)

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           source: 'master'
+          dest: 'main'

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,19 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Mirror master branch to main branch
     steps:
-<<<<<<< HEAD
-    - name: Mirror action step
-      id: mirror
-      uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        source: 'master'
-        dest: 'main'
-=======
       - name: Mirror action step
         id: mirror
         uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           source: 'master'
->>>>>>> c455f1a7 (Grant explicit write permissions.)


### PR DESCRIPTION
Flutter repositories allow readonly workflows by default. Workflows that
require write permissions need to explicitly request them in the
configuration file.