### PR TITLE
Use githubbot token instead of the default one.

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -15,6 +15,6 @@ jobs:
         id: mirror
         uses: google/mirror-branch-action@c6b07e441a7ffc5ae15860c1d0a8107a3a151db8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.FLUTTERGITHUBBOT_TOKEN }}
           source: 'master'
           dest: 'main'


### PR DESCRIPTION
This is to be able to setup branch protection correctly.