### PR TITLE
[app_dart] Truncate luci build push messages before sending as check

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -126,7 +126,18 @@ class GithubChecksService {
   /// Appends triage wiki page to `summaryMarkdown` from LUCI build so that people can easily
   /// reference from github check run page.
   String getGithubSummary(String? summary) {
-    return kGithubSummary + (summary ?? 'Empty summaryMarkdown');
+    if (summary == null) {
+      return kGithubSummary + 'Empty summaryMarkdown';
+    }
+    // This is an imposed GitHub limit
+    const int checkSummaryLimit = 65535;
+    // This is to give buffer room incase GitHub lowers the amount.
+    const int checkSummaryBufferLimit = checkSummaryLimit - 10000 - kGithubSummary.length;
+    // Return the last [checkSummaryBufferLimit] characters as they are likely the most relevant.
+    if (summary.length > checkSummaryBufferLimit) {
+      summary = '[TRUNCATED...] ' + summary.substring(summary.length - checkSummaryBufferLimit);
+    }
+    return kGithubSummary + summary;
   }
 
   /// Transforms a [push_message.Result] to a [github.CheckRunConclusion].

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -133,7 +133,7 @@ void main() {
 
     test('really large summaryMarkdown', () async {
       String summaryMarkdown = '';
-      for (int i = 0; i < 65535; i++) {
+      for (int i = 0; i < 20000; i++) {
         summaryMarkdown += 'test ';
       }
       expect(githubChecksService.getGithubSummary(summaryMarkdown), startsWith('$kGithubSummary[TRUNCATED...]'));

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -130,6 +130,15 @@ void main() {
       const String expectedSummary = '${kGithubSummary}Empty summaryMarkdown';
       expect(githubChecksService.getGithubSummary(null), expectedSummary);
     });
+
+    test('really large summaryMarkdown', () async {
+      String summaryMarkdown = '';
+      for (int i = 0; i < 65535; i++) {
+        summaryMarkdown += 'test ';
+      }
+      expect(githubChecksService.getGithubSummary(summaryMarkdown), startsWith('$kGithubSummary[TRUNCATED...]'));
+      expect(githubChecksService.getGithubSummary(summaryMarkdown).length, lessThan(65535));
+    });
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/87507