### PR TITLE
Fixes build re-run failing with a 400 status code.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -451,7 +451,7 @@ class LuciBuildService {
       },
       notify: NotificationConfig(
         pubsubTopic: 'projects/flutter-dashboard/topics/luci-builds',
-        userData: json.encode(userData),
+        userData: base64Encode(json.encode(userData).codeUnits),
       ),
     ));
     final String buildUrl = 'https://ci.chromium.org/ui/b/${scheduleBuild.id}';


### PR DESCRIPTION
This was caused by pubsub notification topic not being encoded as
base64.

Bug: https://github.com/flutter/flutter/issues/90914