### PR TITLE
Remove `web` as an indicator of golden file test execution

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -107,7 +107,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       for (Map<String, dynamic> checkRun in checkRuns) {
         log.fine('Check run: $checkRun');
         final String name = checkRun['name'].toLowerCase() as String;
-        if (name.contains('framework') || name.contains('web')) {
+        if (name.contains('framework')) {
           runsGoldenFileTests = true;
         }
         if (checkRun['conclusion'] == null || checkRun['conclusion'].toUpperCase() != 'SUCCESS') {


### PR DESCRIPTION
We have a lot more web builds now, they are not indicative of golden file tests being run. 

For example, the flutter-gold check is currently broken on this change: https://github.com/flutter/flutter/pull/90413 This change does not execute golden file tests, so there are no results when it looks up Gold.

Fixes https://github.com/flutter/flutter/issues/90979

