### PR TITLE
Revert "Do not try to submit if PR is not mergeable."

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -421,9 +421,6 @@ class _AutoMergeQueryResult {
           ' check the Google CLA status is present and Flutter Dashboard'
           ' application has multiple checks.');
     }
-    if (!isMergeable) {
-      buffer.writeln('- This commit is not mergeable. Please rebase your PR.');
-    }
     return buffer.toString();
   }
 

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -1009,7 +1009,6 @@ class PullRequestHelper {
     this.lastCommitStatuses = const <StatusHelper>[StatusHelper.flutterBuildSuccess],
     this.lastCommitCheckRuns = const <CheckRunHelper>[CheckRunHelper.luciCompletedSuccess],
     this.dateTime,
-    this.mergeable = 'MERGEABLE',
   }) : _count = _counter++;
 
   static int _counter = 0;
@@ -1023,14 +1022,12 @@ class PullRequestHelper {
   List<StatusHelper>? lastCommitStatuses;
   List<CheckRunHelper>? lastCommitCheckRuns;
   final DateTime? dateTime;
-  final String? mergeable;
 
   Map<String, dynamic> toEntry() {
     return <String, dynamic>{
       'author': <String, dynamic>{'login': author},
       'id': id,
       'number': _count,
-      'mergeable': mergeable,
       'reviews': <String, dynamic>{
         'nodes': reviews.map((PullRequestReviewHelper review) {
           return <String, dynamic>{


### PR DESCRIPTION
Reverts flutter/cocoon#1368

Fixes https://github.com/flutter/flutter/issues/91035

We need the bot to leave the "waiting for tree to go green" label on PRs that are green EXCEPT for the `luci-flutter` check