### PR TITLE
Remove unreliable mHoldingWakeLockSuspendBlocker check

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -192,13 +192,11 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
   Future<HealthCheckResult> screenOnCheck({ProcessManager processManager}) async {
     HealthCheckResult healthCheckResult;
     try {
-      final String result = await eval('adb', <String>['shell', 'dumpsys', 'power', '|', 'grep', 'mHolding'],
+      final String result = await eval(
+          'adb', <String>['shell', 'dumpsys', 'power', '|', 'grep', 'mHoldingDisplaySuspendBlocker'],
           processManager: processManager);
       final Set<String> mHoldings = result.trim().split('\n').map((e) => e.trim()).toSet();
-      final Set<String> expectedHoldings = <String>{
-        'mHoldingWakeLockSuspendBlocker=true',
-        'mHoldingDisplaySuspendBlocker=true'
-      };
+      final Set<String> expectedHoldings = <String>{'mHoldingDisplaySuspendBlocker=true'};
       if (SetEquality().equals(mHoldings, expectedHoldings)) {
         healthCheckResult = HealthCheckResult.success(kScreenOnCheckKey);
       } else {

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:retry/retry.dart';

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -195,9 +195,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       final String result = await eval(
           'adb', <String>['shell', 'dumpsys', 'power', '|', 'grep', 'mHoldingDisplaySuspendBlocker'],
           processManager: processManager);
-      final Set<String> mHoldings = result.trim().split('\n').map((e) => e.trim()).toSet();
-      final Set<String> expectedHoldings = <String>{'mHoldingDisplaySuspendBlocker=true'};
-      if (SetEquality().equals(mHoldings, expectedHoldings)) {
+      if (result.trim() == 'mHoldingDisplaySuspendBlocker=true') {
         healthCheckResult = HealthCheckResult.success(kScreenOnCheckKey);
       } else {
         healthCheckResult = HealthCheckResult.failure(kScreenOnCheckKey, 'screen is off');

--- a/device_doctor/test/src/android_device_test.dart
+++ b/device_doctor/test/src/android_device_test.dart
@@ -196,12 +196,12 @@ void main() {
 
     test('returns success when screen is on', () async {
       const String screenMessage = '''
-      mHoldingWakeLockSuspendBlocker=true
       mHoldingDisplaySuspendBlocker=true
       ''';
       output = <List<int>>[utf8.encode(screenMessage)];
       process = FakeProcess(0, out: output);
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHolding'],
+      when(processManager.start(
+              <dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHoldingDisplaySuspendBlocker'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
@@ -212,12 +212,12 @@ void main() {
 
     test('returns failure when screen is off', () async {
       const String screenMessage = '''
-      mHoldingWakeLockSuspendBlocker=false
       mHoldingDisplaySuspendBlocker=false
       ''';
       output = <List<int>>[utf8.encode(screenMessage)];
       process = FakeProcess(0, out: output);
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHolding'],
+      when(processManager.start(
+              <dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHoldingDisplaySuspendBlocker'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
@@ -229,7 +229,8 @@ void main() {
 
     test('returns failure when adb return none 0 code', () async {
       process = FakeProcess(1);
-      when(processManager.start(<dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHolding'],
+      when(processManager.start(
+              <dynamic>['adb', 'shell', 'dumpsys', 'power', '|', 'grep', 'mHoldingDisplaySuspendBlocker'],
               workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/1370.

It turns out that `mHoldingWakeLockSuspendBlocker` is not reliable to decide if the screen is on.

For example: newly enabled test bed in staging `linux9` is with screen on and running test well, but 
```
  mHoldingWakeLockSuspendBlocker=false
  mHoldingDisplaySuspendBlocker=true
```

On the other hand, `mHoldingDisplaySuspendBlocker=false` always suggests screen is off. So we keep `mHoldingDisplaySuspendBlocker` only as a flag for screen on or off.