### PR TITLE
Add labeling for API docs

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -259,7 +259,8 @@ class GithubWebhook extends RequestHandler<Body> {
       'bin/internal/engine.version': <String>['engine'],
       'dev/': <String>['team'],
       'examples/': <String>['d: examples', 'team'],
-      'examples/flutter_gallery': <String>['d: examples', 'team', 'team: gallery'],
+      'examples/api/': <String>['d: examples', 'team', 'd: api docs', 'documentation'],
+      'examples/flutter_gallery/': <String>['d: examples', 'team', 'team: gallery'],
       'packages/flutter_tools/': <String>['tool'],
       'packages/flutter/': <String>['framework'],
       'packages/flutter_driver/': <String>['framework', 'a: tests'],
@@ -267,7 +268,7 @@ class GithubWebhook extends RequestHandler<Body> {
       'packages/flutter_goldens/': <String>['framework', 'a: tests', 'team'],
       'packages/flutter_goldens_client/': <String>['framework', 'a: tests', 'team'],
       'packages/flutter_test/': <String>['framework', 'a: tests'],
-      'packages/fuchsia_remote_debug_protocol': <String>['tool'],
+      'packages/fuchsia_remote_debug_protocol/': <String>['tool'],
     };
     const Map<String, List<String>> pathContainsLabels = <String, List<String>>{
       'accessibility': <String>['a: accessibility'],

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -330,6 +330,11 @@ void main() {
         expect(GithubWebhook.getLabelsForFrameworkPath('examples/foo/bar/baz.dart'), contains('d: examples'));
       });
 
+      test('API Docs label applied', () {
+        expect(GithubWebhook.getLabelsForFrameworkPath('examples/api/bar/baz.dart'),
+            <String>['d: examples', 'team', 'd: api docs', 'documentation']);
+      });
+
       test('Gallery label applied', () {
         expect(GithubWebhook.getLabelsForFrameworkPath('examples/flutter_gallery/lib/gallery.dart'),
             contains('team: gallery'));


### PR DESCRIPTION
I noticed during triage that the API docs are now in a directory that we can label for.
This accounts for `flutter/examples/api` now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
