### PR TITLE
[cloud_build] Only keep 10 most recent versions

### DIFF
--- a/cloud_build/deploy.sh
+++ b/cloud_build/deploy.sh
@@ -11,4 +11,7 @@ set -e
 gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
 gcloud app deploy --project "$1" app_dart/cron.yaml
 gcloud app services set-traffic default --splits version-$2=1 --quiet
+# Google Cloud quota only allows 30 versions.
+# For daily builds, this will keep the 10 most recent versions, but wipe the rest.
+gcloud app versions list --format="value(version.id)" --sort-by="~version.createTime" | tail -n +11 | xargs -r gcloud app versions delete --quiet
 popd > /dev/null

--- a/cloud_build/deploy.sh
+++ b/cloud_build/deploy.sh
@@ -9,7 +9,7 @@ cp -r scheduler app_dart/build/
 pushd app_dart > /dev/null
 set -e
 gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
-gcloud app deploy --project "$1" app_dart/cron.yaml
+gcloud app deploy --project "$1" cron.yaml
 gcloud app services set-traffic default --splits version-$2=1 --quiet
 # Google Cloud quota only allows 30 versions.
 # For daily builds, this will keep the 10 most recent versions, but wipe the rest.


### PR DESCRIPTION
GAE only allows 30 versions. The past 2 days had issues where it was failing to deploy due to the quota.

This will only keep the 10 most recent versions (gives some room for old versions to fallback to and dev versions).

I ran this command manually, and it takes ~1 minute per version to delete it. I did a bulk delete of 20 instances, so I only expect this to add 1-3 minutes to the cloudbuild workflow.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
