### PR TITLE
Add the ability to bypass the tree status check.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -59,6 +59,11 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                 state
               }
             }
+            labels(first: 100) {
+              nodes {
+                name
+              }
+            }
           }
         }
       }

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -99,6 +99,7 @@ class Config {
 
   // GitHub App properties.
   Future<String> get githubPrivateKey => _getSingleValue('githubapp_private_pem');
+  Future<String> get overrideTreeStatusLabel => _getSingleValue('override_tree_status_label');
   Future<String> get githubPublicKey => _getSingleValue('githubapp_public_pem');
   Future<String> get githubAppId => _getSingleValue('githubapp_id');
   Future<Map<String, dynamic>> get githubAppInstallations async {

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -118,6 +118,7 @@ void main() {
         cirrusGraphQLClient: cirrusGraphQLClient,
         githubGraphQLClient: githubGraphQLClient,
       );
+      config.overrideTreeStatusLabelValue = 'warning: land on red to fix tree breakage';
       flutterRepoPRs.clear();
       engineRepoPRs.clear();
       pluginRepoPRs.clear();
@@ -372,6 +373,30 @@ This pull request is not suitable for automatic merging in its current state.
       await tester.get(handler);
       _verifyQueries();
       githubGraphQLClient.verifyMutations(<MutationOptions>[]);
+    });
+
+    test('Merges PR with failed tree status if override tree status label is provided', () async {
+      branch = 'pull/0';
+      final PullRequestHelper prRequested = PullRequestHelper(
+        lastCommitCheckRuns: const <CheckRunHelper>[
+          CheckRunHelper.luciCompletedSuccess,
+        ],
+        lastCommitStatuses: const <StatusHelper>[
+          StatusHelper.flutterBuildFailure,
+        ],
+        labels: <dynamic>[
+          <String, dynamic>{'name': 'warning: land on red to fix tree breakage'}
+        ],
+      );
+      flutterRepoPRs.add(prRequested);
+      await tester.get(handler);
+      _verifyQueries();
+      githubGraphQLClient.verifyMutations(<MutationOptions>[
+        MutationOptions(document: mergePullRequestMutation, variables: <String, dynamic>{
+          'id': flutterRepoPRs.first.id,
+          'oid': oid,
+        }),
+      ]);
     });
 
     test('Does not merge PR with failed checks', () async {
@@ -1009,6 +1034,7 @@ class PullRequestHelper {
     this.lastCommitStatuses = const <StatusHelper>[StatusHelper.flutterBuildSuccess],
     this.lastCommitCheckRuns = const <CheckRunHelper>[CheckRunHelper.luciCompletedSuccess],
     this.dateTime,
+    this.labels = const <dynamic>[],
   }) : _count = _counter++;
 
   static int _counter = 0;
@@ -1022,6 +1048,7 @@ class PullRequestHelper {
   List<StatusHelper>? lastCommitStatuses;
   List<CheckRunHelper>? lastCommitCheckRuns;
   final DateTime? dateTime;
+  List<dynamic> labels;
 
   Map<String, dynamic> toEntry() {
     return <String, dynamic>{
@@ -1075,6 +1102,9 @@ class PullRequestHelper {
             },
           },
         ],
+      },
+      'labels': <String, dynamic>{
+        'nodes': labels,
       },
     };
   }

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -99,6 +99,7 @@ class FakeConfig implements Config {
   String? flutterGoldStalePRValue;
   List<String>? supportedBranchesValue;
   List<LuciBuilder>? luciBuildersValue;
+  String? overrideTreeStatusLabelValue;
 
   @override
   Future<GitHub> createGitHubClient(RepositorySlug slug) async => githubClient!;
@@ -301,4 +302,7 @@ class FakeConfig implements Config {
 
   @override
   String get frobAccount => 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
+
+  @override
+  Future<String> get overrideTreeStatusLabel async => overrideTreeStatusLabelValue!;
 }


### PR DESCRIPTION
Flutter will stop direct submits and will start using a bot to submit
all the PRs. One of the advantages of direct submits is that if the tree
is broken in a way that requires to submit changes to reopen the trees.
We are adding a new label to allow people with write access to the
repositories to land changes even if the tree is red for emergency
situations.

Bug: https://github.com/flutter/flutter/issues/81568

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
