### PR TITLE
Update ignored ios32 builders

### DIFF
--- a/app_dart/lib/src/request_handlers/deflake_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/deflake_flaky_builders.dart
@@ -42,7 +42,7 @@ class DeflakeFlakyBuilders extends ApiRequestHandler<Body> {
   /// handler.
   static const Set<String> ignoredBuilders = <String>{
     'Mac_ios32 flutter_gallery__transition_perf_e2e_ios32',
-    'Mac_ios32 native_ui_tests_ios32',
+    'Mac_ios32 native_ui_tests_ios',
   };
 
   @override

--- a/app_dart/test/request_handlers/deflake_flaky_builders_test_data.dart
+++ b/app_dart/test/request_handlers/deflake_flaky_builders_test_data.dart
@@ -85,7 +85,7 @@ enabled_branches:
   - master
 
 targets:
-  - name: Mac_ios32 flutter_gallery__transition_perf_e2e_ios32
+  - name: Mac_ios32 native_ui_tests_ios
     presubmit: false
     bringup: true
     scheduler: luci


### PR DESCRIPTION
This fixes: https://github.com/flutter/flutter/issues/91845