### PR TITLE
[app_dart] Merged successful checks even if still running

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -287,12 +287,12 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     log.info('Validating name: $name, branch: $branch, checks: $checkRuns');
     for (Map<String, dynamic> checkRun in checkRuns) {
       final String? name = checkRun['name'] as String?;
-      if (checkRun['status'] != 'COMPLETED') {
-        allSuccess = false;
-      } else if (checkRun['conclusion'] != 'SUCCESS') {
-        allSuccess = false;
+      if (checkRun['conclusion'] == 'SUCCESS') {
+        continue;
+      } else if (checkRun['status'] == 'COMPLETED') {
         failures.add(_FailureDetail(name!, checkRun['detailsUrl'] as String));
       }
+      allSuccess = false;
     }
 
     // Validate cirrus


### PR DESCRIPTION
This will make the CheckRunConclusion take precedent over the status as that's what the GitHub UI does. There's a glitch where a check can be considered still running but it's marked with a green checkmark. To match expectations, that should be marked as a passing run.

Fixes https://github.com/flutter/flutter/issues/91908
https://github.com/flutter/flutter/issues/90970

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
