### PR TITLE
Adjust injected delay for auto-submit bot.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -25,7 +25,10 @@ const int _kMergeCountPerCycle = 2;
 /// Injected latency per repository. Engine and Flutter use an injected latency of 1h meaning
 /// that the bot skips any commits younger than 1h. However 1h is too long for some repositories
 /// whose builds are faster. Use this constant to override the default 1h latency for a given repository.
-const Map<String, Duration> _kInjectedLatencies = <String, Duration>{'cocoon': Duration(minutes: 10), 'packages': Duration(minutes: 10)};
+const Map<String, Duration> _kInjectedLatencies = <String, Duration>{
+  'cocoon': Duration(minutes: 10),
+  'packages': Duration(minutes: 10)
+};
 
 @immutable
 class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {


### PR DESCRIPTION
Packages repo has a max queue time of 3 mins. Making the bot wait for 45
minutes to land a given PR is too long. This PR is adjusting the
injected delay to 10 mins.

Bug: https://github.com/flutter/flutter/issues/92037


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
