### PR TITLE
[Conductor] Added clean confirmation prompt on conductor status

### DIFF
--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -38,27 +38,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(
           title: const Text(_title),
-          actions: [
-            Builder(builder: (context) {
-              return Padding(
-                padding: EdgeInsets.fromLTRB(0, 0, 40, 0),
-                child: IconButton(
-                  key: const Key('conductorClean'),
-                  icon: const Icon(Icons.delete),
-                  onPressed: () {
-                    dialogPrompt(
-                      context: context,
-                      title: 'Are you sure you want to clean up the current release?',
-                      content: 'This will abort and delete a work in progress release. This process is not revertible!',
-                      leftOption: 'Yes',
-                      rightOption: 'No',
-                    );
-                  },
-                  tooltip: 'Clean up the current release.',
-                ),
-              );
-            }),
-          ],
+          actions: [cleanStatus()],
         ),
         body: Padding(
           padding: const EdgeInsets.all(20.0),
@@ -75,6 +55,32 @@ class MyApp extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Widget upon clicking cleans the current release in progress.
+class cleanStatus extends StatelessWidget {
+  const cleanStatus({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(0, 0, 40, 0),
+      child: IconButton(
+        key: const Key('conductorClean'),
+        icon: const Icon(Icons.delete),
+        onPressed: () {
+          dialogPrompt(
+            context: context,
+            title: 'Are you sure you want to clean up the current release?',
+            content: 'This will abort and delete a work in progress release. This process is not revertible!',
+            leftOption: 'Yes',
+            rightOption: 'No',
+          );
+        },
+        tooltip: 'Clean up the current release.',
       ),
     );
   }

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 
 import 'services/conductor.dart';
 import 'services/local_conductor.dart';
+import 'widgets/common/dialog_prompt.dart';
 import 'widgets/progression.dart';
 
 const String _title = 'Flutter Desktop Conductor (Not ready, do not use)';
@@ -37,6 +38,27 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(
           title: const Text(_title),
+          actions: [
+            Builder(builder: (context) {
+              return Padding(
+                padding: EdgeInsets.fromLTRB(0, 0, 40, 0),
+                child: IconButton(
+                  key: const Key('conductorClean'),
+                  icon: const Icon(Icons.delete),
+                  onPressed: () {
+                    dialogPrompt(
+                      context: context,
+                      title: 'Are you sure you want to clean up the current release?',
+                      content: 'This will abort and delete a work in progress release. This process is not revertible!',
+                      leftOption: 'Yes',
+                      rightOption: 'No',
+                    );
+                  },
+                  tooltip: 'Clean up the current release.',
+                ),
+              );
+            }),
+          ],
         ),
         body: Padding(
           padding: const EdgeInsets.all(20.0),

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -38,7 +38,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(
           title: const Text(_title),
-          actions: [cleanStatus()],
+          actions: [cleanRelease()],
         ),
         body: Padding(
           padding: const EdgeInsets.all(20.0),
@@ -61,8 +61,8 @@ class MyApp extends StatelessWidget {
 }
 
 /// Widget upon clicking cleans the current release in progress.
-class cleanStatus extends StatelessWidget {
-  const cleanStatus({Key? key}) : super(key: key);
+class cleanRelease extends StatelessWidget {
+  const cleanRelease({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -60,7 +60,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-/// Widget upon clicking cleans the current release in progress.
+/// Button to clean the current release.
 class cleanRelease extends StatelessWidget {
   const cleanRelease({Key? key}) : super(key: key);
 
@@ -76,8 +76,8 @@ class cleanRelease extends StatelessWidget {
             context: context,
             title: 'Are you sure you want to clean up the current release?',
             content: 'This will abort and delete a work in progress release. This process is not revertible!',
-            leftOption: 'Yes',
-            rightOption: 'No',
+            leftOptionTitle: 'Yes',
+            rightOptionTitle: 'No',
           );
         },
         tooltip: 'Clean up the current release.',

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Widget that prompts an alert dialogue to the current window and forces the user to choose between two options.
+Future<String?> dialogPrompt(
+    {required BuildContext context,
+    required String title,
+    required String content,
+    required String leftOption,
+    required String rightOption}) {
+  return showDialog<String>(
+    context: context,
+    builder: (BuildContext context) => AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context, leftOption),
+          child: Text(leftOption),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, rightOption),
+          child: Text(rightOption),
+        ),
+      ],
+    ),
+  );
+}

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -5,12 +5,15 @@
 import 'package:flutter/material.dart';
 
 /// Widget that prompts an alert dialogue to the current window and forces the user to choose between two options.
-Future<String?> dialogPrompt(
-    {required BuildContext context,
-    required String title,
-    required String content,
-    required String leftOption,
-    required String rightOption}) {
+Future<String?> dialogPrompt({
+  required BuildContext context,
+  required String title,
+  required String content,
+  required String leftOptionTitle,
+  required String rightOptionTitle,
+  VoidCallback? leftOptionCallback,
+  VoidCallback? rightOptionCallback,
+}) {
   return showDialog<String>(
     context: context,
     builder: (BuildContext context) => AlertDialog(
@@ -18,12 +21,18 @@ Future<String?> dialogPrompt(
       content: Text(content),
       actions: <Widget>[
         TextButton(
-          onPressed: () => Navigator.pop(context, leftOption),
-          child: Text(leftOption),
+          onPressed: () {
+            if (leftOptionCallback != null) leftOptionCallback();
+            Navigator.pop(context, leftOptionTitle);
+          },
+          child: Text(leftOptionTitle),
         ),
         TextButton(
-          onPressed: () => Navigator.pop(context, rightOption),
-          child: Text(rightOption),
+          onPressed: () {
+            if (rightOptionCallback != null) rightOptionCallback();
+            Navigator.pop(context, rightOptionTitle);
+          },
+          child: Text(rightOptionTitle),
         ),
       ],
     ),

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -6,7 +6,6 @@ import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
 
-import 'common/dialog_prompt.dart';
 import 'common/tooltip.dart';
 
 /// Displays the current conductor state.

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -6,6 +6,7 @@ import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
 
+import 'common/dialog_prompt.dart';
 import 'common/tooltip.dart';
 
 /// Displays the current conductor state.
@@ -96,46 +97,58 @@ class ConductorStatusState extends State<ConductorStatus> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        Table(
+          columnWidths: const <int, TableColumnWidth>{
+            0: FixedColumnWidth(200.0),
+          },
+          children: <TableRow>[
+            for (String headerElement in ConductorStatus.headerElements)
+              TableRow(
+                children: <Widget>[
+                  Text('$headerElement:'),
+                  SelectableText((currentStatus[headerElement] == null || currentStatus[headerElement] == '')
+                      ? 'Unknown'
+                      : currentStatus[headerElement]! as String),
+                ],
+              ),
+          ],
+        ),
+        const SizedBox(height: 20.0),
+        Wrap(
           children: <Widget>[
-            Table(
-              columnWidths: const <int, TableColumnWidth>{
-                0: FixedColumnWidth(200.0),
-              },
-              children: <TableRow>[
-                for (String headerElement in ConductorStatus.headerElements)
-                  TableRow(
-                    children: <Widget>[
-                      Text('$headerElement:'),
-                      SelectableText((currentStatus[headerElement] == null || currentStatus[headerElement] == '')
-                          ? 'Unknown'
-                          : currentStatus[headerElement]! as String),
-                    ],
-                  ),
+            Column(
+              children: <Widget>[
+                RepoInfoExpansion(engineOrFramework: 'engine', currentStatus: currentStatus),
+                const SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'engine', currentStatus: currentStatus),
               ],
             ),
-            const SizedBox(height: 20.0),
-            Wrap(
+            const SizedBox(width: 20.0),
+            Column(
               children: <Widget>[
-                Column(
-                  children: <Widget>[
-                    RepoInfoExpansion(engineOrFramework: 'engine', currentStatus: currentStatus),
-                    const SizedBox(height: 10.0),
-                    CherrypickTable(engineOrFramework: 'engine', currentStatus: currentStatus),
-                  ],
-                ),
-                const SizedBox(width: 20.0),
-                Column(
-                  children: <Widget>[
-                    RepoInfoExpansion(engineOrFramework: 'framework', currentStatus: currentStatus),
-                    const SizedBox(height: 10.0),
-                    CherrypickTable(engineOrFramework: 'framework', currentStatus: currentStatus),
-                  ],
-                ),
+                RepoInfoExpansion(engineOrFramework: 'framework', currentStatus: currentStatus),
+                const SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'framework', currentStatus: currentStatus),
               ],
-            )
+            ),
           ],
+        ),
+        const SizedBox(height: 30.0),
+        Center(
+          child: ElevatedButton(
+            key: const Key('conductorClean'),
+            style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.red)),
+            onPressed: () {
+              dialogPrompt(
+                context: context,
+                title: 'Are you sure you want to clean up the persistent state file?',
+                content: 'This will abort a work in progress release.',
+                leftOption: 'Yes',
+                rightOption: 'No',
+              );
+            },
+            child: const Text('Clean'),
+          ),
         ),
       ],
     );

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -133,23 +133,6 @@ class ConductorStatusState extends State<ConductorStatus> {
             ),
           ],
         ),
-        const SizedBox(height: 30.0),
-        Center(
-          child: ElevatedButton(
-            key: const Key('conductorClean'),
-            style: ButtonStyle(backgroundColor: MaterialStateProperty.all<Color>(Colors.red)),
-            onPressed: () {
-              dialogPrompt(
-                context: context,
-                title: 'Are you sure you want to clean up the persistent state file?',
-                content: 'This will abort a work in progress release.',
-                leftOption: 'Yes',
-                rightOption: 'No',
-              );
-            },
-            child: const Text('Clean'),
-          ),
-        ),
       ],
     );
   }

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -227,7 +227,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   yaml:
     dependency: transitive
     description:

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -227,7 +227,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   yaml:
     dependency: transitive
     description:

--- a/release_dashboard/test/widgets/common/dialog_prompt_test.dart
+++ b/release_dashboard/test/widgets/common/dialog_prompt_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_ui/widgets/common/dialog_prompt.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('The dialog prompt appears upon clicking on a button', (WidgetTester tester) async {
+    const String title = 'Are you sure you want to clean up the persistent state file?';
+    const String content = 'This will abort a work in progress release.';
+    const String leftOption = 'Yes';
+    const String rightOption = 'No';
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: Builder(
+          builder: (BuildContext context) {
+            return Column(
+              children: <Widget>[
+                ElevatedButton(
+                  onPressed: () {
+                    dialogPrompt(
+                      context: context,
+                      title: title,
+                      content: content,
+                      leftOption: leftOption,
+                      rightOption: rightOption,
+                    );
+                  },
+                  child: const Text('Clean'),
+                )
+              ],
+            );
+          },
+        ),
+      ),
+    ));
+
+    expect(find.byType(ElevatedButton), findsOneWidget);
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(content), findsOneWidget);
+    expect(find.text(leftOption), findsOneWidget);
+    expect(find.text(rightOption), findsOneWidget);
+  });
+}

--- a/release_dashboard/test/widgets/common/dialog_prompt_test.dart
+++ b/release_dashboard/test/widgets/common/dialog_prompt_test.dart
@@ -7,43 +7,172 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('The dialog prompt appears upon clicking on a button', (WidgetTester tester) async {
-    const String title = 'Are you sure you want to clean up the persistent state file?';
-    const String content = 'This will abort a work in progress release.';
-    const String leftOption = 'Yes';
-    const String rightOption = 'No';
+  const String title = 'Are you sure you want to clean up the persistent state file?';
+  const String content = 'This will abort a work in progress release.';
+  const String leftOption = 'Yes';
+  const String rightOption = 'No';
 
-    await tester.pumpWidget(MaterialApp(
-      home: Material(
-        child: Builder(
-          builder: (BuildContext context) {
-            return Column(
-              children: <Widget>[
-                ElevatedButton(
-                  onPressed: () {
-                    dialogPrompt(
-                      context: context,
-                      title: title,
-                      content: content,
-                      leftOption: leftOption,
-                      rightOption: rightOption,
-                    );
-                  },
-                  child: const Text('Clean'),
-                )
-              ],
-            );
-          },
+  group('Dialog prompt UI tests', () {
+    testWidgets('Appears upon clicking on a button', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: title,
+                    content: content,
+                    leftOptionTitle: leftOption,
+                    rightOptionTitle: rightOption,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
         ),
-      ),
-    ));
+      ));
 
-    expect(find.byType(ElevatedButton), findsOneWidget);
-    await tester.tap(find.byType(ElevatedButton));
-    await tester.pumpAndSettle();
-    expect(find.text(title), findsOneWidget);
-    expect(find.text(content), findsOneWidget);
-    expect(find.text(leftOption), findsOneWidget);
-    expect(find.text(rightOption), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text(title), findsOneWidget);
+      expect(find.text(content), findsOneWidget);
+      expect(find.text(leftOption), findsOneWidget);
+      expect(find.text(rightOption), findsOneWidget);
+    });
+
+    testWidgets('Disappears when the left option is clicked', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: title,
+                    content: content,
+                    leftOptionTitle: leftOption,
+                    rightOptionTitle: rightOption,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(leftOption));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('Disappears when the right option is clicked', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: title,
+                    content: content,
+                    leftOptionTitle: leftOption,
+                    rightOptionTitle: rightOption,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(rightOption));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+
+  group('dialog prompt callback tests', () {
+    testWidgets('Executes the left option callback when the left option is clicked', (WidgetTester tester) async {
+      bool isLeftCallbackCalled = false;
+      void leftCallbackTest() {
+        isLeftCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: title,
+                    content: content,
+                    leftOptionTitle: leftOption,
+                    rightOptionTitle: rightOption,
+                    leftOptionCallback: leftCallbackTest,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(leftOption));
+      await tester.pumpAndSettle();
+      expect(isLeftCallbackCalled, equals(true));
+    });
+
+    testWidgets('Executes the right option callback when the right option is clicked', (WidgetTester tester) async {
+      bool isRightCallbackCalled = false;
+      void rightCallbackTest() {
+        isRightCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: title,
+                    content: content,
+                    leftOptionTitle: leftOption,
+                    rightOptionTitle: rightOption,
+                    rightOptionCallback: rightCallbackTest,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(rightOption));
+      await tester.pumpAndSettle();
+      expect(isRightCallbackCalled, equals(true));
+    });
   });
 }


### PR DESCRIPTION
*Added a Clean button to delete the release state file. It is currently not connected with `conductor clean` CLI command yet.*

Migrated from this [PR](https://github.com/flutter/flutter/pull/92505).

Here is a recording of the workflow:


https://user-images.githubusercontent.com/20194490/139136962-5fb9c82c-aa71-4984-a4ac-54182e3efb28.mov



*[Issue](https://github.com/flutter/flutter/issues/91119)*



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
