### PR TITLE
[Conductor] status into state provider

### DIFF
--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -9,6 +9,10 @@ import 'package:flutter/material.dart';
 import 'services/conductor.dart';
 import 'services/local_conductor.dart';
 import 'widgets/common/dialog_prompt.dart';
+import 'package:provider/provider.dart';
+import 'package:conductor_core/proto.dart' as pb;
+
+import 'state/status_state.dart';
 import 'widgets/progression.dart';
 
 const String _title = 'Flutter Desktop Conductor (Not ready, do not use)';
@@ -26,13 +30,17 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   const MyApp(
     this.conductor, {
+    this.testState,
     Key? key,
   }) : super(key: key);
 
   final ConductorService conductor;
+  final pb.ConductorState? testState;
 
   @override
   Widget build(BuildContext context) {
+    context.read<StatusState>().changeCurrentReleaseStatus(ReleaseStatusSetter(testState));
+
     return MaterialApp(
       title: _title,
       home: Scaffold(
@@ -50,7 +58,7 @@ class MyApp extends StatelessWidget {
               ),
               const SizedBox(height: 10.0),
               MainProgression(
-                releaseState: conductor.state,
+                releaseState: testState ?? conductor.state,
               ),
             ],
           ),

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -39,6 +39,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Update the status state with the current state file if it exists at the start of the app
     context.read<StatusState>().changeCurrentReleaseStatus(ReleaseStatusSetter(testState));
 
     return MaterialApp(

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -39,29 +39,28 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Update the status state with the current state file if it exists at the start of the app
-    context.read<StatusState>().changeCurrentReleaseStatus(ReleaseStatusSetter(testState));
-
-    return MaterialApp(
-      title: _title,
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text(_title),
-          actions: const [CleanRelease()],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(20.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              const SelectableText(
-                'Desktop app for managing a release of the Flutter SDK, currently in development',
-              ),
-              const SizedBox(height: 10.0),
-              MainProgression(
-                releaseState: testState ?? conductor.state,
-              ),
-            ],
+    return ChangeNotifierProvider(
+      create: (context) => StatusState(),
+      child: MaterialApp(
+        title: _title,
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text(_title),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const SelectableText(
+                  'Desktop app for managing a release of the Flutter SDK, currently in development',
+                ),
+                const SizedBox(height: 10.0),
+                MainProgression(
+                  releaseState: testState ?? conductor.state,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -37,7 +37,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (context) => StatusState(),
+      create: (context) => StatusState(conductor: conductor),
       child: MaterialApp(
         title: _title,
         home: Scaffold(

--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -10,7 +10,6 @@ import 'services/conductor.dart';
 import 'services/local_conductor.dart';
 import 'widgets/common/dialog_prompt.dart';
 import 'package:provider/provider.dart';
-import 'package:conductor_core/proto.dart' as pb;
 
 import 'state/status_state.dart';
 import 'widgets/progression.dart';
@@ -30,12 +29,10 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   const MyApp(
     this.conductor, {
-    this.testState,
     Key? key,
   }) : super(key: key);
 
   final ConductorService conductor;
-  final pb.ConductorState? testState;
 
   @override
   Widget build(BuildContext context) {
@@ -57,7 +54,7 @@ class MyApp extends StatelessWidget {
                 ),
                 const SizedBox(height: 10.0),
                 MainProgression(
-                  releaseState: testState ?? conductor.state,
+                  releaseState: conductor.state,
                 ),
               ],
             ),

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -3,12 +3,19 @@
 // found in the LICENSE file.
 
 import 'package:conductor_core/conductor_core.dart';
+import '../services/conductor.dart';
 import 'package:flutter/material.dart';
 import 'package:conductor_core/proto.dart' as pb;
 
 /// Widget that saves the global state and provides a method to modify it.
 class StatusState extends ChangeNotifier {
-  Map<String, Object>? releaseStatus;
+  StatusState({
+    required this.conductor,
+  }) : releaseStatus = stateToMap(conductor.state);
+
+  final ConductorService conductor;
+
+  late Map<String, Object>? releaseStatus;
 
   /// Method that modifies the global state in provider.
   Future<void> changeReleaseStatus(Map<String, Object>? data) async {

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -43,11 +43,11 @@ Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
 
   if (state == null) return null;
 
-  return (presentStateDesktop(state));
+  return (getStateDesktop(state));
 }
 
 /// Returns the conductor state in a Map<K, V> format for the desktop app to consume.
-Map<String, Object> presentStateDesktop(pb.ConductorState state) {
+Map<String, Object> getStateDesktop(pb.ConductorState state) {
   final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
   for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {
     engineCherrypicks.add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -46,7 +46,7 @@ Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
   return (getStateDesktop(state));
 }
 
-/// Returns the conductor state in a Map<K, V> format for the desktop app to consume.
+/// Returns the conductor state in a [Map<K, V>] format for the widgets to consume.
 Map<String, Object> getStateDesktop(pb.ConductorState state) {
   final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
   for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -13,14 +13,13 @@ import 'package:conductor_core/proto.dart' as pb;
 class StatusState extends ChangeNotifier {
   Map<String, Object>? currentReleaseStatus;
 
-  // setStatus needs to be asynchronous to make sure it is called before nofityListeners
-  Future<void> setStatus(Map<String, Object>? newStatus) async {
-    currentReleaseStatus = newStatus;
-  }
-
   /// Method that modifies the global state in provider.
   Future<void> changeCurrentReleaseStatus(Map<String, Object>? data) async {
-    await setStatus(data);
+    // status modification needs to be asynchronous to make sure it is called before nofityListeners
+    await () async {
+      currentReleaseStatus = data;
+    }();
+
     notifyListeners();
   }
 }
@@ -28,7 +27,7 @@ class StatusState extends ChangeNotifier {
 /// Reads the current state filed saved in disk, and returns the state in a Map<K, V> format.
 ///
 /// Supports passing a testState to mock the release state.
-Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
+Map<String, Object>? getCurrentState(pb.ConductorState? testState) {
   final pb.ConductorState? state;
 
   if (testState != null) {
@@ -43,11 +42,11 @@ Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
 
   if (state == null) return null;
 
-  return (getStateDesktop(state));
+  return (stateToMap(state));
 }
 
 /// Returns the conductor state in a [Map<K, V>] format for the widgets to consume.
-Map<String, Object> getStateDesktop(pb.ConductorState state) {
+Map<String, Object> stateToMap(pb.ConductorState state) {
   final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
   for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {
     engineCherrypicks.add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_core/conductor_core.dart';
+import 'package:flutter/material.dart';
+import 'package:platform/platform.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:conductor_core/proto.dart' as pb;
+
+class StatusState extends ChangeNotifier {
+  Map<String, Object>? currentReleaseStatus;
+
+  Future<void> changeCurrentReleaseStatus(Map<String, Object>? data) async {
+    // setStatus needs to be asynchronous to make sure it is called before nofityListeners
+    Future<void> setStatus(Map<String, Object>? newStatus) async {
+      currentReleaseStatus = newStatus;
+    }
+
+    await setStatus(data);
+    notifyListeners();
+  }
+}
+
+/// Reads the current state filed saved in disk, and returns the state in a Map<K, V> format.
+///
+/// Supports passing a testState to mock the release state.
+Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
+  final pb.ConductorState? state;
+
+  if (testState != null) {
+    state = testState;
+  } else {
+    const LocalFileSystem fs = LocalFileSystem();
+    const LocalPlatform platform = LocalPlatform();
+    final String stateFilePath = defaultStateFilePath(platform);
+    final File stateFile = fs.file(stateFilePath);
+
+    state = stateFile.existsSync() ? readStateFromFile(stateFile) : null;
+  }
+
+  if (state == null) return null;
+
+  return (presentStateDesktop(state));
+}
+
+/// Returns the conductor state in a Map<K, V> format for the desktop app to consume.
+Map<String, Object> presentStateDesktop(pb.ConductorState state) {
+  final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
+  for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {
+    engineCherrypicks.add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});
+  }
+
+  final List<Map<String, String>> frameworkCherrypicks = <Map<String, String>>[];
+  for (final pb.Cherrypick cherrypick in state.framework.cherrypicks) {
+    frameworkCherrypicks
+        .add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});
+  }
+
+  return <String, Object>{
+    'Conductor Version': state.conductorVersion,
+    'Release Channel': state.releaseChannel,
+    'Release Version': state.releaseVersion,
+    'Release Started at': DateTime.fromMillisecondsSinceEpoch(state.createdDate.toInt()).toString(),
+    'Release Updated at': DateTime.fromMillisecondsSinceEpoch(state.lastUpdatedDate.toInt()).toString(),
+    'Engine Candidate Branch': state.engine.candidateBranch,
+    'Engine Starting Git HEAD': state.engine.startingGitHead,
+    'Engine Current Git HEAD': state.engine.currentGitHead,
+    'Engine Path to Checkout': state.engine.checkoutPath,
+    'Engine LUCI Dashboard': luciConsoleLink(state.releaseChannel, 'engine'),
+    'Engine Cherrypicks': engineCherrypicks,
+    'Dart SDK Revision': state.engine.dartRevision,
+    'Framework Candidate Branch': state.framework.candidateBranch,
+    'Framework Starting Git HEAD': state.framework.startingGitHead,
+    'Framework Current Git HEAD': state.framework.currentGitHead,
+    'Framework Path to Checkout': state.framework.checkoutPath,
+    'Framework LUCI Dashboard': luciConsoleLink(state.releaseChannel, 'flutter'),
+    'Framework Cherrypicks': frameworkCherrypicks,
+    'Current Phase': state.currentPhase,
+  };
+}

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -9,15 +9,17 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:conductor_core/proto.dart' as pb;
 
+/// Widget that saves the global state and provides a method to modify it.
 class StatusState extends ChangeNotifier {
   Map<String, Object>? currentReleaseStatus;
 
-  Future<void> changeCurrentReleaseStatus(Map<String, Object>? data) async {
-    // setStatus needs to be asynchronous to make sure it is called before nofityListeners
-    Future<void> setStatus(Map<String, Object>? newStatus) async {
-      currentReleaseStatus = newStatus;
-    }
+  // setStatus needs to be asynchronous to make sure it is called before nofityListeners
+  Future<void> setStatus(Map<String, Object>? newStatus) async {
+    currentReleaseStatus = newStatus;
+  }
 
+  /// Method that modifies the global state in provider.
+  Future<void> changeCurrentReleaseStatus(Map<String, Object>? data) async {
     await setStatus(data);
     notifyListeners();
   }
@@ -36,7 +38,6 @@ Map<String, Object>? ReleaseStatusSetter(pb.ConductorState? testState) {
     const LocalPlatform platform = LocalPlatform();
     final String stateFilePath = defaultStateFilePath(platform);
     final File stateFile = fs.file(stateFilePath);
-
     state = stateFile.existsSync() ? readStateFromFile(stateFile) : null;
   }
 

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -4,9 +4,6 @@
 
 import 'package:conductor_core/conductor_core.dart';
 import 'package:flutter/material.dart';
-import 'package:platform/platform.dart';
-import 'package:file/file.dart';
-import 'package:file/local.dart';
 import 'package:conductor_core/proto.dart' as pb;
 
 /// Widget that saves the global state and provides a method to modify it.
@@ -24,29 +21,9 @@ class StatusState extends ChangeNotifier {
   }
 }
 
-/// Reads the current state filed saved in disk, and returns the state in a Map<K, V> format.
-///
-/// Supports passing a testState to mock the release state.
-Map<String, Object>? getCurrentState(pb.ConductorState? testState) {
-  final pb.ConductorState? state;
-
-  if (testState != null) {
-    state = testState;
-  } else {
-    const LocalFileSystem fs = LocalFileSystem();
-    const LocalPlatform platform = LocalPlatform();
-    final String stateFilePath = defaultStateFilePath(platform);
-    final File stateFile = fs.file(stateFilePath);
-    state = stateFile.existsSync() ? readStateFromFile(stateFile) : null;
-  }
-
-  if (state == null) return null;
-
-  return (stateToMap(state));
-}
-
 /// Returns the conductor state in a [Map<K, V>] format for the widgets to consume.
-Map<String, Object> stateToMap(pb.ConductorState state) {
+Map<String, Object>? stateToMap(pb.ConductorState? state) {
+  if (state == null) return null;
   final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
   for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {
     engineCherrypicks.add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -8,13 +8,13 @@ import 'package:conductor_core/proto.dart' as pb;
 
 /// Widget that saves the global state and provides a method to modify it.
 class StatusState extends ChangeNotifier {
-  Map<String, Object>? currentReleaseStatus;
+  Map<String, Object>? releaseStatus;
 
   /// Method that modifies the global state in provider.
-  Future<void> changeCurrentReleaseStatus(Map<String, Object>? data) async {
+  Future<void> changeReleaseStatus(Map<String, Object>? data) async {
     // status modification needs to be asynchronous to make sure it is called before nofityListeners
     await () async {
-      currentReleaseStatus = data;
+      releaseStatus = data;
     }();
 
     notifyListeners();

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -44,11 +44,9 @@ class ConductorStatus extends StatefulWidget {
 class ConductorStatusState extends State<ConductorStatus> {
   @override
   Widget build(BuildContext context) {
-    late final Map<String, Object> currentStatus;
-    if (context.watch<StatusState>().currentReleaseStatus == null) {
+    final Map<String, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
+    if (context.watch<StatusState>().releaseStatus == null) {
       return SelectableText('No persistent state file. Try starting a release.');
-    } else {
-      currentStatus = context.watch<StatusState>().currentReleaseStatus!;
     }
 
     return Column(
@@ -102,11 +100,11 @@ class CherrypickTable extends StatefulWidget {
   const CherrypickTable({
     Key? key,
     required this.engineOrFramework,
-    required this.currentStatus,
+    required this.releaseStatus,
   }) : super(key: key);
 
   final String engineOrFramework;
-  final Map<String, Object> currentStatus;
+  final Map<String, Object> releaseStatus;
 
   @override
   State<CherrypickTable> createState() => CherrypickTableState();
@@ -116,8 +114,8 @@ class CherrypickTableState extends State<CherrypickTable> {
   @override
   Widget build(BuildContext context) {
     final List<Map<String, String>> cherrypicks = widget.engineOrFramework == 'engine'
-        ? widget.currentStatus['Engine Cherrypicks']! as List<Map<String, String>>
-        : widget.currentStatus['Framework Cherrypicks']! as List<Map<String, String>>;
+        ? widget.releaseStatus['Engine Cherrypicks']! as List<Map<String, String>>
+        : widget.releaseStatus['Framework Cherrypicks']! as List<Map<String, String>>;
 
     return DataTable(
       dataRowHeight: 30.0,
@@ -165,11 +163,11 @@ class RepoInfoExpansion extends StatefulWidget {
   const RepoInfoExpansion({
     Key? key,
     required this.engineOrFramework,
-    required this.currentStatus,
+    required this.releaseStatus,
   }) : super(key: key);
 
   final String engineOrFramework;
-  final Map<String, Object> currentStatus;
+  final Map<String, Object> releaseStatus;
 
   @override
   State<RepoInfoExpansion> createState() => RepoInfoExpansionState();
@@ -220,9 +218,9 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
                       children: <Widget>[
                         Text('$repoElement:'),
                         SelectableText(
-                            (widget.currentStatus[repoElement] == null || widget.currentStatus[repoElement] == '')
+                            (widget.releaseStatus[repoElement] == null || widget.releaseStatus[repoElement] == '')
                                 ? 'Unknown'
-                                : widget.currentStatus[repoElement]! as String),
+                                : widget.releaseStatus[repoElement]! as String),
                       ],
                     ),
                 ],

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -2,20 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:conductor_core/conductor_core.dart';
-import 'package:conductor_core/proto.dart' as pb;
+import '../state/status_state.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/src/provider.dart';
 
 import 'common/tooltip.dart';
 
 /// Displays the current conductor state.
 class ConductorStatus extends StatefulWidget {
-  const ConductorStatus({
-    Key? key,
-    this.releaseState,
-  }) : super(key: key);
-
-  final pb.ConductorState? releaseState;
+  const ConductorStatus({Key? key}) : super(key: key);
 
   @override
   State<ConductorStatus> createState() => ConductorStatusState();
@@ -47,50 +42,13 @@ class ConductorStatus extends StatefulWidget {
 }
 
 class ConductorStatusState extends State<ConductorStatus> {
-  /// Returns the conductor state in a Map<K, V> format for the desktop app to consume.
-  Map<String, Object> presentStateDesktop(pb.ConductorState state) {
-    final List<Map<String, String>> engineCherrypicks = <Map<String, String>>[];
-    for (final pb.Cherrypick cherrypick in state.engine.cherrypicks) {
-      engineCherrypicks
-          .add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});
-    }
-
-    final List<Map<String, String>> frameworkCherrypicks = <Map<String, String>>[];
-    for (final pb.Cherrypick cherrypick in state.framework.cherrypicks) {
-      frameworkCherrypicks
-          .add(<String, String>{'trunkRevision': cherrypick.trunkRevision, 'state': '${cherrypick.state}'});
-    }
-
-    return <String, Object>{
-      'Conductor Version': state.conductorVersion,
-      'Release Channel': state.releaseChannel,
-      'Release Version': state.releaseVersion,
-      'Release Started at': DateTime.fromMillisecondsSinceEpoch(state.createdDate.toInt()).toString(),
-      'Release Updated at': DateTime.fromMillisecondsSinceEpoch(state.lastUpdatedDate.toInt()).toString(),
-      'Engine Candidate Branch': state.engine.candidateBranch,
-      'Engine Starting Git HEAD': state.engine.startingGitHead,
-      'Engine Current Git HEAD': state.engine.currentGitHead,
-      'Engine Path to Checkout': state.engine.checkoutPath,
-      'Engine LUCI Dashboard': luciConsoleLink(state.releaseChannel, 'engine'),
-      'Engine Cherrypicks': engineCherrypicks,
-      'Dart SDK Revision': state.engine.dartRevision,
-      'Framework Candidate Branch': state.framework.candidateBranch,
-      'Framework Starting Git HEAD': state.framework.startingGitHead,
-      'Framework Current Git HEAD': state.framework.currentGitHead,
-      'Framework Path to Checkout': state.framework.checkoutPath,
-      'Framework LUCI Dashboard': luciConsoleLink(state.releaseChannel, 'flutter'),
-      'Framework Cherrypicks': frameworkCherrypicks,
-      'Current Phase': state.currentPhase,
-    };
-  }
-
   @override
   Widget build(BuildContext context) {
     late final Map<String, Object> currentStatus;
-    if (widget.releaseState == null) {
-      return const SelectableText('No persistent state file. Try starting a release.');
+    if (context.watch<StatusState>().currentReleaseStatus == null) {
+      return SelectableText('No persistent state file. Try starting a release.');
     } else {
-      currentStatus = presentStateDesktop(widget.releaseState!);
+      currentStatus = context.watch<StatusState>().currentReleaseStatus!;
     }
 
     return Column(

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -4,7 +4,7 @@
 
 import '../state/status_state.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/src/provider.dart';
+import 'package:provider/provider.dart';
 
 import 'common/tooltip.dart';
 
@@ -46,7 +46,7 @@ class ConductorStatusState extends State<ConductorStatus> {
   Widget build(BuildContext context) {
     final Map<String, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
     if (context.watch<StatusState>().releaseStatus == null) {
-      return SelectableText('No persistent state file. Try starting a release.');
+      return const SelectableText('No persistent state file. Try starting a release.');
     }
 
     return Column(
@@ -61,9 +61,9 @@ class ConductorStatusState extends State<ConductorStatus> {
               TableRow(
                 children: <Widget>[
                   Text('$headerElement:'),
-                  SelectableText((currentStatus[headerElement] == null || currentStatus[headerElement] == '')
+                  SelectableText((releaseStatus![headerElement] == null || releaseStatus[headerElement] == '')
                       ? 'Unknown'
-                      : currentStatus[headerElement]! as String),
+                      : releaseStatus[headerElement]! as String),
                 ],
               ),
           ],
@@ -73,17 +73,17 @@ class ConductorStatusState extends State<ConductorStatus> {
           children: <Widget>[
             Column(
               children: <Widget>[
-                RepoInfoExpansion(engineOrFramework: 'engine', currentStatus: currentStatus),
+                RepoInfoExpansion(engineOrFramework: 'engine', releaseStatus: releaseStatus!),
                 const SizedBox(height: 10.0),
-                CherrypickTable(engineOrFramework: 'engine', currentStatus: currentStatus),
+                CherrypickTable(engineOrFramework: 'engine', releaseStatus: releaseStatus),
               ],
             ),
             const SizedBox(width: 20.0),
             Column(
               children: <Widget>[
-                RepoInfoExpansion(engineOrFramework: 'framework', currentStatus: currentStatus),
+                RepoInfoExpansion(engineOrFramework: 'framework', releaseStatus: releaseStatus),
                 const SizedBox(height: 10.0),
-                CherrypickTable(engineOrFramework: 'framework', currentStatus: currentStatus),
+                CherrypickTable(engineOrFramework: 'framework', releaseStatus: releaseStatus),
               ],
             ),
           ],

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -41,7 +41,7 @@ class MainProgressionState extends State<MainProgression> {
   @override
   void initState() {
     // Update the status state with the current state file if it exists at the start of the app
-    context.read<StatusState>().changeCurrentReleaseStatus(stateToMap(widget.releaseState));
+    context.read<StatusState>().changeReleaseStatus(stateToMap(widget.releaseState));
     super.initState();
   }
 

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-
+import 'package:conductor_core/proto.dart' as pb;
 import 'conductor_status.dart';
 import 'create_release_substeps.dart';
 import 'substeps.dart';

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -41,7 +41,7 @@ class MainProgressionState extends State<MainProgression> {
   @override
   void initState() {
     // Update the status state with the current state file if it exists at the start of the app
-    context.read<StatusState>().changeCurrentReleaseStatus(getCurrentState(widget.releaseState));
+    context.read<StatusState>().changeCurrentReleaseStatus(stateToMap(widget.releaseState));
     super.initState();
   }
 

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -38,13 +38,6 @@ class MainProgression extends StatefulWidget {
 class MainProgressionState extends State<MainProgression> {
   int _completedStep = 0;
 
-  @override
-  void initState() {
-    // Update the status state with the current state file if it exists at the start of the app
-    context.read<StatusState>().changeReleaseStatus(stateToMap(widget.releaseState));
-    super.initState();
-  }
-
   /// Move forward the stepper to the next step of the release.
   void nextStep() {
     if (_completedStep < MainProgression._stepTitles.length - 1) {

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../state/status_state.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import 'conductor_status.dart';
 import 'create_release_substeps.dart';

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -69,9 +69,7 @@ class MainProgressionState extends State<MainProgression> {
           padding: const EdgeInsets.symmetric(vertical: 12.0),
           physics: const ClampingScrollPhysics(),
           children: <Widget>[
-            ConductorStatus(
-              releaseState: widget.releaseState,
-            ),
+            ConductorStatus(),
             const SizedBox(height: 20.0),
             Stepper(
               controlsBuilder: (BuildContext context, ControlsDetails details) => Row(),

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -2,11 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../state/status_state.dart';
 import 'package:flutter/material.dart';
-import 'package:conductor_core/proto.dart' as pb;
+import 'package:provider/src/provider.dart';
+
 import 'conductor_status.dart';
 import 'create_release_substeps.dart';
 import 'substeps.dart';
+import 'package:conductor_core/proto.dart' as pb;
 
 /// Displays the progression and each step of the release from the conductor.
 ///
@@ -34,6 +37,13 @@ class MainProgression extends StatefulWidget {
 
 class MainProgressionState extends State<MainProgression> {
   int _completedStep = 0;
+
+  @override
+  void initState() {
+    // Update the status state with the current state file if it exists at the start of the app
+    context.read<StatusState>().changeCurrentReleaseStatus(getCurrentState(widget.releaseState));
+    super.initState();
+  }
 
   /// Move forward the stepper to the next step of the release.
   void nextStep() {

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -4,7 +4,7 @@
 
 import '../state/status_state.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/src/provider.dart';
+import 'package:provider/provider.dart';
 
 import 'conductor_status.dart';
 import 'create_release_substeps.dart';
@@ -78,7 +78,7 @@ class MainProgressionState extends State<MainProgression> {
           padding: const EdgeInsets.symmetric(vertical: 12.0),
           physics: const ClampingScrollPhysics(),
           children: <Widget>[
-            ConductorStatus(),
+            const ConductorStatus(),
             const SizedBox(height: 20.0),
             Stepper(
               controlsBuilder: (BuildContext context, ControlsDetails details) => Row(),

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
 
 import 'conductor_status.dart';

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -153,6 +153,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -181,6 +188,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -251,3 +265,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
+  flutter: ">=1.16.0"

--- a/release_dashboard/pubspec.yaml
+++ b/release_dashboard/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
       ref: 125545da322048565911bf81118cce60f05036ce
   flutter:
     sdk: flutter
+  provider: ^6.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/release_dashboard/test/main_test.dart
+++ b/release_dashboard/test/main_test.dart
@@ -5,9 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'package:conductor_ui/main.dart';
-
 import 'package:flutter_test/flutter_test.dart';
-
 import 'src/services/fake_conductor.dart';
 
 void main() {

--- a/release_dashboard/test/src/services/fake_conductor.dart
+++ b/release_dashboard/test/src/services/fake_conductor.dart
@@ -8,6 +8,12 @@ import 'package:file/src/interface/file.dart';
 import 'package:file/src/interface/directory.dart';
 
 class FakeConductor extends ConductorService {
+  FakeConductor({
+    this.testState,
+  });
+
+  final ConductorState? testState;
+
   @override
   Future<void> createRelease(
       {required String candidateBranch,
@@ -23,10 +29,6 @@ class FakeConductor extends ConductorService {
 
   @override
   ConductorState? get state {
-    return ConductorState(
-      conductorVersion: 'abcdef',
-      releaseChannel: 'dev',
-      releaseVersion: 'flutter-2.7-candidate.4',
-    );
+    return testState;
   }
 }

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -4,9 +4,14 @@
 
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
+import 'package:conductor_ui/main.dart';
+import 'package:conductor_ui/state/status_state.dart';
 import 'package:conductor_ui/widgets/conductor_status.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../src/services/fake_conductor.dart';
 
 void main() {
   group('conductor_status', () {
@@ -62,19 +67,12 @@ void main() {
     });
     testWidgets('Conductor_status displays nothing found when there is no state file', (WidgetTester tester) async {
       await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: ListView(
-                  children: const <Widget>[
-                    ConductorStatus(),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
+        Builder(builder: (context) {
+          return ChangeNotifierProvider(
+            create: (context) => StatusState(),
+            child: MyApp(FakeConductor()),
+          );
+        }),
       );
 
       expect(find.text('No persistent state file. Try starting a release.'), findsOneWidget);
@@ -83,21 +81,12 @@ void main() {
 
     testWidgets('Conductor_status displays correct status with a state file', (WidgetTester tester) async {
       await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: ListView(
-                  children: <Widget>[
-                    ConductorStatus(
-                      releaseState: state,
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
+        Builder(builder: (context) {
+          return ChangeNotifierProvider(
+            create: (context) => StatusState(),
+            child: MyApp(FakeConductor(), testState: state),
+          );
+        }),
       );
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
@@ -122,48 +111,30 @@ void main() {
       );
 
       await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: ListView(
-                  children: <Widget>[
-                    ConductorStatus(
-                      releaseState: stateIncomplete,
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
+        Builder(builder: (context) {
+          return ChangeNotifierProvider(
+            create: (context) => StatusState(),
+            child: MyApp(FakeConductor(), testState: stateIncomplete),
+          );
+        }),
       );
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String headerElement in ConductorStatus.headerElements) {
         expect(find.text('$headerElement:'), findsOneWidget);
       }
-      expect(find.text(releaseChannel), findsOneWidget);
+      expect(find.text(releaseChannel), findsNWidgets(2));
       expect(find.text('Unknown'), findsNWidgets(11));
     });
 
     testWidgets('Repo Info section displays corresponding info in a dropdown fashion', (WidgetTester tester) async {
       await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: ListView(
-                  children: <Widget>[
-                    ConductorStatus(
-                      releaseState: state,
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
-        ),
+        Builder(builder: (context) {
+          return ChangeNotifierProvider(
+            create: (context) => StatusState(),
+            child: MyApp(FakeConductor(), testState: state),
+          );
+        }),
       );
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -73,7 +73,7 @@ void main() {
     });
 
     testWidgets('Conductor_status displays correct status with a state file', (WidgetTester tester) async {
-      await tester.pumpWidget(MyApp(FakeConductor(), testState: state));
+      await tester.pumpWidget(MyApp(FakeConductor(testState: state)));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String headerElement in ConductorStatus.headerElements) {
@@ -96,7 +96,7 @@ void main() {
         releaseChannel: releaseChannel,
       );
 
-      await tester.pumpWidget(MyApp(FakeConductor(), testState: stateIncomplete));
+      await tester.pumpWidget(MyApp(FakeConductor(testState: stateIncomplete)));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String headerElement in ConductorStatus.headerElements) {
@@ -107,7 +107,7 @@ void main() {
     });
 
     testWidgets('Repo Info section displays corresponding info in a dropdown fashion', (WidgetTester tester) async {
-      await tester.pumpWidget(MyApp(FakeConductor(), testState: state));
+      await tester.pumpWidget(MyApp(FakeConductor(testState: state)));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String repoElement in ConductorStatus.engineRepoElements) {

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -14,7 +14,7 @@ import 'package:provider/provider.dart';
 import '../src/services/fake_conductor.dart';
 
 void main() {
-  group('conductor_status', () {
+  group('conductor_status, also tests StatusState', () {
     late pb.ConductorState state;
 
     const String conductorVersion = 'v1.0';

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -5,11 +5,9 @@
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:conductor_ui/main.dart';
-import 'package:conductor_ui/state/status_state.dart';
 import 'package:conductor_ui/widgets/conductor_status.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
 
 import '../src/services/fake_conductor.dart';
 
@@ -66,28 +64,16 @@ void main() {
       );
     });
     testWidgets('Conductor_status displays nothing found when there is no state file', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Builder(builder: (context) {
-          return ChangeNotifierProvider(
-            create: (context) => StatusState(),
-            child: MyApp(FakeConductor()),
-          );
-        }),
-      );
+      await tester.pumpWidget(MyApp(
+        FakeConductor(),
+      ));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsOneWidget);
       expect(find.text('Conductor version:'), findsNothing);
     });
 
     testWidgets('Conductor_status displays correct status with a state file', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Builder(builder: (context) {
-          return ChangeNotifierProvider(
-            create: (context) => StatusState(),
-            child: MyApp(FakeConductor(), testState: state),
-          );
-        }),
-      );
+      await tester.pumpWidget(MyApp(FakeConductor(), testState: state));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String headerElement in ConductorStatus.headerElements) {
@@ -110,14 +96,7 @@ void main() {
         releaseChannel: releaseChannel,
       );
 
-      await tester.pumpWidget(
-        Builder(builder: (context) {
-          return ChangeNotifierProvider(
-            create: (context) => StatusState(),
-            child: MyApp(FakeConductor(), testState: stateIncomplete),
-          );
-        }),
-      );
+      await tester.pumpWidget(MyApp(FakeConductor(), testState: stateIncomplete));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String headerElement in ConductorStatus.headerElements) {
@@ -128,14 +107,7 @@ void main() {
     });
 
     testWidgets('Repo Info section displays corresponding info in a dropdown fashion', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        Builder(builder: (context) {
-          return ChangeNotifierProvider(
-            create: (context) => StatusState(),
-            child: MyApp(FakeConductor(), testState: state),
-          );
-        }),
-      );
+      await tester.pumpWidget(MyApp(FakeConductor(), testState: state));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
       for (final String repoElement in ConductorStatus.engineRepoElements) {

--- a/release_dashboard/test/widgets/stepper_test.dart
+++ b/release_dashboard/test/widgets/stepper_test.dart
@@ -8,12 +8,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
+import '../src/services/fake_conductor.dart';
+
 void main() {
   testWidgets('When user clicks on a previously completed step, Stepper does not navigate back.',
       (WidgetTester tester) async {
     await tester.pumpWidget(
       ChangeNotifierProvider(
-        create: (context) => StatusState(),
+        create: (context) => StatusState(conductor: FakeConductor()),
         child: MaterialApp(
           home: Material(
             child: Column(

--- a/release_dashboard/test/widgets/stepper_test.dart
+++ b/release_dashboard/test/widgets/stepper_test.dart
@@ -2,26 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:conductor_ui/state/status_state.dart';
 import 'package:conductor_ui/widgets/progression.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   testWidgets('When user clicks on a previously completed step, Stepper does not navigate back.',
       (WidgetTester tester) async {
     await tester.pumpWidget(
-      StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return MaterialApp(
-            home: Material(
-              child: Column(
-                children: const <Widget>[
-                  MainProgression(),
-                ],
-              ),
+      ChangeNotifierProvider(
+        create: (context) => StatusState(),
+        child: MaterialApp(
+          home: Material(
+            child: Column(
+              children: const <Widget>[
+                MainProgression(),
+              ],
             ),
-          );
-        },
+          ),
+        ),
       ),
     );
 


### PR DESCRIPTION
*Conductor status is in a global state now. Status can be read and modified in any widget now.*

*[Issue](https://github.com/flutter/flutter/issues/91119)*

Currently, the tests for status states are inside `conductor_status_test.dart` as well, since the global states are read in that widget. With the states being read correctly in that widget, it confirms the states are being set properly at the beginning of the app as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
