### PR TITLE
[app_dart] getPullRequestFromCheckRunEvent ignore multiple prs

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -179,6 +179,7 @@ class GithubWebhook extends RequestHandler<Body> {
 
   PullRequest? getPullRequestFromCheckRunEvent(Map<String, dynamic> event) {
     final List<dynamic> pullRequests = event['check_run']['pull_requests'] as List<dynamic>;
+    // Cocoon only processes events on a single pull request. BatchRequests are currently not processed
     if (pullRequests.isEmpty || pullRequests.length != 1) {
       return null;
     }


### PR DESCRIPTION
Quick fix. This isn't a case we really care to throw an exception. On `completed`, they are batched to indicate all the prs that have finished cq.