### PR TITLE
[conductor] added URL launcher

### DIFF
--- a/release_dashboard/lib/widgets/common/url_button.dart
+++ b/release_dashboard/lib/widgets/common/url_button.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/link.dart';
+
+/// Constructs a [TextButton] that displays [textToDisplay].
+///
+/// Clicking on [TextButton] will open [urlOrUri].
+/// Supports opening a URL in the web browser or URI in the local file system.
+/// When [isURL] is true, the widget opens a URL and [urlOrUri] must be a URL.
+/// Otherwise the widget opens a URI and [urlOrUri] must be a URI.
+class UrlButton extends StatelessWidget {
+  const UrlButton({
+    Key? key,
+    required this.textToDisplay,
+    required this.isURL,
+    required this.urlOrUri,
+  }) : super(key: key);
+
+  final String textToDisplay;
+  final bool isURL;
+  final String urlOrUri;
+
+  @override
+  Widget build(BuildContext context) {
+    return Link(
+      uri: isURL ? Uri.parse(urlOrUri) : Uri.file(urlOrUri),
+      target: LinkTarget.blank,
+      builder: (ctx, openLink) {
+        return TextButton(
+          onPressed: openLink,
+          child: Text(textToDisplay),
+        );
+      },
+    );
+  }
+}

--- a/release_dashboard/lib/widgets/common/url_button.dart
+++ b/release_dashboard/lib/widgets/common/url_button.dart
@@ -9,24 +9,24 @@ import 'package:url_launcher/link.dart';
 ///
 /// Clicking on [TextButton] will open [urlOrUri].
 /// Supports opening a URL in the web browser or URI in the local file system.
-/// When [isURL] is true, the widget opens a URL and [urlOrUri] must be a URL.
-/// Otherwise the widget opens a URI and [urlOrUri] must be a URI.
+/// The widget automatically detects if [urlOrUri] is a URL or URI.
 class UrlButton extends StatelessWidget {
   const UrlButton({
     Key? key,
     required this.textToDisplay,
-    required this.isURL,
     required this.urlOrUri,
   }) : super(key: key);
 
   final String textToDisplay;
-  final bool isURL;
   final String urlOrUri;
 
   @override
   Widget build(BuildContext context) {
     return Link(
-      uri: isURL ? Uri.parse(urlOrUri) : Uri.file(urlOrUri),
+      /// URL supports case insensitive links such as 'HTTP://...'.
+      ///
+      /// Converts [urlOrUri] to lowercase first then check if it matches with 'http' to support all cases.
+      uri: urlOrUri.toLowerCase().startsWith('http') ? Uri.parse(urlOrUri) : Uri.file(urlOrUri),
       target: LinkTarget.blank,
       builder: (ctx, openLink) {
         return TextButton(

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -9,6 +9,14 @@ import 'package:provider/provider.dart';
 import 'common/tooltip.dart';
 import 'common/url_button.dart';
 
+enum SubstepEnum {
+  candidateBranch,
+  startingGitHead,
+  currentGitHead,
+  checkoutPath,
+  dashboardLink,
+}
+
 /// Displays the current conductor state.
 class ConductorStatus extends StatefulWidget {
   const ConductorStatus({Key? key}) : super(key: key);
@@ -25,21 +33,21 @@ class ConductorStatus extends StatefulWidget {
     'Dart SDK Revision',
   ];
 
-  static final List<String> engineRepoElements = <String>[
-    'Engine Candidate Branch',
-    'Engine Starting Git HEAD',
-    'Engine Current Git HEAD',
-    'Engine Path to Checkout',
-    'Engine LUCI Dashboard',
-  ];
+  static final Map<SubstepEnum, String> engineRepoElements = <SubstepEnum, String>{
+    SubstepEnum.candidateBranch: 'Engine Candidate Branch',
+    SubstepEnum.startingGitHead: 'Engine Starting Git HEAD',
+    SubstepEnum.currentGitHead: 'Engine Current Git HEAD',
+    SubstepEnum.checkoutPath: 'Engine Path to Checkout',
+    SubstepEnum.dashboardLink: 'Engine LUCI Dashboard',
+  };
 
-  static final List<String> frameworkRepoElements = <String>[
-    'Framework Candidate Branch',
-    'Framework Starting Git HEAD',
-    'Framework Current Git HEAD',
-    'Framework Path to Checkout',
-    'Framework LUCI Dashboard',
-  ];
+  static final Map<SubstepEnum, String> frameworkRepoElements = <SubstepEnum, String>{
+    SubstepEnum.candidateBranch: 'Framework Candidate Branch',
+    SubstepEnum.startingGitHead: 'Framework Starting Git HEAD',
+    SubstepEnum.currentGitHead: 'Framework Current Git HEAD',
+    SubstepEnum.checkoutPath: 'Framework Path to Checkout',
+    SubstepEnum.dashboardLink: 'Framework LUCI Dashboard',
+  };
 }
 
 class ConductorStatusState extends State<ConductorStatus> {
@@ -168,13 +176,6 @@ class RepoInfoExpansion extends StatefulWidget {
   final String engineOrFramework;
   final Map<String, Object> releaseStatus;
 
-  static const Map<String, int> urlElements = <String, int>{
-    'engine path to checkout': 3,
-    'framework path to checkout': 3,
-    'engine luci dashboard': 4,
-    'framework luci dashboard': 4,
-  };
-
   @override
   State<RepoInfoExpansion> createState() => RepoInfoExpansionState();
 }
@@ -189,15 +190,15 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
     });
   }
 
-  /// Helper function to determine if a [UrlButton] should be rendered instead of a [SelectableText].
+  /// Helper function to determine if a clickable [UrlButton] should be rendered instead of a [SelectableText].
   bool isClickable(String repoElement) {
-    return (repoElement ==
-            ConductorStatus.engineRepoElements[RepoInfoExpansion.urlElements['engine luci dashboard']!] ||
-        repoElement ==
-            ConductorStatus.frameworkRepoElements[RepoInfoExpansion.urlElements['framework luci dashboard']!] ||
-        repoElement == ConductorStatus.engineRepoElements[RepoInfoExpansion.urlElements['engine path to checkout']!] ||
-        repoElement ==
-            ConductorStatus.frameworkRepoElements[RepoInfoExpansion.urlElements['framework path to checkout']!]);
+    List<String> clickableElements = <String>[
+      ConductorStatus.engineRepoElements[SubstepEnum.dashboardLink]!,
+      ConductorStatus.engineRepoElements[SubstepEnum.checkoutPath]!,
+      ConductorStatus.frameworkRepoElements[SubstepEnum.dashboardLink]!,
+      ConductorStatus.frameworkRepoElements[SubstepEnum.checkoutPath]!
+    ];
+    return (clickableElements.contains(repoElement));
   }
 
   @override
@@ -228,8 +229,8 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
                 },
                 children: <TableRow>[
                   for (String repoElement in widget.engineOrFramework == 'engine'
-                      ? ConductorStatus.engineRepoElements
-                      : ConductorStatus.frameworkRepoElements)
+                      ? ConductorStatus.engineRepoElements.values
+                      : ConductorStatus.frameworkRepoElements.values)
                     TableRow(
                       decoration: const BoxDecoration(border: Border(top: BorderSide(color: Colors.grey))),
                       children: <Widget>[
@@ -239,8 +240,6 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
                                 alignment: Alignment.centerLeft,
                                 child: UrlButton(
                                   textToDisplay: statusElementToString(widget.currentStatus[repoElement]),
-                                  isURL: repoElement == ConductorStatus.engineRepoElements[4] ||
-                                      repoElement == ConductorStatus.frameworkRepoElements[4],
                                   urlOrUri: statusElementToString(widget.currentStatus[repoElement]),
                                 ),
                               )

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'common/tooltip.dart';
+import 'common/url_button.dart';
 
 /// Displays the current conductor state.
 class ConductorStatus extends StatefulWidget {
@@ -61,9 +62,7 @@ class ConductorStatusState extends State<ConductorStatus> {
               TableRow(
                 children: <Widget>[
                   Text('$headerElement:'),
-                  SelectableText((releaseStatus![headerElement] == null || releaseStatus[headerElement] == '')
-                      ? 'Unknown'
-                      : releaseStatus[headerElement]! as String),
+                  SelectableText(statusElementToString(currentStatus[headerElement])),
                 ],
               ),
           ],
@@ -169,6 +168,13 @@ class RepoInfoExpansion extends StatefulWidget {
   final String engineOrFramework;
   final Map<String, Object> releaseStatus;
 
+  static const Map<String, int> urlElements = <String, int>{
+    'engine path to checkout': 3,
+    'framework path to checkout': 3,
+    'engine luci dashboard': 4,
+    'framework luci dashboard': 4,
+  };
+
   @override
   State<RepoInfoExpansion> createState() => RepoInfoExpansionState();
 }
@@ -181,6 +187,17 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
     setState(() {
       _isExpanded = !_isExpanded;
     });
+  }
+
+  /// Helper function to determine if a [UrlButton] should be rendered instead of a [SelectableText].
+  bool isClickable(String repoElement) {
+    return (repoElement ==
+            ConductorStatus.engineRepoElements[RepoInfoExpansion.urlElements['engine luci dashboard']!] ||
+        repoElement ==
+            ConductorStatus.frameworkRepoElements[RepoInfoExpansion.urlElements['framework luci dashboard']!] ||
+        repoElement == ConductorStatus.engineRepoElements[RepoInfoExpansion.urlElements['engine path to checkout']!] ||
+        repoElement ==
+            ConductorStatus.frameworkRepoElements[RepoInfoExpansion.urlElements['framework path to checkout']!]);
   }
 
   @override
@@ -217,10 +234,17 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
                       decoration: const BoxDecoration(border: Border(top: BorderSide(color: Colors.grey))),
                       children: <Widget>[
                         Text('$repoElement:'),
-                        SelectableText(
-                            (widget.releaseStatus[repoElement] == null || widget.releaseStatus[repoElement] == '')
-                                ? 'Unknown'
-                                : widget.releaseStatus[repoElement]! as String),
+                        isClickable(repoElement)
+                            ? Align(
+                                alignment: Alignment.centerLeft,
+                                child: UrlButton(
+                                  textToDisplay: statusElementToString(widget.currentStatus[repoElement]),
+                                  isURL: repoElement == ConductorStatus.engineRepoElements[4] ||
+                                      repoElement == ConductorStatus.frameworkRepoElements[4],
+                                  urlOrUri: statusElementToString(widget.currentStatus[repoElement]),
+                                ),
+                              )
+                            : SelectableText(statusElementToString(widget.currentStatus[repoElement])),
                       ],
                     ),
                 ],
@@ -231,4 +255,11 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
       ),
     );
   }
+}
+
+/// Converts each status element from an Object to a String.
+///
+/// Returns [Unknown] string if the element is empty.
+String statusElementToString(Object? statusElement) {
+  return ((statusElement == null || statusElement == '') ? 'Unknown' : statusElement as String);
 }

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -70,7 +70,7 @@ class ConductorStatusState extends State<ConductorStatus> {
               TableRow(
                 children: <Widget>[
                   Text('$headerElement:'),
-                  SelectableText(statusElementToString(currentStatus[headerElement])),
+                  SelectableText(statusElementToString(releaseStatus![headerElement])),
                 ],
               ),
           ],
@@ -239,11 +239,11 @@ class RepoInfoExpansionState extends State<RepoInfoExpansion> {
                             ? Align(
                                 alignment: Alignment.centerLeft,
                                 child: UrlButton(
-                                  textToDisplay: statusElementToString(widget.currentStatus[repoElement]),
-                                  urlOrUri: statusElementToString(widget.currentStatus[repoElement]),
+                                  textToDisplay: statusElementToString(widget.releaseStatus[repoElement]),
+                                  urlOrUri: statusElementToString(widget.releaseStatus[repoElement]),
                                 ),
                               )
-                            : SelectableText(statusElementToString(widget.currentStatus[repoElement])),
+                            : SelectableText(statusElementToString(widget.releaseStatus[repoElement])),
                       ],
                     ),
                 ],

--- a/release_dashboard/macos/Flutter/Flutter-Debug.xcconfig
+++ b/release_dashboard/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/release_dashboard/macos/Flutter/Flutter-Release.xcconfig
+++ b/release_dashboard/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/release_dashboard/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/release_dashboard/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/release_dashboard/macos/Podfile
+++ b/release_dashboard/macos/Podfile
@@ -1,0 +1,40 @@
+platform :osx, '10.11'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/release_dashboard/macos/Podfile.lock
+++ b/release_dashboard/macos/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - FlutterMacOS (1.0.0)
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+
+EXTERNAL SOURCES:
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+
+SPEC CHECKSUMS:
+  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  url_launcher_macos: 45af3d61de06997666568a7149c1be98b41c95d4
+
+PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+
+COCOAPODS: 1.11.2

--- a/release_dashboard/macos/Runner.xcodeproj/project.pbxproj
+++ b/release_dashboard/macos/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0DA54A49F15D358C0B64527B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48D860B9A0C465A974CBAD05 /* Pods_Runner.framework */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
@@ -52,9 +53,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		12474F59DE3516740AB20592 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		23B384B11780C9204308350E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* conductor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "conductor.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* conductor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = conductor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -66,8 +69,10 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		48D860B9A0C465A974CBAD05 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		EDFD80A2AEA0746935645836 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DA54A49F15D358C0B64527B /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +105,7 @@
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				D7B153F457453941756FEA67 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -148,8 +155,20 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				48D860B9A0C465A974CBAD05 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D7B153F457453941756FEA67 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				EDFD80A2AEA0746935645836 /* Pods-Runner.debug.xcconfig */,
+				12474F59DE3516740AB20592 /* Pods-Runner.release.xcconfig */,
+				23B384B11780C9204308350E /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -159,11 +178,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				2CEE0B1C35F9774C8825DBF8 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				4C17B9AA8C77F910EE8E17E8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -233,6 +254,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2CEE0B1C35F9774C8825DBF8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,6 +312,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		4C17B9AA8C77F910EE8E17E8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/release_dashboard/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/release_dashboard/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -111,6 +111,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   http:
     dependency: transitive
     description:
@@ -132,6 +137,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -174,6 +186,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   process:
     dependency: transitive
     description:
@@ -241,7 +260,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.7"
   typed_data:
     dependency: transitive
     description:
@@ -249,6 +268,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.12"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   vector_math:
     dependency: transitive
     description:

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -326,4 +326,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=2.5.0"

--- a/release_dashboard/pubspec.yaml
+++ b/release_dashboard/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.1
+  url_launcher: ^6.0.12
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/release_dashboard/test/widgets/common/url_button_test.dart
+++ b/release_dashboard/test/widgets/common/url_button_test.dart
@@ -23,7 +23,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Material(
-            child: UrlButton(textToDisplay: textToDisplay, isURL: true, urlOrUri: url),
+            child: UrlButton(textToDisplay: textToDisplay, urlOrUri: url),
           ),
         ),
       );
@@ -53,7 +53,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Material(
-            child: UrlButton(textToDisplay: textToDisplay, isURL: false, urlOrUri: uri),
+            child: UrlButton(textToDisplay: textToDisplay, urlOrUri: uri),
           ),
         ),
       );

--- a/release_dashboard/test/widgets/common/url_button_test.dart
+++ b/release_dashboard/test/widgets/common/url_button_test.dart
@@ -1,0 +1,77 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_ui/widgets/common/url_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const String textToDisplay = 'Click to open the link';
+  const String url = 'https://flutter.dev';
+  const String uri = '/testDirectory/test';
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/url_launcher');
+
+  group('urlButton tests', () {
+    testWidgets('urlButton can launch a URL', (WidgetTester tester) async {
+      final List<MethodCall> log = <MethodCall>[];
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+      });
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: UrlButton(textToDisplay: textToDisplay, isURL: true, urlOrUri: url),
+          ),
+        ),
+      );
+
+      expect(find.text(textToDisplay), findsOneWidget);
+      await tester.tap(find.byType(UrlButton));
+      await tester.pumpAndSettle();
+
+      // package:url_launcher is expected to throw an exception in test
+      tester.takeException();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('canLaunch', arguments: <String, Object>{
+            'url': url,
+          })
+        ],
+      );
+    });
+
+    testWidgets('urlButton can launch a URI', (WidgetTester tester) async {
+      final List<MethodCall> log = <MethodCall>[];
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+      });
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: UrlButton(textToDisplay: textToDisplay, isURL: false, urlOrUri: uri),
+          ),
+        ),
+      );
+
+      expect(find.text(textToDisplay), findsOneWidget);
+      await tester.tap(find.byType(UrlButton));
+      await tester.pumpAndSettle();
+
+      // package:url_launcher is expected to throw an exception in test
+      tester.takeException();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('canLaunch', arguments: <String, Object>{
+            'url': 'file://$uri',
+          })
+        ],
+      );
+    });
+  });
+}

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -5,6 +5,7 @@
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:conductor_ui/main.dart';
+import 'package:conductor_ui/widgets/common/url_button.dart';
 import 'package:conductor_ui/widgets/conductor_status.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,10 +28,10 @@ void main() {
     const String frameworkCherrypick = '768cd702b691584b2c67b8d30b5cb33e0ef6f0';
     const String engineStartingGitHead = '083049e6cae311910c6a6619a6681b7eba4035b4';
     const String engineCurrentGitHead = '23otn2o3itn2o3int2oi3tno23itno2i3tn';
-    const String engineCheckoutPath = '/Users/alexchen/Desktop/flutter_conductor_checkouts/engine';
+    const String engineCheckoutPath = '/Users/engine';
     const String frameworkStartingGitHead = 'df6981e98rh49er8h149er8h19er8h1';
     const String frameworkCurrentGitHead = '239tnint023t09j2039tj0239tn';
-    const String frameworkCheckoutPath = '/Users/alexchen/Desktop/flutter_conductor_checkouts/framework';
+    const String frameworkCheckoutPath = '/Users/framework';
     final String engineLUCIDashboard = luciConsoleLink(releaseChannel, 'engine');
     final String frameworkLUCIDashboard = luciConsoleLink(releaseChannel, 'flutter');
 
@@ -134,6 +135,24 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.widget<ExpansionPanelList>(find.byType(ExpansionPanelList).first).children[0].isExpanded,
           equals(true));
+    });
+
+    testWidgets('Repo Info section displays URLs', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ListView(
+              children: <Widget>[
+                ConductorStatus(
+                  releaseState: state,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(UrlButton), findsNWidgets(4));
     });
   });
 }

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -137,20 +137,8 @@ void main() {
           equals(true));
     });
 
-    testWidgets('Repo Info section displays URLs', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: ListView(
-              children: <Widget>[
-                ConductorStatus(
-                  releaseState: state,
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
+    testWidgets('Repo Info section displays UrlButton', (WidgetTester tester) async {
+      await tester.pumpWidget(MyApp(FakeConductor(testState: state)));
 
       expect(find.byType(UrlButton), findsNWidgets(4));
     });

--- a/release_dashboard/test/widgets/conductor_status_test.dart
+++ b/release_dashboard/test/widgets/conductor_status_test.dart
@@ -111,10 +111,10 @@ void main() {
       await tester.pumpWidget(MyApp(FakeConductor(testState: state)));
 
       expect(find.text('No persistent state file. Try starting a release.'), findsNothing);
-      for (final String repoElement in ConductorStatus.engineRepoElements) {
+      for (final String repoElement in ConductorStatus.engineRepoElements.values) {
         expect(find.text('$repoElement:'), findsOneWidget);
       }
-      for (final String repoElement in ConductorStatus.frameworkRepoElements) {
+      for (final String repoElement in ConductorStatus.frameworkRepoElements.values) {
         expect(find.text('$repoElement:'), findsOneWidget);
       }
       expect(find.text(engineCandidateBranch), findsOneWidget);


### PR DESCRIPTION
*The conductor status repo info section displays the LUCI dashboard link. Now, this link is clickable, and the URL is launched in a web browser. 3rd party package used: [url_launcher](https://pub.dev/packages/url_launcher)*

*[Issue](https://github.com/flutter/flutter/issues/91119)*

Screen recording:


https://user-images.githubusercontent.com/20194490/139513944-796b0853-cef5-4ebd-b1d3-1c47e2be6fba.mov


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
