### PR TITLE
Update review policy used by auto-submit bot.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -401,8 +401,7 @@ bool _checkApproval(
       changeRequestAuthors.add(authorLogin);
     }
   }
-  final bool approved = (approvers.length > 1) && approvers.isNotEmpty;
-  return approved && changeRequestAuthors.isEmpty;
+  return (approvers.length > 1) && changeRequestAuthors.isEmpty;
 }
 
 /// A model class describing the state of a pull request that has the "waiting

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -210,6 +210,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       final Set<String?> changeRequestAuthors = <String?>{};
       final bool hasApproval = config.rollerAccounts.contains(author) ||
           _checkApproval(
+            author,
             pullRequest['authorAssociation'] as String,
             (pullRequest['reviews']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>(),
             changeRequestAuthors,
@@ -373,14 +374,17 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 /// Returns true if at least one approved review and no outstanding change
 /// request reviews.
 bool _checkApproval(
+  String? author,
   String authorAssociation,
   List<Map<String, dynamic>> reviewNodes,
   Set<String?> changeRequestAuthors,
 ) {
   assert(changeRequestAuthors.isEmpty);
-  final Set<String> allowedReviewers = <String>{'MEMBER', 'OWNER'};
-  final bool authorIsOwnerOrMember = allowedReviewers.contains(authorAssociation);
+  const Set<String> allowedReviewers = <String>{'MEMBER', 'OWNER'};
   final Set<String?> approvers = <String?>{};
+  if (allowedReviewers.contains(authorAssociation)) {
+    approvers.add(author);
+  }
   for (Map<String, dynamic> review in reviewNodes) {
     // Ignore reviews from non-members/owners.
     if (!allowedReviewers.contains(review['authorAssociation'])) {
@@ -397,7 +401,7 @@ bool _checkApproval(
       changeRequestAuthors.add(authorLogin);
     }
   }
-  final bool approved = (approvers.length > 1) || (authorIsOwnerOrMember && approvers.isNotEmpty);
+  final bool approved = (approvers.length > 1) && approvers.isNotEmpty;
   return approved && changeRequestAuthors.isEmpty;
 }
 
@@ -483,7 +487,8 @@ class _AutoMergeQueryResult {
         'current state.');
     buffer.writeln();
     if (!hasApprovedReview && changeRequestAuthors.isEmpty) {
-      buffer.writeln('- Please get at least one approved review before re-applying this '
+      buffer.writeln('- Please get at least one approved review if you are already '
+          'a member or two member reviews if you are not a member before re-applying this '
           'label. __Reviewers__: If you left a comment approving, please use '
           'the "approve" review action instead.');
     }

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -210,6 +210,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       final Set<String?> changeRequestAuthors = <String?>{};
       final bool hasApproval = config.rollerAccounts.contains(author) ||
           _checkApproval(
+            pullRequest['authorAssociation'] as String,
             (pullRequest['reviews']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>(),
             changeRequestAuthors,
           );
@@ -353,8 +354,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 
 /// Parses the graphQL response reviews.
 ///
-/// Checks that the authorAssociation is of a MEMBER or OWNER (ignore reviews
-/// from people who don't have write access to the repo).
+/// If author is a MEMBER or OWNER then it only requires a single review from
+/// another MEMBER or OWNER. If the author is not a MEMBER or OWNER then it
+/// requires two reviews from MEMBERs or OWNERS.
 ///
 /// If there are any CHANGES_REQUESTED reviews, checks if the same author has
 /// subsequently APPROVED.  From testing, dismissing a review means it won't
@@ -371,14 +373,17 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
 /// Returns true if at least one approved review and no outstanding change
 /// request reviews.
 bool _checkApproval(
+  String authorAssociation,
   List<Map<String, dynamic>> reviewNodes,
   Set<String?> changeRequestAuthors,
 ) {
   assert(changeRequestAuthors.isEmpty);
-  bool hasAtLeastOneApprove = false;
+  final Set<String> allowedReviewers = <String>{'MEMBER', 'OWNER'};
+  final bool authorIsOwnerOrMember = allowedReviewers.contains(authorAssociation);
+  final Set<String?> approvers = <String?>{};
   for (Map<String, dynamic> review in reviewNodes) {
     // Ignore reviews from non-members/owners.
-    if (review['authorAssociation'] != 'MEMBER' && review['authorAssociation'] != 'OWNER') {
+    if (!allowedReviewers.contains(review['authorAssociation'])) {
       continue;
     }
 
@@ -386,14 +391,14 @@ bool _checkApproval(
     final String? state = review['state'] as String?;
     final String? authorLogin = review['author']['login'] as String?;
     if (state == 'APPROVED') {
-      hasAtLeastOneApprove = true;
+      approvers.add(authorLogin);
       changeRequestAuthors.remove(authorLogin);
     } else if (state == 'CHANGES_REQUESTED') {
       changeRequestAuthors.add(authorLogin);
     }
   }
-
-  return hasAtLeastOneApprove && changeRequestAuthors.isEmpty;
+  final bool approved = (approvers.length > 1) || (authorIsOwnerOrMember && approvers.isNotEmpty);
+  return approved && changeRequestAuthors.isEmpty;
 }
 
 /// A model class describing the state of a pull request that has the "waiting

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -510,7 +510,7 @@ This pull request is not suitable for automatic merging in its current state.
       ]);
     });
 
-    test('Does not merge if non member does not have at lease 2 member reviews', () async {
+    test('Does not merge if non member does not have at least 2 member reviews', () async {
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
         authorAssociation: '',
@@ -531,7 +531,41 @@ This pull request is not suitable for automatic merging in its current state.
             'id': flutterRepoPRs.first.id,
             'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+''',
+            'labelId': base64LabelId,
+          },
+        ),
+      ]);
+    });
+
+    test('Self review is disallowed', () async {
+      branch = 'pull/0';
+      final PullRequestHelper prRequested = PullRequestHelper(
+        author: 'some_rando',
+        authorAssociation: 'MEMBER',
+        reviews: <PullRequestReviewHelper>[
+          const PullRequestReviewHelper(
+              authorName: 'some_rando', state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
+        ],
+        lastCommitCheckRuns: const <CheckRunHelper>[
+          CheckRunHelper.luciCompletedSuccess,
+        ],
+        lastCommitStatuses: const <StatusHelper>[
+          StatusHelper.flutterBuildSuccess,
+        ],
+      );
+      flutterRepoPRs.add(prRequested);
+      await tester.get(handler);
+      _verifyQueries();
+      githubGraphQLClient.verifyMutations(<MutationOptions>[
+        MutationOptions(
+          document: removeLabelMutation,
+          variables: <String, dynamic>{
+            'id': flutterRepoPRs.first.id,
+            'sBody': '''This pull request is not suitable for automatic merging in its current state.
+
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
             'labelId': base64LabelId,
           },
@@ -633,7 +667,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': engineRepoPRs.first.id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },
@@ -644,7 +678,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': flutterRepoPRs.first.id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },
@@ -708,7 +742,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': flutterRepoPRs[1].id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },
@@ -836,7 +870,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': prNonMemberApprove.id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },
@@ -847,7 +881,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': prNonMemberChangeRequest.id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },
@@ -919,7 +953,7 @@ This pull request is not suitable for automatic merging in its current state.
               'id': prNoReviews.id,
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
-- Please get at least one approved review before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
+- Please get at least one approved review if you are already a member or two member reviews if you are not a member before re-applying this label. __Reviewers__: If you left a comment approving, please use the "approve" review action instead.
 ''',
               'labelId': base64LabelId,
             },


### PR DESCRIPTION
The new policy requires two member reviews for not member PRs and a
single member review for member PRs.

Bug: https://github.com/flutter/flutter/issues/81710

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
