### PR TITLE
[scheduler] ci.yaml models

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -6,7 +6,7 @@ import 'package:gcloud/db.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import '../../service/luci.dart';
-import '../proto/internal/scheduler.pb.dart';
+import '../ci_yaml/target.dart';
 import 'commit.dart';
 import 'key_converter.dart';
 
@@ -77,16 +77,16 @@ class Task extends Model<int> {
   }) {
     return Task(
       attempts: 1,
-      builderName: target.name,
+      builderName: target.value.name,
       commitKey: commit.key,
       createTimestamp: commit.timestamp!,
-      isFlaky: target.bringup,
+      isFlaky: target.value.bringup,
       key: commit.key.append(Task),
-      name: target.name,
-      requiredCapabilities: <String>[target.testbed],
-      stageName: target.scheduler.toString(),
+      name: target.value.name,
+      requiredCapabilities: <String>[target.value.testbed],
+      stageName: target.value.scheduler.toString(),
       status: Task.statusNew,
-      timeoutInMinutes: target.timeout,
+      timeoutInMinutes: target.value.timeout,
     );
   }
 

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -13,21 +13,67 @@ import 'target.dart';
 ///
 /// See //CI_YAML.md for high level documentation.
 class CiYaml {
-  CiYaml(this.config, this.slug);
+  CiYaml({
+    required this.config,
+    required this.slug,
+    required this.branch,
+  });
 
+  /// The underlying protobuf that contains the raw data from .ci.yaml.
   final pb.SchedulerConfig config;
 
+  /// The [RepositorySlug] that [config] is from.
   final RepositorySlug slug;
 
-  List<Target> getPresubmitTargets() {
-    
+  /// The git branch currently being scheduled against.
+  final String branch;
+
+  /// Gets all [Target] that run on presubmit for this config.
+  List<Target> get presubmitTargets {
+    if (!config.enabledBranches.contains(branch)) {
+      throw Exception('$branch is not enabled for this .ci.yaml.\nAdd it to run tests against this PR.');
+    }
+    final Iterable<Target> presubmitTargets =
+        _targets.where((Target target) => target.value.presubmit && !target.value.bringup);
+
+    return _filterEnabledTargets(presubmitTargets);
   }
 
-  List<Target> get _targets => config.targets
-      .map((pb.Target target) => Target(
-            schedulerConfig: config,
-            value: target,
-            slug: slug,
-          ))
-      .toList();
+  /// Gets all [Target] that run on postsubmit for this config.
+  List<Target> get postsubmitTargets {
+    final Iterable<Target> postsubmitTargets = _targets.where((Target target) => target.value.postsubmit);
+
+    return _filterEnabledTargets(postsubmitTargets);
+  }
+
+  Iterable<Target> get _targets => config.targets.map((pb.Target target) => Target(
+        schedulerConfig: config,
+        value: target,
+        slug: slug,
+      ));
+
+  /// Filter [targets] to only those that are expected to run for [branch].
+  ///
+  /// A [Target] is expected to run if:
+  ///   1. [Target.enabledBranches] exists and contains [branch].
+  ///   2. Otherwise, [config.enabledBranches] contains [branch].
+  List<Target> _filterEnabledTargets(Iterable<Target> targets) {
+    final List<Target> filteredTargets = <Target>[];
+
+    // 1. Add targets with local definition
+    final Iterable<Target> overrideBranchTargets =
+        targets.where((Target target) => target.value.enabledBranches.isNotEmpty);
+    final Iterable<Target> enabledTargets =
+        overrideBranchTargets.where((Target target) => target.value.enabledBranches.contains(branch));
+    filteredTargets.addAll(enabledTargets);
+
+    // 2. Add targets with global definition
+    if (config.enabledBranches.contains(branch)) {
+      final Iterable<Target> defaultBranchTargets =
+          targets.where((Target target) => target.value.enabledBranches.isEmpty);
+      filteredTargets.addAll(defaultBranchTargets);
+    }
+
+    return filteredTargets;
+  }
 }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -1,0 +1,33 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:github/github.dart';
+
+import '../proto/internal/scheduler.pb.dart' as pb;
+import 'target.dart';
+
+///
+///
+/// This is a wrapper class around the underlying protos.
+///
+/// See //CI_YAML.md for high level documentation.
+class CiYaml {
+  CiYaml(this.config, this.slug);
+
+  final pb.SchedulerConfig config;
+
+  final RepositorySlug slug;
+
+  List<Target> getPresubmitTargets() {
+    
+  }
+
+  List<Target> get _targets => config.targets
+      .map((pb.Target target) => Target(
+            schedulerConfig: config,
+            value: target,
+            slug: slug,
+          ))
+      .toList();
+}

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -46,6 +46,13 @@ class CiYaml {
     return _filterEnabledTargets(postsubmitTargets);
   }
 
+  /// Filters [targets] to those that should be started immediately.
+  ///
+  /// Targets with dependencies are triggered when there dependency pushes a notification that it has finished.
+  List<Target> getInitialTargets(List<Target> targets) {
+    return targets.where((Target target) => target.value.dependencies.isEmpty).toList();
+  }
+
   Iterable<Target> get _targets => config.targets.map((pb.Target target) => Target(
         schedulerConfig: config,
         value: target,

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -7,9 +7,7 @@ import 'package:github/github.dart';
 import '../proto/internal/scheduler.pb.dart' as pb;
 import 'target.dart';
 
-///
-///
-/// This is a wrapper class around the underlying protos.
+/// This is a wrapper class around S[pb.SchedulerConfig].
 ///
 /// See //CI_YAML.md for high level documentation.
 class CiYaml {
@@ -48,7 +46,9 @@ class CiYaml {
 
   /// Filters [targets] to those that should be started immediately.
   ///
-  /// Targets with dependencies are triggered when there dependency pushes a notification that it has finished.
+  /// Targets with a dependency are triggered when there dependency pushes a notification that it has finished.
+  /// This shouldn't be confused for targets that have the property named dependency, which is used by the
+  /// flutter_deps recipe module on LUCI.
   List<Target> getInitialTargets(List<Target> targets) {
     return targets.where((Target target) => target.value.dependencies.isEmpty).toList();
   }
@@ -74,7 +74,7 @@ class CiYaml {
         overrideBranchTargets.where((Target target) => target.value.enabledBranches.contains(branch));
     filteredTargets.addAll(enabledTargets);
 
-    // 2. Add targets with global definition
+    // 2. Add targets with global definition (this is the majority of targets)
     if (config.enabledBranches.contains(branch)) {
       final Iterable<Target> defaultBranchTargets =
           targets.where((Target target) => target.value.enabledBranches.isEmpty);

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -31,6 +31,9 @@ class Target {
   /// The [RepositorySlug] this [Target] is run for.
   final RepositorySlug slug;
 
+  /// Target prefixes that indicate it will run on an ios device.
+  static const List<String> iosPlatforms = <String>['mac_ios', 'mac_ios32'];
+
   /// Gets the assembled properties for this [pb.Target].
   ///
   /// Target properties are prioritized in:
@@ -73,7 +76,7 @@ class Target {
         'sdk_version': properties['xcode']!,
       };
 
-      if (<String>['mac_ios', 'mac_ios32'].contains(getPlatform())) {
+      if (iosPlatforms.contains(getPlatform())) {
         mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;
       } else {
         mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
@@ -114,13 +117,15 @@ class Target {
   /// Changes made here should also be made to [_platform_properties] and [_properties] in:
   ///  * https://cs.opensource.google/flutter/infra/+/main:config/lib/ci_yaml/ci_yaml.star
   Object _parseProperty(String key, String value) {
+    // Yaml will escape new lines unnecessarily for strings.
+    final List<String> newLineIssues = <String>['android_sdk_license', 'android_sdk_preview_license'];
     if (value == 'true') {
       return true;
     } else if (value == 'false') {
       return false;
     } else if (value.startsWith('[')) {
       return jsonDecode(value) as Object;
-    } else if (<String>['android_sdk_license', 'android_sdk_preview_license'].contains(key)) {
+    } else if (newLineIssues.contains(key)) {
       return value.replaceAll('\\n', '\n');
     } else if (int.tryParse(value) != null) {
       return int.parse(value);

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -1,0 +1,167 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:github/github.dart';
+
+import '../../service/logging.dart';
+import '../proto/internal/scheduler.pb.dart' as pb;
+
+/// Wrapper class around [pb.Target] to support aggregate properties.
+///
+/// Changes here may also need to be upstreamed in:
+///  * https://flutter.googlesource.com/infra/+/refs/heads/main/config/lib/ci_yaml/ci_yaml.star
+class Target {
+  Target({
+    required this.value,
+    required this.schedulerConfig,
+    required this.slug,
+  });
+
+  /// Underlying [Target] this is based on.
+  final pb.Target value;
+
+  /// The [SchedulerConfig] [value] is from.
+  ///
+  /// This is passed for necessary lookups to platform level details.
+  final pb.SchedulerConfig schedulerConfig;
+
+  /// The [RepositorySlug] this [Target] is run for.
+  final RepositorySlug slug;
+
+  /// Gets the assembled properties for this [pb.Target].
+  ///
+  /// Target properties are prioritized in:
+  ///   1. [schedulerConfig.platformProperties]
+  ///   2. [pb.Target.properties]
+  Map<String, Object> getProperties() {
+    final Map<String, Object> platformProperties = _getPlatformProperties();
+    final Map<String, Object> properties = _getTargetProperties();
+    final Map<String, Object> mergedProperties = <String, Object>{}
+      ..addAll(platformProperties)
+      ..addAll(properties);
+
+    final List<Dependency> targetDependencies = <Dependency>[];
+    if (properties.containsKey('dependencies')) {
+      final List<dynamic> rawDeps = properties['dependencies'] as List<dynamic>;
+      final Iterable<Dependency> deps = rawDeps.map((dynamic rawDep) => Dependency.fromJson(rawDep as Object));
+      targetDependencies.addAll(deps);
+    }
+    final List<Dependency> platformDependencies = <Dependency>[];
+    if (platformProperties.containsKey('dependencies')) {
+      final List<dynamic> rawDeps = platformProperties['dependencies'] as List<dynamic>;
+      final Iterable<Dependency> deps = rawDeps.map((dynamic rawDep) => Dependency.fromJson(rawDep as Object));
+      platformDependencies.addAll(deps);
+    }
+    // Lookup map to make merging [targetDependencies] and [platformDependencies] simpler.
+    final Map<String, Dependency> mergedDependencies = <String, Dependency>{};
+    for (Dependency dep in targetDependencies) {
+      mergedDependencies[dep.name] = dep;
+    }
+    for (Dependency dep in platformDependencies) {
+      if (!mergedDependencies.containsKey(dep.name)) {
+        mergedDependencies[dep.name] = dep;
+      }
+    }
+    mergedProperties['dependencies'] = mergedDependencies.values.map((Dependency dep) => dep.toJson()).toList();
+
+    // xcode is a special property as there's different download policies if its in the devicelab.
+    if (properties.containsKey('xcode')) {
+      final Object xcodeVersion = <String, Object>{
+        'sdk_version': properties['xcode']!,
+      };
+
+      if (<String>['mac_ios', 'mac_ios32'].contains(getPlatform())) {
+        mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;
+      } else {
+        mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
+      }
+    }
+
+    mergedProperties['bringup'] = value.bringup;
+
+    return mergedProperties;
+  }
+
+  Map<String, Object> _getTargetProperties() {
+    final Map<String, Object> properties = <String, Object>{};
+    for (String key in value.properties.keys) {
+      properties[key] = _parseProperty(key, value.properties[key]!);
+    }
+
+    return properties;
+  }
+
+  Map<String, Object> _getPlatformProperties() {
+    if (!schedulerConfig.platformProperties.containsKey(getPlatform())) {
+      log.fine('${getPlatform()} was not found in platform properties');
+      return <String, Object>{};
+    }
+
+    final Map<String, String> platformProperties = schedulerConfig.platformProperties[getPlatform()]!.properties;
+    final Map<String, Object> properties = <String, Object>{};
+    for (String key in platformProperties.keys) {
+      properties[key] = _parseProperty(key, platformProperties[key]!);
+    }
+
+    return properties;
+  }
+
+  /// Converts property strings to their correct type.
+  ///
+  /// Changes made here should also be made to [_platform_properties] and [_properties] in:
+  ///  * https://cs.opensource.google/flutter/infra/+/main:config/lib/ci_yaml/ci_yaml.star
+  Object _parseProperty(String key, String value) {
+    if (value == 'true') {
+      return true;
+    } else if (value == 'false') {
+      return false;
+    } else if (value.startsWith('[')) {
+      return jsonDecode(value) as Object;
+    } else if (<String>['android_sdk_license', 'android_sdk_preview_license'].contains(key)) {
+      return value.replaceAll('\\n', '\n');
+    } else if (int.tryParse(value) != null) {
+      return int.parse(value);
+    }
+
+    return value;
+  }
+
+  /// Get the platform of this [Target].
+  ///
+  /// Platform is extracted as the first word in a target's name.
+  String getPlatform() {
+    return value.name.split(' ').first.toLowerCase();
+  }
+}
+
+/// Representation of a Flutter dependency.
+///
+/// See more:
+///   * https://flutter.googlesource.com/recipes/+/refs/heads/main/recipe_modules/flutter_deps/api.py
+class Dependency {
+  Dependency(this.name, this.version);
+
+  /// Constructor for converting from the flutter_deps format.
+  factory Dependency.fromJson(Object json) {
+    final Map<String, dynamic> map = json as Map<String, dynamic>;
+    return Dependency(map['dependency']! as String, map['version'] as String?);
+  }
+
+  /// Human readable name of the dependency.
+  final String name;
+
+  /// CIPD tag to use.
+  ///
+  /// If null, will use the version set in the flutter_deps recipe_module.
+  final String? version;
+
+  Map<String, Object> toJson() {
+    return <String, Object>{
+      'dependency': name,
+      if (version != null) 'version': version!,
+    };
+  }
+}

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -11,7 +11,7 @@ import '../../cocoon_service.dart';
 import '../../src/service/luci.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/github_build_status_update.dart';
-import '../model/proto/internal/scheduler.pb.dart';
+import '../model/ci_yaml/ci_yaml.dart';
 import '../request_handling/api_request_handler.dart';
 import '../service/build_status_provider.dart';
 import '../service/datastore.dart';
@@ -64,8 +64,8 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       sha: config.defaultBranch,
       repository: slug.fullName,
     );
-    final SchedulerConfig schedulerConfig = await scheduler!.getSchedulerConfig(tipOfTreeCommit);
-    List<LuciBuilder> postsubmitBuilders = await scheduler!.getPostSubmitBuilders(tipOfTreeCommit, schedulerConfig);
+    final CiYaml ciYaml = await scheduler!.getCiYaml(tipOfTreeCommit);
+    List<LuciBuilder> postsubmitBuilders = await scheduler!.getPostSubmitBuilders(ciYaml);
     // Filter the builders to only those that can block the tree
     postsubmitBuilders = postsubmitBuilders.where((LuciBuilder builder) => !builder.flaky!).toList();
     final LuciService luciService = luciServiceProvider(this);

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -11,7 +11,7 @@ import '../foundation/typedefs.dart';
 import '../foundation/utils.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
-import '../model/proto/internal/scheduler.pb.dart';
+import '../model/ci_yaml/ci_yaml.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
@@ -57,8 +57,8 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
     final LuciService luciService = luciServiceProvider(this);
     final DatastoreService datastore = datastoreProvider(config.db);
     final Commit latestCommit = await datastore.queryRecentCommits(limit: 1).single;
-    final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(latestCommit);
-    final List<LuciBuilder> postsubmitBuilders = await scheduler.getPostSubmitBuilders(latestCommit, schedulerConfig);
+    final CiYaml ciYaml = await scheduler.getCiYaml(latestCommit);
+    final List<LuciBuilder> postsubmitBuilders = await scheduler.getPostSubmitBuilders(ciYaml);
     final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks = await luciService.getBranchRecentTasks(
       builders: postsubmitBuilders,
       requireTaskName: true,

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -13,9 +13,9 @@ import '../../cocoon_service.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/key_helper.dart';
 import '../model/appengine/task.dart';
+import '../model/ci_yaml/ci_yaml.dart';
 import '../model/google/token_info.dart';
 import '../model/luci/buildbucket.dart';
-import '../model/proto/internal/scheduler.pb.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/exceptions.dart';
 import '../service/datastore.dart';
@@ -86,8 +86,8 @@ class ResetProdTask extends ApiRequestHandler<Body> {
       commitSha = commit.sha!;
       builder = task.builderName;
       if (builder == null) {
-        final SchedulerConfig schedulerConfig = await scheduler.getSchedulerConfig(commit);
-        final List<LuciBuilder> builders = await scheduler.getPostSubmitBuilders(commit, schedulerConfig);
+        final CiYaml ciYaml = await scheduler.getCiYaml(commit);
+        final List<LuciBuilder> builders = await scheduler.getPostSubmitBuilders(ciYaml);
         builder = builders
             .where((LuciBuilder builder) => builder.taskName == task!.name)
             .map((LuciBuilder builder) => builder.name)

--- a/app_dart/lib/src/service/luci.dart
+++ b/app_dart/lib/src/service/luci.dart
@@ -6,15 +6,15 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:appengine/appengine.dart';
-import 'package:github/github.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 
 import '../model/appengine/task.dart';
+import '../model/ci_yaml/target.dart';
 import '../model/luci/buildbucket.dart';
-import '../model/proto/internal/scheduler.pb.dart';
 import '../request_handling/api_request_handler.dart';
+
 import 'buildbucket.dart';
 import 'config.dart';
 
@@ -235,18 +235,14 @@ class LuciBuilder {
     this.taskName,
   });
 
-  /// Create a new [LuciBuilder] object from its JSON representation.
-  // TODO(chillers): Remove once *_builder.json is removed. https://github.com/flutter/flutter/issues/76140
-  factory LuciBuilder.fromJson(Map<String, dynamic> json) => _$LuciBuilderFromJson(json);
-
   /// Create a new [LuciBuilder] from a [Target].
-  factory LuciBuilder.fromTarget(Target target, RepositorySlug slug) {
+  factory LuciBuilder.fromTarget(Target target) {
     return LuciBuilder(
-      name: target.name,
-      repo: slug.name,
-      runIf: target.runIf,
-      taskName: target.name,
-      flaky: target.bringup,
+      name: target.value.name,
+      repo: target.slug.name,
+      runIf: target.value.runIf,
+      taskName: target.value.name,
+      flaky: target.value.bringup,
     );
   }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -174,7 +174,8 @@ class Scheduler {
   }
 
   /// Load in memory the `.ci.yaml`.
-  Future<CiYaml> getCiYaml(Commit commit, {
+  Future<CiYaml> getCiYaml(
+    Commit commit, {
     RetryOptions retryOptions = const RetryOptions(maxAttempts: 3),
   }) async {
     final String ciPath = '${commit.repository}/${commit.sha!}/$kCiYamlPath';
@@ -209,7 +210,9 @@ class Scheduler {
   ///
   /// If GitHub returns [HttpStatus.notFound], an empty config will be inserted assuming
   /// that commit does not support the scheduler config file.
-  Future<Uint8List> _downloadCiYaml(Commit commit, String ciPath, {
+  Future<Uint8List> _downloadCiYaml(
+    Commit commit,
+    String ciPath, {
     RetryOptions retryOptions = const RetryOptions(maxAttempts: 3),
   }) async {
     final String configContent = await githubFileContent(

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -347,7 +347,9 @@ class Scheduler {
   Future<List<LuciBuilder>> getPresubmitBuilders(github.PullRequest pullRequest) async {
     final Commit commit = Commit(
       branch: pullRequest.base!.ref,
-      repository: pullRequest.base!.repo!.fullName, sha: pullRequest.head!.sha,);
+      repository: pullRequest.base!.repo!.fullName,
+      sha: pullRequest.head!.sha,
+    );
     final CiYaml ciYaml = await getCiYaml(commit);
     final Iterable<Target> presubmitTargets =
         ciYaml.presubmitTargets.where((Target target) => target.value.scheduler == pb.SchedulerSystem.luci);

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -166,10 +166,10 @@ class Scheduler {
     return true;
   }
 
-  /// Create [Tasks] specified in [commit] scheduler config.
+  /// Create all [Task] specified in the [CiYaml] for [Commit].
   Future<List<Task>> _getTasks(Commit commit) async {
     final CiYaml ciYaml = await getCiYaml(commit);
-    final List<Target> initialTargets = _getInitialPostSubmitTargets(commit, ciYaml);
+    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets);
     return targetsToTask(commit, initialTargets).toList();
   }
 
@@ -194,14 +194,6 @@ class Scheduler {
       slug: commit.slug,
       branch: commit.branch!,
     );
-  }
-
-  /// Get all postsubmit targets that should be immediately started for [Commit].
-  List<Target> _getInitialPostSubmitTargets(Commit commit, CiYaml ciYaml) {
-    // Filter targets to only those without dependencies.
-    final List<Target> initialTargets =
-        ciYaml.postsubmitTargets.where((Target target) => target.value.dependencies.isEmpty).toList();
-    return initialTargets;
   }
 
   /// Get all [LuciBuilder] run for [ciYaml].

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handlers/push_build_status_to_github.dart';
@@ -83,9 +82,8 @@ void main() {
       );
       tester = ApiRequestHandlerTester(context: authContext);
       mockLuciService = MockLuciService();
-      scheduler = FakeScheduler(config: config, schedulerConfig: exampleConfig);
-      builders = await scheduler.getPostSubmitBuilders(
-          Commit(repository: config.engineSlug.fullName, sha: 'master'), exampleConfig);
+      scheduler = FakeScheduler(config: config, ciYaml: exampleConfig);
+      builders = await scheduler.getPostSubmitBuilders(exampleConfig);
       handler = PushBuildStatusToGithub(
         config,
         FakeAuthenticationProvider(clientContext: clientContext),

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -48,7 +48,7 @@ void main() {
         mockLuciBuildService,
         FakeScheduler(
           config: config,
-          schedulerConfig: exampleConfig,
+          ciYaml: exampleConfig,
         ),
       );
       tester.requestData = <String, dynamic>{

--- a/app_dart/test/request_handlers/vacuum_github_commits_test.dart
+++ b/app_dart/test/request_handlers/vacuum_github_commits_test.dart
@@ -80,7 +80,7 @@ void main() {
       auth = FakeAuthenticationProvider();
       scheduler = FakeScheduler(
         config: config,
-        schedulerConfig: exampleConfig,
+        ciYaml: exampleConfig,
       );
       tester = ApiRequestHandlerTester();
       handler = VacuumGithubCommits(

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -45,7 +45,7 @@ void main() {
       config: config,
       luciBuildService: mockLuciBuildService,
       githubChecksUtil: mockGithubChecksUtil,
-      schedulerConfig: exampleConfig,
+      ciYaml: exampleConfig,
     );
     checkRun = github.CheckRun.fromJson(
       jsonDecode(
@@ -64,26 +64,26 @@ void main() {
           CheckSuiteEvent.fromJson(jsonDecode(checkSuiteString) as Map<String, dynamic>);
       when(mockGithubChecksUtil.createCheckRun(any, any, any, output: anyNamed('output')))
           .thenAnswer((_) async => generateCheckRun(1));
-      final PullRequest pullRequest = generatePullRequest(id: 758, repo: 'cocoon');
+      final PullRequest pullRequest = generatePullRequest(id: 758);
       await githubChecksService.handleCheckSuite(pullRequest, checkSuiteEvent, scheduler);
       verify(
         mockLuciBuildService.scheduleTryBuilds(
           builders: <LuciBuilder>[
             const LuciBuilder(
               name: 'Linux A',
-              repo: 'cocoon',
+              repo: 'flutter',
               flaky: false,
               taskName: 'Linux A',
             ),
             const LuciBuilder(
               name: 'Mac A',
-              repo: 'cocoon',
+              repo: 'flutter',
               flaky: false,
               taskName: 'Mac A',
             ),
             const LuciBuilder(
               name: 'Windows A',
-              repo: 'cocoon',
+              repo: 'flutter',
               flaky: false,
               taskName: 'Windows A',
             ),

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -227,7 +227,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
This refactors to add a wrapper on top of the protobuf. This wrapper is where new functionality should be added instead of the increasing the service of the scheduler service. It's based on pain points i've found while developing the scheduler the past few months.

To start, I moved the postsubmitTargets and presubmitTargets logic to this wrapper.

https://github.com/flutter/flutter/issues/92301 - Requires a wrapper around the protobuf for parsing properties
https://github.com/flutter/flutter/issues/87954 - Requires scheduler validation logic to not contain any dart:mirrors related code
https://github.com/flutter/flutter/issues/92301 - Add getProperties() to `Target` that parses <String, String> to the correct data types (based on logic from flutter/infra)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
