### PR TITLE
Use staging data when auto deflake tests

### DIFF
--- a/app_dart/lib/src/service/bigquery.dart
+++ b/app_dart/lib/src/service/bigquery.dart
@@ -47,7 +47,7 @@ group by builder_name;
 ''';
 
 const String getRecordsQuery = r'''
-select sha, is_flaky, failure_count from `flutter-dashboard.datasite.luci_prod_build_status`
+select sha, is_flaky, failure_count from `flutter-dashboard.datasite.luci_staging_build_status`
 where builder_name=@BUILDER_NAME
 order by time desc
 limit @LIMIT
@@ -139,6 +139,10 @@ class BigqueryService {
       throw 'job does not complete';
     }
     final List<BuilderRecord> result = <BuilderRecord>[];
+    // When a test is newly marked as flaky, it is possible no execution exists.
+    if (response.rows == null) {
+      return result;
+    }
     for (final TableRow row in response.rows!) {
       result.add(BuilderRecord(
         commit: row.f![0].v as String,

--- a/app_dart/test/service/bigquery_test.dart
+++ b/app_dart/test/service/bigquery_test.dart
@@ -32,6 +32,12 @@ const String semanticsIntegrationTestResponse = '''
 }
 ''';
 
+const String noRecordsResponse = '''
+{
+  "jobComplete" : true
+}
+''';
+
 const String jobNotCompleteResponse = '''
 {
   "jobComplete" : false
@@ -84,5 +90,15 @@ void main() {
     expect(statisticList[0].flakyBuilds![2], '101');
     expect(statisticList[0].recentCommit, 'abc');
     expect(statisticList[0].flakyBuildOfRecentCommit, '103');
+  });
+
+  test('return empty build list when bigquery returns no rows', () async {
+    when(jobsResource.query(captureAny, expectedProjectId)).thenAnswer((Invocation invocation) {
+      return Future<QueryResponse>.value(
+          QueryResponse.fromJson(jsonDecode(noRecordsResponse) as Map<dynamic, dynamic>));
+    });
+    final List<BuilderRecord> records =
+        await service.listRecentBuildRecordsForBuilder(expectedProjectId, builder: 'test', limit: 10);
+    expect(records.length, 0);
   });
 }


### PR DESCRIPTION
This solves: https://github.com/flutter/flutter/issues/92999

changes:
1) switch query to staging runs instead of prod (with support of cl/407390665)
2) fix corner case when no rows are returned.