### PR TITLE
Skip PR creation when a flaky bug exists and is open or closed recently

### DIFF
--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -363,6 +363,8 @@ void main() {
           .single as Map<String, dynamic>;
       // Verify no issue is created.
       verifyNever(mockIssuesService.create(captureAny, captureAny));
+      // Verify no pr is created.
+      verifyNever(mockPullRequestsService.create(captureAny, captureAny));
       expect(result['Status'], 'success');
     });
 
@@ -405,6 +407,8 @@ void main() {
           .single as Map<String, dynamic>;
       // Verify no issue is created.
       verifyNever(mockIssuesService.create(captureAny, captureAny));
+      // Verify no pr is created.
+      verifyNever(mockPullRequestsService.create(captureAny, captureAny));
       expect(result['Status'], 'success');
     });
 


### PR DESCRIPTION
This fixes: https://github.com/flutter/flutter/issues/92430

This PR skip deflake PR if there exists a flaky bug that is open or closed < 15 days.
(Tests need validation in https://github.com/flutter/flutter/issues/90139)