### PR TITLE
Enable test check for packages and plugins repos

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -382,15 +382,22 @@ class GithubWebhook extends RequestHandler<Body> {
 
     await for (PullRequestFile file in files) {
       final String filename = file.filename!;
-      if (filename.endsWith('.c') ||
-          filename.endsWith('.cc') ||
-          filename.endsWith('.cpp') ||
-          filename.endsWith('.dart') ||
-          filename.endsWith('.java') ||
-          filename.endsWith('.kt') ||
-          filename.endsWith('.m') ||
-          filename.endsWith('.mm') ||
-          filename.endsWith('.swift')) {
+
+      // When null, do not assume 0 lines have been added.
+      final int linesAdded = file.additionsCount ?? 1;
+      final int linesDeleted = file.deletionsCount ?? 0;
+      final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
+      final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
+
+      if (addedCode &&
+          !filename.endsWith('AUTHORS') &&
+          !filename.endsWith('CODEOWNERS') &&
+          !filename.endsWith('pubspec.yaml') &&
+          !filename.endsWith('.ci.yaml') &&
+          !filename.endsWith('.cirrus.yml') &&
+          !filename.contains('.ci/') &&
+          !filename.contains('.github/') &&
+          !filename.endsWith('.md')) {
         needsTests = true;
       }
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -242,6 +242,7 @@ class FakeConfig implements Config {
       RepositorySlug('flutter', 'engine'),
       RepositorySlug('flutter', 'cocoon'),
       RepositorySlug('flutter', 'packages'),
+      RepositorySlug('flutter', 'plugins'),
     ].contains(slug);
   }
 


### PR DESCRIPTION
Enables the auto-comment bot for missing tests in flutter/packages and
flutter/plugins. The patterns are based on the standard pattern for Dart
tests, plus patterns specific to the various documented flutter/plugins
native test types; this should be essentially correct, but may require
fine-tuning later if there are special cases that weren't covered.

Fixes https://github.com/flutter/flutter/issues/83514

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
