### PR TITLE
Don't request tests for some commment-only changes

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -398,7 +398,7 @@ class GithubWebhook extends RequestHandler<Body> {
           !filename.contains('.ci/') &&
           !filename.contains('.github/') &&
           !filename.endsWith('.md')) {
-        needsTests = true;
+        needsTests = !_allChangesAreCodeComments(file);
       }
 
       // See https://github.com/flutter/flutter/wiki/Plugin-Tests for discussion
@@ -514,5 +514,51 @@ class GithubWebhook extends RequestHandler<Body> {
     } on FormatException {
       return null;
     }
+  }
+
+  /// Returns true if the changes to [file] are all code comments.
+  ///
+  /// If that cannot be determined with confidence, returns false. False
+  /// negatives (e.g., for /* */-style multi-line comments) should be expected.
+  bool _allChangesAreCodeComments(PullRequestFile file) {
+    final int? linesAdded = file.additionsCount;
+    final int? linesDeleted = file.deletionsCount;
+    final String? patch = file.patch;
+    // If information is missing, err or the side of assuming it's a non-comment
+    // change.
+    if (linesAdded == null || linesDeleted == null || patch == null) {
+      return false;
+    }
+
+    // Ensure that the file is a language reconized by the check below.
+    const Set<String> codeExtensions = <String>{
+      'cc',
+      'cpp',
+      'dart',
+      'java',
+      'kt',
+      'm',
+      'mm',
+      'swift',
+    };
+    final String filename = file.filename!;
+    final String? extension = filename.contains('.') ?
+      filename.split('.').last.toLowerCase() : null;
+    if (extension == null || !codeExtensions.contains(extension)) {
+      return false;
+    }
+
+    // Only handle single-line comments; identifying multi-line comments
+    // would require the full file and non-trivial parsing.
+    final RegExp commentRegex = RegExp(r'[+-]\s*//');
+    for (String line in patch.split('\n')) {
+      if (!line.startsWith('+') && !line.startsWith('-')) {
+        continue;
+      }
+      if (!commentRegex.hasMatch(line)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -548,8 +548,9 @@ class GithubWebhook extends RequestHandler<Body> {
       return false;
     }
 
-    // Only handle single-line comments; identifying multi-line comments
-    // would require the full file and non-trivial parsing.
+    // Only handles single-line comments; identifying multi-line comments
+    // would require the full file and non-trivial parsing. Also doesn't handle
+    // end-of-line comments (e.g., "int x = 0; // Info about x").
     final RegExp commentRegex = RegExp(r'[+-]\s*//');
     for (String line in patch.split('\n')) {
       if (!line.startsWith('+') && !line.startsWith('-')) {

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -542,8 +542,7 @@ class GithubWebhook extends RequestHandler<Body> {
       'swift',
     };
     final String filename = file.filename!;
-    final String? extension = filename.contains('.') ?
-      filename.split('.').last.toLowerCase() : null;
+    final String? extension = filename.contains('.') ? filename.split('.').last.toLowerCase() : null;
     if (extension == null || !codeExtensions.contains(extension)) {
       return false;
     }

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -1084,7 +1084,6 @@ void main() {
       request.headers.set('X-Hub-Signature', 'sha1=$hmac');
       final RepositorySlug slug = RepositorySlug('flutter', 'plugins');
 
-
       const String patch = '''
 @@ -128,8 +128,8 @@
   NSString* foo = "";
@@ -1101,7 +1100,8 @@ void main() {
 
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
         (_) => Stream<PullRequestFile>.value(
-          PullRequestFile()..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
+          PullRequestFile()
+            ..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
             ..additionsCount = 2
             ..deletionsCount = 2
             ..changesCount = 4
@@ -1146,7 +1146,6 @@ void main() {
       request.headers.set('X-Hub-Signature', 'sha1=$hmac');
       final RepositorySlug slug = RepositorySlug('flutter', 'plugins');
 
-
       const String patch = '''
 @@ -128,7 +128,7 @@
   int foo = 0;
@@ -1161,7 +1160,8 @@ void main() {
 
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
         (_) => Stream<PullRequestFile>.value(
-          PullRequestFile()..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
+          PullRequestFile()
+            ..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
             ..additionsCount = 1
             ..deletionsCount = 1
             ..changesCount = 2
@@ -1220,7 +1220,8 @@ void foo() {
 
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
         (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'packages/foo/lib/foo.dart'
+          PullRequestFile()
+            ..filename = 'packages/foo/lib/foo.dart'
             ..additionsCount = 1
             ..deletionsCount = 1
             ..changesCount = 2

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -1025,7 +1025,7 @@ void main() {
       ));
     });
 
-    test('Plugins comments and labels if no tests', () async {
+    test('Plugins comments and labels if no tests and no patch info', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
       request.body = generatePullRequestEvent(
@@ -1066,6 +1066,175 @@ void main() {
         issueNumber,
         <String>['needs tests'],
       )).called(1);
+    });
+
+    test('Plugins comments and labels for code change', () async {
+      const int issueNumber = 123;
+      request.headers.set('X-GitHub-Event', 'pull_request');
+      request.body = generatePullRequestEvent(
+        'opened',
+        issueNumber,
+        kDefaultBranchName,
+        repoName: 'plugins',
+        repoFullName: 'flutter/plugins',
+      );
+      final Uint8List body = utf8.encode(request.body!) as Uint8List;
+      final Uint8List key = utf8.encode(keyString) as Uint8List;
+      final String hmac = getHmac(body, key);
+      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
+      final RepositorySlug slug = RepositorySlug('flutter', 'plugins');
+
+
+      const String patch = '''
+@@ -128,8 +128,8 @@
+  NSString* foo = "";
+  int bar = 0;
+
+-  // Some incorrect code:
+-  int baz = 7 / bar;
++  // Better code:
++  int baz = 7 * bar;
+  return baz;
+}
+
+''';
+
+      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.value(
+          PullRequestFile()..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
+            ..additionsCount = 2
+            ..deletionsCount = 2
+            ..changesCount = 4
+            ..patch = patch,
+        ),
+      );
+
+      when(issuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer(
+        (_) => Stream<IssueComment>.value(
+          IssueComment()..body = 'some other comment',
+        ),
+      );
+
+      await tester.post(webhook);
+
+      verify(issuesService.createComment(
+        slug,
+        issueNumber,
+        argThat(contains(config.missingTestsPullRequestMessageValue)),
+      )).called(1);
+
+      verify(issuesService.addLabelsToIssue(
+        slug,
+        issueNumber,
+        <String>['needs tests'],
+      )).called(1);
+    });
+
+    test('Plugins comments and labels for code removal with comment addition', () async {
+      const int issueNumber = 123;
+      request.headers.set('X-GitHub-Event', 'pull_request');
+      request.body = generatePullRequestEvent(
+        'opened',
+        issueNumber,
+        kDefaultBranchName,
+        repoName: 'plugins',
+        repoFullName: 'flutter/plugins',
+      );
+      final Uint8List body = utf8.encode(request.body!) as Uint8List;
+      final Uint8List key = utf8.encode(keyString) as Uint8List;
+      final String hmac = getHmac(body, key);
+      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
+      final RepositorySlug slug = RepositorySlug('flutter', 'plugins');
+
+
+      const String patch = '''
+@@ -128,7 +128,7 @@
+  int foo = 0;
+
+  int bar = 0;
+-  int baz = 0;
++  // int baz = 0;
+
+  // More code here:
+
+''';
+
+      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.value(
+          PullRequestFile()..filename = 'packages/foo/foo_ios/ios/Classes/Foo.m'
+            ..additionsCount = 1
+            ..deletionsCount = 1
+            ..changesCount = 2
+            ..patch = patch,
+        ),
+      );
+
+      when(issuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer(
+        (_) => Stream<IssueComment>.value(
+          IssueComment()..body = 'some other comment',
+        ),
+      );
+
+      await tester.post(webhook);
+
+      verify(issuesService.createComment(
+        slug,
+        issueNumber,
+        argThat(contains(config.missingTestsPullRequestMessageValue)),
+      )).called(1);
+
+      verify(issuesService.addLabelsToIssue(
+        slug,
+        issueNumber,
+        <String>['needs tests'],
+      )).called(1);
+    });
+
+    test('Plugins does not comment for comment-only changes', () async {
+      const int issueNumber = 123;
+      request.headers.set('X-GitHub-Event', 'pull_request');
+      request.body = generatePullRequestEvent(
+        'opened',
+        issueNumber,
+        kDefaultBranchName,
+        repoName: 'plugins',
+        repoFullName: 'flutter/plugins',
+      );
+      final Uint8List body = utf8.encode(request.body!) as Uint8List;
+      final Uint8List key = utf8.encode(keyString) as Uint8List;
+      final String hmac = getHmac(body, key);
+      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
+      final RepositorySlug slug = RepositorySlug('flutter', 'plugins');
+
+      const String patch = '''
+@@ -128,7 +128,7 @@
+
+/// Insert interesting comment here.
+///
+-/// More details here, but some of them are wrong.
++/// These are the right details!
+void foo() {
+  int bar = 0;
+  String baz = '';
+''';
+
+      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+          PullRequestFile()..filename = 'packages/foo/lib/foo.dart'
+            ..additionsCount = 1
+            ..deletionsCount = 1
+            ..changesCount = 2
+            ..patch = patch,
+        ]),
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(issuesService.createComment(
+        slug,
+        issueNumber,
+        argThat(contains(config.missingTestsPullRequestMessageValue)),
+      ));
     });
 
     test('Plugins does not comment if Dart tests', () async {


### PR DESCRIPTION
Adds the ability to recognize PRs that only change single-line comments,
and exempts them from test requests.

- Currently only handles a specific set of languages that use `//`.
- Makes no attempt to handle multi-line (`/* */`) blocks, so tests will
  still sometimes be requested for comment-only changes (e.g., to
  Javadoc comments).
- Currently enabled only for flutter/plugins and flutter/packages in
  order to evaluate it before rolling it out to other repositories.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
