### PR TITLE
Conductor delete error msg

### DIFF
--- a/release_dashboard/test/main_test.dart
+++ b/release_dashboard/test/main_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Platform;
 
 import 'package:conductor_ui/main.dart';
+import 'package:conductor_ui/widgets/clean_release_button.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'src/services/fake_conductor.dart';
 
@@ -15,7 +16,7 @@ void main() {
 
       expect(find.textContaining('Flutter Desktop Conductor'), findsOneWidget);
       expect(find.textContaining('Desktop app for managing a release'), findsOneWidget);
-      expect(find.byType(CleanRelease), findsOneWidget);
+      expect(find.byType(CleanReleaseButton), findsOneWidget);
     });
   }, skip: Platform.isWindows); // This app does not support Windows [intended]
 }

--- a/release_dashboard/test/main_test.dart
+++ b/release_dashboard/test/main_test.dart
@@ -15,6 +15,7 @@ void main() {
 
       expect(find.textContaining('Flutter Desktop Conductor'), findsOneWidget);
       expect(find.textContaining('Desktop app for managing a release'), findsOneWidget);
+      expect(find.byType(CleanRelease), findsOneWidget);
     });
   }, skip: Platform.isWindows); // This app does not support Windows [intended]
 }


### PR DESCRIPTION
`CleanRelease` widget was created and tested correctly, but it was never called inside `main`. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
