### PR TITLE
[device doctor] Add android device battery health check

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -16,6 +16,9 @@ import 'host_utils.dart';
 import 'mac.dart';
 import 'utils.dart';
 
+const int _kBatteryMinLevel = 15;
+const int _kBatteryMaxTemperature = 34;
+
 class AndroidDeviceDiscovery implements DeviceDiscovery {
   factory AndroidDeviceDiscovery(String output) {
     return _instance ??= AndroidDeviceDiscovery._(output);
@@ -103,6 +106,8 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       checks.add(await developerModeCheck(processManager: processManager));
       checks.add(await screenOnCheck(processManager: processManager));
       checks.add(await screenSaverCheck(processManager: processManager));
+      checks.add(await batteryLevelCheck(processManager: processManager));
+      checks.add(await batteryTemperatureCheck(processManager: processManager));
       if (Platform.isMacOS) {
         checks.add(await userAutoLoginCheck(processManager: processManager));
       }
@@ -264,6 +269,51 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       }
     } on BuildFailedError catch (error) {
       healthCheckResult = HealthCheckResult.failure(kScreenSaverCheckKey, error.toString());
+    }
+    return healthCheckResult;
+  }
+
+  /// The health check for battery level.
+  Future<HealthCheckResult> batteryLevelCheck({ProcessManager processManager}) async {
+    HealthCheckResult healthCheckResult;
+    try {
+      // The battery level returns two rows. For example:
+      //   level: 100
+      //   mod level: -1
+      final String levelResults = await eval('adb', <String>['shell', 'dumpsys', 'battery', '|', 'grep', 'level'],
+          processManager: processManager);
+      final List<String> levels = levelResults.trim().split('\n').toList();
+      final int level = int.parse(levels.where((element) => element.startsWith('level:')).single.split(':')[1].trim());
+      if (level < _kBatteryMinLevel) {
+        healthCheckResult =
+            HealthCheckResult.failure(kBatteryLevelCheckKey, 'Battery level ($level) is below $_kBatteryMinLevel');
+      } else {
+        healthCheckResult = HealthCheckResult.success(kBatteryLevelCheckKey);
+      }
+    } on BuildFailedError catch (error) {
+      healthCheckResult = HealthCheckResult.failure(kScreenSaverCheckKey, error.toString());
+    }
+    return healthCheckResult;
+  }
+
+  /// The health check for battery temperature.
+  Future<HealthCheckResult> batteryTemperatureCheck({ProcessManager processManager}) async {
+    HealthCheckResult healthCheckResult;
+    try {
+      // The battery temperature returns one row. For example:
+      //  temperature: 240
+      // It means 24°C.
+      final String tempResult = await eval('adb', <String>['shell', 'dumpsys', 'battery', '|', 'grep', 'temperature'],
+          processManager: processManager);
+      final int temperature = int.parse(tempResult.split(':')[1].trim());
+      if (temperature > _kBatteryMaxTemperature * 10) {
+        healthCheckResult = HealthCheckResult.failure(kBatteryTemperatureCheckKey,
+            'Battery temperature (${(temperature * 0.1).toInt()}°C) is over $_kBatteryMaxTemperature°C');
+      } else {
+        healthCheckResult = HealthCheckResult.success(kBatteryTemperatureCheckKey);
+      }
+    } on BuildFailedError catch (error) {
+      healthCheckResult = HealthCheckResult.failure(kBatteryTemperatureCheckKey, error.toString());
     }
     return healthCheckResult;
   }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -16,9 +16,9 @@ import 'host_utils.dart';
 import 'mac.dart';
 import 'utils.dart';
 
-// The minimum battery level to run a task with a scale of 100.
+// The minimum battery level to run a task with a scale of 100%.
 const int _kBatteryMinLevel = 15;
-// The maxium battery temprature to run a task with a Celsius degree.
+// The maximum battery temprature to run a task with a Celsius degree.
 const int _kBatteryMaxTemperatureInCelsius = 34;
 
 class AndroidDeviceDiscovery implements DeviceDiscovery {
@@ -284,8 +284,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       //   mod level: -1
       final String levelResults = await eval('adb', <String>['shell', 'dumpsys', 'battery', '|', 'grep', 'level'],
           processManager: processManager);
-      final List<String> levels = levelResults.trim().split('\n').toList();
-      final int level = int.parse(levels.where((element) => element.startsWith('level:')).single.split(':')[1].trim());
+      final RegExp levelRegExp = RegExp('level: (?<level>.+)');
+      final RegExpMatch match = levelRegExp.firstMatch(levelResults);
+      final int level = int.parse(match.namedGroup('level'));
       if (level < _kBatteryMinLevel) {
         healthCheckResult =
             HealthCheckResult.failure(kBatteryLevelCheckKey, 'Battery level ($level) is below $_kBatteryMinLevel');
@@ -307,7 +308,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       // It means 24°C.
       final String tempResult = await eval('adb', <String>['shell', 'dumpsys', 'battery', '|', 'grep', 'temperature'],
           processManager: processManager);
-      final int temperature = int.parse(tempResult.split(':')[1].trim());
+      final RegExp tempRegExp = RegExp('temperature: (?<temperature>.+)');
+      final RegExpMatch match = tempRegExp.firstMatch(tempResult);
+      final int temperature = int.parse(match.namedGroup('temperature'));
       if (temperature > _kBatteryMaxTemperatureInCelsius * 10) {
         healthCheckResult = HealthCheckResult.failure(kBatteryTemperatureCheckKey,
             'Battery temperature (${(temperature * 0.1).toInt()}°C) is over $_kBatteryMaxTemperatureInCelsius°C');

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -16,8 +16,10 @@ import 'host_utils.dart';
 import 'mac.dart';
 import 'utils.dart';
 
+// The minimum battery level to run a task with a scale of 100.
 const int _kBatteryMinLevel = 15;
-const int _kBatteryMaxTemperature = 34;
+// The maxium battery temprature to run a task with a Celsius degree.
+const int _kBatteryMaxTemperatureInCelsius = 34;
 
 class AndroidDeviceDiscovery implements DeviceDiscovery {
   factory AndroidDeviceDiscovery(String output) {
@@ -306,9 +308,9 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
       final String tempResult = await eval('adb', <String>['shell', 'dumpsys', 'battery', '|', 'grep', 'temperature'],
           processManager: processManager);
       final int temperature = int.parse(tempResult.split(':')[1].trim());
-      if (temperature > _kBatteryMaxTemperature * 10) {
+      if (temperature > _kBatteryMaxTemperatureInCelsius * 10) {
         healthCheckResult = HealthCheckResult.failure(kBatteryTemperatureCheckKey,
-            'Battery temperature (${(temperature * 0.1).toInt()}°C) is over $_kBatteryMaxTemperature°C');
+            'Battery temperature (${(temperature * 0.1).toInt()}°C) is over $_kBatteryMaxTemperatureInCelsius°C');
       } else {
         healthCheckResult = HealthCheckResult.success(kBatteryTemperatureCheckKey);
       }

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -24,6 +24,8 @@ const String kUnlockLoginKeychain = '/usr/local/bin/unlock_login_keychain.sh';
 const String kCertCheckKey = 'codesigning_cert';
 const String kDevicePairCheckKey = 'device_pair';
 const String kScreenSaverCheckKey = 'screensaver';
+const String kBatteryLevelCheckKey = 'battery_level';
+const String kBatteryTemperatureCheckKey = 'battery_temperature';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {


### PR DESCRIPTION
Partly solves https://github.com/flutter/flutter/issues/92915.

This PR adds health checks for android device battery:
1) check battery level > 15 (100 scale)
2) check battery temperature < 34°C