### PR TITLE
[app_dart] Allow waiting for green to accept empty statuses

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -247,7 +247,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
           title: title,
           sha: sha,
           labelId: labelId!,
-          emptyValidations: checkRuns.isEmpty || statuses.isEmpty,
+          emptyValidations: checkRuns.isEmpty && statuses.isEmpty,
           isConflicting: isConflicting,
           unknownMergeableState: unknownMergeableState,
           labels: labels));

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -247,7 +247,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
           title: title,
           sha: sha,
           labelId: labelId!,
-          emptyValidations: checkRuns.isEmpty && statuses.isEmpty,
+          emptyChecks: checkRuns.isEmpty,
           isConflicting: isConflicting,
           unknownMergeableState: unknownMergeableState,
           labels: labels));
@@ -389,7 +389,7 @@ class _AutoMergeQueryResult {
     required this.title,
     required this.sha,
     required this.labelId,
-    required this.emptyValidations,
+    required this.emptyChecks,
     required this.isConflicting,
     required this.unknownMergeableState,
     required this.labels,
@@ -422,8 +422,8 @@ class _AutoMergeQueryResult {
   /// The GitHub GraphQL ID of the waiting label.
   final String labelId;
 
-  /// Whether the commit has empty validations or not.
-  final bool emptyValidations;
+  /// Whether the commit has checks or not.
+  final bool emptyChecks;
 
   /// Whether the PR has conflicts or not.
   final bool isConflicting;
@@ -440,13 +440,13 @@ class _AutoMergeQueryResult {
       failures.isEmpty &&
       hasApprovedReview &&
       changeRequestAuthors.isEmpty &&
-      !emptyValidations &&
+      !emptyChecks &&
       !unknownMergeableState &&
       !isConflicting;
 
   /// Whether the auto-merge label should be removed from this PR.
   bool get shouldRemoveLabel =>
-      !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyValidations || isConflicting;
+      !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyChecks || isConflicting;
 
   String get removalMessage {
     if (!shouldRemoveLabel) {
@@ -469,10 +469,9 @@ class _AutoMergeQueryResult {
       buffer.writeln('- The status or check suite ${detail.markdownLink} has failed. Please fix the '
           'issues identified (or deflake) before re-applying this label.');
     }
-    if (emptyValidations) {
-      buffer.writeln('- This commit has empty status or empty checks. Please'
-          ' check the Google CLA status is present and Flutter Dashboard'
-          ' application has multiple checks.');
+    if (emptyChecks) {
+      buffer.writeln('- This commit has no checks. Please check that ci.yaml validation has started'
+          ' and there are multiple checks. If not, try uploading an empty commit.');
     }
     if (isConflicting) {
       buffer.writeln('- This commit is not mergeable and has conflicts. Please'
@@ -490,7 +489,7 @@ class _AutoMergeQueryResult {
         'hasApprovedReview: $hasApprovedReview, '
         'changeRequestAuthors: $changeRequestAuthors, '
         'labelId: $labelId, '
-        'emptyValidations: $emptyValidations, '
+        'emptyValidations: $emptyChecks, '
         'shouldMerge: $shouldMerge}';
   }
 }

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -17,6 +17,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
               login
             }
             id
+            baseRepository
             number
             title
             mergeable

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -52,6 +52,12 @@ class Config {
     RepositorySlug('flutter', 'flutter'),
   };
 
+  /// GitHub repositories that use CI status to determine if pull requests can be submitted.
+  static Set<RepositorySlug> reposWithTreeStatus = <RepositorySlug>{
+    RepositorySlug('flutter', 'engine'),
+    RepositorySlug('flutter', 'flutter'),
+  };
+
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -5,6 +5,7 @@
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/request_handlers/check_for_waiting_pull_requests_queries.dart';
 import 'package:cocoon_service/src/service/logging.dart';
+import 'package:github/github.dart';
 
 import 'package:graphql/client.dart';
 import 'package:logging/logging.dart';
@@ -287,7 +288,6 @@ void main() {
         lastCommitCheckRuns: const <CheckRunHelper>[
           CheckRunHelper.windowsInProgress,
         ],
-        lastCommitStatuses: const <StatusHelper>[],
       );
       flutterRepoPRs.add(prInProgress);
       await tester.get(handler);
@@ -301,7 +301,6 @@ void main() {
         lastCommitCheckRuns: const <CheckRunHelper>[
           CheckRunHelper.macQueued,
         ],
-        lastCommitStatuses: const <StatusHelper>[],
       );
       flutterRepoPRs.add(prQueued);
       await tester.get(handler);
@@ -315,7 +314,6 @@ void main() {
         lastCommitCheckRuns: const <CheckRunHelper>[
           CheckRunHelper.linuxRequested,
         ],
-        lastCommitStatuses: const <StatusHelper>[],
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -462,6 +460,7 @@ This pull request is not suitable for automatic merging in its current state.
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
+- The status or check suite [tree status luci-flutter](https://flutter-dashboard.appspot.com/#/build) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 - This commit has no checks. Please check that ci.yaml validation has started and there are multiple checks. If not, try uploading an empty commit.
 ''',
           },
@@ -469,12 +468,14 @@ This pull request is not suitable for automatic merging in its current state.
       ]);
     });
 
-    test('Merge PR with successful checks but null status checks', () async {
+    test('Merge PR with successful checks on repo without tree status', () async {
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
+        repo: 'cocoon',
         lastCommitCheckRuns: const <CheckRunHelper>[
           CheckRunHelper.luciCompletedSuccess,
         ],
+        lastCommitStatuses: const <StatusHelper>[],
       );
       prRequested.lastCommitStatuses = null;
       flutterRepoPRs.add(prRequested);
@@ -975,6 +976,7 @@ class CheckRunHelper {
 class PullRequestHelper {
   PullRequestHelper({
     this.author = 'some_rando',
+    this.repo = 'flutter',
     this.title = 'some_title',
     this.reviews = const <PullRequestReviewHelper>[
       PullRequestReviewHelper(authorName: 'member', state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
@@ -991,6 +993,7 @@ class PullRequestHelper {
   final int _count;
   String get id => _count.toString();
 
+  final String repo;
   final String author;
   final String title;
   final List<PullRequestReviewHelper> reviews;
@@ -1000,10 +1003,15 @@ class PullRequestHelper {
   final DateTime? dateTime;
   List<dynamic> labels;
 
+  RepositorySlug get slug => RepositorySlug('flutter', repo);
+
   Map<String, dynamic> toEntry() {
     return <String, dynamic>{
       'author': <String, dynamic>{'login': author},
       'id': id,
+      'baseRepository': <String, dynamic>{
+        'nameWithOwner': slug.fullName,
+      },
       'number': _count,
       'title': title,
       'reviews': <String, dynamic>{

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -292,20 +292,7 @@ void main() {
       flutterRepoPRs.add(prInProgress);
       await tester.get(handler);
       _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[
-        MutationOptions(
-          document: removeLabelMutation,
-          variables: <String, dynamic>{
-            'id': flutterRepoPRs.first.id,
-            'labelId': base64LabelId,
-            'sBody': '''
-This pull request is not suitable for automatic merging in its current state.
-
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
-''',
-          },
-        ),
-      ]);
+      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
     });
 
     test('Does not merge PR with queued checks', () async {
@@ -319,20 +306,7 @@ This pull request is not suitable for automatic merging in its current state.
       flutterRepoPRs.add(prQueued);
       await tester.get(handler);
       _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[
-        MutationOptions(
-          document: removeLabelMutation,
-          variables: <String, dynamic>{
-            'id': flutterRepoPRs.first.id,
-            'labelId': base64LabelId,
-            'sBody': '''
-This pull request is not suitable for automatic merging in its current state.
-
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
-''',
-          },
-        ),
-      ]);
+      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
     });
 
     test('Does not merge PR with requested checks', () async {
@@ -346,20 +320,7 @@ This pull request is not suitable for automatic merging in its current state.
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
       _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[
-        MutationOptions(
-          document: removeLabelMutation,
-          variables: <String, dynamic>{
-            'id': flutterRepoPRs.first.id,
-            'labelId': base64LabelId,
-            'sBody': '''
-This pull request is not suitable for automatic merging in its current state.
-
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
-''',
-          },
-        ),
-      ]);
+      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
     });
 
     test('Does not merge PR with failed status', () async {
@@ -476,7 +437,7 @@ This pull request is not suitable for automatic merging in its current state.
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
+- This commit has no checks. Please check that ci.yaml validation has started and there are multiple checks. If not, try uploading an empty commit.
 ''',
           },
         ),
@@ -501,14 +462,14 @@ This pull request is not suitable for automatic merging in its current state.
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
+- This commit has no checks. Please check that ci.yaml validation has started and there are multiple checks. If not, try uploading an empty commit.
 ''',
           },
         ),
       ]);
     });
 
-    test('Does not fail with null statuses', () async {
+    test('Merge PR with successful checks but null status checks', () async {
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
         lastCommitCheckRuns: const <CheckRunHelper>[
@@ -521,16 +482,8 @@ This pull request is not suitable for automatic merging in its current state.
       _verifyQueries();
       githubGraphQLClient.verifyMutations(<MutationOptions>[
         MutationOptions(
-          document: removeLabelMutation,
-          variables: <String, dynamic>{
-            'id': flutterRepoPRs.first.id,
-            'labelId': base64LabelId,
-            'sBody': '''
-This pull request is not suitable for automatic merging in its current state.
-
-- This commit has empty status or empty checks. Please check the Google CLA status is present and Flutter Dashboard application has multiple checks.
-''',
-          },
+          document: mergePullRequestMutation,
+          variables: getMergePullRequestVariables(flutterRepoPRs.first.id),
         ),
       ]);
     });


### PR DESCRIPTION
Google's CLA status was moved to a GitHub check. Instead, we should be checking iff the checks are empty.

Most repos still have a status (like WIP), but Cocoon only had the CLA bot. Now it's blocked on having PRs submitted by the bot.

Fixes https://github.com/flutter/flutter/issues/93418

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.