### PR TITLE
[conductor] Removed URL padding

### DIFF
--- a/release_dashboard/lib/widgets/common/url_button.dart
+++ b/release_dashboard/lib/widgets/common/url_button.dart
@@ -30,6 +30,7 @@ class UrlButton extends StatelessWidget {
       target: LinkTarget.blank,
       builder: (ctx, openLink) {
         return TextButton(
+          style: TextButton.styleFrom(padding: EdgeInsets.zero),
           onPressed: openLink,
           child: Text(textToDisplay),
         );


### PR DESCRIPTION
`UrlButton` widget uses `TextButton` with a default leading and trailing padding. When displayed as a link in the UI, it has not aligned with the rest of the text as shown below:


![image](https://user-images.githubusercontent.com/20194490/141538703-2de86d85-73d2-4c20-bd67-8009ab5b44b9.png)

This sets the padding of `TextButton` to zero and aligns with the rest of the text.

![image](https://user-images.githubusercontent.com/20194490/141539394-37026d60-6955-41f4-b01f-66c6c00a601e.png)


*[Issue](https://github.com/flutter/flutter/issues/91119)*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
