### PR TITLE
Adjust integration test labelling

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -270,6 +270,7 @@ class GithubWebhook extends RequestHandler<Body> {
       'packages/flutter_goldens_client/': <String>['framework', 'a: tests', 'team'],
       'packages/flutter_test/': <String>['framework', 'a: tests'],
       'packages/fuchsia_remote_debug_protocol/': <String>['tool'],
+      'packages/integration_test/': <String>['integration_test'],
     };
     const Map<String, List<String>> pathContainsLabels = <String, List<String>>{
       'accessibility': <String>['a: accessibility'],
@@ -277,7 +278,6 @@ class GithubWebhook extends RequestHandler<Body> {
       'cupertino': <String>['f: cupertino'],
       'focus': <String>['f: focus'],
       'gestures': <String>['f: gestures'],
-      'integration_test': <String>['integration_test'],
       'material': <String>['f: material design'],
       'navigator': <String>['f: routes'],
       'route': <String>['f: routes'],

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -403,11 +403,14 @@ void main() {
             contains('f: scrolling'));
       });
 
-      test('integration_test label applied', () {
+      test('integration_test label is/isn\'t applied', () {
+        // Label does not apply to integration tests outside of the
+        // integration_test package.
         expect(
             GithubWebhook.getLabelsForFrameworkPath(
                 'dev/integration_tests/web_e2e_tests/test_driver/text_editing_integration.dart'),
-            contains('integration_test'));
+            <String>{'team', 'a: text input'});
+        // Label applies to integration_test package
         expect(GithubWebhook.getLabelsForFrameworkPath('packages/integration_test/lib/common.dart'),
             contains('integration_test'));
       });


### PR DESCRIPTION
Fixes eager label bot tagging integration tests outside of the package with the package-specific label.
Fixes https://github.com/flutter/flutter/issues/92939

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
