### PR TITLE
Use correct bucket stats when file/update flaky bugs

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -140,9 +140,6 @@ class IssueUpdateBuilder {
   }
 
   String get issueUpdateComment {
-    if (statistic.flakyBuilds!.length + statistic.succeededBuilds!.length < kFlayRatioBuildNumberList) {
-      return 'Current flaky ratio is not available (< $kFlayRatioBuildNumberList commits).\n';
-    }
     String result = 'Current flaky ratio for the past (up to) 100 commits is ${_formatRate(statistic.flakyRate)}%.\n';
     if (statistic.flakyRate > 0.0) {
       result = result +

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -120,7 +120,7 @@ class IssueUpdateBuilder {
   final BuilderStatistic statistic;
   final double threshold;
   final Issue existingIssue;
-  final String bucket;
+  final Bucket bucket;
 
   bool get isBelow => statistic.flakyRate < threshold;
 
@@ -465,12 +465,12 @@ Map<String, dynamic>? retrieveMetaTagsFromContent(String content) {
 
 String _formatRate(double rate) => (rate * 100).toStringAsFixed(2);
 
-String _issueBuildLinks({String? builder, required List<String> builds, String bucket = 'prod'}) {
+String _issueBuildLinks({String? builder, required List<String> builds, Bucket bucket = Bucket.prod}) {
   return '${builds.map((String build) => _issueBuildLink(builder: builder, build: build, bucket: bucket)).join('\n')}';
 }
 
-String _issueBuildLink({String? builder, String? build, String bucket = 'prod'}) {
-  final String buildPrefix = bucket == 'staging' ? _stagingBuildPrefix : _prodBuildPrefix;
+String _issueBuildLink({String? builder, String? build, Bucket bucket = Bucket.prod}) {
+  final String buildPrefix = bucket == Bucket.staging ? _stagingBuildPrefix : _prodBuildPrefix;
   return Uri.encodeFull('$buildPrefix$builder/$build');
 }
 
@@ -510,6 +510,11 @@ enum BuilderType {
   shard,
   firebaselab,
   unknown,
+}
+
+enum Bucket {
+  prod,
+  staging,
 }
 
 enum Team {

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -44,7 +44,8 @@ const String kModifyType = 'blob';
 const int kSuccessBuildNumberLimit = 3;
 
 const String _commitPrefix = 'https://github.com/flutter/flutter/commit/';
-const String _buildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/prod/';
+const String _prodBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/prod/';
+const String _stagingBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/staging/';
 const String _flakeRecordPrefix =
     'https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:';
 
@@ -78,7 +79,7 @@ class IssueBuilder {
   String get issueBody {
     return '''
 ${_buildHiddenMetaTags(name: statistic.name)}
-The post-submit test builder `${statistic.name}` had a flaky ratio ${_formatRate(statistic.flakyRate)}% for the past 15 days, which is above our ${_formatRate(threshold)}% threshold.
+The post-submit test builder `${statistic.name}` had a flaky ratio ${_formatRate(statistic.flakyRate)}% for the past (up to) 100 commits, which is above our ${_formatRate(threshold)}% threshold.
 
 One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit)}
 Commit: $_commitPrefix${statistic.recentCommit}
@@ -113,11 +114,13 @@ class IssueUpdateBuilder {
     required this.statistic,
     required this.threshold,
     required this.existingIssue,
+    required this.bucket,
   });
 
   final BuilderStatistic statistic;
   final double threshold;
   final Issue existingIssue;
+  final String bucket;
 
   bool get isBelow => statistic.flakyRate < threshold;
 
@@ -136,14 +139,14 @@ class IssueUpdateBuilder {
   }
 
   String get issueUpdateComment {
-    String result = 'Current flaky ratio for the past 15 days is ${_formatRate(statistic.flakyRate)}%.\n';
+    String result = 'Current flaky ratio for the past (up to) 100 commits is ${_formatRate(statistic.flakyRate)}%.\n';
     if (statistic.flakyRate > 0.0) {
       result = result +
           '''
 One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit)}
 Commit: $_commitPrefix${statistic.recentCommit}
 Flaky builds:
-${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!)}
+${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!, bucket: bucket)}
 ''';
     }
     return result;
@@ -462,12 +465,13 @@ Map<String, dynamic>? retrieveMetaTagsFromContent(String content) {
 
 String _formatRate(double rate) => (rate * 100).toStringAsFixed(2);
 
-String _issueBuildLinks({String? builder, required List<String> builds}) {
-  return '${builds.map((String build) => _issueBuildLink(builder: builder, build: build)).join('\n')}';
+String _issueBuildLinks({String? builder, required List<String> builds, String bucket = 'prod'}) {
+  return '${builds.map((String build) => _issueBuildLink(builder: builder, build: build, bucket: bucket)).join('\n')}';
 }
 
-String _issueBuildLink({String? builder, String? build}) {
-  return Uri.encodeFull('$_buildPrefix$builder/$build');
+String _issueBuildLink({String? builder, String? build, String bucket = 'prod'}) {
+  final String buildPrefix = bucket == 'staging' ? _stagingBuildPrefix : _prodBuildPrefix;
+  return Uri.encodeFull('$buildPrefix$builder/$build');
 }
 
 Team _teamFromString(String teamString) {

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -42,6 +42,7 @@ const String kModifyMode = '100755';
 const String kModifyType = 'blob';
 
 const int kSuccessBuildNumberLimit = 3;
+const int kFlayRatioBuildNumberList = 10;
 
 const String _commitPrefix = 'https://github.com/flutter/flutter/commit/';
 const String _prodBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/prod/';
@@ -139,6 +140,9 @@ class IssueUpdateBuilder {
   }
 
   String get issueUpdateComment {
+    if (statistic.flakyBuilds!.length + statistic.succeededBuilds!.length < kFlayRatioBuildNumberList) {
+      return 'Current flaky ratio is not available (< $kFlayRatioBuildNumberList commits).\n';
+    }
     String result = 'Current flaky ratio for the past (up to) 100 commits is ${_formatRate(statistic.flakyRate)}%.\n';
     if (statistic.flakyRate > 0.0) {
       result = result +

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -9,7 +9,6 @@ import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart';
 
 import '../../protos.dart' as pb;
-import '../service/scheduler/graph.dart';
 import '../foundation/utils.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/authentication.dart';
@@ -17,6 +16,7 @@ import '../request_handling/body.dart';
 import '../service/bigquery.dart';
 import '../service/config.dart';
 import '../service/github_service.dart';
+import '../service/scheduler/graph.dart';
 import 'flaky_handler_utils.dart';
 
 /// This handler updates existing open flaky issues with the latest build

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -68,7 +68,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   Future<void> _addCommentToExistingIssue(
     GithubService gitHub,
     RepositorySlug slug, {
-    required String bucket,
+    required Bucket bucket,
     required BuilderStatistic statistic,
     required Issue existingIssue,
   }) async {
@@ -131,7 +131,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   }
 
   /// Return bucket info for the builder runs.
-  String _getBucket(Map<String, bool> builderFlakyMap, String builderName) {
-    return builderFlakyMap[builderName] == true ? 'staging' : 'prod';
+  Bucket _getBucket(Map<String, bool> builderFlakyMap, String builderName) {
+    return builderFlakyMap[builderName] == true ? Bucket.staging : Bucket.prod;
   }
 }

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -112,7 +112,8 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     for (final BuilderStatistic statistic in prodBuilderStatisticList) {
       if (nameToExistingIssue.containsKey(statistic.name) &&
           builderFlakyMap.containsKey(statistic.name) &&
-          builderFlakyMap[statistic.name] == false) {
+          builderFlakyMap[statistic.name] == false &&
+          _buildsAreEnough(statistic)) {
         await _addCommentToExistingIssue(gitHub, slug,
             bucket: _getBucket(builderFlakyMap, statistic.name),
             statistic: statistic,
@@ -121,13 +122,20 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     }
     // For all staging builder stats, updates any existing flaky bug.
     for (final BuilderStatistic statistic in stagingBuilderStatisticList) {
-      if (nameToExistingIssue.containsKey(statistic.name)) {
+      if (nameToExistingIssue.containsKey(statistic.name) && _buildsAreEnough(statistic)) {
         await _addCommentToExistingIssue(gitHub, slug,
             bucket: _getBucket(builderFlakyMap, statistic.name),
             statistic: statistic,
             existingIssue: nameToExistingIssue[statistic.name]!);
       }
     }
+  }
+
+  /// Check if there are enough builds to calculate the flaky ratio.
+  ///
+  /// Default threshold is [kFlayRatioBuildNumberList].
+  bool _buildsAreEnough(BuilderStatistic statistic) {
+    return statistic.flakyBuilds!.length + statistic.succeededBuilds!.length >= kFlayRatioBuildNumberList;
   }
 
   /// Return bucket info for the builder runs.

--- a/app_dart/lib/src/service/bigquery.dart
+++ b/app_dart/lib/src/service/bigquery.dart
@@ -58,7 +58,7 @@ select builder_name,
        array_agg(case when is_flaky = 1 then sha end IGNORE NULLS ORDER BY date DESC)[ordinal(1)] as recent_flaky_commit,
        array_agg(case when is_flaky = 1 then flaky_builds end IGNORE NULLS ORDER BY date DESC)[ordinal(1)] as flaky_build_of_recent_flaky_commit,
        sum(is_flaky)/count(*) as flaky_ratio
-from (select *, row_number() over (partition by builder_name order by time desc) as rank from `flutter-dashboard.datasite.luci_starging_build_status`)
+from (select *, row_number() over (partition by builder_name order by time desc) as rank from `flutter-dashboard.datasite.luci_staging_build_status`)
 where date>=date_sub(current_date(), interval 30 day) and
       builder_name not like '%Drone' and
       repo='flutter' and

--- a/app_dart/lib/src/service/bigquery.dart
+++ b/app_dart/lib/src/service/bigquery.dart
@@ -49,6 +49,27 @@ where date>=date_sub(current_date(), interval 30 day) and
 group by builder_name;
 ''';
 
+const String getStagingBuilderStatisticQuery = r'''
+select builder_name,
+       sum(is_flaky) as flaky_number,
+       count(*) as total_number,
+       string_agg(case when is_flaky = 1 then flaky_builds end, ', ') as flaky_builds,
+       string_agg(succeeded_builds, ', ') as succeeded_builds,
+       array_agg(case when is_flaky = 1 then sha end IGNORE NULLS ORDER BY date DESC)[ordinal(1)] as recent_flaky_commit,
+       array_agg(case when is_flaky = 1 then flaky_builds end IGNORE NULLS ORDER BY date DESC)[ordinal(1)] as flaky_build_of_recent_flaky_commit,
+       sum(is_flaky)/count(*) as flaky_ratio
+from (select *, row_number() over (partition by builder_name order by time desc) as rank from `flutter-dashboard.datasite.luci_starging_build_status`)
+where date>=date_sub(current_date(), interval 30 day) and
+      builder_name not like '%Drone' and
+      repo='flutter' and
+      branch='master' and
+      pool = 'luci.flutter.staging' and
+      builder_name not like '%Beta%' and
+      builder_name not like '% beta %' and
+      rank<=@LIMIT
+group by builder_name;
+''';
+
 const String getRecordsQuery = r'''
 select sha, is_flaky, failure_count from `flutter-dashboard.datasite.luci_staging_build_status`
 where builder_name=@BUILDER_NAME
@@ -82,10 +103,11 @@ class BigqueryService {
   ///
   /// See getBuilderStatisticQuery to get the detail information about the table
   /// schema
-  Future<List<BuilderStatistic>> listBuilderStatistic(String projectId, {int limit = 100}) async {
+  Future<List<BuilderStatistic>> listBuilderStatistic(String projectId,
+      {int limit = 100, String bucket = 'prod'}) async {
     final JobsResource jobsResource = await defaultJobs();
     final QueryRequest query = QueryRequest.fromJson(<String, Object>{
-      'query': getBuilderStatisticQuery,
+      'query': bucket == 'staging' ? getStagingBuilderStatisticQuery : getBuilderStatisticQuery,
       'queryParameters': <Map<String, Object>>[
         <String, Object>{
           'name': 'LIMIT',

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -149,6 +149,71 @@ void main() {
       expect(result['Status'], 'success');
     });
 
+    test('Can add existing issue comment when not enough data', () async {
+      const int existingIssueNumber = 1234;
+      final List<IssueLabel> existingLabels = <IssueLabel>[
+        IssueLabel(name: 'some random label'),
+        IssueLabel(name: 'P2'),
+      ];
+      // When queries flaky data from BigQuery.
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponseNotEnoughData);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+      });
+      // when gets existing flaky issues.
+      when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
+          .thenAnswer((Invocation invocation) {
+        return Stream<Issue>.fromIterable(<Issue>[
+          Issue(
+            assignee: User(login: 'some dude'),
+            number: existingIssueNumber,
+            state: 'open',
+            labels: existingLabels,
+            title: expectedSemanticsIntegrationTestResponseTitle,
+            body: expectedSemanticsIntegrationTestResponseBody,
+            createdAt:
+                DateTime.now().subtract(const Duration(days: UpdateExistingFlakyIssue.kFreshPeriodForOpenFlake + 1)),
+          )
+        ]);
+      });
+      // when firing github request.
+      // This is for replacing labels.
+      when(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).thenAnswer((Invocation invocation) {
+        return Future<Response>.value(Response('[]', 200));
+      });
+      final Map<String, dynamic> result = await utf8.decoder
+          .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
+          .transform(json.decoder)
+          .single as Map<String, dynamic>;
+
+      // Verify comment is created correctly.
+      List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[1], existingIssueNumber);
+      expect(captured[2], expectedSemanticsIntegrationTestNotEnoughDataComment);
+
+      // Verify labels are applied correctly.
+      captured = verify(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), 'PUT');
+      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
+
+      expect(result['Status'], 'success');
+    });
+
     test('Can add existing issue comment based on staging stats', () async {
       const int existingIssueNumber = 1234;
       final List<IssueLabel> existingLabels = <IssueLabel>[

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -94,6 +94,10 @@ void main() {
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
         return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
       });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+      });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
           .thenAnswer((Invocation invocation) {
@@ -145,6 +149,71 @@ void main() {
       expect(result['Status'], 'success');
     });
 
+    test('Can add existing issue comment based on staging stats', () async {
+      const int existingIssueNumber = 1234;
+      final List<IssueLabel> existingLabels = <IssueLabel>[
+        IssueLabel(name: 'some random label'),
+        IssueLabel(name: 'P2'),
+      ];
+      // When queries flaky data from BigQuery.
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+      });
+      // when gets existing flaky issues.
+      when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
+          .thenAnswer((Invocation invocation) {
+        return Stream<Issue>.fromIterable(<Issue>[
+          Issue(
+            assignee: User(login: 'some dude'),
+            number: existingIssueNumber,
+            state: 'open',
+            labels: existingLabels,
+            title: expectedStagingSemanticsIntegrationTestResponseTitle,
+            body: expectedStagingSemanticsIntegrationTestResponseBody,
+            createdAt:
+                DateTime.now().subtract(const Duration(days: UpdateExistingFlakyIssue.kFreshPeriodForOpenFlake + 1)),
+          )
+        ]);
+      });
+      // when firing github request.
+      // This is for replacing labels.
+      when(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).thenAnswer((Invocation invocation) {
+        return Future<Response>.value(Response('[]', 200));
+      });
+      final Map<String, dynamic> result = await utf8.decoder
+          .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
+          .transform(json.decoder)
+          .single as Map<String, dynamic>;
+
+      // Verify comment is created correctly.
+      List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[1], existingIssueNumber);
+      expect(captured[2], expectedStagingSemanticsIntegrationTestIssueComment);
+
+      // Verify labels are applied correctly.
+      captured = verify(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), 'PUT');
+      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
+
+      expect(result['Status'], 'success');
+    });
+
     test('Can assign test owner', () async {
       const int existingIssueNumber = 1234;
       final List<IssueLabel> existingLabels = <IssueLabel>[
@@ -154,6 +223,10 @@ void main() {
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
         return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -204,6 +277,10 @@ void main() {
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
         return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponseZeroFlake);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -265,6 +342,10 @@ void main() {
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
         return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponseZeroFlake);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -149,7 +149,7 @@ void main() {
       expect(result['Status'], 'success');
     });
 
-    test('Can add existing issue comment when not enough data', () async {
+    test('Do not add issue comment when not enough data', () async {
       const int existingIssueNumber = 1234;
       final List<IssueLabel> existingLabels = <IssueLabel>[
         IssueLabel(name: 'some random label'),
@@ -193,23 +193,14 @@ void main() {
           .transform(json.decoder)
           .single as Map<String, dynamic>;
 
-      // Verify comment is created correctly.
-      List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
-      expect(captured.length, 3);
-      expect(captured[0].toString(), config.flutterSlug.toString());
-      expect(captured[1], existingIssueNumber);
-      expect(captured[2], expectedSemanticsIntegrationTestNotEnoughDataComment);
+      verifyNever(mockIssuesService.createComment(captureAny, captureAny, captureAny));
 
-      // Verify labels are applied correctly.
-      captured = verify(mockGitHubClient.request(
+      // Verify labels are the same.
+      verifyNever(mockGitHubClient.request(
         captureAny,
         captureAny,
         body: captureAnyNamed('body'),
-      )).captured;
-      expect(captured.length, 3);
-      expect(captured[0].toString(), 'PUT');
-      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
-      expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
+      ));
 
       expect(result['Status'], 'success');
     });

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -16,6 +16,16 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/101
 ''';
 
+const String expectedStagingSemanticsIntegrationTestIssueComment = '''
+Current flaky ratio for the past 15 days is 50.00%.
+One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
+Commit: https://github.com/flutter/flutter/commit/abc
+Flaky builds:
+https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/103
+https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/102
+https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/101
+''';
+
 const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
 Current flaky ratio for the past 15 days is 0.00%.
 ''';
@@ -34,6 +44,28 @@ final List<BuilderStatistic> semanticsIntegrationTestResponseZeroFlake = <Builde
 final List<BuilderStatistic> semanticsIntegrationTestResponse = <BuilderStatistic>[
   BuilderStatistic(
     name: 'Mac_android android_semantics_integration_test',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+  )
+];
+
+final List<BuilderStatistic> shardSemanticsIntegrationTestResponse = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Mac build_tests_1_4',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+  )
+];
+
+final List<BuilderStatistic> stagingSemanticsIntegrationTestResponse = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Linux ci_yaml flutter roller',
     flakyRate: 0.5,
     flakyBuilds: <String>['103', '102', '101'],
     succeededBuilds: <String>['203', '202', '201'],
@@ -68,6 +100,31 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
+const String expectedStagingSemanticsIntegrationTestResponseTitle = 'Linux ci_yaml flutter roller is 50.00% flaky';
+const String expectedStagingSemanticsIntegrationTestResponseBody = '''
+<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
+{
+  "name": "Linux ci_yaml flutter roller"
+}
+-->
+
+The post-submit test builder `Linux ci_yaml flutter roller` had a flaky ratio 50.00% for the past 15 days, which is above our 2.00% threshold.
+
+One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
+Commit: https://github.com/flutter/flutter/commit/abc
+Flaky builds:
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/102
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/101
+
+Succeeded builds (3 most recent):
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/203
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/202
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/201
+
+Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
+''';
+
 const String ciYamlContent = '''
 # Describes the targets run in continuous integration environment.
 #
@@ -87,6 +144,37 @@ targets:
     properties:
       tags: >
         ["devicelab"]
+
+  - name: Linux ci_yaml flutter roller
+    recipe: infra/ci_yaml
+    bringup: true # TODO(chillers): https://github.com/flutter/flutter/issues/93225
+    timeout: 30
+    properties:
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
+    runIf:
+      - .ci.yaml
+
+  - name: Mac build_tests_1_4
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:29.0"},
+          {"dependency": "chrome_and_driver", "version": "version:84"},
+          {"dependency": "open_jdk"},
+          {"dependency": "xcode"},
+          {"dependency": "gems"},
+          {"dependency": "goldctl"}
+        ]
+      shard: build_tests
+      subshard: "1_4"
+      tags: >
+        ["framework","hostonly","shard"]
+    scheduler: luci
 ''';
 
 const String testOwnersContent = '''

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:cocoon_service/src/service/bigquery.dart';
 
 const String expectedSemanticsIntegrationTestIssueComment = '''
-Current flaky ratio for the past 15 days is 50.00%.
+Current flaky ratio for the past (up to) 100 commits is 50.00%.
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
 Commit: https://github.com/flutter/flutter/commit/abc
 Flaky builds:
@@ -17,7 +17,7 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 ''';
 
 const String expectedStagingSemanticsIntegrationTestIssueComment = '''
-Current flaky ratio for the past 15 days is 50.00%.
+Current flaky ratio for the past (up to) 100 commits is 50.00%.
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
 Commit: https://github.com/flutter/flutter/commit/abc
 Flaky builds:
@@ -27,7 +27,7 @@ https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%
 ''';
 
 const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
-Current flaky ratio for the past 15 days is 0.00%.
+Current flaky ratio for the past (up to) 100 commits is 0.00%.
 ''';
 
 final List<BuilderStatistic> semanticsIntegrationTestResponseZeroFlake = <BuilderStatistic>[

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -30,12 +30,16 @@ const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
 Current flaky ratio for the past (up to) 100 commits is 0.00%.
 ''';
 
+const String expectedSemanticsIntegrationTestNotEnoughDataComment = '''
+Current flaky ratio is not available (< 10 commits).
+''';
+
 final List<BuilderStatistic> semanticsIntegrationTestResponseZeroFlake = <BuilderStatistic>[
   BuilderStatistic(
     name: 'Mac_android android_semantics_integration_test',
     flakyRate: 0.0,
     flakyBuilds: <String>[],
-    succeededBuilds: <String>[],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197', '196', '195', '194'],
     recentCommit: '',
     flakyBuildOfRecentCommit: '',
   )
@@ -46,7 +50,18 @@ final List<BuilderStatistic> semanticsIntegrationTestResponse = <BuilderStatisti
     name: 'Mac_android android_semantics_integration_test',
     flakyRate: 0.5,
     flakyBuilds: <String>['103', '102', '101'],
-    succeededBuilds: <String>['203', '202', '201'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+  )
+];
+
+final List<BuilderStatistic> semanticsIntegrationTestResponseNotEnoughData = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Mac_android android_semantics_integration_test',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201', '200'],
     recentCommit: 'abc',
     flakyBuildOfRecentCommit: '103',
   )
@@ -57,7 +72,7 @@ final List<BuilderStatistic> shardSemanticsIntegrationTestResponse = <BuilderSta
     name: 'Mac build_tests_1_4',
     flakyRate: 0.5,
     flakyBuilds: <String>['103', '102', '101'],
-    succeededBuilds: <String>['203', '202', '201'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
     recentCommit: 'abc',
     flakyBuildOfRecentCommit: '103',
   )
@@ -68,7 +83,7 @@ final List<BuilderStatistic> stagingSemanticsIntegrationTestResponse = <BuilderS
     name: 'Linux ci_yaml flutter roller',
     flakyRate: 0.5,
     flakyBuilds: <String>['103', '102', '101'],
-    succeededBuilds: <String>['203', '202', '201'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
     recentCommit: 'abc',
     flakyBuildOfRecentCommit: '103',
   )

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -279,8 +279,9 @@ class MockBigqueryService extends _i1.Mock implements _i20.BigqueryService {
   _i14.Future<_i6.JobsResource> defaultJobs() => (super.noSuchMethod(Invocation.method(#defaultJobs, []),
       returnValue: Future<_i6.JobsResource>.value(_FakeJobsResource_5())) as _i14.Future<_i6.JobsResource>);
   @override
-  _i14.Future<List<_i20.BuilderStatistic>> listBuilderStatistic(String? projectId, {int? limit = 100}) =>
-      (super.noSuchMethod(Invocation.method(#listBuilderStatistic, [projectId], {#limit: limit}),
+  _i14.Future<List<_i20.BuilderStatistic>> listBuilderStatistic(String? projectId,
+          {int? limit = 100, String? bucket = r'prod'}) =>
+      (super.noSuchMethod(Invocation.method(#listBuilderStatistic, [projectId], {#limit: limit, #bucket: bucket}),
               returnValue: Future<List<_i20.BuilderStatistic>>.value(<_i20.BuilderStatistic>[]))
           as _i14.Future<List<_i20.BuilderStatistic>>);
   @override


### PR DESCRIPTION
This solves: https://github.com/flutter/flutter/issues/93678

This PR does
1) Update flaky bug body to reflect recent changes (https://github.com/flutter/flutter/issues/92502)
2) Update flaky bugs using staging stats for builders marked as `bringup: true`, which are expected to run in `staging` pool.
3) Update flaky bugs using prod stats for builders (such as shard builders) without `bringup: true`.