### PR TITLE
Calculate tree status from both master and main.

### DIFF
--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -17,6 +17,9 @@ import 'datastore.dart';
 /// Function signature for a [BuildStatusService] provider.
 typedef BuildStatusServiceProvider = BuildStatusService Function(DatastoreService datastoreService);
 
+/// Branches that are used to calculate the tree status.
+const Set<String> defaultBranches = <String>{'refs/heads/main', 'refs/heads/master'};
+
 /// Class that calculates the current build status.
 class BuildStatusService {
   const BuildStatusService(this.datastoreService);
@@ -129,7 +132,7 @@ class BuildStatusService {
   /// retrieved from BuildBucket using RPCs.
   Future<String> latestLUCIStatus(List<LuciTask> tasks) async {
     for (LuciTask task in tasks) {
-      if (task.ref != 'refs/heads/master') {
+      if (!defaultBranches.contains(task.ref)) {
         log.fine('Skipping ${task.status} from commit ${task.commitSha} ref ${task.ref} builder ${task.builderName}');
         continue;
       }


### PR DESCRIPTION
For engine repository main became the default branch and we need to
allow tree status calculations main.

Bug: https://github.com/flutter/flutter/issues/90476

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
