### PR TITLE
[release_dashboard] Add substeps for `Codesign Engine binaries` step

### DIFF
--- a/release_dashboard/lib/widgets/clean_release_button.dart
+++ b/release_dashboard/lib/widgets/clean_release_button.dart
@@ -27,7 +27,6 @@ class CleanReleaseButton extends StatefulWidget {
 class _CleanReleaseState extends State<CleanReleaseButton> {
   String? _errorMsg;
 
-  /// Updates [_errorMsg] with [errorMsg].
   void _updateErrorMsg(String? errorMsg) {
     setState(() {
       _errorMsg = errorMsg;

--- a/release_dashboard/lib/widgets/codesign_engine_substeps.dart
+++ b/release_dashboard/lib/widgets/codesign_engine_substeps.dart
@@ -42,7 +42,7 @@ class CodesignEngineSubsteps extends StatefulWidget {
     CodesignEngineSubstep.updateLicenseHash:
         'There might be a license failure under the Linux Unopt test for the engine PR. '
             "Visit the test's stdout, and there should be instructions on how to update the license hash number"
-            ' in the local checkout directory. After the update, please push the changes to the engine PR.\n\n'
+            ' in the local checkout directory. After the update, please push the changes to the feature branch on your mirror.\n\n'
             'Just check this substep if there is no Linux Unopt test failure.',
     CodesignEngineSubstep.preSubmitCI:
         'Make sure all tests on Github pass for the engine PR. Fix any test failures first. \n'

--- a/release_dashboard/lib/widgets/codesign_engine_substeps.dart
+++ b/release_dashboard/lib/widgets/codesign_engine_substeps.dart
@@ -1,0 +1,144 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_core/conductor_core.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/status_state.dart';
+import 'common/checkbox_substep.dart';
+import 'common/url_button.dart';
+
+enum CodesignEngineSubstep {
+  updateLicenseHash,
+  preSubmitCI,
+  postSubmitCI,
+  codesign,
+}
+
+/// Group and display all substeps related to the 'Apply Engine Cherrypicks' step into a widget.
+///
+/// When all substeps are completed, [nextStep] can be executed to proceed to the next step.
+class CodesignEngineSubsteps extends StatefulWidget {
+  const CodesignEngineSubsteps({
+    Key? key,
+    required this.nextStep,
+  }) : super(key: key);
+
+  final VoidCallback nextStep;
+
+  @override
+  State<CodesignEngineSubsteps> createState() => ConductorSubstepsState();
+
+  static const Map<CodesignEngineSubstep, String> substepTitles = <CodesignEngineSubstep, String>{
+    CodesignEngineSubstep.updateLicenseHash: 'Update the license hash number',
+    CodesignEngineSubstep.preSubmitCI: 'Validate pre-submit CI, have the engine PR reviewed, approved and merged',
+    CodesignEngineSubstep.postSubmitCI: 'Validate post-submit CI',
+    CodesignEngineSubstep.codesign: 'Codesign the engine binaries',
+  };
+
+  static const Map<CodesignEngineSubstep, String> substepSubtitles = <CodesignEngineSubstep, String>{
+    CodesignEngineSubstep.updateLicenseHash:
+        'There might be a license failure under the Linux Unopt test for the engine PR. '
+            "Visit the test's stdout, and there should be instructions on how to update the license hash number"
+            ' in the local checkout directory. After the update, please push the changes to the engine PR.\n\n'
+            'Just check this substep if there is no Linux Unopt test failure.',
+    CodesignEngineSubstep.preSubmitCI:
+        'Make sure all tests on Github pass for the engine PR. Fix any test failures first. \n'
+            'Get the engine PR reviewed, approved and merged.',
+    CodesignEngineSubstep.postSubmitCI: 'Make sure all engine binaries post-submit CI tests pass here: ',
+    CodesignEngineSubstep.codesign: 'An authorized person has to codesign the engine binaries.',
+  };
+
+  static const releaseChannelMissingErr = 'Error: Release Channel cannot be found';
+}
+
+class ConductorSubstepsState extends State<CodesignEngineSubsteps> {
+  final Map<CodesignEngineSubstep, bool> _isEachSubstepChecked = <CodesignEngineSubstep, bool>{};
+
+  @override
+  void initState() {
+    /// If [substep] is false, that [substep] is unchecked, otherwise, it is checked.
+    ///
+    /// All substeps are unchecked at the beginning.
+    for (final CodesignEngineSubstep substep in CodesignEngineSubstep.values) {
+      _isEachSubstepChecked[substep] = false;
+    }
+    super.initState();
+  }
+
+  /// Toggle the boolean value of [substepName].
+  void substepPressed(CodesignEngineSubstep substep) {
+    setState(() {
+      _isEachSubstepChecked[substep] = !_isEachSubstepChecked[substep]!;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
+
+    return Column(
+      children: <Widget>[
+        CheckboxAsSubstep(
+          substepName: CodesignEngineSubsteps.substepTitles[CodesignEngineSubstep.updateLicenseHash]!,
+          subtitle: SelectableText(CodesignEngineSubsteps.substepSubtitles[CodesignEngineSubstep.updateLicenseHash]!),
+          isChecked: _isEachSubstepChecked[CodesignEngineSubstep.updateLicenseHash]!,
+          clickCallback: () {
+            substepPressed(CodesignEngineSubstep.updateLicenseHash);
+          },
+        ),
+        CheckboxAsSubstep(
+          substepName: CodesignEngineSubsteps.substepTitles[CodesignEngineSubstep.preSubmitCI]!,
+          subtitle: SelectableText(CodesignEngineSubsteps.substepSubtitles[CodesignEngineSubstep.preSubmitCI]!),
+          isChecked: _isEachSubstepChecked[CodesignEngineSubstep.preSubmitCI]!,
+          clickCallback: () {
+            substepPressed(CodesignEngineSubstep.preSubmitCI);
+          },
+        ),
+        CheckboxAsSubstep(
+          substepName: CodesignEngineSubsteps.substepTitles[CodesignEngineSubstep.postSubmitCI]!,
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SelectableText(CodesignEngineSubsteps.substepSubtitles[CodesignEngineSubstep.postSubmitCI]!),
+              releaseStatus == null || releaseStatus['Release Channel'] == null
+                  ? Text(
+                      CodesignEngineSubsteps.releaseChannelMissingErr,
+                      style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.red),
+                    )
+                  : UrlButton(
+                      textToDisplay: luciConsoleLink(releaseStatus['Release Channel'] as String, 'engine'),
+                      urlOrUri: luciConsoleLink(releaseStatus['Release Channel'] as String, 'engine'),
+                    ),
+            ],
+          ),
+          isChecked: _isEachSubstepChecked[CodesignEngineSubstep.postSubmitCI]!,
+          clickCallback: () {
+            substepPressed(CodesignEngineSubstep.postSubmitCI);
+          },
+        ),
+        CheckboxAsSubstep(
+          substepName: CodesignEngineSubsteps.substepTitles[CodesignEngineSubstep.codesign]!,
+          subtitle: SelectableText(CodesignEngineSubsteps.substepSubtitles[CodesignEngineSubstep.codesign]!),
+          isChecked: _isEachSubstepChecked[CodesignEngineSubstep.codesign]!,
+          clickCallback: () {
+            substepPressed(CodesignEngineSubstep.codesign);
+          },
+        ),
+        if (!_isEachSubstepChecked.containsValue(false))
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 25, 0, 0),
+            child: ElevatedButton(
+              key: const Key('CodesignEngineSubstepsContinue'),
+              onPressed: () {
+                widget.nextStep();
+              },
+              child: const Text('Continue'),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/release_dashboard/lib/widgets/codesign_engine_substeps.dart
+++ b/release_dashboard/lib/widgets/codesign_engine_substeps.dart
@@ -43,7 +43,7 @@ class CodesignEngineSubsteps extends StatefulWidget {
         'There might be a license failure under the Linux Unopt test for the engine PR. '
             "Visit the test's stdout, and there should be instructions on how to update the license hash number"
             ' in the local checkout directory. After the update, please push the changes to the feature branch on your mirror.\n\n'
-            'Just check this substep if there is no Linux Unopt test failure.',
+            'This box can be checked if Linux Unopt passes pre-submit.',
     CodesignEngineSubstep.preSubmitCI:
         'Make sure all tests on Github pass for the engine PR. Fix any test failures first. \n'
             'Get the engine PR reviewed, approved and merged.',

--- a/release_dashboard/lib/widgets/codesign_engine_substeps.dart
+++ b/release_dashboard/lib/widgets/codesign_engine_substeps.dart
@@ -6,6 +6,7 @@ import 'package:conductor_core/conductor_core.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../models/conductor_status.dart';
 import '../state/status_state.dart';
 import 'common/checkbox_substep.dart';
 import 'common/url_button.dart';
@@ -76,7 +77,7 @@ class ConductorSubstepsState extends State<CodesignEngineSubsteps> {
 
   @override
   Widget build(BuildContext context) {
-    final Map<String, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
+    final Map<ConductorStatusEntry, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
 
     return Column(
       children: <Widget>[
@@ -102,14 +103,15 @@ class ConductorSubstepsState extends State<CodesignEngineSubsteps> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               SelectableText(CodesignEngineSubsteps.substepSubtitles[CodesignEngineSubstep.postSubmitCI]!),
-              releaseStatus == null || releaseStatus['Release Channel'] == null
+              releaseStatus == null || releaseStatus[ConductorStatusEntry.releaseChannel] == null
                   ? Text(
                       CodesignEngineSubsteps.releaseChannelMissingErr,
                       style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.red),
                     )
                   : UrlButton(
-                      textToDisplay: luciConsoleLink(releaseStatus['Release Channel'] as String, 'engine'),
-                      urlOrUri: luciConsoleLink(releaseStatus['Release Channel'] as String, 'engine'),
+                      textToDisplay:
+                          luciConsoleLink(releaseStatus[ConductorStatusEntry.releaseChannel] as String, 'engine'),
+                      urlOrUri: luciConsoleLink(releaseStatus[ConductorStatusEntry.releaseChannel] as String, 'engine'),
                     ),
             ],
           ),

--- a/release_dashboard/lib/widgets/codesign_engine_substeps.dart
+++ b/release_dashboard/lib/widgets/codesign_engine_substeps.dart
@@ -59,9 +59,8 @@ class ConductorSubstepsState extends State<CodesignEngineSubsteps> {
 
   @override
   void initState() {
-    /// If [substep] is false, that [substep] is unchecked, otherwise, it is checked.
-    ///
-    /// All substeps are unchecked at the beginning.
+    // If [substep] is false, that [substep] is unchecked, otherwise, it is checked.
+    // All substeps are unchecked at the beginning.
     for (final CodesignEngineSubstep substep in CodesignEngineSubstep.values) {
       _isEachSubstepChecked[substep] = false;
     }

--- a/release_dashboard/lib/widgets/common/url_button.dart
+++ b/release_dashboard/lib/widgets/common/url_button.dart
@@ -17,6 +17,8 @@ class UrlButton extends StatelessWidget {
     required this.urlOrUri,
   }) : super(key: key);
 
+// TODO(Yugue): [release_dashboard] UrlButton textToDisplay should be a widget
+// https://github.com/flutter/flutter/issues/93931
   final String textToDisplay;
   final String urlOrUri;
 

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -51,7 +51,7 @@ class ConductorStatusState extends State<ConductorStatus> {
   @override
   Widget build(BuildContext context) {
     final Map<ConductorStatusEntry, Object>? releaseStatus = context.watch<StatusState>().releaseStatus;
-    if (context.watch<StatusState>().releaseStatus == null) {
+    if (releaseStatus == null) {
       return const SelectableText('No persistent state file. Try starting a release.');
     }
 
@@ -67,7 +67,7 @@ class ConductorStatusState extends State<ConductorStatus> {
               TableRow(
                 children: <Widget>[
                   Text('${headerElement.value}:'),
-                  SelectableText(statusElementToString(releaseStatus![headerElement.key])),
+                  SelectableText(statusElementToString(releaseStatus[headerElement.key])),
                 ],
               ),
           ],
@@ -76,10 +76,10 @@ class ConductorStatusState extends State<ConductorStatus> {
         Wrap(
           children: <Widget>[
             Column(
-              children: const <Widget>[
-                RepoInfoExpansion(engineOrFramework: 'engine'),
-                SizedBox(height: 10.0),
-                CherrypickTable(engineOrFramework: 'engine'),
+              children: <Widget>[
+                RepoInfoExpansion(engineOrFramework: 'engine', releaseStatus: releaseStatus),
+                const SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'engine', releaseStatus: releaseStatus),
               ],
             ),
             const SizedBox(width: 20.0),

--- a/release_dashboard/lib/widgets/conductor_status.dart
+++ b/release_dashboard/lib/widgets/conductor_status.dart
@@ -76,10 +76,10 @@ class ConductorStatusState extends State<ConductorStatus> {
         Wrap(
           children: <Widget>[
             Column(
-              children: <Widget>[
-                RepoInfoExpansion(engineOrFramework: 'engine', releaseStatus: releaseStatus),
-                const SizedBox(height: 10.0),
-                CherrypickTable(engineOrFramework: 'engine', releaseStatus: releaseStatus),
+              children: const <Widget>[
+                RepoInfoExpansion(engineOrFramework: 'engine'),
+                SizedBox(height: 10.0),
+                CherrypickTable(engineOrFramework: 'engine'),
               ],
             ),
             const SizedBox(width: 20.0),

--- a/release_dashboard/lib/widgets/create_release_substeps.dart
+++ b/release_dashboard/lib/widgets/create_release_substeps.dart
@@ -32,7 +32,7 @@ class CreateReleaseSubsteps extends StatefulWidget {
   @override
   State<CreateReleaseSubsteps> createState() => CreateReleaseSubstepsState();
 
-  static Map<CreateReleaseSubstep, String> substepTitles = <CreateReleaseSubstep, String>{
+  static const Map<CreateReleaseSubstep, String> substepTitles = <CreateReleaseSubstep, String>{
     CreateReleaseSubstep.candidateBranch: 'Candidate Branch',
     CreateReleaseSubstep.releaseChannel: 'Release Channel',
     CreateReleaseSubstep.frameworkMirror: 'Framework Mirror',
@@ -42,6 +42,9 @@ class CreateReleaseSubsteps extends StatefulWidget {
     CreateReleaseSubstep.dartRevision: 'Dart Revision (if necessary)',
     CreateReleaseSubstep.increment: 'Increment',
   };
+
+  static const List<String> releaseChannels = <String>['dev', 'beta', 'stable'];
+  static const List<String> releaseIncrements = <String>['y', 'z', 'm', 'n'];
 }
 
 class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
@@ -111,7 +114,7 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
           substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!,
           releaseData: releaseData,
           setReleaseData: setReleaseData,
-          options: const <String>['dev', 'beta', 'stable'],
+          options: CreateReleaseSubsteps.releaseChannels,
           changeIsDropdownValid: changeIsEachInputValid,
         ),
         InputAsSubstep(
@@ -153,7 +156,7 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
           substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!,
           releaseData: releaseData,
           setReleaseData: setReleaseData,
-          options: const <String>['y', 'z', 'm', 'n'],
+          options: CreateReleaseSubsteps.releaseIncrements,
           changeIsDropdownValid: changeIsEachInputValid,
         ),
         const SizedBox(height: 20.0),

--- a/release_dashboard/lib/widgets/engine_cherrypicks_substeps.dart
+++ b/release_dashboard/lib/widgets/engine_cherrypicks_substeps.dart
@@ -52,7 +52,7 @@ class ConductorSubstepsState extends State<EngineCherrypicksSubsteps> {
 
   @override
   void initState() {
-    /// If [substep] in [_isEachSubstepChecked] is false, that [substep] is unchecked, otherwise, it is checked.
+    /// If [substep] is false, that substep is unchecked, otherwise, it is checked.
     ///
     /// All substeps are unchecked at the beginning.
     for (final EngineCherrypicksSubstep substep in EngineCherrypicksSubstep.values) {
@@ -61,7 +61,7 @@ class ConductorSubstepsState extends State<EngineCherrypicksSubsteps> {
     super.initState();
   }
 
-  /// Toggle the boolean value of [substepName] in [_isEachSubstepChecked].
+  /// Toggle the boolean value [substepName].
   void substepPressed(EngineCherrypicksSubstep substep) {
     setState(() {
       _isEachSubstepChecked[substep] = !_isEachSubstepChecked[substep]!;

--- a/release_dashboard/lib/widgets/progression.dart
+++ b/release_dashboard/lib/widgets/progression.dart
@@ -5,6 +5,7 @@
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
 
+import 'codesign_engine_substeps.dart';
 import 'conductor_status.dart';
 import 'create_release_substeps.dart';
 import 'engine_cherrypicks_substeps.dart';
@@ -28,7 +29,7 @@ class MainProgression extends StatefulWidget {
   static const List<String> _stepTitles = <String>[
     'Initialize a New Flutter Release',
     'Apply Engine Cherrypicks',
-    'Apply Framework Cherrypicks',
+    'Codesign Engine Binaries',
     'Publish the Release',
     'Release is Successfully published'
   ];
@@ -46,7 +47,7 @@ class MainProgressionState extends State<MainProgression> {
     }
   }
 
-  /// Change each step's state according to [_completedStep].
+  /// Change each step's state according to the current completed step.
   StepState handleStepState(int index) {
     if (_completedStep > index) {
       return StepState.complete;
@@ -102,7 +103,7 @@ class MainProgressionState extends State<MainProgression> {
                   title: Text(MainProgression._stepTitles[2]),
                   content: Column(
                     children: <Widget>[
-                      ConductorSubsteps(nextStep: nextStep),
+                      CodesignEngineSubsteps(nextStep: nextStep),
                     ],
                   ),
                   isActive: true,

--- a/release_dashboard/test/widgets/codesign_engine_substeps_test.dart
+++ b/release_dashboard/test/widgets/codesign_engine_substeps_test.dart
@@ -1,0 +1,123 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_core/conductor_core.dart';
+import 'package:conductor_core/proto.dart' as pb;
+import 'package:conductor_ui/state/status_state.dart';
+import 'package:conductor_ui/widgets/codesign_engine_substeps.dart';
+import 'package:conductor_ui/widgets/common/url_button.dart';
+import 'package:conductor_ui/widgets/create_release_substeps.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../src/services/fake_conductor.dart';
+
+void main() {
+  group('UI tests', () {
+    testWidgets('Titles and subtitles of checkboxes are rendered correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (context) => StatusState(conductor: FakeConductor()),
+          child: MaterialApp(
+            home: Material(
+              child: CodesignEngineSubsteps(nextStep: () {}),
+            ),
+          ),
+        ),
+      );
+
+      for (final CodesignEngineSubstep substep in CodesignEngineSubstep.values) {
+        expect(find.text(CodesignEngineSubsteps.substepTitles[substep]!), findsOneWidget);
+        expect(find.text(CodesignEngineSubsteps.substepSubtitles[substep]!), findsOneWidget);
+      }
+    });
+
+    group('Validate post-submit CI', () {
+      for (final String releaseChannel in CreateReleaseSubsteps.releaseChannels) {
+        testWidgets('Displays the correct $releaseChannel LUCI dashboard URL', (WidgetTester tester) async {
+          final pb.ConductorState testState = pb.ConductorState(
+            releaseChannel: releaseChannel,
+          );
+          await tester.pumpWidget(
+            ChangeNotifierProvider(
+              create: (context) => StatusState(conductor: FakeConductor(testState: testState)),
+              child: MaterialApp(
+                home: Material(
+                  child: CodesignEngineSubsteps(nextStep: () {}),
+                ),
+              ),
+            ),
+          );
+
+          expect(find.text(luciConsoleLink(releaseChannel, 'engine')), findsOneWidget);
+          expect(find.byType(UrlButton), findsOneWidget);
+        });
+      }
+    });
+
+    testWidgets('Validate post-submit CI displays an error message if state is null', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (context) => StatusState(conductor: FakeConductor()),
+          child: MaterialApp(
+            home: Material(
+              child: CodesignEngineSubsteps(nextStep: () {}),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(CodesignEngineSubsteps.releaseChannelMissingErr), findsOneWidget);
+      expect(find.byType(UrlButton), findsNothing);
+    });
+  });
+
+  group('Checksteps and continue button logic tests', () {
+    testWidgets('Continue button appears when all substeps are checked', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (context) => StatusState(conductor: FakeConductor()),
+          child: MaterialApp(
+            home: Material(
+              child: CodesignEngineSubsteps(nextStep: () {}),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('CodesignEngineSubstepsContinue')), findsNothing);
+
+      for (final CodesignEngineSubstep substep in CodesignEngineSubstep.values) {
+        await tester.tap(find.text(CodesignEngineSubsteps.substepTitles[substep]!));
+      }
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('CodesignEngineSubstepsContinue')), findsOneWidget);
+    });
+
+    testWidgets('Click on the continue button proceeds to the next step', (WidgetTester tester) async {
+      bool isNextStep = false;
+      void nextStep() => isNextStep = true;
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (context) => StatusState(conductor: FakeConductor()),
+          child: MaterialApp(
+            home: Material(
+              child: CodesignEngineSubsteps(nextStep: nextStep),
+            ),
+          ),
+        ),
+      );
+
+      for (final CodesignEngineSubstep substep in CodesignEngineSubstep.values) {
+        await tester.tap(find.text(CodesignEngineSubsteps.substepTitles[substep]!));
+      }
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('CodesignEngineSubstepsContinue')));
+      await tester.pumpAndSettle();
+      expect(isNextStep, equals(true));
+    });
+  });
+}


### PR DESCRIPTION
Made UI for the substeps of the step `Codesign Engine Binaries`. The CI dashboard link changes according to the release channel.

Main Issue: 
- [x] https://github.com/flutter/flutter/issues/93751


Screen Capture:

![image](https://user-images.githubusercontent.com/20194490/142701190-7cd4a79a-07d2-4d01-96ac-f72f2196f1c2.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
