### PR TITLE
[ci.yaml] Support branch regexes

### DIFF
--- a/CI_YAML.md
+++ b/CI_YAML.md
@@ -15,9 +15,12 @@ are welcome.
 Example config:
 ```yaml
 # /.ci.yaml
+
+# Enabled branches is a list of regexes, with the assumption that these are full line matches.
+# Internally, Cocoon prefixes these with $ and suffixes with ^ to enable matches.
 enabled_branches:
-  - master
-  - flutter-\\d+.\\d+-candidate.\\d+
+  - main
+  - flutter-\\d+\\.\\d+-candidate\\.\\d+
 
 targets:
 # A Target is an individual unit of work that is scheduled by Flutter infra

--- a/CI_YAML.md
+++ b/CI_YAML.md
@@ -17,7 +17,7 @@ Example config:
 # /.ci.yaml
 enabled_branches:
   - master
-  - flutter-\d+.\d+-candidate.\d+
+  - flutter-\\d+.\\d+-candidate.\\d+
 
 targets:
 # A Target is an individual unit of work that is scheduled by Flutter infra

--- a/CI_YAML.md
+++ b/CI_YAML.md
@@ -17,6 +17,8 @@ Example config:
 # /.ci.yaml
 enabled_branches:
   - master
+  - flutter-\d+.\d+-candidate.\d+
+
 targets:
 # A Target is an individual unit of work that is scheduled by Flutter infra
 # Target's are composed of the following properties:

--- a/app_dart/integration_test/validate_all_ci_configs_test.dart
+++ b/app_dart/integration_test/validate_all_ci_configs_test.dart
@@ -2,9 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:core';
+import 'dart:io';
+
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
+import 'package:cocoon_service/src/model/proto/internal/scheduler.pbserver.dart' as pb;
 import 'package:github/github.dart';
 import 'package:http/http.dart' as http;
+import 'package:process/process.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
@@ -13,7 +19,7 @@ import 'common.dart';
 /// List of repositories that have supported .ci.yaml config files.
 final List<SupportedConfig> configs = <SupportedConfig>[
   SupportedConfig(RepositorySlug('flutter', 'cocoon'), 'main'),
-  SupportedConfig(RepositorySlug('flutter', 'engine')),
+  SupportedConfig(RepositorySlug('flutter', 'engine'), 'main'),
   SupportedConfig(RepositorySlug('flutter', 'flutter')),
   SupportedConfig(RepositorySlug('flutter', 'packages')),
   SupportedConfig(RepositorySlug('flutter', 'plugins')),
@@ -35,5 +41,72 @@ Future<void> main() async {
         fail(e.message);
       }
     });
+
+    test('validate enabled branches of $config', () async {
+      final String configContent = await githubFileContent(
+        config.slug,
+        kCiYamlPath,
+        httpClientProvider: () => http.Client(),
+        ref: config.branch,
+      );
+      final YamlMap configYaml = loadYaml(configContent) as YamlMap;
+      final pb.SchedulerConfig schedulerConfig = schedulerConfigFromYaml(configYaml);
+      final List<String> githubBranches = getBranchesForRepository(config.slug);
+
+      final Map<String, bool> validEnabledBranches = <String, bool>{};
+      // Add config wide enabled branches
+      for (String enabledBranch in schedulerConfig.enabledBranches) {
+        validEnabledBranches[enabledBranch] = false;
+      }
+      // Add all target specific enabled branches
+      for (pb.Target target in schedulerConfig.targets) {
+        for (String enabledBranch in target.enabledBranches) {
+          validEnabledBranches[enabledBranch] = false;
+        }
+      }
+
+      // N^2 scan to verify all enabled branch patterns match an exist branch on the repo.
+      for (String enabledBranch in validEnabledBranches.keys) {
+        for (String githubBranch in githubBranches) {
+          if (CiYaml.enabledBranchesMatchesCurrentBranch(<String>[enabledBranch], githubBranch)) {
+            validEnabledBranches[enabledBranch] = true;
+          }
+        }
+      }
+
+      if (config.slug.name == 'engine') {
+        print(githubBranches);
+        print(validEnabledBranches);
+      }
+
+      // Verify the enabled branches
+      for (String enabledBranch in validEnabledBranches.keys) {
+        expect(validEnabledBranches[enabledBranch], isTrue,
+            reason: '$enabledBranch does not match to a branch in ${config.slug.fullName}');
+      }
+    }, skip: config.slug.name == 'flutter');
   }
+}
+
+/// Gets all branches for [slug].
+///
+/// Internally, uses the git on path to get the branches from the remote for [slug].
+List<String> getBranchesForRepository(RepositorySlug slug) {
+  const ProcessManager processManager = LocalProcessManager();
+  final ProcessResult result =
+      processManager.runSync(<String>['git', 'ls-remote', '--head', 'https://github.com/${slug.fullName}']);
+  final List<String> lines = (result.stdout as String).split('\n');
+
+  final List<String> githubBranches = <String>[];
+  for (String line in lines) {
+    if (line.isEmpty) {
+      continue;
+    }
+    // Lines follow the format of `$sha\t$ref`
+    final String ref = line.split('\t')[1];
+    final String branch = ref.replaceAll('refs/heads/', '');
+    githubBranches.add(branch);
+  }
+
+  return githubBranches;
 }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -62,8 +62,8 @@ class CiYaml {
   /// Filter [targets] to only those that are expected to run for [branch].
   ///
   /// A [Target] is expected to run if:
-  ///   1. [Target.enabledBranches] exists and contains [branch].
-  ///   2. Otherwise, [config.enabledBranches] contains [branch].
+  ///   1. [Target.enabledBranches] exists and matches [branch].
+  ///   2. Otherwise, [config.enabledBranches] matches [branch].
   List<Target> _filterEnabledTargets(Iterable<Target> targets) {
     final List<Target> filteredTargets = <Target>[];
 
@@ -71,11 +71,11 @@ class CiYaml {
     final Iterable<Target> overrideBranchTargets =
         targets.where((Target target) => target.value.enabledBranches.isNotEmpty);
     final Iterable<Target> enabledTargets =
-        overrideBranchTargets.where((Target target) => target.value.enabledBranches.contains(branch));
+        overrideBranchTargets.where((Target target) => RegExp(target.value.enabledBranches.join('|')).hasMatch(branch));
     filteredTargets.addAll(enabledTargets);
 
     // 2. Add targets with global definition (this is the majority of targets)
-    if (config.enabledBranches.contains(branch)) {
+    if (RegExp(config.enabledBranches.join('|')).hasMatch(branch)) {
       final Iterable<Target> defaultBranchTargets =
           targets.where((Target target) => target.value.enabledBranches.isEmpty);
       filteredTargets.addAll(defaultBranchTargets);

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -477,6 +477,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   pointycastle:
     dependency: transitive
     description:
@@ -491,6 +498,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
+  process:
+    dependency: "direct dev"
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.4"
   protobuf:
     dependency: "direct main"
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -36,6 +36,7 @@ dev_dependencies:
   fake_async: ^1.2.0
   json_serializable: ^6.0.0
   mockito: ^5.0.14
+  process: ^4.2.4
   test: ^1.17.11
 
 builders:

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('enabledBranchesMatchesCurrentBranch', () {
+    final List<EnabledBranchesRegexTest> tests = <EnabledBranchesRegexTest>[
+      EnabledBranchesRegexTest('matches main', 'main', <String>['main']),
+      EnabledBranchesRegexTest(
+          'matches candidate branch', 'flutter-2.4-candidate.3', <String>['flutter-\\d+\\.\\d+-candidate\\.\\d+']),
+      EnabledBranchesRegexTest('matches main when not first pattern', 'main', <String>['dev', 'main']),
+      EnabledBranchesRegexTest('does not do partial matches', 'super-main', <String>['main'], false),
+    ];
+
+    for (EnabledBranchesRegexTest regexTest in tests) {
+      test(regexTest.name, () {
+        expect(CiYaml.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
+            regexTest.expectation);
+      });
+    }
+  });
+}
+
+/// Wrapper class for table driven design of [CiYaml.enabledBranchesMatchesCurrentBranch].
+class EnabledBranchesRegexTest {
+  EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches, [this.expectation = true]);
+
+  final String branch;
+  final List<String> enabledBranches;
+  final String name;
+  final bool expectation;
+}

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
@@ -44,6 +43,7 @@ targets:
       - stable
     scheduler: luci
   - name: Google Internal Roll
+    postsubmit: true
     presubmit: false
     scheduler: google_internal
 ''';
@@ -291,11 +291,13 @@ enabled_branches:
   - master
 targets:
   - name: Linux A
+    presubmit: true
     scheduler: luci
   - name: Linux B
     scheduler: luci
     enabled_branches:
       - stable
+    presubmit: true
   - name: Linux C
     scheduler: luci
     enabled_branches:
@@ -304,10 +306,12 @@ targets:
   - name: Linux D
     scheduler: luci
     bringup: true
+    presubmit: true
   - name: Google-internal roll
     scheduler: google_internal
     enabled_branches:
       - master
+    presubmit: true
           ''', 200);
           }
           throw Exception('Failed to find ${request.url.path}');
@@ -327,6 +331,7 @@ enabled_branches:
   - master
 targets:
   - name: Linux A
+    presubmit: true
     scheduler: luci
           ''', 200);
           }
@@ -385,34 +390,10 @@ targets:
             <dynamic>[CheckRunStatus.completed, CheckRunConclusion.success]);
       });
 
-      test('ci.yaml validation passes with retry', () async {
-        bool retried = false;
-        httpClient = MockClient((http.Request request) async {
-          if (request.url.path.contains('.ci.yaml')) {
-            if (retried) {
-              return http.Response(singleCiYaml, HttpStatus.ok);
-            }
-            retried = true;
-            return http.Response('FAILURE', HttpStatus.internalServerError);
-          }
-          throw Exception('Failed to find ${request.url.path}');
-        });
-        when(mockGithubChecksUtil.getCheckRun(any, any, any))
-            .thenAnswer((Invocation invocation) async => createCheckRun(id: 0));
-        await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
-        expect(
-            verify(mockGithubChecksUtil.updateCheckRun(any, any, any,
-                    status: captureAnyNamed('status'),
-                    conclusion: captureAnyNamed('conclusion'),
-                    output: anyNamed('output')))
-                .captured,
-            <dynamic>[CheckRunStatus.completed, CheckRunConclusion.success]);
-      });
-
       test('ci.yaml validation fails with empty config', () async {
         httpClient = MockClient((http.Request request) async {
           if (request.url.path.contains('.ci.yaml')) {
-            return http.Response('', HttpStatus.ok);
+            return http.Response('', 200);
           }
           throw Exception('Failed to find ${request.url.path}');
         });


### PR DESCRIPTION
This makes the release process easier. Instead of adding the candidate branch each time to the ci.yaml, we can insert the regex from this test and forget about the step.

Fixes https://github.com/flutter/flutter/issues/84356

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
