### PR TITLE
Remove use of primaryBrightnessColor.

### DIFF
--- a/dashboard/lib/widgets/app_bar.dart
+++ b/dashboard/lib/widgets/app_bar.dart
@@ -23,14 +23,15 @@ class CocoonAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
     return AppBar(
       title: title,
       backgroundColor: backgroundColor,
       actions: <Widget>[
         ...?actions,
         if (actions != null && actions.isNotEmpty) const SizedBox(width: 8),
-        const SignInButton(),
+        const SignInButton(
+          colorBrightness: Brightness.dark,
+        ),
       ],
     );
   }

--- a/dashboard/lib/widgets/app_bar.dart
+++ b/dashboard/lib/widgets/app_bar.dart
@@ -23,14 +23,15 @@ class CocoonAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return AppBar(
       title: title,
       backgroundColor: backgroundColor,
       actions: <Widget>[
         ...?actions,
         if (actions != null && actions.isNotEmpty) const SizedBox(width: 8),
-        const SignInButton(
-          colorBrightness: Brightness.dark,
+        SignInButton(
+          colorBrightness: theme.brightness == Brightness.light ? Brightness.dark : Brightness.light,
         ),
       ],
     );

--- a/dashboard/lib/widgets/app_bar.dart
+++ b/dashboard/lib/widgets/app_bar.dart
@@ -30,9 +30,7 @@ class CocoonAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: <Widget>[
         ...?actions,
         if (actions != null && actions.isNotEmpty) const SizedBox(width: 8),
-        SignInButton(
-          colorBrightness: theme.appBarTheme.systemOverlayStyle ?? theme.primaryColorBrightness,
-        ),
+        const SignInButton(),
       ],
     );
   }


### PR DESCRIPTION
This is to fix the analyzer error complaining about the deprecation of primaryBrightnessColor.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
