### PR TITLE
Use main as default branch when pushing tree status.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -86,16 +86,16 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       }
     });
     await _insertBigquery(slug, status, defaultBranch, config);
-    await _updatePRs(slug, status, datastore);
+    await _updatePRs(slug, status, datastore, defaultBranch);
     log.fine('All the PRs for $repo have been updated with $status');
 
     return Body.empty;
   }
 
-  Future<void> _updatePRs(RepositorySlug slug, String status, DatastoreService datastore) async {
+  Future<void> _updatePRs(RepositorySlug slug, String status, DatastoreService datastore, String defaultBranch) async {
     final GitHub github = await config.createGitHubClient(slug: slug);
     final List<GithubBuildStatusUpdate> updates = <GithubBuildStatusUpdate>[];
-    await for (PullRequest pr in github.pullRequests.list(slug, base: config.defaultBranch)) {
+    await for (PullRequest pr in github.pullRequests.list(slug, base: defaultBranch)) {
       final GithubBuildStatusUpdate update = await datastore.queryLastStatusUpdate(slug, pr);
       if (update.status != status) {
         log.fine('Updating status of ${slug.fullName}#${pr.number} from ${update.status} to $status');


### PR DESCRIPTION
While other parts of the handler to push status to github where using
the correct branch the logic to update the status in github was still
using master.

Bug: https://github.com/flutter/flutter/issues/93872

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
