### PR TITLE
[release_conductor] add dialogue prompt with input confirmation

### DIFF
--- a/release_dashboard/lib/widgets/clean_release_button.dart
+++ b/release_dashboard/lib/widgets/clean_release_button.dart
@@ -21,10 +21,12 @@ class CleanReleaseButton extends StatefulWidget {
   final ConductorService conductor;
 
   @override
-  State<CleanReleaseButton> createState() => _CleanReleaseState();
+  State<CleanReleaseButton> createState() => _CleanReleaseButtonState();
+
+  static const String requiredConfirmationString = 'clean release';
 }
 
-class _CleanReleaseState extends State<CleanReleaseButton> {
+class _CleanReleaseButtonState extends State<CleanReleaseButton> {
   String? _errorMsg;
 
   void _updateErrorMsg(String? errorMsg) {
@@ -40,21 +42,25 @@ class _CleanReleaseState extends State<CleanReleaseButton> {
       child: IconButton(
         key: const Key('conductorClean'),
         icon: const Icon(Icons.delete),
-        onPressed: () {
-          dialogPrompt(
-            context: context,
-            title: 'Are you sure you want to clean up the current release?',
-            content: 'This will abort and delete a work in progress release. This process is not revertible!',
-            leftOptionTitle: 'Yes',
-            rightOptionTitle: 'No',
-            leftOptionCallback: () {
+        onPressed: () => showDialog(
+          context: context,
+          builder: (_) => DialogPromptInputConfirm(
+            confirmationString: CleanReleaseButton.requiredConfirmationString,
+            title: Text(
+              'Are you sure you want to clean up the current releas?',
+              style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.red),
+            ),
+            content: const Text('This will abort and delete a release in progress. This process is not reversible!'),
+            leftButtonTitle: 'No',
+            rightButtonTitle: 'Yes',
+            rightButtonCallback: () {
               _updateErrorMsg('Feature has not been implemented yet. Please use conductor clean of the CLI tool!');
               if (_errorMsg != null) {
                 snackbarPrompt(context: context, msg: _errorMsg!);
               }
             },
-          );
-        },
+          ),
+        ),
         tooltip: 'Clean up the current release.',
       ),
     );

--- a/release_dashboard/lib/widgets/clean_release_button.dart
+++ b/release_dashboard/lib/widgets/clean_release_button.dart
@@ -50,7 +50,7 @@ class _CleanReleaseButtonState extends State<CleanReleaseButton> {
               'Are you sure you want to clean up the current releas?',
               style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.red),
             ),
-            content: const Text('This will abort and delete a release in progress. This process is not reversible!'),
+            content: const Text('This will abort and delete a release in progress. This process is irreversible!'),
             leftButtonTitle: 'No',
             rightButtonTitle: 'Yes',
             rightButtonCallback: () {

--- a/release_dashboard/lib/widgets/clean_release_button.dart
+++ b/release_dashboard/lib/widgets/clean_release_button.dart
@@ -44,16 +44,16 @@ class _CleanReleaseButtonState extends State<CleanReleaseButton> {
         icon: const Icon(Icons.delete),
         onPressed: () => showDialog(
           context: context,
-          builder: (_) => DialogPromptInputConfirm(
+          builder: (_) => DialogPromptConfirmInput(
             confirmationString: CleanReleaseButton.requiredConfirmationString,
             title: Text(
-              'Are you sure you want to clean up the current releas?',
+              'Are you sure you want to clean up the current release',
               style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.red),
             ),
             content: const Text('This will abort and delete a release in progress. This process is irreversible!'),
             leftButtonTitle: 'No',
             rightButtonTitle: 'Yes',
-            rightButtonCallback: () {
+            rightButtonCallback: () async {
               _updateErrorMsg('Feature has not been implemented yet. Please use conductor clean of the CLI tool!');
               if (_errorMsg != null) {
                 snackbarPrompt(context: context, msg: _errorMsg!);

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 typedef DynamicFuture = Future<dynamic> Function();
 
-/// Function that prompts an alert to the current window and forces the user to choose between two options.
+/// Prompts an alert to the current window and forces the user to choose between two options.
 Future<String?> dialogPrompt({
   required BuildContext context,
   required Widget title,

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -4,37 +4,113 @@
 
 import 'package:flutter/material.dart';
 
-/// Widget that prompts an alert dialogue to the current window and forces the user to choose between two options.
+/// Function that prompts an alert to the current window and forces the user to choose between two options.
 Future<String?> dialogPrompt({
   required BuildContext context,
-  required String title,
-  required String content,
-  required String leftOptionTitle,
-  required String rightOptionTitle,
-  VoidCallback? leftOptionCallback,
-  VoidCallback? rightOptionCallback,
+  required Widget title,
+  required Widget? content,
+  required String leftButtonTitle,
+  required String rightButtonTitle,
+  VoidCallback? leftButtonCallback,
+  VoidCallback? rightButtonCallback,
 }) {
   return showDialog<String>(
     context: context,
     builder: (BuildContext context) => AlertDialog(
-      title: Text(title),
-      content: Text(content),
+      title: title,
+      content: content,
       actions: <Widget>[
         TextButton(
           onPressed: () {
-            if (leftOptionCallback != null) leftOptionCallback();
-            Navigator.pop(context, leftOptionTitle);
+            if (leftButtonCallback != null) leftButtonCallback();
+            Navigator.pop(context, leftButtonTitle);
           },
-          child: Text(leftOptionTitle),
+          child: Text(leftButtonTitle),
         ),
         TextButton(
           onPressed: () {
-            if (rightOptionCallback != null) rightOptionCallback();
-            Navigator.pop(context, rightOptionTitle);
+            if (rightButtonCallback != null) rightButtonCallback();
+            Navigator.pop(context, rightButtonTitle);
           },
-          child: Text(rightOptionTitle),
+          child: Text(rightButtonTitle),
         ),
       ],
     ),
   );
+}
+
+/// Widget that prompts an alert to the current window and forces the user to choose between two options.
+///
+/// User also has to input [confirmationString] as an extra layer of validation.
+/// The right button becomes enabled when [_userInput] matches [confirmationString], otherwise it is disabled.
+class DialogPromptInputConfirm extends StatefulWidget {
+  const DialogPromptInputConfirm({
+    required this.title,
+    required this.content,
+    required this.leftButtonTitle,
+    required this.rightButtonTitle,
+    required this.confirmationString,
+    this.leftButtonCallback,
+    this.rightButtonCallback,
+    Key? key,
+  }) : super(key: key);
+
+  final Widget title;
+  final Widget? content;
+  final String leftButtonTitle;
+  final String rightButtonTitle;
+  final String confirmationString;
+  final VoidCallback? leftButtonCallback;
+  final VoidCallback? rightButtonCallback;
+
+  @override
+  State<DialogPromptInputConfirm> createState() => _DialogPromptInputConfirmState();
+}
+
+class _DialogPromptInputConfirmState extends State<DialogPromptInputConfirm> {
+  String _userInput = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: widget.title,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (widget.content != null) widget.content!,
+          TextFormField(
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            decoration: InputDecoration(
+              labelText: "Please type '${widget.confirmationString}' to confirm",
+            ),
+            onChanged: (String data) {
+              setState(() {
+                _userInput = data;
+              });
+            },
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          key: Key(widget.leftButtonTitle),
+          onPressed: () {
+            if (widget.leftButtonCallback != null) widget.leftButtonCallback!();
+            Navigator.pop(context, widget.leftButtonTitle);
+          },
+          child: Text(widget.leftButtonTitle),
+        ),
+        TextButton(
+          key: Key(widget.rightButtonTitle),
+          onPressed: _userInput == widget.confirmationString
+              ? () {
+                  if (widget.rightButtonCallback != null) widget.rightButtonCallback!();
+                  Navigator.pop(context, widget.rightButtonTitle);
+                }
+              : null,
+          child: Text(widget.rightButtonTitle),
+        ),
+      ],
+    );
+  }
 }

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -45,6 +45,8 @@ Future<String?> dialogPrompt({
       title: title,
       content: content,
       actions: <Widget>[
+        // TODO(Yugue): Add loading button to dialog_prompt action button,
+        // https://github.com/flutter/flutter/issues/94079.
         TextButton(
           onPressed: () async {
             if (leftButtonCallback != null) await leftButtonCallback();

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -7,6 +7,29 @@ import 'package:flutter/material.dart';
 typedef DynamicFuture = Future<dynamic> Function();
 
 /// Prompts an alert to the current window and forces the user to choose between two options.
+///
+/// The `context` argument is used to look up the [Navigator] for the dialog.
+/// It is only used when the method is called.
+///
+/// The `title` argument is used to display a [Widget] at the topmost area of the dialogue.
+///
+/// The `content` argument is used to display an optional [Widget] below the `title`.
+///
+/// The `leftButtonTitle` argument is used to display its content in a [Text]
+/// as the child of [TextButton], which is the left button of the dialogue.
+/// It is also being used as the result of the route that is popped when
+/// the left button is clicked.
+///
+/// The `rightButtonTitle` argument is used to display its content in a [Text]
+/// as the child of [TextButton], which is the right button of the dialogue.
+/// It is also being used as the result of the route that is popped when
+/// the right button is clicked.
+///
+/// The `leftButtonCallback` argument is used to be executed right after the left
+/// button is clicked. `leftButtonCallback` must asynchronous.
+///
+/// The `rightButtonCallback` argument is used to be executed right after the right
+/// button is clicked. `rightButtonCallback` must asynchronous.
 Future<String?> dialogPrompt({
   required BuildContext context,
   required Widget title,

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/material.dart';
 
+typedef DynamicFuture = Future<dynamic> Function();
+
 /// Function that prompts an alert to the current window and forces the user to choose between two options.
 Future<String?> dialogPrompt({
   required BuildContext context,
@@ -11,8 +13,8 @@ Future<String?> dialogPrompt({
   required Widget? content,
   required String leftButtonTitle,
   required String rightButtonTitle,
-  VoidCallback? leftButtonCallback,
-  VoidCallback? rightButtonCallback,
+  DynamicFuture? leftButtonCallback,
+  DynamicFuture? rightButtonCallback,
 }) {
   return showDialog<String>(
     context: context,
@@ -21,15 +23,15 @@ Future<String?> dialogPrompt({
       content: content,
       actions: <Widget>[
         TextButton(
-          onPressed: () {
-            if (leftButtonCallback != null) leftButtonCallback();
+          onPressed: () async {
+            if (leftButtonCallback != null) await leftButtonCallback();
             Navigator.pop(context, leftButtonTitle);
           },
           child: Text(leftButtonTitle),
         ),
         TextButton(
-          onPressed: () {
-            if (rightButtonCallback != null) rightButtonCallback();
+          onPressed: () async {
+            if (rightButtonCallback != null) await rightButtonCallback();
             Navigator.pop(context, rightButtonTitle);
           },
           child: Text(rightButtonTitle),
@@ -42,9 +44,9 @@ Future<String?> dialogPrompt({
 /// Widget that prompts an alert to the current window and forces the user to choose between two options.
 ///
 /// User also has to input [confirmationString] as an extra layer of validation.
-/// The right button becomes enabled when [_userInput] matches [confirmationString], otherwise it is disabled.
-class DialogPromptInputConfirm extends StatefulWidget {
-  const DialogPromptInputConfirm({
+/// The right button becomes enabled when the user input matches [confirmationString], otherwise it is disabled.
+class DialogPromptConfirmInput extends StatefulWidget {
+  const DialogPromptConfirmInput({
     required this.title,
     required this.content,
     required this.leftButtonTitle,
@@ -60,14 +62,14 @@ class DialogPromptInputConfirm extends StatefulWidget {
   final String leftButtonTitle;
   final String rightButtonTitle;
   final String confirmationString;
-  final VoidCallback? leftButtonCallback;
-  final VoidCallback? rightButtonCallback;
+  final DynamicFuture? leftButtonCallback;
+  final DynamicFuture? rightButtonCallback;
 
   @override
-  State<DialogPromptInputConfirm> createState() => _DialogPromptInputConfirmState();
+  State<DialogPromptConfirmInput> createState() => _DialogPromptConfirmInputState();
 }
 
-class _DialogPromptInputConfirmState extends State<DialogPromptInputConfirm> {
+class _DialogPromptConfirmInputState extends State<DialogPromptConfirmInput> {
   String _userInput = '';
 
   @override
@@ -94,8 +96,8 @@ class _DialogPromptInputConfirmState extends State<DialogPromptInputConfirm> {
       actions: <Widget>[
         TextButton(
           key: Key(widget.leftButtonTitle),
-          onPressed: () {
-            if (widget.leftButtonCallback != null) widget.leftButtonCallback!();
+          onPressed: () async {
+            if (widget.leftButtonCallback != null) await widget.leftButtonCallback!();
             Navigator.pop(context, widget.leftButtonTitle);
           },
           child: Text(widget.leftButtonTitle),
@@ -103,8 +105,8 @@ class _DialogPromptInputConfirmState extends State<DialogPromptInputConfirm> {
         TextButton(
           key: Key(widget.rightButtonTitle),
           onPressed: _userInput == widget.confirmationString
-              ? () {
-                  if (widget.rightButtonCallback != null) widget.rightButtonCallback!();
+              ? () async {
+                  if (widget.rightButtonCallback != null) await widget.rightButtonCallback!();
                   Navigator.pop(context, widget.rightButtonTitle);
                 }
               : null,

--- a/release_dashboard/lib/widgets/common/dialog_prompt.dart
+++ b/release_dashboard/lib/widgets/common/dialog_prompt.dart
@@ -8,28 +8,28 @@ typedef DynamicFuture = Future<dynamic> Function();
 
 /// Prompts an alert to the current window and forces the user to choose between two options.
 ///
-/// The `context` argument is used to look up the [Navigator] for the dialog.
+/// The [context] argument is used to look up the [Navigator] for the dialog.
 /// It is only used when the method is called.
 ///
-/// The `title` argument is used to display a [Widget] at the topmost area of the dialogue.
+/// The [title] argument is used to display a [Widget] at the topmost area of the dialogue.
 ///
-/// The `content` argument is used to display an optional [Widget] below the `title`.
+/// The [content] argument is used to display an optional [Widget] below the [title].
 ///
-/// The `leftButtonTitle` argument is used to display its content in a [Text]
+/// The [leftButtonTitle] argument is used to display its content in a [Text]
 /// as the child of [TextButton], which is the left button of the dialogue.
 /// It is also being used as the result of the route that is popped when
 /// the left button is clicked.
 ///
-/// The `rightButtonTitle` argument is used to display its content in a [Text]
+/// The [rightButtonTitle] argument is used to display its content in a [Text]
 /// as the child of [TextButton], which is the right button of the dialogue.
 /// It is also being used as the result of the route that is popped when
 /// the right button is clicked.
 ///
-/// The `leftButtonCallback` argument is used to be executed right after the left
-/// button is clicked. `leftButtonCallback` must asynchronous.
+/// The [leftButtonCallback] argument is used to be executed right after the left
+/// button is clicked. [leftButtonCallback] must asynchronous.
 ///
-/// The `rightButtonCallback` argument is used to be executed right after the right
-/// button is clicked. `rightButtonCallback` must asynchronous.
+/// The [rightButtonCallback] argument is used to be executed right after the right
+/// button is clicked. [rightButtonCallback] must asynchronous.
 Future<String?> dialogPrompt({
   required BuildContext context,
   required Widget title,

--- a/release_dashboard/lib/widgets/common/snackbar_prompt.dart
+++ b/release_dashboard/lib/widgets/common/snackbar_prompt.dart
@@ -8,6 +8,11 @@ import 'package:flutter/material.dart';
 ///
 /// Clicking on 'Ok' will close the snackbar.
 /// The snackbar will stay displayed for 2 minutes unless 'Ok' is clicked.
+///
+/// The `context` argument is used to look up the [theme] for the prompt.
+///
+/// The `msg` argument is used to display a red error message as the `content`
+/// of [SnackBar].
 void snackbarPrompt({
   required BuildContext context,
   required String msg,

--- a/release_dashboard/test/widgets/clean_release_button_test.dart
+++ b/release_dashboard/test/widgets/clean_release_button_test.dart
@@ -34,6 +34,8 @@ void main() {
       await tester.tap(find.byType(CleanReleaseButton));
       await tester.pumpAndSettle();
       expect(find.byType(SnackBar), findsNothing);
+      await tester.enterText(find.byType(TextFormField), CleanReleaseButton.requiredConfirmationString);
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Yes'));
       await tester.pumpAndSettle();
       expect(find.byType(SnackBar), findsOneWidget);

--- a/release_dashboard/test/widgets/common/dialog_prompt_test.dart
+++ b/release_dashboard/test/widgets/common/dialog_prompt_test.dart
@@ -309,7 +309,7 @@ void main() {
       expect(isRightButtonCallbackCalled, equals(false));
     });
 
-    testWidgets('Right button enables when the user input is correct, disables otherwise', (WidgetTester tester) async {
+    testWidgets('Right button enables when the user input is correct', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -337,6 +337,38 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
       expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(false));
+      await tester.enterText(find.byType(TextFormField), requiredConfirmationString);
+      await tester.pumpAndSettle();
+      expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(true));
+    });
+
+    testWidgets('Right button disables when the user input becomes incorrect', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (_) => const DialogPromptConfirmInput(
+                      confirmationString: requiredConfirmationString,
+                      title: Text(title),
+                      content: Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                    ),
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextFormField), requiredConfirmationString);
       await tester.pumpAndSettle();
       expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(true));

--- a/release_dashboard/test/widgets/common/dialog_prompt_test.dart
+++ b/release_dashboard/test/widgets/common/dialog_prompt_test.dart
@@ -106,44 +106,15 @@ void main() {
       expect(find.byType(AlertDialog), findsNothing);
     });
 
-    testWidgets('Executes the left button callback when the left button is clicked', (WidgetTester tester) async {
+    testWidgets('Executes the left button callback when the left button is clicked, right callback is not called',
+        (WidgetTester tester) async {
       bool isLeftButtonCallbackCalled = false;
-      void leftButtonCallback() {
+      Future<void> leftButtonCallback() async {
         isLeftButtonCallbackCalled = true;
       }
 
-      await tester.pumpWidget(MaterialApp(
-        home: Material(
-          child: Builder(
-            builder: (BuildContext context) {
-              return ElevatedButton(
-                onPressed: () {
-                  dialogPrompt(
-                    context: context,
-                    title: const Text(title),
-                    content: const Text(content),
-                    leftButtonTitle: leftButtonTitle,
-                    rightButtonTitle: rightButtonTitle,
-                    leftButtonCallback: leftButtonCallback,
-                  );
-                },
-                child: const Text('Clean'),
-              );
-            },
-          ),
-        ),
-      ));
-
-      await tester.tap(find.byType(ElevatedButton));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(leftButtonTitle));
-      await tester.pumpAndSettle();
-      expect(isLeftButtonCallbackCalled, equals(true));
-    });
-
-    testWidgets('Executes the right button callback when the right button is clicked', (WidgetTester tester) async {
       bool isRightButtonCallbackCalled = false;
-      void rightButtonCallback() {
+      Future<void> rightButtonCallback() async {
         isRightButtonCallbackCalled = true;
       }
 
@@ -159,6 +130,50 @@ void main() {
                     content: const Text(content),
                     leftButtonTitle: leftButtonTitle,
                     rightButtonTitle: rightButtonTitle,
+                    leftButtonCallback: leftButtonCallback,
+                    rightButtonCallback: rightButtonCallback,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(leftButtonTitle));
+      await tester.pumpAndSettle();
+      expect(isLeftButtonCallbackCalled, equals(true));
+      expect(isRightButtonCallbackCalled, equals(false));
+    });
+
+    testWidgets('Executes the right button callback when the right button is clicked, left callback is not called',
+        (WidgetTester tester) async {
+      bool isLeftButtonCallbackCalled = false;
+      Future<void> leftButtonCallback() async {
+        isLeftButtonCallbackCalled = true;
+      }
+
+      bool isRightButtonCallbackCalled = false;
+      Future<void> rightButtonCallback() async {
+        isRightButtonCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
+                    leftButtonCallback: leftButtonCallback,
                     rightButtonCallback: rightButtonCallback,
                   );
                 },
@@ -173,6 +188,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text(rightButtonTitle));
       await tester.pumpAndSettle();
+      expect(isLeftButtonCallbackCalled, equals(false));
       expect(isRightButtonCallbackCalled, equals(true));
     });
   });
@@ -188,7 +204,7 @@ void main() {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => const DialogPromptInputConfirm(
+                    builder: (_) => const DialogPromptConfirmInput(
                       confirmationString: requiredConfirmationString,
                       title: Text(title),
                       content: Text(content),
@@ -207,7 +223,7 @@ void main() {
       expect(find.byType(ElevatedButton), findsOneWidget);
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      expect(find.byType(DialogPromptInputConfirm), findsOneWidget);
+      expect(find.byType(DialogPromptConfirmInput), findsOneWidget);
       expect(find.text(title), findsOneWidget);
       expect(find.text(content), findsOneWidget);
       expect(find.text(leftButtonTitle), findsOneWidget);
@@ -223,7 +239,7 @@ void main() {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => const DialogPromptInputConfirm(
+                    builder: (_) => const DialogPromptConfirmInput(
                       confirmationString: requiredConfirmationString,
                       title: Text(title),
                       content: Text(content),
@@ -241,16 +257,22 @@ void main() {
 
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      expect(find.byType(DialogPromptInputConfirm), findsOneWidget);
+      expect(find.byType(DialogPromptConfirmInput), findsOneWidget);
       await tester.tap(find.text(leftButtonTitle));
       await tester.pumpAndSettle();
-      expect(find.byType(DialogPromptInputConfirm), findsNothing);
+      expect(find.byType(DialogPromptConfirmInput), findsNothing);
     });
 
-    testWidgets('Executes the left button callback when the left button is clicked', (WidgetTester tester) async {
+    testWidgets('Executes the left button callback when the left button is clicked, right callback is not called',
+        (WidgetTester tester) async {
       bool isLeftButtonCallbackCalled = false;
-      void leftButtonCallback() {
+      Future<void> leftButtonCallback() async {
         isLeftButtonCallbackCalled = true;
+      }
+
+      bool isRightButtonCallbackCalled = false;
+      Future<void> rightButtonCallback() async {
+        isRightButtonCallbackCalled = true;
       }
 
       await tester.pumpWidget(MaterialApp(
@@ -261,13 +283,14 @@ void main() {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => DialogPromptInputConfirm(
+                    builder: (_) => DialogPromptConfirmInput(
                       confirmationString: requiredConfirmationString,
                       title: const Text(title),
                       content: const Text(content),
                       leftButtonTitle: leftButtonTitle,
                       rightButtonTitle: rightButtonTitle,
                       leftButtonCallback: leftButtonCallback,
+                      rightButtonCallback: rightButtonCallback,
                     ),
                   );
                 },
@@ -283,6 +306,7 @@ void main() {
       await tester.tap(find.text(leftButtonTitle));
       await tester.pumpAndSettle();
       expect(isLeftButtonCallbackCalled, equals(true));
+      expect(isRightButtonCallbackCalled, equals(false));
     });
 
     testWidgets('Right button enables when the user input is correct, disables otherwise', (WidgetTester tester) async {
@@ -294,7 +318,7 @@ void main() {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => const DialogPromptInputConfirm(
+                    builder: (_) => const DialogPromptConfirmInput(
                       confirmationString: requiredConfirmationString,
                       title: Text(title),
                       content: Text(content),
@@ -321,10 +345,16 @@ void main() {
       expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(false));
     });
 
-    testWidgets('Executes the right button callback when the user input is correct and the right button is clicked',
+    testWidgets(
+        'Executes the right button callback when the user input is correct and the right button is clicked, left callback is not called',
         (WidgetTester tester) async {
+      bool isLeftButtonCallbackCalled = false;
+      Future<void> leftButtonCallback() async {
+        isLeftButtonCallbackCalled = true;
+      }
+
       bool isRightButtonCallbackCalled = false;
-      void rightButtonCallback() {
+      Future<void> rightButtonCallback() async {
         isRightButtonCallbackCalled = true;
       }
 
@@ -336,12 +366,13 @@ void main() {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => DialogPromptInputConfirm(
+                    builder: (_) => DialogPromptConfirmInput(
                       confirmationString: requiredConfirmationString,
                       title: const Text(title),
                       content: const Text(content),
                       leftButtonTitle: leftButtonTitle,
                       rightButtonTitle: rightButtonTitle,
+                      leftButtonCallback: leftButtonCallback,
                       rightButtonCallback: rightButtonCallback,
                     ),
                   );
@@ -359,6 +390,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text(rightButtonTitle));
       await tester.pumpAndSettle();
+      expect(isLeftButtonCallbackCalled, equals(false));
       expect(isRightButtonCallbackCalled, equals(true));
     });
   });

--- a/release_dashboard/test/widgets/common/dialog_prompt_test.dart
+++ b/release_dashboard/test/widgets/common/dialog_prompt_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:conductor_ui/widgets/clean_release_button.dart';
 import 'package:conductor_ui/widgets/common/dialog_prompt.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,10 +10,10 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   const String title = 'Are you sure you want to clean up the persistent state file?';
   const String content = 'This will abort a work in progress release.';
-  const String leftOption = 'Yes';
-  const String rightOption = 'No';
+  const String leftButtonTitle = 'Yes';
+  const String rightButtonTitle = 'No';
 
-  group('Dialog prompt UI tests', () {
+  group('Dialog prompt without input confirmation tests', () {
     testWidgets('Appears upon clicking on a button', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
@@ -22,10 +23,10 @@ void main() {
                 onPressed: () {
                   dialogPrompt(
                     context: context,
-                    title: title,
-                    content: content,
-                    leftOptionTitle: leftOption,
-                    rightOptionTitle: rightOption,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
                   );
                 },
                 child: const Text('Clean'),
@@ -41,11 +42,11 @@ void main() {
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(find.text(title), findsOneWidget);
       expect(find.text(content), findsOneWidget);
-      expect(find.text(leftOption), findsOneWidget);
-      expect(find.text(rightOption), findsOneWidget);
+      expect(find.text(leftButtonTitle), findsOneWidget);
+      expect(find.text(rightButtonTitle), findsOneWidget);
     });
 
-    testWidgets('Disappears when the left option is clicked', (WidgetTester tester) async {
+    testWidgets('Disappears when the left button is clicked', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -54,10 +55,10 @@ void main() {
                 onPressed: () {
                   dialogPrompt(
                     context: context,
-                    title: title,
-                    content: content,
-                    leftOptionTitle: leftOption,
-                    rightOptionTitle: rightOption,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
                   );
                 },
                 child: const Text('Clean'),
@@ -69,12 +70,13 @@ void main() {
 
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      await tester.tap(find.text(leftOption));
+      expect(find.byType(AlertDialog), findsOneWidget);
+      await tester.tap(find.text(leftButtonTitle));
       await tester.pumpAndSettle();
       expect(find.byType(AlertDialog), findsNothing);
     });
 
-    testWidgets('Disappears when the right option is clicked', (WidgetTester tester) async {
+    testWidgets('Disappears when the right button is clicked', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
@@ -83,10 +85,10 @@ void main() {
                 onPressed: () {
                   dialogPrompt(
                     context: context,
-                    title: title,
-                    content: content,
-                    leftOptionTitle: leftOption,
-                    rightOptionTitle: rightOption,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
                   );
                 },
                 child: const Text('Clean'),
@@ -98,32 +100,101 @@ void main() {
 
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      await tester.tap(find.text(rightOption));
+      expect(find.byType(AlertDialog), findsOneWidget);
+      await tester.tap(find.text(rightButtonTitle));
       await tester.pumpAndSettle();
       expect(find.byType(AlertDialog), findsNothing);
+    });
+
+    testWidgets('Executes the left button callback when the left button is clicked', (WidgetTester tester) async {
+      bool isLeftButtonCallbackCalled = false;
+      void leftButtonCallback() {
+        isLeftButtonCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
+                    leftButtonCallback: leftButtonCallback,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(leftButtonTitle));
+      await tester.pumpAndSettle();
+      expect(isLeftButtonCallbackCalled, equals(true));
+    });
+
+    testWidgets('Executes the right button callback when the right button is clicked', (WidgetTester tester) async {
+      bool isRightButtonCallbackCalled = false;
+      void rightButtonCallback() {
+        isRightButtonCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  dialogPrompt(
+                    context: context,
+                    title: const Text(title),
+                    content: const Text(content),
+                    leftButtonTitle: leftButtonTitle,
+                    rightButtonTitle: rightButtonTitle,
+                    rightButtonCallback: rightButtonCallback,
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(rightButtonTitle));
+      await tester.pumpAndSettle();
+      expect(isRightButtonCallbackCalled, equals(true));
     });
   });
 
-  group('dialog prompt callback tests', () {
-    testWidgets('Executes the left option callback when the left option is clicked', (WidgetTester tester) async {
-      bool isLeftCallbackCalled = false;
-      void leftCallbackTest() {
-        isLeftCallbackCalled = true;
-      }
-
+  group('Dialog prompt with input confirmation tests', () {
+    const String requiredConfirmationString = CleanReleaseButton.requiredConfirmationString;
+    testWidgets('Appears upon clicking on a button', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
             builder: (BuildContext context) {
               return ElevatedButton(
                 onPressed: () {
-                  dialogPrompt(
+                  showDialog(
                     context: context,
-                    title: title,
-                    content: content,
-                    leftOptionTitle: leftOption,
-                    rightOptionTitle: rightOption,
-                    leftOptionCallback: leftCallbackTest,
+                    builder: (_) => const DialogPromptInputConfirm(
+                      confirmationString: requiredConfirmationString,
+                      title: Text(title),
+                      content: Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                    ),
                   );
                 },
                 child: const Text('Clean'),
@@ -133,32 +204,32 @@ void main() {
         ),
       ));
 
+      expect(find.byType(ElevatedButton), findsOneWidget);
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      await tester.tap(find.text(leftOption));
-      await tester.pumpAndSettle();
-      expect(isLeftCallbackCalled, equals(true));
+      expect(find.byType(DialogPromptInputConfirm), findsOneWidget);
+      expect(find.text(title), findsOneWidget);
+      expect(find.text(content), findsOneWidget);
+      expect(find.text(leftButtonTitle), findsOneWidget);
+      expect(find.text(rightButtonTitle), findsOneWidget);
     });
 
-    testWidgets('Executes the right option callback when the right option is clicked', (WidgetTester tester) async {
-      bool isRightCallbackCalled = false;
-      void rightCallbackTest() {
-        isRightCallbackCalled = true;
-      }
-
+    testWidgets('Disappears when the left button is clicked', (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Material(
           child: Builder(
             builder: (BuildContext context) {
               return ElevatedButton(
                 onPressed: () {
-                  dialogPrompt(
+                  showDialog(
                     context: context,
-                    title: title,
-                    content: content,
-                    leftOptionTitle: leftOption,
-                    rightOptionTitle: rightOption,
-                    rightOptionCallback: rightCallbackTest,
+                    builder: (_) => const DialogPromptInputConfirm(
+                      confirmationString: requiredConfirmationString,
+                      title: Text(title),
+                      content: Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                    ),
                   );
                 },
                 child: const Text('Clean'),
@@ -170,9 +241,125 @@ void main() {
 
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
-      await tester.tap(find.text(rightOption));
+      expect(find.byType(DialogPromptInputConfirm), findsOneWidget);
+      await tester.tap(find.text(leftButtonTitle));
       await tester.pumpAndSettle();
-      expect(isRightCallbackCalled, equals(true));
+      expect(find.byType(DialogPromptInputConfirm), findsNothing);
+    });
+
+    testWidgets('Executes the left button callback when the left button is clicked', (WidgetTester tester) async {
+      bool isLeftButtonCallbackCalled = false;
+      void leftButtonCallback() {
+        isLeftButtonCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (_) => DialogPromptInputConfirm(
+                      confirmationString: requiredConfirmationString,
+                      title: const Text(title),
+                      content: const Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                      leftButtonCallback: leftButtonCallback,
+                    ),
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(leftButtonTitle));
+      await tester.pumpAndSettle();
+      expect(isLeftButtonCallbackCalled, equals(true));
+    });
+
+    testWidgets('Right button enables when the user input is correct, disables otherwise', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (_) => const DialogPromptInputConfirm(
+                      confirmationString: requiredConfirmationString,
+                      title: Text(title),
+                      content: Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                    ),
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(false));
+      await tester.enterText(find.byType(TextFormField), requiredConfirmationString);
+      await tester.pumpAndSettle();
+      expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(true));
+      await tester.enterText(find.byType(TextFormField), '$requiredConfirmationString@');
+      await tester.pumpAndSettle();
+      expect(tester.widget<TextButton>(find.byKey(const Key(rightButtonTitle))).enabled, equals(false));
+    });
+
+    testWidgets('Executes the right button callback when the user input is correct and the right button is clicked',
+        (WidgetTester tester) async {
+      bool isRightButtonCallbackCalled = false;
+      void rightButtonCallback() {
+        isRightButtonCallbackCalled = true;
+      }
+
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (_) => DialogPromptInputConfirm(
+                      confirmationString: requiredConfirmationString,
+                      title: const Text(title),
+                      content: const Text(content),
+                      leftButtonTitle: leftButtonTitle,
+                      rightButtonTitle: rightButtonTitle,
+                      rightButtonCallback: rightButtonCallback,
+                    ),
+                  );
+                },
+                child: const Text('Clean'),
+              );
+            },
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField), requiredConfirmationString);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(rightButtonTitle));
+      await tester.pumpAndSettle();
+      expect(isRightButtonCallbackCalled, equals(true));
     });
   });
 }


### PR DESCRIPTION
User must input a confirmation string in order to clean a current release. This adds another layer of validation and security.


Main Issue:
- [x] https://github.com/flutter/flutter/issues/93817

Extras:
- [x] Existing `dialogPrompt`'s title and content accepts widgets now instead of only strings before
- [x] Naming issue


Screen recording:

https://user-images.githubusercontent.com/20194490/142506577-3493733a-b268-49b9-91a7-42fec82435c1.mov


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
