### PR TITLE
Update device doctor build script to use dart compile exe

### DIFF
--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -20,12 +20,15 @@ for %%a in (%DIR:~0,-1%) do set "BUILD_DIR=%%~dpa"
 PUSHD %BUILD_DIR%
 if exist %BUILD_DIR%\build (
         ECHO "Please remove the build directory before proceeding"
-        EXIT
+        EXIT 1
 )
 MKDIR %BUILD_DIR%\build
 
 call tool\dart-sdk\bin\pub.bat get
 call tool\dart-sdk\bin\dart.exe compile exe bin\main.dart -o build\device_doctor.exe
+IF "%ERRORLEVEL%" NEQ "0" (
+        EXIT 1
+)
 
 REM Add PATH for xcopy
 SET "PATH=%PATH%;C:\Windows\system32"

--- a/device_doctor/tool/build.bat
+++ b/device_doctor/tool/build.bat
@@ -25,7 +25,7 @@ if exist %BUILD_DIR%\build (
 MKDIR %BUILD_DIR%\build
 
 call tool\dart-sdk\bin\pub.bat get
-call tool\dart-sdk\bin\dart2native.bat bin\main.dart -o build\device_doctor.exe
+call tool\dart-sdk\bin\dart.exe compile exe bin\main.dart -o build\device_doctor.exe
 
 REM Add PATH for xcopy
 SET "PATH=%PATH%;C:\Windows\system32"

--- a/device_doctor/tool/build.sh
+++ b/device_doctor/tool/build.sh
@@ -29,7 +29,7 @@ fi
 
 mkdir -p build
 tool/dart-sdk/bin/pub get
-tool/dart-sdk/bin/dart2native bin/main.dart -o build/device_doctor
+tool/dart-sdk/bin/dart compile exe bin/main.dart -o build/device_doctor
 
 cp -f LICENSE build/
 


### PR DESCRIPTION
The device_doctor build script relied on `dart2native`, which is deprecated: https://github.com/dart-lang/sdk/issues/46100

Updating to use `dart compile exe`.

Issue: https://github.com/flutter/flutter/issues/93942