### PR TITLE
Clean up github token for test flaky bot

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -129,8 +129,6 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  Future<String> get githubFlakyBotOAuthToken => _getSingleValue('GitHubFlakyBotToken');
-
   String get wrongBaseBranchPullRequestMessage => 'This pull request was opened against a branch other than '
       '_${kDefaultBranchName}_. Since Flutter pull requests should not '
       'normally be opened against branches other than $kDefaultBranchName, I '

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -29,7 +29,6 @@ class FakeConfig implements Config {
     this.keyHelperValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
-    this.githubFlakyBotOAuthTokenValue,
     this.mergeConflictPullRequestMessageValue = 'default mergeConflictPullRequestMessageValue',
     this.missingTestsPullRequestMessageValue = 'default missingTestsPullRequestMessageValue',
     this.wrongBaseBranchPullRequestMessageValue,
@@ -74,7 +73,6 @@ class FakeConfig implements Config {
   FakeKeyHelper? keyHelperValue;
   String? oauthClientIdValue;
   String? githubOAuthTokenValue;
-  String? githubFlakyBotOAuthTokenValue;
   String mergeConflictPullRequestMessageValue;
   String missingTestsPullRequestMessageValue;
   String? wrongBaseBranchPullRequestMessageValue;
@@ -189,9 +187,6 @@ class FakeConfig implements Config {
 
   @override
   Future<String> get githubOAuthToken async => githubOAuthTokenValue ?? 'token';
-
-  @override
-  Future<String> get githubFlakyBotOAuthToken async => githubFlakyBotOAuthTokenValue!;
 
   @override
   String get mergeConflictPullRequestMessage => mergeConflictPullRequestMessageValue;


### PR DESCRIPTION
The `GitHubFlakyBotToken` was created for testing purpose, this PR cleans up related codes as we have switched to use `fluttergithubbot`.