### PR TITLE
[release_dashboard] nextContext Connect

### DIFF
--- a/release_dashboard/lib/services/conductor.dart
+++ b/release_dashboard/lib/services/conductor.dart
@@ -47,4 +47,7 @@ abstract class ConductorService {
   ///
   /// Throws an exception if the file cannot be deleted or is not found.
   Future<void> cleanRelease(BuildContext context);
+
+  /// Proceeds to the next phase of the release.
+  Future<void> conductorNext(BuildContext context);
 }

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -25,6 +25,7 @@ import 'package:provider/provider.dart';
 import '../state/status_state.dart';
 import 'conductor.dart';
 import 'release_dashboard_start_context.dart';
+import 'release_dashboard_next_context.dart';
 
 /// Service class for using the conductor in a local environment.
 ///
@@ -58,6 +59,16 @@ class LocalConductorService extends ConductorService {
       return readStateFromFile(stateFile);
     }
     return null;
+  }
+
+  Checkouts get checkouts {
+    return Checkouts(
+      parentDirectory: rootDirectory,
+      processManager: processManager,
+      fileSystem: fs,
+      platform: platform,
+      stdio: stdio,
+    );
   }
 
   @override
@@ -112,5 +123,17 @@ class LocalConductorService extends ConductorService {
     CleanContext cleanContext = CleanContext(stateFile: stateFile);
     await cleanContext.run();
     context.read<StatusState>().syncStatusWithState();
+  }
+
+  @override
+  Future<void> conductorNext(BuildContext context) async {
+    final ReleaseDashboardNextContext nextContext = ReleaseDashboardNextContext(
+      autoAccept: false,
+      force: false,
+      checkouts: checkouts,
+      stateFile: stateFile,
+      context: context,
+    );
+    await nextContext.run(state!);
   }
 }

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -110,7 +110,7 @@ class LocalConductorService extends ConductorService {
       // the methods of [BuildContext] should not be cached beyond the execution of a
       // single synchronous function.
       syncStatusWithState: context.read<StatusState>().syncStatusWithState,
-      // TODO(yugue): Add a button switch to toggle the force parameter of StartContext.
+      // TODO(yugue): Add a button switch to toggle the force parameter.
       // https://github.com/flutter/flutter/issues/94384
     );
     await startContext.run();
@@ -129,6 +129,8 @@ class LocalConductorService extends ConductorService {
   Future<void> conductorNext(BuildContext context) async {
     final ReleaseDashboardNextContext nextContext = ReleaseDashboardNextContext(
       autoAccept: false,
+      // TODO(yugue): Add a button switch to toggle the force parameter.
+      // https://github.com/flutter/flutter/issues/94384
       force: false,
       checkouts: checkouts,
       stateFile: stateFile,

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -61,15 +61,13 @@ class LocalConductorService extends ConductorService {
     return null;
   }
 
-  Checkouts get checkouts {
-    return Checkouts(
-      parentDirectory: rootDirectory,
-      processManager: processManager,
-      fileSystem: fs,
-      platform: platform,
-      stdio: stdio,
-    );
-  }
+  late final Checkouts checkouts = Checkouts(
+    parentDirectory: rootDirectory,
+    processManager: processManager,
+    fileSystem: fs,
+    platform: platform,
+    stdio: stdio,
+  );
 
   @override
   Future<void> createRelease({
@@ -83,13 +81,6 @@ class LocalConductorService extends ConductorService {
     required String releaseChannel,
     required BuildContext context,
   }) async {
-    final Checkouts checkouts = Checkouts(
-      parentDirectory: rootDirectory,
-      processManager: processManager,
-      fileSystem: fs,
-      platform: platform,
-      stdio: stdio,
-    );
     final ReleaseDashboardStartContext startContext = ReleaseDashboardStartContext(
       candidateBranch: candidateBranch,
       checkouts: checkouts,
@@ -128,13 +119,13 @@ class LocalConductorService extends ConductorService {
   @override
   Future<void> conductorNext(BuildContext context) async {
     final ReleaseDashboardNextContext nextContext = ReleaseDashboardNextContext(
+      syncStatusWithState: context.read<StatusState>().syncStatusWithState,
       autoAccept: false,
       // TODO(yugue): Add a button switch to toggle the force parameter.
       // https://github.com/flutter/flutter/issues/94384
       force: false,
       checkouts: checkouts,
       stateFile: stateFile,
-      context: context,
     );
     await nextContext.run(state!);
   }

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -24,8 +24,8 @@ import 'package:provider/provider.dart';
 
 import '../state/status_state.dart';
 import 'conductor.dart';
-import 'release_dashboard_start_context.dart';
 import 'release_dashboard_next_context.dart';
+import 'release_dashboard_start_context.dart';
 
 /// Service class for using the conductor in a local environment.
 ///

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -119,6 +119,9 @@ class LocalConductorService extends ConductorService {
   @override
   Future<void> conductorNext(BuildContext context) async {
     final ReleaseDashboardNextContext nextContext = ReleaseDashboardNextContext(
+      // [context] cannot be passed beyong this point, because values returned from
+      // the methods of [BuildContext] should not be cached beyond the execution of a
+      // single synchronous function.
       syncStatusWithState: context.read<StatusState>().syncStatusWithState,
       autoAccept: false,
       // TODO(yugue): Add a button switch to toggle the force parameter.

--- a/release_dashboard/lib/services/release_dashboard_next_context.dart
+++ b/release_dashboard/lib/services/release_dashboard_next_context.dart
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_core/conductor_core.dart';
+import 'package:conductor_core/proto.dart' as pb;
+import 'package:file/file.dart' show File;
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/status_state.dart';
+
+/// Service class for using [NextContext] in the local release dashboard environment.
+class ReleaseDashboardNextContext extends NextContext {
+  ReleaseDashboardNextContext({
+    required this.context,
+    required bool autoAccept,
+    required bool force,
+    required Checkouts checkouts,
+    required File stateFile,
+  }) : super(
+          autoAccept: autoAccept,
+          force: force,
+          checkouts: checkouts,
+          stateFile: stateFile,
+        );
+
+  final BuildContext context;
+
+  /// Update the release's state file based on the current progression.
+  ///
+  /// Sync the release status with the state after the update.
+  @override
+  void updateState(pb.ConductorState state, [List<String> logs = const <String>[]]) {
+    super.updateState(state, logs);
+    context.read<StatusState>().syncStatusWithState();
+  }
+}

--- a/release_dashboard/lib/services/release_dashboard_next_context.dart
+++ b/release_dashboard/lib/services/release_dashboard_next_context.dart
@@ -6,18 +6,15 @@ import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:file/file.dart' show File;
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
-import '../state/status_state.dart';
 
 /// Service class for using [NextContext] in the local release dashboard environment.
 class ReleaseDashboardNextContext extends NextContext {
   ReleaseDashboardNextContext({
-    required this.context,
     required bool autoAccept,
     required bool force,
     required Checkouts checkouts,
     required File stateFile,
+    required this.syncStatusWithState,
   }) : super(
           autoAccept: autoAccept,
           force: force,
@@ -25,7 +22,7 @@ class ReleaseDashboardNextContext extends NextContext {
           stateFile: stateFile,
         );
 
-  final BuildContext context;
+  final VoidCallback syncStatusWithState;
 
   /// Update the release's state file based on the current progression.
   ///
@@ -33,6 +30,6 @@ class ReleaseDashboardNextContext extends NextContext {
   @override
   void updateState(pb.ConductorState state, [List<String> logs = const <String>[]]) {
     super.updateState(state, logs);
-    context.read<StatusState>().syncStatusWithState();
+    syncStatusWithState();
   }
 }

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -49,26 +49,6 @@ class StatusState extends ChangeNotifier {
     releaseStatus = stateToMap(conductor.state);
     notifyListeners();
   }
-
-  /// Updates the release status with the latest values saved in the state file.
-  ///
-  /// Use the code below to call the method:
-  ///
-  /// {@tool snippet}
-  ///
-  /// [context] is the [BuildContext] of the widget which is calling this method.
-  /// [read] is from 'package:provider/provider.dart'.
-  ///
-  /// An example on how to call this method:
-  ///
-  /// ```dart
-  /// context.read<StatusState>().syncStatusWithState();
-  /// ```
-  /// {@end-tool}
-  void syncStatusWithState() {
-    releaseStatus = stateToMap(conductor.state);
-    notifyListeners();
-  }
 }
 
 // TODO(Yugue): Add another abstraction between services and state,

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -49,6 +49,26 @@ class StatusState extends ChangeNotifier {
     releaseStatus = stateToMap(conductor.state);
     notifyListeners();
   }
+
+  /// Updates the release status with the latest values saved in the state file.
+  ///
+  /// Use the code below to call the method:
+  ///
+  /// {@tool snippet}
+  ///
+  /// [context] is the [BuildContext] of the widget which is calling this method.
+  /// [read] is from 'package:provider/provider.dart'.
+  ///
+  /// An example on how to call this method:
+  ///
+  /// ```dart
+  /// context.read<StatusState>().syncStatusWithState();
+  /// ```
+  /// {@end-tool}
+  void syncStatusWithState() {
+    releaseStatus = stateToMap(conductor.state);
+    notifyListeners();
+  }
 }
 
 // TODO(Yugue): Add another abstraction between services and state,

--- a/release_dashboard/lib/widgets/cherrypicks_substeps.dart
+++ b/release_dashboard/lib/widgets/cherrypicks_substeps.dart
@@ -158,14 +158,13 @@ class CherrypicksSubstepsState extends State<CherrypicksSubsteps> {
             error: _error,
             onPressedCallback: () async {
               setError(null);
-              try {
-                await statusState.conductor.conductorNext(context);
-              } catch (error, stackTrace) {
+              statusState.conductor.conductorNext(context).catchError((error, stackTrace) {
                 setError(errorToString(error, stackTrace));
-              }
-              if (_error == null) {
-                widget.nextStep();
-              }
+              }).whenComplete(() {
+                if (_error == null) {
+                  widget.nextStep();
+                }
+              });
             },
             isLoading: false),
       ],

--- a/release_dashboard/lib/widgets/cherrypicks_substeps.dart
+++ b/release_dashboard/lib/widgets/cherrypicks_substeps.dart
@@ -4,11 +4,11 @@
 
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
-import 'package:conductor_ui/logic/error_to_string.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../logic/cherrypick_state.dart';
+import '../logic/error_to_string.dart';
 import '../logic/repositories_name.dart';
 import '../models/cherrypick.dart';
 import '../models/conductor_status.dart';

--- a/release_dashboard/test/fakes/fake_next_context.dart
+++ b/release_dashboard/test/fakes/fake_next_context.dart
@@ -1,0 +1,58 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_core/conductor_core.dart';
+import 'package:conductor_core/src/proto/conductor_state.pb.dart';
+import 'package:conductor_ui/services/release_dashboard_next_context.dart';
+import 'package:file/file.dart';
+import 'package:flutter/material.dart';
+
+const String kFlutterRoot = '/flutter';
+const String kCheckoutsParentDirectory = '$kFlutterRoot/dev/tools/';
+
+/// Initializes a fake [ReleaseDashboardNextContext] in a fake local environment.
+///
+/// [runOverride] parameter overrides the parent's [run] method
+class FakeNextContext implements ReleaseDashboardNextContext {
+  FakeNextContext({
+    this.runOverride,
+  });
+
+  /// An optional override async callback for the real [run] method.
+  Future<void> Function()? runOverride;
+
+  /// Either call [runOverride] if it is not null, else an empty function is called.
+  @override
+  Future<void> run(state) async {
+    if (runOverride != null) {
+      return runOverride!();
+    }
+  }
+
+  @override
+  bool get autoAccept => throw UnimplementedError();
+
+  @override
+  Checkouts get checkouts => throw UnimplementedError();
+
+  @override
+  bool get force => throw UnimplementedError();
+
+  @override
+  Future<bool> prompt(String message) {
+    throw UnimplementedError();
+  }
+
+  @override
+  File get stateFile => throw UnimplementedError();
+
+  @override
+  Stdio get stdio => throw UnimplementedError();
+
+  @override
+  void updateState(ConductorState state, [List<String> logs = const <String>[]]) {}
+
+  @override
+  BuildContext get context => throw UnimplementedError();
+}

--- a/release_dashboard/test/fakes/fake_next_context.dart
+++ b/release_dashboard/test/fakes/fake_next_context.dart
@@ -54,5 +54,5 @@ class FakeNextContext implements ReleaseDashboardNextContext {
   void updateState(ConductorState state, [List<String> logs = const <String>[]]) {}
 
   @override
-  BuildContext get context => throw UnimplementedError();
+  VoidCallback get syncStatusWithState => throw UnimplementedError();
 }

--- a/release_dashboard/test/fakes/services/fake_conductor.dart
+++ b/release_dashboard/test/fakes/services/fake_conductor.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:platform/platform.dart';
 
 import '../fake_clean_context.dart';
+import '../fake_next_context.dart';
 import '../fake_start_context.dart';
 
 /// Fake service class for using the conductor in a fake local environment.
@@ -17,12 +18,16 @@ import '../fake_start_context.dart';
 /// When [fakeStartContextProvided] is not provided, the class initializes
 /// a [createRelease] method that does not throw any error by default.
 ///
+/// When [fakeNextContextProvided] is not provided, the class initializes
+/// a [conductorNext] method that does not throw any error by default.
+///
 /// [testState] parameter accepts a fake test state and passes it to the
 /// release dashboard.
 class FakeConductor extends ConductorService {
   FakeConductor({
     this.fakeCleanContextProvided,
     this.fakeStartContextProvided,
+    this.fakeNextContextProvided,
     this.testState,
   }) {
     /// If there is no [fakeCleanContextProvided], initialize a [FakeCleanContext]
@@ -32,7 +37,8 @@ class FakeConductor extends ConductorService {
 
   late FakeCleanContext? fakeCleanContextProvided;
   final FakeStartContext? fakeStartContextProvided;
-  final ConductorState? testState;
+  FakeNextContext? fakeNextContextProvided;
+  ConductorState? testState;
 
   final FileSystem fs = MemoryFileSystem.test();
   final Platform platform = FakePlatform(
@@ -69,6 +75,16 @@ class FakeConductor extends ConductorService {
         releaseChannel: releaseChannel,
       );
       return fakeStartContext.run();
+    }
+  }
+
+  @override
+  Future<void> conductorNext(BuildContext context) async {
+    if (fakeNextContextProvided != null) {
+      return fakeNextContextProvided!.run(testState!);
+    } else {
+      final FakeNextContext fakeNextContext = FakeNextContext();
+      return fakeNextContext.run(testState!);
     }
   }
 

--- a/release_dashboard/test/src/test_state_generator.dart
+++ b/release_dashboard/test/src/test_state_generator.dart
@@ -28,11 +28,12 @@ const String kEngineMirror = 'git@github.com:User/engine.git';
 const String kFrameworkMirror = 'git@github.com:User/engine.git';
 const String kEngineUpstream = 'https://github.com/org/engine.git';
 const String kFrameworkUpstream = 'https://github.com/org/framework.git';
+const pb.ReleasePhase kCurrentPhase = pb.ReleasePhase.APPLY_ENGINE_CHERRYPICKS;
 
 /// Generates a test conductor state.
 ///
 /// Default state has all the fields complete and valid with no cherrypick conflicts,
-/// and an engine PR and a framework PR are required.
+/// an engine is PR, a framework PR is required, and at the `apply engine cherrypicks` phase.
 ///
 /// If [engineCherrypicksInConflict] is true, the function generates a state
 /// with 2/3 of the engine cherrypicks in conflict.
@@ -69,6 +70,7 @@ pb.ConductorState generateConductorState({
   String? frameworkStartingGitHead = kFrameworkStartingGitHead,
   String? frameworkCurrentGitHead = kFrameworkCurrentGitHead,
   String? frameworkCheckoutPath = kFrameworkCheckoutPath,
+  pb.ReleasePhase? currentPhase = kCurrentPhase,
 }) {
   return pb.ConductorState(
     engine: pb.Repository(
@@ -111,5 +113,6 @@ pb.ConductorState generateConductorState({
     conductorVersion: conductorVersion,
     releaseChannel: releaseChannel,
     releaseVersion: releaseVersion,
+    currentPhase: currentPhase,
   );
 }

--- a/release_dashboard/test/widgets/engine_cherrypicks_substeps_test.dart
+++ b/release_dashboard/test/widgets/engine_cherrypicks_substeps_test.dart
@@ -39,15 +39,14 @@ void main() {
         ),
       ));
 
-      expect(find.byKey(const Key('applyEngineCherrypicksContinue')), findsOneWidget);
-      expect(tester.widget<ElevatedButton>(find.byKey(const Key('applyEngineCherrypicksContinue'))).enabled,
-          equals(false));
+      final Finder continueButton = find.byKey(const Key('applyEngineCherrypicksContinue'));
+      expect((continueButton), findsOneWidget);
+      expect(tester.widget<ElevatedButton>(continueButton).enabled, equals(false));
       for (final String substep in CherrypicksSubsteps.substepTitles.values) {
         await tester.tap(find.text(substep));
       }
       await tester.pumpAndSettle();
-      expect(
-          tester.widget<ElevatedButton>(find.byKey(const Key('applyEngineCherrypicksContinue'))).enabled, equals(true));
+      expect(tester.widget<ElevatedButton>(continueButton).enabled, equals(true));
     });
 
     testWidgets('Clicking on the continue button proceeds to the next step', (WidgetTester tester) async {

--- a/release_dashboard/test/widgets/framework_cherrypicks_substeps_test.dart
+++ b/release_dashboard/test/widgets/framework_cherrypicks_substeps_test.dart
@@ -22,7 +22,7 @@ void main() {
     stateWithoutConflicts = generateConductorState();
   });
   group('Framework cherrypick substeps tests', () {
-    testWidgets('Continue button appears when all substeps are checked', (WidgetTester tester) async {
+    testWidgets('Continue button enables when all substeps are checked', (WidgetTester tester) async {
       await tester.pumpWidget(ChangeNotifierProvider(
         create: (context) => StatusState(conductor: FakeConductor(testState: stateWithoutConflicts)),
         child: MaterialApp(

--- a/release_dashboard/test/widgets/framework_cherrypicks_substeps_test.dart
+++ b/release_dashboard/test/widgets/framework_cherrypicks_substeps_test.dart
@@ -38,7 +38,7 @@ void main() {
         ),
       ));
 
-      Finder continueButton = find.byKey(const Key('applyFrameworkCherrypicksContinue'));
+      final Finder continueButton = find.byKey(const Key('applyFrameworkCherrypicksContinue'));
       expect(continueButton, findsOneWidget);
       expect(tester.widget<ElevatedButton>(continueButton).enabled, equals(false));
       expect(find.text(CherrypicksSubsteps.substepTitles[CherrypicksSubstep.verifyRelease]!), findsNothing);


### PR DESCRIPTION
*Added `conductor next` implementation for `Apply engine cherrypicks` step*, and for `Apply framework cherrypicks` step.

Main Issue:
- [x] https://github.com/flutter/flutter/issues/94627

PR that needed to be landed before this:
- [ ] https://github.com/flutter/cocoon/pull/1494
- [x] https://github.com/flutter/flutter/pull/93896
- [x] https://github.com/flutter/flutter/pull/91768

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
