### PR TITLE
[release_dashboard] Disabled inputs and dropdowns on loading

### DIFF
--- a/release_dashboard/lib/widgets/create_release_substeps.dart
+++ b/release_dashboard/lib/widgets/create_release_substeps.dart
@@ -13,6 +13,8 @@ import '../services/conductor.dart';
 import '../state/status_state.dart';
 import 'common/tooltip.dart';
 
+/// Very important! The order of this enum decides which order the initialization
+/// parameter widgets get rendered.
 enum CreateReleaseSubstep {
   candidateBranch,
   releaseChannel,
@@ -24,9 +26,20 @@ enum CreateReleaseSubstep {
   increment,
 }
 
-/// Displays all substeps related to the 1st step.
+/// Displays all substeps related to initializing a release.
 ///
 /// Uses input fields and dropdowns to capture all the parameters of the conductor start command.
+///
+/// Validates each input value. Displays an error message if it is not valid.
+///
+/// The continue button becomes enabled when all inputs are valid. Disabled otherwise.
+///
+/// When the continue button is pressed, a release starts to initialize based on all inputs provided.
+/// While it is being initialized, the continue button becomes disabled, and a loading
+/// animation will display.
+///
+/// When the release is successfully initialized, proceed to the next step. Otherwise, display
+/// a red error message. The continue button will become enabled again.
 class CreateReleaseSubsteps extends StatefulWidget {
   const CreateReleaseSubsteps({
     Key? key,
@@ -49,6 +62,22 @@ class CreateReleaseSubsteps extends StatefulWidget {
     CreateReleaseSubstep.increment: 'Increment',
   };
 
+  static const Map<CreateReleaseSubstep, String> inputHintText = <CreateReleaseSubstep, String>{
+    CreateReleaseSubstep.candidateBranch: 'The candidate branch the release will be based on.',
+    CreateReleaseSubstep.engineMirror: "Git remote of the Conductor user's Engine repository mirror.",
+    CreateReleaseSubstep.frameworkMirror: "Git remote of the Conductor user's Framework repository mirror.",
+    CreateReleaseSubstep.engineCherrypicks:
+        'Engine cherrypick hashes to be applied. Multiple hashes delimited by a comma.',
+    CreateReleaseSubstep.frameworkCherrypicks:
+        'Framework cherrypick hashes to be applied. Multiple hashes delimited by a comma.',
+    CreateReleaseSubstep.dartRevision: 'New Dart revision to cherrypick.',
+  };
+
+  static const List<CreateReleaseSubstep> dropdownElements = <CreateReleaseSubstep>[
+    CreateReleaseSubstep.releaseChannel,
+    CreateReleaseSubstep.increment,
+  ];
+
   static const List<String> releaseChannels = <String>['dev', 'beta', 'stable'];
   static const List<String> releaseIncrements = <String>['y', 'z', 'm', 'n'];
 }
@@ -56,25 +85,25 @@ class CreateReleaseSubsteps extends StatefulWidget {
 class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
   /// Initialize a public state so it could be accessed in the test file.
   @visibleForTesting
-  late Map<String, String?> releaseData = <String, String?>{};
+  late Map<CreateReleaseSubstep, String?> releaseData = <CreateReleaseSubstep, String?>{};
   String? _error;
   bool _isLoading = false;
 
   /// When [substep] in [isEachInputValid] is true, [substep] is valid. Otherwise, it is invalid.
   @visibleForTesting
-  Map<String, bool> isEachInputValid = <String, bool>{};
+  Map<CreateReleaseSubstep, bool> isEachInputValid = <CreateReleaseSubstep, bool>{};
 
   @override
   void initState() {
-    List<String> kOptionalInput = <String>[
-      CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!,
-      CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!,
-      CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!,
+    List<CreateReleaseSubstep> kOptionalInput = <CreateReleaseSubstep>[
+      CreateReleaseSubstep.engineCherrypicks,
+      CreateReleaseSubstep.frameworkCherrypicks,
+      CreateReleaseSubstep.dartRevision,
     ];
     // Engine cherrypicks, framework cherrypicks and dart revision are optional
     // and valid with empty input at the beginning.
-    for (final String substep in CreateReleaseSubsteps.substepTitles.values) {
-      isEachInputValid = <String, bool>{
+    for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+      isEachInputValid = <CreateReleaseSubstep, bool>{
         ...isEachInputValid,
         substep: kOptionalInput.contains(substep),
       };
@@ -83,21 +112,21 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
   }
 
   /// Updates the corresponding [field] in [releaseData] with [data].
-  void setReleaseData(String field, String data) {
+  void setReleaseData(CreateReleaseSubstep substep, String data) {
     setState(() {
-      releaseData = <String, String?>{
+      releaseData = <CreateReleaseSubstep, String?>{
         ...releaseData,
-        field: data,
+        substep: data,
       };
     });
   }
 
-  /// Modifies [name] in [isEachInputValid] with [isValid].
-  void changeIsEachInputValid(String name, bool isValid) {
+  /// Modifies [substep] in [isEachInputValid] with [isValid].
+  void changeIsEachInputValid(CreateReleaseSubstep substep, bool isValid) {
     setState(() {
-      isEachInputValid = <String, bool>{
+      isEachInputValid = <CreateReleaseSubstep, bool>{
         ...isEachInputValid,
-        name: isValid,
+        substep: isValid,
       };
     });
   }
@@ -120,18 +149,15 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
   Future<void> runCreateRelease(ConductorService conductor) {
     // Data captured by the input forms and dropdowns are transformed to conform the formats of StartContext.
     return conductor.createRelease(
-      candidateBranch: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]] ?? '',
-      releaseChannel: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]] ?? '',
-      frameworkMirror: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]] ?? '',
-      engineMirror: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]] ?? '',
-      engineCherrypickRevisions: cherrypickStringtoArray(
-          releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]]),
-      frameworkCherrypickRevisions: cherrypickStringtoArray(
-          releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]]),
-      dartRevision: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]] == ''
-          ? null
-          : releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]],
-      incrementLetter: releaseData[CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]] ?? '',
+      candidateBranch: releaseData[CreateReleaseSubstep.candidateBranch] ?? '',
+      releaseChannel: releaseData[CreateReleaseSubstep.releaseChannel] ?? '',
+      frameworkMirror: releaseData[CreateReleaseSubstep.frameworkMirror] ?? '',
+      engineMirror: releaseData[CreateReleaseSubstep.engineMirror] ?? '',
+      engineCherrypickRevisions: cherrypickStringtoArray(releaseData[CreateReleaseSubstep.engineCherrypicks]),
+      frameworkCherrypickRevisions: cherrypickStringtoArray(releaseData[CreateReleaseSubstep.frameworkCherrypicks]),
+      dartRevision:
+          releaseData[CreateReleaseSubstep.dartRevision] == '' ? null : releaseData[CreateReleaseSubstep.dartRevision],
+      incrementLetter: releaseData[CreateReleaseSubstep.increment] ?? '',
     );
   }
 
@@ -142,67 +168,42 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
     final GitValidation multiGitHash = MultiGitHash();
     final GitValidation gitHash = GitHash();
 
+    final Map<CreateReleaseSubstep, GitValidation> gitValidatonMapping = <CreateReleaseSubstep, GitValidation>{
+      CreateReleaseSubstep.candidateBranch: candidateBranch,
+      CreateReleaseSubstep.frameworkMirror: gitRemote,
+      CreateReleaseSubstep.engineMirror: gitRemote,
+      CreateReleaseSubstep.engineCherrypicks: multiGitHash,
+      CreateReleaseSubstep.frameworkCherrypicks: multiGitHash,
+      CreateReleaseSubstep.dartRevision: gitHash,
+    };
+
     final ConductorService conductor = context.watch<StatusState>().conductor;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]!,
-          setReleaseData: setReleaseData,
-          hintText: 'The candidate branch the release will be based on.',
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: candidateBranch,
-        ),
-        DropdownAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!,
-          releaseData: releaseData,
-          setReleaseData: setReleaseData,
-          options: CreateReleaseSubsteps.releaseChannels,
-          changeIsDropdownValid: changeIsEachInputValid,
-        ),
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!,
-          setReleaseData: setReleaseData,
-          hintText: "Git remote of the Conductor user's Framework repository mirror.",
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: gitRemote,
-        ),
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!,
-          setReleaseData: setReleaseData,
-          hintText: "Git remote of the Conductor user's Engine repository mirror.",
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: gitRemote,
-        ),
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!,
-          setReleaseData: setReleaseData,
-          hintText: 'Engine cherrypick hashes to be applied. Multiple hashes delimited by a comma.',
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: multiGitHash,
-        ),
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!,
-          setReleaseData: setReleaseData,
-          hintText: 'Framework cherrypick hashes to be applied. Multiple hashes delimited by a comma.',
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: multiGitHash,
-        ),
-        InputAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!,
-          setReleaseData: setReleaseData,
-          hintText: 'New Dart revision to cherrypick.',
-          changeIsInputValid: changeIsEachInputValid,
-          validationClass: gitHash,
-        ),
-        DropdownAsSubstep(
-          substepName: CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!,
-          releaseData: releaseData,
-          setReleaseData: setReleaseData,
-          options: CreateReleaseSubsteps.releaseIncrements,
-          changeIsDropdownValid: changeIsEachInputValid,
-        ),
+        for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values)
+          if (CreateReleaseSubsteps.dropdownElements.contains(substep)) ...[
+            DropdownAsSubstep(
+              substep: substep,
+              releaseData: releaseData[substep],
+              setReleaseData: setReleaseData,
+              options: substep == CreateReleaseSubstep.releaseChannel
+                  ? CreateReleaseSubsteps.releaseChannels
+                  : CreateReleaseSubsteps.releaseIncrements,
+              changeIsDropdownValid: changeIsEachInputValid,
+              isLoading: _isLoading,
+            )
+          ] else ...[
+            InputAsSubstep(
+              substep: substep,
+              setReleaseData: setReleaseData,
+              hintText: CreateReleaseSubsteps.inputHintText[substep],
+              changeIsInputValid: changeIsEachInputValid,
+              validationClass: gitValidatonMapping[substep]!,
+              isLoading: _isLoading,
+            )
+          ],
         const SizedBox(height: 20.0),
         if (_error != null)
           Center(
@@ -248,41 +249,63 @@ class CreateReleaseSubstepsState extends State<CreateReleaseSubsteps> {
   }
 }
 
-typedef SetReleaseData = void Function(String name, String data);
-typedef ChangeIsEachInputValid = void Function(String name, bool isValid);
+typedef SetReleaseData = void Function(CreateReleaseSubstep name, String data);
+typedef ChangeIsEachInputValid = void Function(CreateReleaseSubstep name, bool isValid);
 
-/// Captures the input values and updates the corresponding field in [releaseData].
+/// Captures and validates the input values and updates the corresponding field in [releaseData].
+///
+/// [substep] parameter is a [CreateReleaseSubstep] enum that represents the current substep
+/// this widget renders.
+///
+/// [setReleaseData] parameter is the method for modifying the state that stores all release
+/// data needed for initialization.
+///
+/// [hintText] parameter is the optional hintText of [TextFormField]. If it is not provided,
+/// no hintText will be displayed.
+///
+/// [changeIsInputValid] parameter is the method for modifying the state that tracks if
+/// the current input field is valid.
+///
+/// [validationClass] parameter is the Git class used to validate the current input, and display
+/// corresponding error messages if the validation fails.
+///
+/// [isLoading] parameter keeps track if a current release is currently initializing.
+/// If it is true, [TextFormField] is disabled, not allowing users to modify the current input
+/// during a loading phase. Else, [TextFormField] is enabled, allowing editing.
 class InputAsSubstep extends StatelessWidget {
   const InputAsSubstep({
     Key? key,
-    required this.substepName,
+    required this.substep,
     required this.setReleaseData,
     this.hintText,
     required this.changeIsInputValid,
     required this.validationClass,
+    required this.isLoading,
   }) : super(key: key);
 
-  final String substepName;
+  final CreateReleaseSubstep substep;
   final SetReleaseData setReleaseData;
   final String? hintText;
   final ChangeIsEachInputValid changeIsInputValid;
   final GitValidation validationClass;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      key: Key(substepName),
+      key: Key(CreateReleaseSubsteps.substepTitles[substep]!),
       autovalidateMode: AutovalidateMode.onUserInteraction,
+      enabled: !isLoading,
       decoration: InputDecoration(
-        labelText: substepName,
+        labelText: CreateReleaseSubsteps.substepTitles[substep]!,
         hintText: hintText,
       ),
       onChanged: (String? data) {
-        setReleaseData(substepName, validationClass.sanitize(data));
+        setReleaseData(substep, validationClass.sanitize(data));
         if (!validationClass.isValid(data)) {
-          changeIsInputValid(substepName, false);
+          changeIsInputValid(substep, false);
         } else {
-          changeIsInputValid(substepName, true);
+          changeIsInputValid(substep, true);
         }
       },
       validator: (String? value) {
@@ -296,33 +319,53 @@ class InputAsSubstep extends StatelessWidget {
   }
 }
 
-/// Captures the chosen option and updates the corresponding field in [releaseData].
+/// Captures the chosen option in a dropdown and updates the corresponding field in [releaseData].
+///
+/// [substep] parameter is a [CreateReleaseSubstep] enum that represents the current substep
+/// this widget renders.
+///
+/// [releaseData] parameter is current dropdown's value stored in the state that stores all release
+/// data needed for initialization.
+///
+/// [setReleaseData] parameter is the method for modifying the state that stores all release
+/// data needed for initialization.
+///
+/// [options] parameter is a list of all the choices of the dropdown.
+///
+/// [changeIsDropdownValid] parameter is the method for modifying the state that tracks if
+/// each dropdown value is valid.
+///
+/// [isLoading] parameter keeps track if a current release is currently initializing.
+/// If true, [DropdownButton] is disabled, not allowing users to modify the current dropdown during
+/// a loading phase. Else, [DropdownButton] is enabled, allowing editing.
 class DropdownAsSubstep extends StatelessWidget {
   const DropdownAsSubstep({
     Key? key,
-    required this.substepName,
+    required this.substep,
     required this.releaseData,
     required this.setReleaseData,
     required this.options,
     required this.changeIsDropdownValid,
+    required this.isLoading,
   }) : super(key: key);
 
-  final String substepName;
-  final Map<String, String?> releaseData;
+  final CreateReleaseSubstep substep;
+  final String? releaseData;
   final SetReleaseData setReleaseData;
   final List<String> options;
   final ChangeIsEachInputValid changeIsDropdownValid;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: <Widget>[
         Text(
-          substepName,
+          CreateReleaseSubsteps.substepTitles[substep]!,
           style: Theme.of(context).textTheme.subtitle1!.copyWith(color: Colors.grey[700]),
         ),
         // Only add a tooltip for the increment dropdown
-        if (substepName == CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!)
+        if (substep == CreateReleaseSubstep.increment)
           const Padding(
             padding: EdgeInsets.fromLTRB(10.0, 0, 0, 0),
             child: InfoTooltip(
@@ -339,8 +382,8 @@ z:    Indicates a hotfix to a stable release.''',
         const SizedBox(width: 20.0),
         DropdownButton<String>(
           hint: const Text('-'), // Dropdown initially displays the hint when no option is selected.
-          key: Key(substepName),
-          value: releaseData[substepName],
+          key: Key(CreateReleaseSubsteps.substepTitles[substep]!),
+          value: releaseData,
           icon: const Icon(Icons.arrow_downward),
           items: options.map<DropdownMenuItem<String>>((String value) {
             return DropdownMenuItem<String>(
@@ -348,10 +391,12 @@ z:    Indicates a hotfix to a stable release.''',
               child: Text(value),
             );
           }).toList(),
-          onChanged: (String? newValue) {
-            changeIsDropdownValid(substepName, true);
-            setReleaseData(substepName, newValue!);
-          },
+          onChanged: isLoading == true
+              ? null
+              : (String? newValue) {
+                  changeIsDropdownValid(substep, true);
+                  setReleaseData(substep, newValue!);
+                },
         ),
       ],
     );

--- a/release_dashboard/lib/widgets/create_release_substeps.dart
+++ b/release_dashboard/lib/widgets/create_release_substeps.dart
@@ -13,8 +13,7 @@ import '../services/conductor.dart';
 import '../state/status_state.dart';
 import 'common/tooltip.dart';
 
-/// Very important! The order of this enum decides which order the initialization
-/// parameter widgets get rendered.
+/// The order of this enum decides which order the widgets in [CreateReleaseSubsteps] get rendered.
 enum CreateReleaseSubstep {
   candidateBranch,
   releaseChannel,
@@ -26,7 +25,7 @@ enum CreateReleaseSubstep {
   increment,
 }
 
-/// Displays all substeps related to initializing a release.
+/// Displays all substeps related to create a release.
 ///
 /// Uses input fields and dropdowns to capture all the parameters of the conductor start command.
 ///
@@ -254,22 +253,22 @@ typedef ChangeIsEachInputValid = void Function(CreateReleaseSubstep name, bool i
 
 /// Captures and validates the input values and updates the corresponding field in [releaseData].
 ///
-/// [substep] parameter is a [CreateReleaseSubstep] enum that represents the current substep
+/// [substep] is a [CreateReleaseSubstep] that represents the current substep
 /// this widget renders.
 ///
-/// [setReleaseData] parameter is the method for modifying the state that stores all release
+/// [setReleaseData] is the method for modifying the state that stores all release
 /// data needed for initialization.
 ///
-/// [hintText] parameter is the optional hintText of [TextFormField]. If it is not provided,
+/// [hintText] is the optional hintText of [TextFormField]. If it is not provided,
 /// no hintText will be displayed.
 ///
-/// [changeIsInputValid] parameter is the method for modifying the state that tracks if
+/// [changeIsInputValid] is the method for modifying the state that tracks if
 /// the current input field is valid.
 ///
-/// [validationClass] parameter is the Git class used to validate the current input, and display
+/// [validationClass] is the Git class used to validate the current input, and display
 /// corresponding error messages if the validation fails.
 ///
-/// [isLoading] parameter keeps track if a current release is currently initializing.
+/// [isLoading] keeps track if a current release is currently initializing.
 /// If it is true, [TextFormField] is disabled, not allowing users to modify the current input
 /// during a loading phase. Else, [TextFormField] is enabled, allowing editing.
 class InputAsSubstep extends StatelessWidget {
@@ -321,21 +320,21 @@ class InputAsSubstep extends StatelessWidget {
 
 /// Captures the chosen option in a dropdown and updates the corresponding field in [releaseData].
 ///
-/// [substep] parameter is a [CreateReleaseSubstep] enum that represents the current substep
+/// [substep] is a [CreateReleaseSubstep] that represents the current substep
 /// this widget renders.
 ///
-/// [releaseData] parameter is current dropdown's value stored in the state that stores all release
+/// [releaseData] is current dropdown's value stored in the state that stores all release
 /// data needed for initialization.
 ///
-/// [setReleaseData] parameter is the method for modifying the state that stores all release
+/// [setReleaseData] is the method for modifying the state that stores all release
 /// data needed for initialization.
 ///
-/// [options] parameter is a list of all the choices of the dropdown.
+/// [options] is a list of all the choices of the dropdown.
 ///
-/// [changeIsDropdownValid] parameter is the method for modifying the state that tracks if
+/// [changeIsDropdownValid] is the method for modifying the state that tracks if
 /// each dropdown value is valid.
 ///
-/// [isLoading] parameter keeps track if a current release is currently initializing.
+/// [isLoading] keeps track if a current release is currently initializing.
 /// If true, [DropdownButton] is disabled, not allowing users to modify the current dropdown during
 /// a loading phase. Else, [DropdownButton] is enabled, allowing editing.
 class DropdownAsSubstep extends StatelessWidget {

--- a/release_dashboard/test/widgets/create_release_substeps_test.dart
+++ b/release_dashboard/test/widgets/create_release_substeps_test.dart
@@ -26,23 +26,22 @@ void main() {
   const String validGitHash2 = 'bfadad702e9f699f4ab024c335e7498152d26e34';
   const String validGitHash3 = 'bfadad702e9f699f4ab024c335e7498152d26e35';
 
-  /// Construct test inputs in a map that has the same names as [CreateReleaseSubsteps.substepTitles].
-  Map<String, String> testInputsCorrect = <String, String>{
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]!: candidateBranch,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!: releaseChannel,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!: frameworkMirror,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!: engineMirror,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!: validGitHash1,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!: validGitHash2,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!: validGitHash3,
-    CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!: increment,
+  /// Construct test inputs in [Map<K, V>] that uses [CreateReleaseSubstep] as keys.
+  Map<CreateReleaseSubstep, String> testInputsCorrect = <CreateReleaseSubstep, String>{
+    CreateReleaseSubstep.candidateBranch: candidateBranch,
+    CreateReleaseSubstep.releaseChannel: releaseChannel,
+    CreateReleaseSubstep.frameworkMirror: frameworkMirror,
+    CreateReleaseSubstep.engineMirror: engineMirror,
+    CreateReleaseSubstep.frameworkCherrypicks: validGitHash1,
+    CreateReleaseSubstep.engineCherrypicks: validGitHash2,
+    CreateReleaseSubstep.dartRevision: validGitHash3,
+    CreateReleaseSubstep.increment: increment,
   };
 
   group('Dropdown validator', () {
-    for (final String parameterName in CreateReleaseSubsteps.substepTitles.values) {
-      if (parameterName == CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]! ||
-          parameterName == CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!) {
-        testWidgets('$parameterName dropdown test', (WidgetTester tester) async {
+    for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+      if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+        testWidgets('$substep dropdown test', (WidgetTester tester) async {
           await tester.pumpWidget(ChangeNotifierProvider(
             create: (context) => StatusState(conductor: FakeConductor()),
             child: MaterialApp(
@@ -61,24 +60,23 @@ void main() {
           final StatefulElement createReleaseSubsteps = tester.element(find.byType(CreateReleaseSubsteps));
           final CreateReleaseSubstepsState createReleaseSubstepsState =
               createReleaseSubsteps.state as CreateReleaseSubstepsState;
-          final Map<String, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
+          final Map<CreateReleaseSubstep, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
 
-          isEachInputValid[parameterName] = false;
-          await tester.tap(find.byKey(Key(parameterName)));
+          isEachInputValid[substep] = false;
+          await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)));
           await tester.pumpAndSettle();
-          await tester.tap(find.text(testInputsCorrect[parameterName]!).last);
+          await tester.tap(find.text(testInputsCorrect[substep]!).last);
           await tester.pumpAndSettle();
-          isEachInputValid[parameterName] = true;
+          isEachInputValid[substep] = true;
         });
       }
     }
   });
 
   group("Input textfield validator", () {
-    for (final String parameterName in CreateReleaseSubsteps.substepTitles.values) {
-      if (parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]! &&
-          parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!) {
-        testWidgets('$parameterName input test', (WidgetTester tester) async {
+    for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+      if (!CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+        testWidgets('$substep input test', (WidgetTester tester) async {
           await tester.pumpWidget(ChangeNotifierProvider(
             create: (context) => StatusState(conductor: FakeConductor()),
             child: MaterialApp(
@@ -97,25 +95,24 @@ void main() {
           final StatefulElement createReleaseSubsteps = tester.element(find.byType(CreateReleaseSubsteps));
           final CreateReleaseSubstepsState createReleaseSubstepsState =
               createReleaseSubsteps.state as CreateReleaseSubstepsState;
-          final Map<String, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
+          final Map<CreateReleaseSubstep, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
 
-          await tester.enterText(find.byKey(Key(parameterName)), testInputsCorrect[parameterName]!);
-          isEachInputValid[parameterName] = true;
-          await tester.enterText(find.byKey(Key(parameterName)), '@@invalidInput@@!!');
-          isEachInputValid[parameterName] = false;
+          await tester.enterText(
+              find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), testInputsCorrect[substep]!);
+          isEachInputValid[substep] = true;
+          await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), '@@invalidInput@@!!');
+          isEachInputValid[substep] = false;
         });
       }
     }
   });
 
   group('Input textfields whitespaces', () {
-    for (final String parameterName in CreateReleaseSubsteps.substepTitles.values) {
+    for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
       // the test does not apply to dropdowns
-      if (parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]! &&
-          parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!) {
-        if (parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]! &&
-            parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!) {
-          testWidgets('$parameterName should trim leading and trailing whitespaces before validating',
+      if (!CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+        if (substep != CreateReleaseSubstep.engineCherrypicks && substep != CreateReleaseSubstep.frameworkCherrypicks) {
+          testWidgets('$substep should trim leading and trailing whitespaces before validating',
               (WidgetTester tester) async {
             await tester.pumpWidget(ChangeNotifierProvider(
               create: (context) => StatusState(conductor: FakeConductor()),
@@ -135,15 +132,16 @@ void main() {
             final StatefulElement createReleaseSubsteps = tester.element(find.byType(CreateReleaseSubsteps));
             final CreateReleaseSubstepsState createReleaseSubstepsState =
                 createReleaseSubsteps.state as CreateReleaseSubstepsState;
-            final Map<String, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
+            final Map<CreateReleaseSubstep, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
 
-            isEachInputValid[parameterName] = false;
+            isEachInputValid[substep] = false;
             // input field should trim any leading or trailing whitespaces
-            await tester.enterText(find.byKey(Key(parameterName)), '   ${testInputsCorrect[parameterName]!}  ');
-            isEachInputValid[parameterName] = true;
+            await tester.enterText(
+                find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), '   ${testInputsCorrect[substep]!}  ');
+            isEachInputValid[substep] = true;
           });
 
-          testWidgets('$parameterName should trim leading and trailing whitespaces before saving the value',
+          testWidgets('$substep should trim leading and trailing whitespaces before saving the value',
               (WidgetTester tester) async {
             await tester.pumpWidget(ChangeNotifierProvider(
               create: (context) => StatusState(conductor: FakeConductor()),
@@ -164,11 +162,12 @@ void main() {
             final CreateReleaseSubstepsState createReleaseSubstepsState =
                 createReleaseSubsteps.state as CreateReleaseSubstepsState;
 
-            await tester.enterText(find.byKey(Key(parameterName)), '   ${testInputsCorrect[parameterName]!}  ');
-            expect(createReleaseSubstepsState.releaseData[parameterName], equals(testInputsCorrect[parameterName]!));
+            await tester.enterText(
+                find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), '   ${testInputsCorrect[substep]!}  ');
+            expect(createReleaseSubstepsState.releaseData[substep], equals(testInputsCorrect[substep]!));
           });
         } else {
-          testWidgets('$parameterName should remove any whitespace before validating', (WidgetTester tester) async {
+          testWidgets('$substep should remove any whitespace before validating', (WidgetTester tester) async {
             await tester.pumpWidget(ChangeNotifierProvider(
               create: (context) => StatusState(conductor: FakeConductor()),
               child: MaterialApp(
@@ -187,15 +186,15 @@ void main() {
             final StatefulElement createReleaseSubsteps = tester.element(find.byType(CreateReleaseSubsteps));
             final CreateReleaseSubstepsState createReleaseSubstepsState =
                 createReleaseSubsteps.state as CreateReleaseSubstepsState;
-            final Map<String, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
+            final Map<CreateReleaseSubstep, bool> isEachInputValid = createReleaseSubstepsState.isEachInputValid;
 
-            isEachInputValid[parameterName] = false;
+            isEachInputValid[substep] = false;
             // input field should remove any whitespace present
-            await tester.enterText(find.byKey(Key(parameterName)), '   $validGitHash1  ,  $validGitHash2    ');
-            isEachInputValid[parameterName] = true;
+            await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)),
+                '   $validGitHash1  ,  $validGitHash2    ');
+            isEachInputValid[substep] = true;
           });
-          testWidgets('$parameterName should remove any whitespace before saving the value',
-              (WidgetTester tester) async {
+          testWidgets('$substep should remove any whitespace before saving the value', (WidgetTester tester) async {
             await tester.pumpWidget(ChangeNotifierProvider(
               create: (context) => StatusState(conductor: FakeConductor()),
               child: MaterialApp(
@@ -215,8 +214,9 @@ void main() {
             final CreateReleaseSubstepsState createReleaseSubstepsState =
                 createReleaseSubsteps.state as CreateReleaseSubstepsState;
 
-            await tester.enterText(find.byKey(Key(parameterName)), '   $validGitHash1  ,  $validGitHash2    ');
-            expect(createReleaseSubstepsState.releaseData[parameterName], equals('$validGitHash1,$validGitHash2'));
+            await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)),
+                '   $validGitHash1  ,  $validGitHash2    ');
+            expect(createReleaseSubstepsState.releaseData[substep], equals('$validGitHash1,$validGitHash2'));
           });
         }
       }
@@ -228,31 +228,30 @@ void main() {
     final GitValidation multiGitHash = MultiGitHash();
     final GitValidation gitRemote = GitRemote();
     final GitValidation candidateBranch = CandidateBranch();
-    for (final String parameterName in CreateReleaseSubsteps.substepTitles.values) {
+    for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
       // the test does not apply to dropdowns
-      if (parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]! &&
-          parameterName != CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!) {
+      if (!CreateReleaseSubsteps.dropdownElements.contains(substep)) {
         // assign the corresponding error message manually to each type of input
         late final String validatorErrorMsg;
-        switch (parameterName) {
-          case 'Candidate Branch':
+        switch (substep) {
+          case CreateReleaseSubstep.candidateBranch:
             validatorErrorMsg = candidateBranch.errorMsg;
             break;
-          case 'Framework Mirror':
-          case 'Engine Mirror':
+          case CreateReleaseSubstep.frameworkMirror:
+          case CreateReleaseSubstep.engineMirror:
             validatorErrorMsg = gitRemote.errorMsg;
             break;
-          case 'Engine Cherrypicks (if necessary)':
-          case 'Framework Cherrypicks (if necessary)':
+          case CreateReleaseSubstep.engineCherrypicks:
+          case CreateReleaseSubstep.frameworkCherrypicks:
             validatorErrorMsg = multiGitHash.errorMsg;
             break;
-          case 'Dart Revision (if necessary)':
+          case CreateReleaseSubstep.dartRevision:
             validatorErrorMsg = gitHash.errorMsg;
             break;
           default:
             break;
         }
-        testWidgets('$parameterName validator error message displays correctly', (WidgetTester tester) async {
+        testWidgets('$substep validator error message displays correctly', (WidgetTester tester) async {
           await tester.pumpWidget(ChangeNotifierProvider(
             create: (context) => StatusState(conductor: FakeConductor()),
             child: MaterialApp(
@@ -268,7 +267,7 @@ void main() {
             ),
           ));
 
-          await tester.enterText(find.byKey(Key(parameterName)), '@@invalidInput@@!!');
+          await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), '@@invalidInput@@!!');
           await tester.pumpAndSettle();
           expect(find.text(validatorErrorMsg), findsOneWidget);
         });
@@ -293,47 +292,43 @@ void main() {
         ),
       ));
 
-      await tester.enterText(find.byKey(const Key('Candidate Branch')), testInputsCorrect['Candidate Branch']!);
+      await tester.enterText(
+          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]!)),
+          testInputsCorrect[CreateReleaseSubstep.candidateBranch]!);
 
       final StatefulElement createReleaseSubsteps = tester.element(find.byType(CreateReleaseSubsteps));
       final CreateReleaseSubstepsState createReleaseSubstepsState =
           createReleaseSubsteps.state as CreateReleaseSubstepsState;
 
       /// Tests the Release Channel dropdown menu.
-      await tester.tap(find.byKey(const Key('Release Channel')));
+      await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!)));
       await tester.pumpAndSettle(); // finish the menu animation
-      expect(createReleaseSubstepsState.releaseData['Release Channel'], equals(null));
-      await tester.tap(find.text(testInputsCorrect['Release Channel']!).last);
+      expect(createReleaseSubstepsState.releaseData[CreateReleaseSubstep.releaseChannel], equals(null));
+      await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.releaseChannel]!).last);
       await tester.pumpAndSettle(); // finish the menu animation
 
-      await tester.enterText(find.byKey(const Key('Framework Mirror')), testInputsCorrect['Framework Mirror']!);
-      await tester.enterText(find.byKey(const Key('Engine Mirror')), testInputsCorrect['Engine Mirror']!);
-      await tester.enterText(find.byKey(const Key('Engine Cherrypicks (if necessary)')),
-          testInputsCorrect['Engine Cherrypicks (if necessary)']!);
-      await tester.enterText(find.byKey(const Key('Framework Cherrypicks (if necessary)')),
-          testInputsCorrect['Framework Cherrypicks (if necessary)']!);
       await tester.enterText(
-          find.byKey(const Key('Dart Revision (if necessary)')), testInputsCorrect['Dart Revision (if necessary)']!);
+          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!)),
+          testInputsCorrect[CreateReleaseSubstep.frameworkMirror]!);
+      await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!)),
+          testInputsCorrect[CreateReleaseSubstep.engineMirror]!);
+      await tester.enterText(
+          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!)),
+          testInputsCorrect[CreateReleaseSubstep.engineCherrypicks]!);
+      await tester.enterText(
+          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!)),
+          testInputsCorrect[CreateReleaseSubstep.frameworkCherrypicks]!);
+      await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!)),
+          testInputsCorrect[CreateReleaseSubstep.dartRevision]!);
 
       /// Tests the Increment dropdown menu.
-      await tester.tap(find.byKey(const Key('Increment')));
+      await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!)));
       await tester.pumpAndSettle(); // finish the menu animation
-      expect(createReleaseSubstepsState.releaseData['Increment'], equals(null));
-      await tester.tap(find.text(testInputsCorrect['Increment']!).last);
+      expect(createReleaseSubstepsState.releaseData[CreateReleaseSubstep.increment], equals(null));
+      await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.increment]!).last);
       await tester.pumpAndSettle(); // finish the menu animation
 
-      expect(
-          createReleaseSubstepsState.releaseData,
-          equals(<String, String>{
-            'Candidate Branch': testInputsCorrect['Candidate Branch']!,
-            'Release Channel': testInputsCorrect['Release Channel']!,
-            'Framework Mirror': testInputsCorrect['Framework Mirror']!,
-            'Engine Mirror': testInputsCorrect['Engine Mirror']!,
-            'Engine Cherrypicks (if necessary)': testInputsCorrect['Engine Cherrypicks (if necessary)']!,
-            'Framework Cherrypicks (if necessary)': testInputsCorrect['Framework Cherrypicks (if necessary)']!,
-            'Dart Revision (if necessary)': testInputsCorrect['Dart Revision (if necessary)']!,
-            'Increment': testInputsCorrect['Increment']!,
-          }));
+      expect(createReleaseSubstepsState.releaseData, testInputsCorrect);
     });
 
     testWidgets('Continue button should be enabled when all the parameters are entered correctly',
@@ -360,15 +355,15 @@ void main() {
       // default isEachInputValid state values, optional fields are valid from the start
       expect(
         createReleaseSubstepsState.isEachInputValid,
-        equals(<String, bool>{
-          'Candidate Branch': false,
-          'Release Channel': false,
-          'Framework Mirror': false,
-          'Engine Mirror': false,
-          'Engine Cherrypicks (if necessary)': true,
-          'Framework Cherrypicks (if necessary)': true,
-          'Dart Revision (if necessary)': true,
-          'Increment': false,
+        equals(<CreateReleaseSubstep, bool>{
+          CreateReleaseSubstep.candidateBranch: false,
+          CreateReleaseSubstep.releaseChannel: false,
+          CreateReleaseSubstep.frameworkMirror: false,
+          CreateReleaseSubstep.engineMirror: false,
+          CreateReleaseSubstep.engineCherrypicks: true,
+          CreateReleaseSubstep.frameworkCherrypicks: true,
+          CreateReleaseSubstep.dartRevision: true,
+          CreateReleaseSubstep.increment: false,
         }),
       );
 
@@ -378,17 +373,8 @@ void main() {
       // continue button is enabled, and all the parameters are validated
       expect(tester.widget<ElevatedButton>(continueButton).enabled, true);
       expect(
-        createReleaseSubstepsState.isEachInputValid,
-        equals(<String, bool>{
-          'Candidate Branch': true,
-          'Release Channel': true,
-          'Framework Mirror': true,
-          'Engine Mirror': true,
-          'Engine Cherrypicks (if necessary)': true,
-          'Framework Cherrypicks (if necessary)': true,
-          'Dart Revision (if necessary)': true,
-          'Increment': true,
-        }),
+        createReleaseSubstepsState.isEachInputValid.containsValue(false),
+        false,
       );
     });
   });
@@ -541,25 +527,105 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(tester.widget<ElevatedButton>(continueButton).enabled, true);
     });
+
+    testWidgets('Disable all inputs and dropdowns when loading, enable when loading is finished',
+        (WidgetTester tester) async {
+      const String exceptionMsg = 'There is a general Exception';
+      final FakeStartContext startContext = FakeStartContext(
+        runOverride: () async => throw Exception(exceptionMsg),
+      );
+
+      // This completer signifies the completion of `startContext.run()` function
+      final Completer<void> completer = Completer<void>();
+
+      startContext.addCommand(FakeCommand(
+        command: const <String>[
+          'git',
+          'clone',
+          '--origin',
+          'upstream',
+          '--',
+          EngineRepository.defaultUpstream,
+          '${kCheckoutsParentDirectory}flutter_conductor_checkouts/engine'
+        ],
+        completer: completer,
+      ));
+
+      await tester.pumpWidget(ChangeNotifierProvider(
+        create: (context) => StatusState(conductor: FakeConductor(fakeStartContextProvided: startContext)),
+        child: MaterialApp(
+          home: Material(
+            child: ListView(
+              children: <Widget>[
+                CreateReleaseSubsteps(
+                  nextStep: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ));
+
+      final Finder continueButton = find.byKey(const Key('createReleaseContinue'));
+      await fillAllParameters(tester, testInputsCorrect);
+      await tester.drag(continueButton, const Offset(-250, 0));
+      await tester.pump();
+      await tester.tap(continueButton);
+      await tester.pump();
+
+      // Every input and dropdown is disabled.
+      for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+        if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+          expect(
+              tester.widget<DropdownButton>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).onChanged,
+              equals(null));
+        } else {
+          expect(tester.widget<TextFormField>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).enabled,
+              equals(false));
+        }
+      }
+
+      completer.complete();
+      await tester.pumpAndSettle();
+
+      // Every input and dropdown is enabled.
+      for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+        if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+          expect(
+              tester.widget<DropdownButton>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).onChanged,
+              isNot(equals(null)));
+        } else {
+          expect(tester.widget<TextFormField>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).enabled,
+              equals(true));
+        }
+      }
+    });
   });
 }
 
 /// Fills every input and dropdown with correct test data.
-Future<void> fillAllParameters(WidgetTester tester, Map<String, String> testInputsCorrect) async {
-  await tester.enterText(find.byKey(const Key('Candidate Branch')), testInputsCorrect['Candidate Branch']!);
-  await tester.tap(find.byKey(const Key('Release Channel')));
+Future<void> fillAllParameters(WidgetTester tester, Map<CreateReleaseSubstep, String> testInputsCorrect) async {
+  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]!)),
+      testInputsCorrect[CreateReleaseSubstep.candidateBranch]!);
+
+  await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!)));
   await tester.pumpAndSettle();
-  await tester.tap(find.text(testInputsCorrect['Release Channel']!).last);
-  await tester.enterText(find.byKey(const Key('Framework Mirror')), testInputsCorrect['Framework Mirror']!);
-  await tester.enterText(find.byKey(const Key('Engine Mirror')), testInputsCorrect['Engine Mirror']!);
-  await tester.enterText(find.byKey(const Key('Engine Cherrypicks (if necessary)')),
-      testInputsCorrect['Engine Cherrypicks (if necessary)']!);
-  await tester.enterText(find.byKey(const Key('Framework Cherrypicks (if necessary)')),
-      testInputsCorrect['Framework Cherrypicks (if necessary)']!);
+  await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.releaseChannel]!).last);
+
+  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!)),
+      testInputsCorrect[CreateReleaseSubstep.frameworkMirror]!);
+  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!)),
+      testInputsCorrect[CreateReleaseSubstep.engineMirror]!);
+  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!)),
+      testInputsCorrect[CreateReleaseSubstep.engineCherrypicks]!);
   await tester.enterText(
-      find.byKey(const Key('Dart Revision (if necessary)')), testInputsCorrect['Dart Revision (if necessary)']!);
-  await tester.tap(find.byKey(const Key('Increment')));
+      find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!)),
+      testInputsCorrect[CreateReleaseSubstep.frameworkCherrypicks]!);
+  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!)),
+      testInputsCorrect[CreateReleaseSubstep.dartRevision]!);
+
+  await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!)));
   await tester.pumpAndSettle();
-  await tester.tap(find.text(testInputsCorrect['Increment']!).last);
+  await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.increment]!).last);
   await tester.pumpAndSettle();
 }

--- a/release_dashboard/test/widgets/create_release_substeps_test.dart
+++ b/release_dashboard/test/widgets/create_release_substeps_test.dart
@@ -528,12 +528,8 @@ void main() {
       expect(tester.widget<ElevatedButton>(continueButton).enabled, true);
     });
 
-    testWidgets('Disable all inputs and dropdowns when loading, enable when loading is finished',
-        (WidgetTester tester) async {
-      const String exceptionMsg = 'There is a general Exception';
-      final FakeStartContext startContext = FakeStartContext(
-        runOverride: () async => throw Exception(exceptionMsg),
-      );
+    testWidgets('Disable all inputs and dropdowns when loading', (WidgetTester tester) async {
+      final FakeStartContext startContext = FakeStartContext();
 
       // This completer signifies the completion of `startContext.run()` function
       final Completer<void> completer = Completer<void>();
@@ -587,18 +583,6 @@ void main() {
 
       completer.complete();
       await tester.pumpAndSettle();
-
-      // Every input and dropdown is enabled.
-      for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
-        if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
-          expect(
-              tester.widget<DropdownButton>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).onChanged,
-              isNot(equals(null)));
-        } else {
-          expect(tester.widget<TextFormField>(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!))).enabled,
-              equals(true));
-        }
-      }
     });
   });
 }

--- a/release_dashboard/test/widgets/create_release_substeps_test.dart
+++ b/release_dashboard/test/widgets/create_release_substeps_test.dart
@@ -300,33 +300,20 @@ void main() {
       final CreateReleaseSubstepsState createReleaseSubstepsState =
           createReleaseSubsteps.state as CreateReleaseSubstepsState;
 
-      /// Tests the Release Channel dropdown menu.
-      await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!)));
-      await tester.pumpAndSettle(); // finish the menu animation
-      expect(createReleaseSubstepsState.releaseData[CreateReleaseSubstep.releaseChannel], equals(null));
-      await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.releaseChannel]!).last);
-      await tester.pumpAndSettle(); // finish the menu animation
-
-      await tester.enterText(
-          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!)),
-          testInputsCorrect[CreateReleaseSubstep.frameworkMirror]!);
-      await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!)),
-          testInputsCorrect[CreateReleaseSubstep.engineMirror]!);
-      await tester.enterText(
-          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!)),
-          testInputsCorrect[CreateReleaseSubstep.engineCherrypicks]!);
-      await tester.enterText(
-          find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!)),
-          testInputsCorrect[CreateReleaseSubstep.frameworkCherrypicks]!);
-      await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!)),
-          testInputsCorrect[CreateReleaseSubstep.dartRevision]!);
-
-      /// Tests the Increment dropdown menu.
-      await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!)));
-      await tester.pumpAndSettle(); // finish the menu animation
-      expect(createReleaseSubstepsState.releaseData[CreateReleaseSubstep.increment], equals(null));
-      await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.increment]!).last);
-      await tester.pumpAndSettle(); // finish the menu animation
+      for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+        if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+          /// Tests the dropdown menu.
+          await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)));
+          await tester.pumpAndSettle(); // finish the menu animation
+          expect(createReleaseSubstepsState.releaseData[substep], equals(null));
+          await tester.tap(find.text(testInputsCorrect[substep]!).last);
+        } else {
+          /// Tests the input forms.
+          await tester.enterText(
+              find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), testInputsCorrect[substep]!);
+        }
+      }
+      await tester.pumpAndSettle();
 
       expect(createReleaseSubstepsState.releaseData, testInputsCorrect);
     });
@@ -589,27 +576,15 @@ void main() {
 
 /// Fills every input and dropdown with correct test data.
 Future<void> fillAllParameters(WidgetTester tester, Map<CreateReleaseSubstep, String> testInputsCorrect) async {
-  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.candidateBranch]!)),
-      testInputsCorrect[CreateReleaseSubstep.candidateBranch]!);
-
-  await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.releaseChannel]!)));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.releaseChannel]!).last);
-
-  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkMirror]!)),
-      testInputsCorrect[CreateReleaseSubstep.frameworkMirror]!);
-  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineMirror]!)),
-      testInputsCorrect[CreateReleaseSubstep.engineMirror]!);
-  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.engineCherrypicks]!)),
-      testInputsCorrect[CreateReleaseSubstep.engineCherrypicks]!);
-  await tester.enterText(
-      find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.frameworkCherrypicks]!)),
-      testInputsCorrect[CreateReleaseSubstep.frameworkCherrypicks]!);
-  await tester.enterText(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.dartRevision]!)),
-      testInputsCorrect[CreateReleaseSubstep.dartRevision]!);
-
-  await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[CreateReleaseSubstep.increment]!)));
-  await tester.pumpAndSettle();
-  await tester.tap(find.text(testInputsCorrect[CreateReleaseSubstep.increment]!).last);
+  for (final CreateReleaseSubstep substep in CreateReleaseSubstep.values) {
+    if (CreateReleaseSubsteps.dropdownElements.contains(substep)) {
+      await tester.tap(find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(testInputsCorrect[substep]!).last);
+    } else {
+      await tester.enterText(
+          find.byKey(Key(CreateReleaseSubsteps.substepTitles[substep]!)), testInputsCorrect[substep]!);
+    }
+  }
   await tester.pumpAndSettle();
 }


### PR DESCRIPTION
Inputs and dropdowns disable when start initialization is being loaded. Also changed all keys that are hard-coded strings in `CreateReleaseSubsteps` to enums, which required a significant amount of refactoring.

Fore example, before, the release data are stored in `Map<String, String?>`, now they are in `Map<Enum, String?>`. 

Main Issue:
- [x] https://github.com/flutter/flutter/issues/94562

Side Issue:
- [x] https://github.com/flutter/flutter/issues/94563


Screen recording (inputs and dropdowns become disabled when loading):


https://user-images.githubusercontent.com/20194490/144473669-281b7971-b89e-4eda-b9fc-60cc79974e00.mov




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
