### PR TITLE
[app_dart] Pass repo for Task and Commit

### DIFF
--- a/app_dart/lib/src/request_handlers/deflake_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/deflake_flaky_builders.dart
@@ -47,7 +47,7 @@ class DeflakeFlakyBuilders extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final RepositorySlug slug = config.flutterSlug;
+    final RepositorySlug slug = Config.flutterSlug;
     final GithubService gitHub = config.createGithubServiceWithToken(await config.githubOAuthToken);
     final BigqueryService bigquery = await config.createBigQueryService();
     final String ciContent = await gitHub.getFileContent(slug, kCiYamlPath);

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -33,7 +33,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final RepositorySlug slug = config.flutterSlug;
+    final RepositorySlug slug = Config.flutterSlug;
     final GithubService gitHub = config.createGithubServiceWithToken(await config.githubOAuthToken);
     final BigqueryService bigquery = await config.createBigQueryService();
     final List<BuilderStatistic> builderStatisticList = await bigquery.listBuilderStatistic(kBigQueryProjectId);

--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../../protos.dart' show BuildStatusResponse, EnumBuildStatus;
@@ -26,14 +27,15 @@ class GetBuildStatus extends RequestHandler<Body> {
   final DatastoreServiceProvider datastoreProvider;
   final BuildStatusServiceProvider buildStatusProvider;
 
-  static const String branchParam = 'branch';
+  static const String kRepoParam = 'repo';
 
   @override
   Future<Body> get() async {
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusProvider(datastore);
-    final String branch = request!.uri.queryParameters[branchParam] ?? 'master';
-    final BuildStatus status = (await buildStatusService.calculateCumulativeStatus(branch: branch))!;
+    final String repoName = request!.uri.queryParameters[kRepoParam] ?? 'flutter';
+    final RepositorySlug slug = RepositorySlug('flutter', repoName);
+    final BuildStatus status = (await buildStatusService.calculateCumulativeStatus(slug))!;
     final BuildStatusResponse response = BuildStatusResponse()
       ..buildStatus = status.succeeded ? EnumBuildStatus.success : EnumBuildStatus.failure
       ..failingTasks.addAll(status.failedTasks);

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -38,7 +38,7 @@ class GetStatus extends RequestHandler<Body> {
     final String? encodedLastCommitKey = request!.uri.queryParameters[kLastCommitKeyParam];
     final String repoName = request!.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
-    final String branch = request!.uri.queryParameters[kBranchParam] ?? 'master';
+    final String branch = request!.uri.queryParameters[kBranchParam] ?? Config.defaultBranch(slug);
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusProvider(datastore);
     final KeyHelper keyHelper = config.keyHelper;

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -36,7 +36,7 @@ class GetStatus extends RequestHandler<Body> {
   @override
   Future<Body> get() async {
     final String? encodedLastCommitKey = request!.uri.queryParameters[kLastCommitKeyParam];
-    final String repoName = request!.uri.queryParameters[kRepoParam] ?? config.flutterSlug.name;
+    final String repoName = request!.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
     final String branch = request!.uri.queryParameters[kBranchParam] ?? 'master';
     final DatastoreService datastore = datastoreProvider(config.db);

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:gcloud/db.dart';
+import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
@@ -28,13 +29,16 @@ class GetStatus extends RequestHandler<Body> {
   final DatastoreServiceProvider datastoreProvider;
   final BuildStatusServiceProvider buildStatusProvider;
 
-  static const String lastCommitKeyParam = 'lastCommitKey';
-  static const String branchParam = 'branch';
+  static const String kLastCommitKeyParam = 'lastCommitKey';
+  static const String kBranchParam = 'branch';
+  static const String kRepoParam = 'repo';
 
   @override
   Future<Body> get() async {
-    final String? encodedLastCommitKey = request!.uri.queryParameters[lastCommitKeyParam];
-    final String branch = request!.uri.queryParameters[branchParam] ?? 'master';
+    final String? encodedLastCommitKey = request!.uri.queryParameters[kLastCommitKeyParam];
+    final String repoName = request!.uri.queryParameters[kRepoParam] ?? config.flutterSlug.name;
+    final RepositorySlug slug = RepositorySlug('flutter', repoName);
+    final String branch = request!.uri.queryParameters[kBranchParam] ?? 'master';
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusProvider(datastore);
     final KeyHelper keyHelper = config.keyHelper;
@@ -42,7 +46,12 @@ class GetStatus extends RequestHandler<Body> {
     final int lastCommitTimestamp = await _obtainTimestamp(encodedLastCommitKey, keyHelper, datastore);
 
     final List<SerializableCommitStatus> statuses = await buildStatusService
-        .retrieveCommitStatus(limit: commitNumber, timestamp: lastCommitTimestamp, branch: branch)
+        .retrieveCommitStatus(
+          limit: commitNumber,
+          timestamp: lastCommitTimestamp,
+          branch: branch,
+          slug: slug,
+        )
         .map<SerializableCommitStatus>(
             (CommitStatus status) => SerializableCommitStatus(status, keyHelper.encode(status.commit.key)))
         .toList();

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -443,7 +443,7 @@ class GithubWebhook extends RequestHandler<Body> {
       }
       return;
     }
-    if (config.isDefaultBranch(pr.base!.ref!)) {
+    if (Config.defaultBranch(pr.base!.repo!.slug()) == pr.base!.ref!) {
       return;
     }
     final RegExp candidateTest = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
@@ -462,7 +462,7 @@ class GithubWebhook extends RequestHandler<Body> {
       await gitHubClient.pullRequests.edit(
         slug,
         pr.number!,
-        base: config.defaultBranch,
+        base: Config.defaultBranch(slug),
       );
       await gitHubClient.issues.createComment(slug, pr.number!, body);
     }

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -59,11 +59,9 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     final RepositorySlug slug = RepositorySlug.full(repo);
     final DatastoreService datastore = datastoreProvider(config.db);
     final BuildStatusService buildStatusService = buildStatusServiceProvider(datastore);
-    // TODO(godofredoc): remove after https://github.com/flutter/flutter/issues/90476 is complete.
-    final String defaultBranch = repo == 'flutter/engine' ? 'main' : config.defaultBranch;
 
     final Commit tipOfTreeCommit = Commit(
-      sha: defaultBranch,
+      sha: Config.defaultBranch(slug),
       repository: slug.fullName,
     );
     final CiYaml ciYaml = await scheduler!.getCiYaml(tipOfTreeCommit);
@@ -85,8 +83,8 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
         status = GithubBuildStatusUpdate.statusFailure;
       }
     });
-    await _insertBigquery(slug, status, defaultBranch, config);
-    await _updatePRs(slug, status, datastore, defaultBranch);
+    await _insertBigquery(slug, status, Config.defaultBranch(slug), config);
+    await _updatePRs(slug, status, datastore, Config.defaultBranch(slug));
     log.fine('All the PRs for $repo have been updated with $status');
 
     return Body.empty;

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -46,7 +46,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       return Body.empty;
     }
 
-    final RepositorySlug slug = config.flutterSlug;
+    final RepositorySlug slug = Config.flutterSlug;
     final GitHub gitHubClient = await config.createGitHubClient(slug: slug);
     final List<GithubGoldStatusUpdate> statusUpdates = <GithubGoldStatusUpdate>[];
     log.fine('Beginning Gold checks...');

--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -57,7 +57,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final String repoName = request!.uri.queryParameters[kRepoParam] ?? config.flutterSlug.name;
+    final String repoName = request!.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
     final LuciService luciService = luciServiceProvider(this);
     final DatastoreService datastore = datastoreProvider(config.db);

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -34,7 +34,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
 
   @override
   Future<Body> get() async {
-    final RepositorySlug slug = config.flutterSlug;
+    final RepositorySlug slug = Config.flutterSlug;
     final GithubService gitHub = config.createGithubServiceWithToken(await config.githubOAuthToken);
     final BigqueryService bigquery = await config.createBigQueryService();
     final YamlMap? ci = loadYaml(await gitHub.getFileContent(slug, kCiYamlPath)) as YamlMap?;

--- a/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
@@ -78,7 +78,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
     }
 
     // For release branches, only look at the latest commit.
-    if (branch != config.defaultBranch && commits.isNotEmpty) {
+    if (branch != Config.defaultBranch(slug) && commits.isNotEmpty) {
       commits = <RepositoryCommit>[commits.last];
     }
 

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -58,6 +58,15 @@ class Config {
     RepositorySlug('flutter', 'flutter'),
   };
 
+  /// The tip of tree branch for [slug].
+  static String defaultBranch(RepositorySlug slug) {
+    if (slug == flutterSlug) {
+      return 'master';
+    }
+
+    return 'main';
+  }
+
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 
@@ -238,10 +247,6 @@ class Config {
 
   KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
 
-  String get defaultBranch => kDefaultBranchName;
-
-  bool isDefaultBranch(String branch) => branch == kDefaultBranchName || branch == 'main';
-
   // Default number of commits to return for benchmark dashboard.
   int /*!*/ get maxRecords => 50;
 
@@ -252,8 +257,8 @@ class Config {
   String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
 
-  RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
-  RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
+  static RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
+  static RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -586,7 +586,12 @@ class LuciBuildService {
     if (!taskFailStatusSet.contains(luciTask.status) || retries >= config.maxLuciTaskRetries) {
       return false;
     }
-    final Commit latestCommit = await datastore!.queryRecentCommits(limit: 1).single;
+    final Commit latestCommit = await datastore!
+        .queryRecentCommits(
+          limit: 1,
+          slug: commit.slug,
+        )
+        .single;
     return latestCommit.sha == commit.sha;
   }
 }

--- a/app_dart/test/request_handlers/deflake_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/deflake_flaky_builders_test.dart
@@ -149,7 +149,7 @@ void main() {
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0], config.flutterSlug);
+      expect(captured[0], Config.flutterSlug);
       expect(captured[1] as int?, existingIssueNumber);
 
       // Verify tree is created correctly.
@@ -190,7 +190,7 @@ void main() {
       // Verify pr is created correctly.
       captured = verify(mockPullRequestsService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<CreatePullRequest>());
       final CreatePullRequest pr = captured[1] as CreatePullRequest;
       expect(pr.title, expectedSemanticsIntegrationTestPullRequestTitle);
@@ -286,7 +286,7 @@ void main() {
       // Verify pr is created correctly.
       captured = verify(mockPullRequestsService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<CreatePullRequest>());
       final CreatePullRequest pr = captured[1] as CreatePullRequest;
       expect(pr.title, expectedSemanticsIntegrationTestPullRequestTitle);
@@ -335,7 +335,7 @@ void main() {
       // Verify it gets the correct issue.
       final List<dynamic> captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0], config.flutterSlug);
+      expect(captured[0], Config.flutterSlug);
       expect(captured[1] as int?, existingIssueNumber);
 
       // Verify pr is not created.
@@ -374,7 +374,7 @@ void main() {
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0], config.flutterSlug);
+      expect(captured[0], Config.flutterSlug);
       expect(captured[1] as int?, existingIssueNumber);
 
       // Verify pr is not created.
@@ -413,7 +413,7 @@ void main() {
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0], config.flutterSlug);
+      expect(captured[0], Config.flutterSlug);
       expect(captured[1] as int?, existingIssueNumber);
 
       // Verify pr is not created.
@@ -480,7 +480,7 @@ void main() {
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0], config.flutterSlug);
+      expect(captured[0], Config.flutterSlug);
       expect(captured[1] as int?, existingIssueNumber);
 
       // Verify pr is not created.

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -144,7 +144,7 @@ void main() {
       // Verify issue is created correctly.
       List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       final IssueRequest issueRequest = captured[1] as IssueRequest;
       expect(issueRequest.title, expectedSemanticsIntegrationTestResponseTitle);
@@ -191,7 +191,7 @@ void main() {
       // Verify pr is created correctly.
       captured = verify(mockPullRequestsService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<CreatePullRequest>());
       final CreatePullRequest pr = captured[1] as CreatePullRequest;
       expect(pr.title, expectedSemanticsIntegrationTestPullRequestTitle);
@@ -235,7 +235,7 @@ void main() {
       // Verify issue is created correctly.
       List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       final IssueRequest issueRequest = captured[1] as IssueRequest;
       expect(issueRequest.assignee, expectedAnalyzeTestResponseAssignee);
@@ -244,7 +244,7 @@ void main() {
       // Verify pr is created correctly.
       captured = verify(mockPullRequestsService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<CreatePullRequest>());
 
       expect(result['Status'], 'success');
@@ -267,7 +267,7 @@ void main() {
       // Verify issue is created correctly.
       final List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       final IssueRequest issueRequest = captured[1] as IssueRequest;
       expect(issueRequest.body, expectedLimitedNumberOfBuildsResponseBody);
@@ -292,7 +292,7 @@ void main() {
       // Verify issue is created correctly.
       final List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       final IssueRequest issueRequest = captured[1] as IssueRequest;
       expect(issueRequest.assignee, expectedFrameworkTestResponseAssignee);
@@ -320,7 +320,7 @@ void main() {
       // Verify issue is created correctly.
       final List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       // Verify no pr is created.
       verifyNever(mockPullRequestsService.create(captureAny, captureAny));
@@ -452,7 +452,7 @@ void main() {
       // Verify issue is created correctly.
       final List<dynamic> captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
       expect(captured.length, 2);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], isA<IssueRequest>());
       final IssueRequest issueRequest = captured[1] as IssueRequest;
       expect(issueRequest.title, expectedSemanticsIntegrationTestResponseTitle);

--- a/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
+++ b/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/request_handlers/flaky_handler_utils.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart' hide Team;
 import 'package:mockito/mockito.dart';
@@ -110,7 +111,7 @@ abc_test.sh @ghi @flutter/framework
         final FakeConfig config = FakeConfig(
           githubService: GithubService(mockGitHubClient),
         );
-        expect(() => getExistingPRs(config.githubService!, config.flutterSlug), throwsA(predicate<String>((String e) {
+        expect(() => getExistingPRs(config.githubService!, Config.flutterSlug), throwsA(predicate<String>((String e) {
           return e.contains('Unable to parse body of $expectedHtml');
         })));
       });
@@ -128,7 +129,7 @@ abc_test.sh @ghi @flutter/framework
         final FakeConfig config = FakeConfig(
           githubService: GithubService(mockGitHubClient),
         );
-        expect(await getExistingPRs(config.githubService!, config.flutterSlug), <String?, PullRequest>{});
+        expect(await getExistingPRs(config.githubService!, Config.flutterSlug), <String?, PullRequest>{});
       });
     });
   });

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -117,7 +117,7 @@ void main() {
           'ahNzfmZsdXR0ZXItZGFzaGJvYXJkckcLEglDaGVja2xpc3QiOGZsdXR0ZXIvZmx1dHRlci9lYTI4YTljMzRkYzcwMWRlODkxZWFmNzQ1MDNjYTQ3MTcwMTlmODI5DA';
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
-        GetStatus.lastCommitKeyParam: expectedLastCommitKeyEncoded,
+        GetStatus.kLastCommitKeyParam: expectedLastCommitKeyEncoded,
       });
       final Map<String, dynamic> result = (await decodeHandlerBody())!;
 
@@ -158,7 +158,7 @@ void main() {
       expect(config.db.values.length, 2);
 
       tester.request = FakeHttpRequest(queryParametersValue: <String, String>{
-        GetStatus.branchParam: branch,
+        GetStatus.kBranchParam: branch,
       });
       final Map<String, dynamic> result = (await decodeHandlerBody())!;
 

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -72,7 +72,7 @@ void main() {
     when(issuesService.listCommentsByIssue(any, any))
         .thenAnswer((_) => Stream<IssueComment>.fromIterable(<IssueComment>[IssueComment()]));
     pullRequestsService = MockPullRequestsService();
-    when(pullRequestsService.listFiles(config.flutterSlug, any))
+    when(pullRequestsService.listFiles(Config.flutterSlug, any))
         .thenAnswer((_) => const Stream<PullRequestFile>.empty());
     when(pullRequestsService.edit(any, any, title: anyNamed('title'), state: anyNamed('state'), base: anyNamed('base')))
         .thenAnswer((_) async => PullRequest());
@@ -160,13 +160,13 @@ void main() {
       final String hmac = getHmac(body, key);
       request.headers.set('X-Hub-Signature', 'sha1=$hmac');
 
-      when(pullRequestsService.listFiles(config.flutterSlug, issueNumber)).thenAnswer(
+      when(pullRequestsService.listFiles(Config.flutterSlug, issueNumber)).thenAnswer(
         (_) => Stream<PullRequestFile>.value(
           PullRequestFile()..filename = 'packages/flutter/blah.dart',
         ),
       );
 
-      when(issuesService.listCommentsByIssue(config.flutterSlug, issueNumber)).thenAnswer(
+      when(issuesService.listCommentsByIssue(Config.flutterSlug, issueNumber)).thenAnswer(
         (_) => Stream<IssueComment>.value(
           IssueComment()..body = 'some other comment',
         ),
@@ -175,13 +175,13 @@ void main() {
       await tester.post(webhook);
 
       verify(pullRequestsService.edit(
-        config.flutterSlug,
+        Config.flutterSlug,
         issueNumber,
         state: 'closed',
       )).called(1);
 
       verify(issuesService.createComment(
-        config.flutterSlug,
+        Config.flutterSlug,
         issueNumber,
         argThat(contains(config.wrongHeadBranchPullRequestMessageValue)),
       )).called(1);
@@ -849,7 +849,7 @@ void main() {
       request.body = generatePullRequestEvent(
         'opened',
         issueNumber,
-        kDefaultBranchName,
+        'main',
         repoName: 'engine',
         repoFullName: 'flutter/engine',
       );
@@ -1786,7 +1786,7 @@ void foo() {
         request.headers.set('X-Hub-Signature', 'sha1=$hmac');
 
         await tester.post(webhook);
-        verify(issuesService.createComment(config.flutterSlug, issueNumber, config.mergeConflictPullRequestMessage));
+        verify(issuesService.createComment(Config.flutterSlug, issueNumber, config.mergeConflictPullRequestMessage));
       });
 
       test('When synchronized, cancels existing builds and schedules new ones', () async {

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/src/model/appengine/github_build_status_update.da
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handlers/push_build_status_to_github.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci.dart';
 import 'package:gcloud/db.dart';
@@ -54,7 +55,7 @@ void main() {
     GithubBuildStatusUpdate newStatusUpdate(PullRequest pr, BuildStatus status) {
       return GithubBuildStatusUpdate(
         key: db.emptyKey.append(GithubBuildStatusUpdate, id: pr.number),
-        repository: config.flutterSlug.fullName,
+        repository: Config.flutterSlug.fullName,
         status: status.githubStatus,
         pr: pr.number!,
         head: pr.head!.sha,
@@ -96,7 +97,7 @@ void main() {
       when(github.pullRequests).thenReturn(pullRequestsService);
       when(github.issues).thenReturn(issuesService);
       when(github.repositories).thenReturn(repositoriesService);
-      when(pullRequestsService.list(any, base: config.defaultBranch)).thenAnswer((Invocation _) {
+      when(pullRequestsService.list(any, base: Config.defaultBranch(Config.flutterSlug))).thenAnswer((Invocation _) {
         return Stream<PullRequest>.fromIterable(prsFromGitHub);
       });
       when(repositoriesService.createStatus(any, any, any)).thenAnswer(
@@ -238,7 +239,7 @@ void main() {
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_test_1']));
 
       config.db.values[status.key] = status;
-      builders.add(LuciBuilder(name: 'flaky', repo: config.engineSlug.name, flaky: true));
+      builders.add(LuciBuilder(name: 'flaky', repo: Config.engineSlug.name, flaky: true));
       final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
         builders,
         key: (dynamic builder) => builder as LuciBuilder,

--- a/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_chromebot_status_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/request_handlers/refresh_chromebot_status.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci.dart';
 import 'package:gcloud/db.dart';
@@ -39,7 +40,7 @@ void main() {
     setUp(() async {
       tabledataResource = FakeTabledataResource();
       config = FakeConfig(tabledataResource: tabledataResource);
-      config.flutterBranchesValue = <String>[config.defaultBranch];
+      config.flutterBranchesValue = <String>[Config.defaultBranch(Config.flutterSlug)];
       tester = ApiRequestHandlerTester();
       mockLuciService = MockLuciService();
       mockLuciBuildService = MockLuciBuildService();
@@ -61,8 +62,8 @@ void main() {
       commit = Commit(
         key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/master/abc'),
         sha: 'abc',
-        branch: config.defaultBranch,
-        repository: config.flutterSlug.fullName,
+        branch: Config.defaultBranch(Config.flutterSlug),
+        repository: Config.flutterSlug.fullName,
       );
       builders = await scheduler.getPostSubmitBuilders(exampleConfig);
     });
@@ -149,7 +150,7 @@ void main() {
           key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/test/abc'),
           sha: 'abc',
           branch: 'test',
-          repository: config.flutterSlug.fullName,
+          repository: Config.flutterSlug.fullName,
         );
         final Task task = Task(
           key: branchCommit.key.append(Task, id: 123),
@@ -355,14 +356,14 @@ void main() {
           key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/test/def'),
           sha: 'def',
           branch: 'test',
-          repository: config.flutterSlug.fullName,
+          repository: Config.flutterSlug.fullName,
         );
         final Task task = Task(
             key: branchCommit.key.append(Task, id: 456),
             commitKey: branchCommit.key,
             name: 'Linux A',
             status: Task.statusNew);
-        config.flutterBranchesValue = <String>[config.defaultBranch, 'test'];
+        config.flutterBranchesValue = <String>[Config.defaultBranch(Config.flutterSlug), 'test'];
         config.db.values[commit.key] = commit;
         config.db.values[branchCommit.key] = branchCommit;
         config.db.values[task.key] = task;
@@ -430,7 +431,7 @@ void main() {
         config.db.values[task.key] = task;
         final Map<BranchLuciBuilder, Map<String, List<LuciTask>>> luciTasks =
             Map<BranchLuciBuilder, Map<String, List<LuciTask>>>.fromIterable(<LuciBuilder>[
-          LuciBuilder(name: 'Mac abc', repo: config.flutterSlug.name, taskName: 'def', flaky: false)
+          LuciBuilder(name: 'Mac abc', repo: Config.flutterSlug.name, taskName: 'def', flaky: false)
         ],
                 key: (dynamic builder) => BranchLuciBuilder(luciBuilder: builder as LuciBuilder?, branch: 'master'),
                 value: (dynamic builder) => <String, List<LuciTask>>{

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -131,7 +131,7 @@ void main() {
       // Verify comment is created correctly.
       List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
       expect(captured.length, 3);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], existingIssueNumber);
       expect(captured[2], expectedSemanticsIntegrationTestIssueComment);
 
@@ -143,7 +143,7 @@ void main() {
       )).captured;
       expect(captured.length, 3);
       expect(captured[0].toString(), 'PUT');
-      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[1], '/repos/${Config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
       expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
 
       expect(result['Status'], 'success');
@@ -252,7 +252,7 @@ void main() {
       // Verify comment is created correctly.
       List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
       expect(captured.length, 3);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], existingIssueNumber);
       expect(captured[2], expectedStagingSemanticsIntegrationTestIssueComment);
 
@@ -264,7 +264,7 @@ void main() {
       )).captured;
       expect(captured.length, 3);
       expect(captured[0].toString(), 'PUT');
-      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[1], '/repos/${Config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
       expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
 
       expect(result['Status'], 'success');
@@ -316,7 +316,7 @@ void main() {
       // Verify comment is created correctly.
       final List<dynamic> captured = verify(mockIssuesService.edit(captureAny, captureAny, captureAny)).captured;
       expect(captured.length, 3);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], existingIssueNumber);
       final IssueRequest request = captured[2] as IssueRequest;
       expect(request.assignee, 'HansMuller');
@@ -371,7 +371,7 @@ void main() {
       // Verify issue is created correctly.
       List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
       expect(captured.length, 3);
-      expect(captured[0].toString(), config.flutterSlug.toString());
+      expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], existingIssueNumber);
       expect(captured[2], expectedSemanticsIntegrationTestZeroFlakeIssueComment);
 
@@ -383,7 +383,7 @@ void main() {
       )).captured;
       expect(captured.length, 3);
       expect(captured[0].toString(), 'PUT');
-      expect(captured[1], '/repos/${config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[1], '/repos/${Config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
       expect(captured[2], GitHubJson.encode(<String>['some random label', 'P2']));
 
       expect(result['Status'], 'success');

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handlers/update_task_status.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
@@ -42,7 +43,7 @@ void main() {
       );
       commit = Commit(
         key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/master/$commitSha'),
-        repository: config.flutterSlug.fullName,
+        repository: Config.flutterSlug.fullName,
         sha: commitSha,
         timestamp: 123,
       );

--- a/app_dart/test/service/datastore_test.dart
+++ b/app_dart/test/service/datastore_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/datastore.dart' as gcloud_datastore;
 import 'package:gcloud/db.dart';
@@ -41,7 +42,7 @@ void main() {
       commit = Commit(
         key: config.db.emptyKey.append(Commit, id: 'abc_master'),
         sha: 'abc_master',
-        repository: config.flutterSlug.fullName,
+        repository: Config.flutterSlug.fullName,
         branch: 'master',
       );
     });
@@ -57,7 +58,7 @@ void main() {
         for (String branch in <String>['master', 'release']) {
           final Commit commit = Commit(
             key: config.db.emptyKey.append(Commit, id: 'abc_$branch'),
-            repository: config.flutterSlug.fullName,
+            repository: Config.flutterSlug.fullName,
             sha: 'abc_$branch',
             branch: branch,
           );

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -11,6 +11,7 @@ import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/logging.dart';
 import 'package:cocoon_service/src/service/luci.dart';
@@ -63,7 +64,7 @@ void main() {
         );
       });
       final Iterable<Build> builds = await service.getTryBuilds(
-        config.flutterSlug,
+        Config.flutterSlug,
         'shasha',
         'abcd',
       );
@@ -102,7 +103,7 @@ void main() {
         );
       });
       final Iterable<Build> builds = await service.getTryBuilds(
-        config.flutterSlug,
+        Config.flutterSlug,
         'shasha',
         'abcd',
       );

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -127,9 +127,6 @@ class FakeConfig implements Config {
   FakeDatastoreDB get db => dbValue;
 
   @override
-  String get defaultBranch => kDefaultBranchName;
-
-  @override
   int get maxTaskRetries => maxTaskRetriesValue!;
 
   /// Size of the shards to send to buildBucket when scheduling builds.
@@ -222,9 +219,6 @@ class FakeConfig implements Config {
   String get waitingForTreeToGoGreenLabelName => waitingForTreeToGoGreenLabelNameValue!;
 
   @override
-  RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
-
-  @override
   Future<ServiceAccountCredentials> get taskLogServiceAccount async => taskLogServiceAccountValue!;
 
   @override
@@ -270,9 +264,6 @@ class FakeConfig implements Config {
   Future<List<String>> getSupportedBranches(RepositorySlug slug) async => supportedBranchesValue!;
 
   @override
-  RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
-
-  @override
   Future<GithubService> createDefaultGitHubService() async => githubService!;
 
   @override
@@ -280,7 +271,4 @@ class FakeConfig implements Config {
 
   @override
   Future<String> get overrideTreeStatusLabel async => overrideTreeStatusLabelValue!;
-
-  @override
-  bool isDefaultBranch(String branch) => branch == kDefaultBranchName || branch == 'main';
 }

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -178,7 +178,9 @@ class FakeQuery<T extends Model<dynamic>> implements Query<T> {
     for (FakeFilterSpec filter in filters) {
       final String filterString = filter.filterString;
       final Object? value = filter.comparisonObject;
-      if (filterString.contains('branch =') || filterString.contains('head =')) {
+      if (filterString.contains('branch =') ||
+          filterString.contains('head =') ||
+          filterString.contains('repository =')) {
         resultsView = resultsView.where((T result) => result.toString().contains(value.toString()));
       }
     }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -5,6 +5,7 @@
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci.dart';
+import 'package:github/github.dart';
 
 class FakeBuildStatusService implements BuildStatusService {
   FakeBuildStatusService({
@@ -16,7 +17,7 @@ class FakeBuildStatusService implements BuildStatusService {
   List<CommitStatus>? commitStatuses;
 
   @override
-  Future<BuildStatus?> calculateCumulativeStatus({String? branch}) async {
+  Future<BuildStatus?> calculateCumulativeStatus(RepositorySlug slug) async {
     if (cumulativeStatus == null) {
       throw AssertionError();
     }
@@ -24,7 +25,12 @@ class FakeBuildStatusService implements BuildStatusService {
   }
 
   @override
-  Stream<CommitStatus> retrieveCommitStatus({int limit = 100, int? timestamp, String? branch}) {
+  Stream<CommitStatus> retrieveCommitStatus({
+    int limit = 100,
+    int? timestamp,
+    String? branch,
+    required RepositorySlug slug,
+  }) {
     if (commitStatuses == null) {
       throw AssertionError();
     }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/94522

## Test Env

http://testchillers.flutter-dashboard.appspot.com/api/public/get-status?flushCache=true&repo=engine

## Future work

1. Add other repos to supported scheduler repos (to start writing to datastore)
  A. This should get a soak time of 30 commits for each repo to populate enough data for dashboards and tree status
2. Add refresh chromebot cron jobs for each repo (temporary measure until cocoon scheduler is available)
3. Revert tree status back to the datastore algorithm
3. Update frontend to allow for repo switching

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.