### PR TITLE
[release_dashboard] continue button common widget

### DIFF
--- a/release_dashboard/lib/widgets/cherrypicks_substeps.dart
+++ b/release_dashboard/lib/widgets/cherrypicks_substeps.dart
@@ -152,6 +152,7 @@ class CherrypicksSubstepsState extends State<CherrypicksSubsteps> {
             substepPressed(CherrypicksSubstep.applyCherrypicks);
           },
         ),
+        const SizedBox(height: 20.0),
         ContinueButton(
             elevatedButtonKey: Key('apply${repositoryName(widget.repository, true)}CherrypicksContinue'),
             enabled: !_isEachSubstepChecked.containsValue(false),

--- a/release_dashboard/test/widgets/common/continue_button_test.dart
+++ b/release_dashboard/test/widgets/common/continue_button_test.dart
@@ -1,0 +1,113 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_ui/widgets/common/continue_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const Key buttonKey = Key('testButton');
+  const String errorMsg = 'There is an error';
+
+  group('Continue button tests', () {
+    testWidgets('Renders elements correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ContinueButton(
+              elevatedButtonKey: buttonKey,
+              enabled: true,
+              onPressedCallback: () async {},
+              isLoading: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(buttonKey), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.byType(SelectableText), findsNothing);
+      expect(tester.widget<ElevatedButton>(find.byKey(buttonKey)).enabled, equals(true));
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('Display the error message', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ContinueButton(
+              elevatedButtonKey: buttonKey,
+              error: errorMsg,
+              enabled: true,
+              onPressedCallback: () async {},
+              isLoading: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text(errorMsg), findsOneWidget);
+      expect(find.byType(SelectableText), findsOneWidget);
+    });
+
+    testWidgets('Disable the button', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ContinueButton(
+              elevatedButtonKey: buttonKey,
+              enabled: false,
+              onPressedCallback: () async {},
+              isLoading: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(tester.widget<ElevatedButton>(find.byKey(buttonKey)).enabled, equals(false));
+    });
+
+    testWidgets('Display the loading widget', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ContinueButton(
+              elevatedButtonKey: buttonKey,
+              enabled: true,
+              onPressedCallback: () async {},
+              isLoading: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('Execute onPressedCallback if button is enabled', (WidgetTester tester) async {
+      bool callbackExecuted = false;
+      Future<void> onPressedCallback() async {
+        callbackExecuted = true;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ContinueButton(
+              elevatedButtonKey: buttonKey,
+              enabled: true,
+              onPressedCallback: onPressedCallback,
+              isLoading: false,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pumpAndSettle();
+      expect(callbackExecuted, true);
+    });
+  });
+}


### PR DESCRIPTION
Made `continueButton` of each step a common widget so it could be used across any steps.

Main Issue:
- [x] https://github.com/flutter/flutter/issues/94582

PR needs to be rebased and updated after this has been merged:
https://github.com/flutter/cocoon/pull/1482
https://github.com/flutter/cocoon/pull/1483
https://github.com/flutter/cocoon/pull/1484
https://github.com/flutter/cocoon/pull/1487

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
