### PR TITLE
[release_dashboard] Add tests for cherrypickState

### DIFF
--- a/release_dashboard/lib/logic/cherrypick_state.dart
+++ b/release_dashboard/lib/logic/cherrypick_state.dart
@@ -4,6 +4,13 @@
 
 import 'package:conductor_core/proto.dart' as pb;
 
+const Map<pb.CherrypickState, String> cherrypickStates = <pb.CherrypickState, String>{
+  pb.CherrypickState.PENDING: 'PENDING',
+  pb.CherrypickState.PENDING_WITH_CONFLICT: 'PENDING_WITH_CONFLICT',
+  pb.CherrypickState.COMPLETED: 'COMPLETED',
+  pb.CherrypickState.ABANDONED: 'ABANDONED',
+};
+
 // TODO(Yugue): [conductor] add extension method that returns the cherrypick state string,
 // https://github.com/flutter/flutter/issues/94387.
 extension CherrypickStateExtension on pb.CherrypickState {
@@ -21,12 +28,6 @@ extension CherrypickStateExtension on pb.CherrypickState {
   /// ```
   /// {@end-tool}
   String string() {
-    const Map<pb.CherrypickState, String> cherrypickStates = <pb.CherrypickState, String>{
-      pb.CherrypickState.PENDING: 'PENDING',
-      pb.CherrypickState.PENDING_WITH_CONFLICT: 'PENDING_WITH_CONFLICT',
-      pb.CherrypickState.COMPLETED: 'COMPLETED',
-      pb.CherrypickState.ABANDONED: 'ABANDONED',
-    };
     return (cherrypickStates[this]!);
   }
 }

--- a/release_dashboard/lib/logic/cherrypick_state.dart
+++ b/release_dashboard/lib/logic/cherrypick_state.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:conductor_core/proto.dart' as pb;
+import 'package:flutter/material.dart';
 
+@visibleForTesting
 const Map<pb.CherrypickState, String> cherrypickStates = <pb.CherrypickState, String>{
   pb.CherrypickState.PENDING: 'PENDING',
   pb.CherrypickState.PENDING_WITH_CONFLICT: 'PENDING_WITH_CONFLICT',

--- a/release_dashboard/pubspec.lock
+++ b/release_dashboard/pubspec.lock
@@ -158,6 +158,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:

--- a/release_dashboard/test/logic/cherrypick_state_test.dart
+++ b/release_dashboard/test/logic/cherrypick_state_test.dart
@@ -2,15 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:conductor_core/proto.dart' as pb;
 import 'package:conductor_ui/logic/cherrypick_state.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Cherrypick State extension tests', () {
-    for (MapEntry cherrypickState in cherrypickStates.entries) {
-      test('${cherrypickState.key} state is able to be converted to its corresponding string correctly', () {
-        expect(cherrypickState.key.toString(), equals(cherrypickState.value));
-      });
-    }
+    cherrypickStates.forEach(
+      (pb.CherrypickState state, String stateValue) => {
+        test('$state state is able to be converted to its corresponding string correctly', () {
+          expect(state.string(), equals(stateValue));
+        })
+      },
+    );
   });
 }

--- a/release_dashboard/test/logic/cherrypick_state_test.dart
+++ b/release_dashboard/test/logic/cherrypick_state_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:conductor_ui/logic/cherrypick_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Cherrypick State extension tests', () {
+    for (MapEntry cherrypickState in cherrypickStates.entries) {
+      test('${cherrypickState.key} state is able to be converted to its corresponding string correctly', () {
+        expect(cherrypickState.key.toString(), equals(cherrypickState.value));
+      });
+    }
+  });
+}

--- a/release_dashboard/test/logic/cherrypick_state_test.dart
+++ b/release_dashboard/test/logic/cherrypick_state_test.dart
@@ -9,9 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Cherrypick State extension tests', () {
     cherrypickStates.forEach(
-      (pb.CherrypickState state, String stateValue) => {
+      (pb.CherrypickState state, String stateStr) => {
         test('$state state is able to be converted to its corresponding string correctly', () {
-          expect(state.string(), equals(stateValue));
+          expect(state.string(), equals(stateStr));
         })
       },
     );


### PR DESCRIPTION
Previously the `cherrypickState` `toString` extension function does not have tests. This PR adds the missing tests.

Main Issue:
- [x] https://github.com/flutter/flutter/issues/94742

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
