### PR TITLE
[release_dashboard] Add follow each step and substeps in order

### DIFF
--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -56,12 +56,18 @@ class MyApp extends StatelessWidget {
             padding: const EdgeInsets.all(20.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              children: const <Widget>[
+              children: <Widget>[
                 SelectableText(
                   'Desktop app for managing a release of the Flutter SDK, currently in development',
+                  style: Theme.of(context).textTheme.subtitle1,
                 ),
-                SizedBox(height: 10.0),
-                MainProgression(),
+                const SizedBox(height: 10.0),
+                SelectableText(
+                  'Please follow each step and substep in order.',
+                  style: Theme.of(context).textTheme.subtitle1,
+                ),
+                const SizedBox(height: 10.0),
+                const MainProgression(),
               ],
             ),
           ),

--- a/release_dashboard/test/main_test.dart
+++ b/release_dashboard/test/main_test.dart
@@ -6,6 +6,7 @@ import 'dart:io' show Platform;
 
 import 'package:conductor_ui/main.dart';
 import 'package:conductor_ui/widgets/clean_release_button.dart';
+import 'package:conductor_ui/widgets/progression.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'fakes/services/fake_conductor.dart';
@@ -17,7 +18,9 @@ void main() {
 
       expect(find.textContaining('Flutter Desktop Conductor'), findsOneWidget);
       expect(find.textContaining('Desktop app for managing a release'), findsOneWidget);
+      expect(find.text('Please follow each step and substep in order.'), findsOneWidget);
       expect(find.byType(CleanReleaseButton), findsOneWidget);
+      expect(find.byType(MainProgression), findsOneWidget);
     });
   }, skip: Platform.isWindows); // This app does not support Windows [intended]
 }


### PR DESCRIPTION
Added a message that remains the users to follow each step and substep in order.

Main Issue:
- [x] https://github.com/flutter/flutter/issues/94052

Screen capture:

![Screen Shot 2021-12-06 at 3 01 21 PM](https://user-images.githubusercontent.com/20194490/144916017-d4bf6c68-c6b8-46cf-98a8-a27577d32436.png)



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
