### PR TITLE
Fix auto flake comment on open flaky bug for a recently deflaked builder

### DIFF
--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -122,7 +122,9 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     }
     // For all staging builder stats, updates any existing flaky bug.
     for (final BuilderStatistic statistic in stagingBuilderStatisticList) {
-      if (nameToExistingIssue.containsKey(statistic.name) && _buildsAreEnough(statistic)) {
+      if (nameToExistingIssue.containsKey(statistic.name) &&
+          builderFlakyMap[statistic.name] == true &&
+          _buildsAreEnough(statistic)) {
         await _addCommentToExistingIssue(gitHub, slug,
             bucket: _getBucket(builderFlakyMap, statistic.name),
             statistic: statistic,

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -149,6 +149,71 @@ void main() {
       expect(result['Status'], 'success');
     });
 
+    test('Add only one comment on existing issue when a builder has been marked as unflaky', () async {
+      const int existingIssueNumber = 1234;
+      final List<IssueLabel> existingLabels = <IssueLabel>[
+        IssueLabel(name: 'some random label'),
+        IssueLabel(name: 'P2'),
+      ];
+      // When queries flaky data from BigQuery.
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
+      });
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSameBuilderSemanticsIntegrationTestResponse);
+      });
+      // when gets existing flaky issues.
+      when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
+          .thenAnswer((Invocation invocation) {
+        return Stream<Issue>.fromIterable(<Issue>[
+          Issue(
+            assignee: User(login: 'some dude'),
+            number: existingIssueNumber,
+            state: 'open',
+            labels: existingLabels,
+            title: expectedSemanticsIntegrationTestResponseTitle,
+            body: expectedSemanticsIntegrationTestResponseBody,
+            createdAt:
+                DateTime.now().subtract(const Duration(days: UpdateExistingFlakyIssue.kFreshPeriodForOpenFlake + 1)),
+          )
+        ]);
+      });
+      // when firing github request.
+      // This is for replacing labels.
+      when(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).thenAnswer((Invocation invocation) {
+        return Future<Response>.value(Response('[]', 200));
+      });
+      final Map<String, dynamic> result = await utf8.decoder
+          .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
+          .transform(json.decoder)
+          .single as Map<String, dynamic>;
+
+      // Verify comment is created correctly.
+      List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), Config.flutterSlug.toString());
+      expect(captured[1], existingIssueNumber);
+      expect(captured[2], expectedSemanticsIntegrationTestIssueComment);
+
+      // Verify labels are applied correctly.
+      captured = verify(mockGitHubClient.request(
+        captureAny,
+        captureAny,
+        body: captureAnyNamed('body'),
+      )).captured;
+      expect(captured.length, 3);
+      expect(captured[0].toString(), 'PUT');
+      expect(captured[1], '/repos/${Config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
+      expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
+
+      expect(result['Status'], 'success');
+    });
+
     test('Do not add issue comment when not enough data', () async {
       const int existingIssueNumber = 1234;
       final List<IssueLabel> existingLabels = <IssueLabel>[

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -56,6 +56,17 @@ final List<BuilderStatistic> semanticsIntegrationTestResponse = <BuilderStatisti
   )
 ];
 
+final List<BuilderStatistic> stagingSameBuilderSemanticsIntegrationTestResponse = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Mac_android android_semantics_integration_test',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+  )
+];
+
 final List<BuilderStatistic> semanticsIntegrationTestResponseNotEnoughData = <BuilderStatistic>[
   BuilderStatistic(
     name: 'Mac_android android_semantics_integration_test',


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/1464/files updated the bot to comment on open flaky bugs based on different pool stats. But it missed a corner case when a builder was marked as unflaky but a flaky bug is still open. For this case, the bot logic updates the bug twice.

This PR skip the update from staging side, as the builder has been marked as unflaky.

Context: https://github.com/flutter/flutter/issues/93804#