### PR TITLE
[scheduler] Move packages/plugins default branch back to master

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -40,31 +40,35 @@ class Config {
   ///
   /// Relies on the GitHub Checks API being enabled for this repo.
   static Set<RepositorySlug> supportedRepos = <RepositorySlug>{
-    RepositorySlug('flutter', 'cocoon'),
-    RepositorySlug('flutter', 'engine'),
-    RepositorySlug('flutter', 'flutter'),
-    RepositorySlug('flutter', 'packages'),
-    RepositorySlug('flutter', 'plugins'),
+    cocoonSlug,
+    engineSlug,
+    flutterSlug,
+    packagesSlug,
+    pluginsSlug,
   };
 
   /// List of GitHub repositories that are supported by [Scheduler].
   static Set<RepositorySlug> schedulerSupportedRepos = <RepositorySlug>{
-    RepositorySlug('flutter', 'flutter'),
+    flutterSlug,
   };
 
   /// GitHub repositories that use CI status to determine if pull requests can be submitted.
   static Set<RepositorySlug> reposWithTreeStatus = <RepositorySlug>{
-    RepositorySlug('flutter', 'engine'),
-    RepositorySlug('flutter', 'flutter'),
+    engineSlug,
+    flutterSlug,
   };
 
   /// The tip of tree branch for [slug].
   static String defaultBranch(RepositorySlug slug) {
-    if (slug == flutterSlug) {
-      return 'master';
-    }
+    final Map<RepositorySlug, String> defaultBranches = <RepositorySlug, String>{
+      cocoonSlug: 'main',
+      flutterSlug: 'master',
+      engineSlug: 'main',
+      pluginsSlug: 'master',
+      packagesSlug: 'master',
+    };
 
-    return 'main';
+    return defaultBranches[slug] ?? kDefaultBranchName;
   }
 
   /// Memorystore subcache name to store [CocoonConfig] values in.
@@ -257,8 +261,11 @@ class Config {
   String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
 
+  static RepositorySlug get cocoonSlug => RepositorySlug('flutter', 'cocoon');
   static RepositorySlug get engineSlug => RepositorySlug('flutter', 'engine');
   static RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
+  static RepositorySlug get packagesSlug => RepositorySlug('flutter', 'packages');
+  static RepositorySlug get pluginsSlug => RepositorySlug('flutter', 'plugins');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/94790

Making this an explicit map so it's easier to review what the default branch is for each repo

This moves plugins and packages to use master as their default branch.
