### PR TITLE
[app_dart] Update flaky issue bot to link to build dashboard for overviews

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -45,6 +45,7 @@ const int kSuccessBuildNumberLimit = 3;
 const int kFlayRatioBuildNumberList = 10;
 
 const String _commitPrefix = 'https://github.com/flutter/flutter/commit/';
+const String _buildDashboardPrefix = 'https://flutter-dashboard.appspot.com/#/build';
 const String _prodBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/prod/';
 const String _stagingBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/staging/';
 const String _flakeRecordPrefix =
@@ -84,11 +85,12 @@ The post-submit test builder `${statistic.name}` had a flaky ratio ${_formatRate
 
 One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit)}
 Commit: $_commitPrefix${statistic.recentCommit}
+
 Flaky builds:
 ${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!)}
 
-Succeeded builds (3 most recent):
-${_issueBuildLinks(builder: statistic.name, builds: statistic.succeededBuilds!.sublist(0, numberOfSuccessBuilds(statistic.succeededBuilds!.length)))}
+Recent test runs:
+${_issueBuilderLink(statistic.name)}
 
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
@@ -148,6 +150,9 @@ One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic
 Commit: $_commitPrefix${statistic.recentCommit}
 Flaky builds:
 ${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!, bucket: bucket)}
+
+Recent test runs:
+${_issueBuilderLink(statistic.name)}
 ''';
     }
     return result;
@@ -473,6 +478,10 @@ String _issueBuildLinks({String? builder, required List<String> builds, Bucket b
 String _issueBuildLink({String? builder, String? build, Bucket bucket = Bucket.prod}) {
   final String buildPrefix = bucket == Bucket.staging ? _stagingBuildPrefix : _prodBuildPrefix;
   return Uri.encodeFull('$buildPrefix$builder/$build');
+}
+
+String _issueBuilderLink(String? builder) {
+  return Uri.encodeFull('$_buildDashboardPrefix?taskFilter=$builder');
 }
 
 Team _teamFromString(String teamString) {

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
@@ -143,10 +143,8 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/102
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/101
 
-Succeeded builds (3 most recent):
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/203
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/202
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/201
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
 
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
@@ -230,8 +228,8 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/102
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/101
 
-Succeeded builds (3 most recent):
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/201
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
 
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -14,6 +14,9 @@ Flaky builds:
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/102
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/101
+
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
 ''';
 
 const String expectedStagingSemanticsIntegrationTestIssueComment = '''
@@ -24,6 +27,9 @@ Flaky builds:
 https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/103
 https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/102
 https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/101
+
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller
 ''';
 
 const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
@@ -118,10 +124,8 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semanti
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/102
 https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/101
 
-Succeeded builds (3 most recent):
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/203
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/202
-https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/201
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
 
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
@@ -143,10 +147,8 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20r
 https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/102
 https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/101
 
-Succeeded builds (3 most recent):
-https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/203
-https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/202
-https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/201
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter%20roller
 
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/94319

When showing overviews of builders, the MILO pages can disappear. This should instead point to the build dashboard which can show the overview.

Since the flaky issue bot only directly links to builds, I replaced the successful builds section with a recent test runs pointing to the build dashboard.