### PR TITLE
[scheduler] Pass git_branch

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -176,6 +176,7 @@ class LuciBuildService {
     }
     properties ??= <String, dynamic>{};
     properties.addAll(<String, String>{
+      'git_branch': pullRequest.base!.ref!.replaceAll('refs/heads/', ''),
       'git_url': 'https://github.com/${pullRequest.base!.repo!.fullName}',
       'git_ref': 'refs/pull/${pullRequest.number}/head',
     });

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -207,6 +207,7 @@ void main() {
       expect(properties, <String, dynamic>{
         'dependencies': <dynamic>[],
         'bringup': false,
+        'git_branch': 'master',
         'git_url': 'https://github.com/flutter/flutter',
         'git_ref': 'refs/pull/123/head',
       });


### PR DESCRIPTION
Quick fix. Cocoon's scheduler wasn't passing anything so it was using the starlark defaults (which for presubmit can be incorrect on release branches)