### PR TITLE
[release_dashboard] Add dialogPrompt to receive prompt from the core

### DIFF
--- a/release_dashboard/lib/main.dart
+++ b/release_dashboard/lib/main.dart
@@ -65,7 +65,7 @@ class MyApp extends StatelessWidget {
                   style: Theme.of(context).textTheme.subtitle1,
                 ),
                 const SizedBox(height: 10.0),
-                const MainProgression(),
+                MainProgression(conductor: conductor),
               ],
             ),
           ),

--- a/release_dashboard/lib/services/conductor.dart
+++ b/release_dashboard/lib/services/conductor.dart
@@ -2,14 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:file/file.dart';
 import 'package:flutter/material.dart';
+
+import '../widgets/progression.dart' show DialogPromptChanger;
 
 /// Service class for interacting with the conductor library.
 ///
 /// This exists as a common interface for user interface to rely on.
 abstract class ConductorService {
+  late DialogPromptChanger dialogPromptChanger;
+
   /// Returns the directory where checkout is saved.
   Directory get rootDirectory;
 

--- a/release_dashboard/lib/services/dev_local_conductor.dart
+++ b/release_dashboard/lib/services/dev_local_conductor.dart
@@ -74,6 +74,7 @@ class DevLocalConductorService extends LocalConductorService {
       syncStatusWithState: context.read<StatusState>().syncStatusWithState,
       // TODO(yugue): Add a button switch to toggle the force parameter of StartContext.
       // https://github.com/flutter/flutter/issues/94384
+      dialogPromptChanger: super.dialogPromptChanger,
     );
     return startContext.run();
   }

--- a/release_dashboard/lib/services/local_conductor.dart
+++ b/release_dashboard/lib/services/local_conductor.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:conductor_core/conductor_core.dart'
@@ -101,6 +102,7 @@ class LocalConductorService extends ConductorService {
       // the methods of [BuildContext] should not be cached beyond the execution of a
       // single synchronous function.
       syncStatusWithState: context.read<StatusState>().syncStatusWithState,
+      dialogPromptChanger: super.dialogPromptChanger,
       // TODO(yugue): Add a button switch to toggle the force parameter.
       // https://github.com/flutter/flutter/issues/94384
     );
@@ -129,6 +131,7 @@ class LocalConductorService extends ConductorService {
       force: false,
       checkouts: checkouts,
       stateFile: stateFile,
+      dialogPromptChanger: super.dialogPromptChanger,
     );
     await nextContext.run(state!);
   }

--- a/release_dashboard/lib/services/release_dashboard_next_context.dart
+++ b/release_dashboard/lib/services/release_dashboard_next_context.dart
@@ -2,10 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:file/file.dart' show File;
 import 'package:flutter/material.dart';
+
+import '../widgets/progression.dart' show DialogPromptChanger;
 
 /// Service class for using [NextContext] in the local release dashboard environment.
 class ReleaseDashboardNextContext extends NextContext {
@@ -15,6 +19,7 @@ class ReleaseDashboardNextContext extends NextContext {
     required Checkouts checkouts,
     required File stateFile,
     required this.syncStatusWithState,
+    required this.dialogPromptChanger,
   }) : super(
           autoAccept: autoAccept,
           force: force,
@@ -23,6 +28,7 @@ class ReleaseDashboardNextContext extends NextContext {
         );
 
   final VoidCallback syncStatusWithState;
+  final DialogPromptChanger dialogPromptChanger;
 
   /// Update the release's state file based on the current progression.
   ///
@@ -33,10 +39,10 @@ class ReleaseDashboardNextContext extends NextContext {
     syncStatusWithState();
   }
 
-  // TODO(Yugue): [release_dashboard] Add DialoguePrompt for all NextContext command,
-  // https://github.com/flutter/flutter/issues/94222.
   @override
   Future<bool> prompt(String message) async {
-    return true;
+    final Completer<bool> completer = Completer<bool>();
+    dialogPromptChanger(message, completer);
+    return completer.future;
   }
 }

--- a/release_dashboard/lib/services/release_dashboard_start_context.dart
+++ b/release_dashboard/lib/services/release_dashboard_start_context.dart
@@ -2,11 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:file/file.dart';
 import 'package:flutter/material.dart';
 import 'package:process/process.dart';
+
+import '../widgets/progression.dart' show DialogPromptChanger;
 
 class ReleaseDashboardStartContext extends StartContext {
   ReleaseDashboardStartContext({
@@ -26,6 +30,7 @@ class ReleaseDashboardStartContext extends StartContext {
     required Checkouts checkouts,
     required File stateFile,
     bool force = false,
+    required this.dialogPromptChanger,
   }) : super(
           candidateBranch: candidateBranch,
           checkouts: checkouts,
@@ -45,6 +50,7 @@ class ReleaseDashboardStartContext extends StartContext {
         );
 
   final VoidCallback syncStatusWithState;
+  final DialogPromptChanger dialogPromptChanger;
 
   @override
   void updateState(pb.ConductorState state, [List<String> logs = const <String>[]]) {
@@ -52,10 +58,10 @@ class ReleaseDashboardStartContext extends StartContext {
     syncStatusWithState();
   }
 
-  // TODO(Yugue): Add prompt UI to confirm tag creation at startContext.
-  // https://github.com/flutter/flutter/issues/94072.
   @override
   Future<bool> prompt(String message) async {
-    return true;
+    final Completer<bool> completer = Completer<bool>();
+    dialogPromptChanger(message, completer);
+    return completer.future;
   }
 }

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';
@@ -18,7 +20,6 @@ class StatusState extends ChangeNotifier {
   }) : releaseStatus = stateToMap(conductor.state);
 
   final ConductorService conductor;
-
   late Map<ConductorStatusEntry, Object>? releaseStatus;
 
   /// Method that modifies the global state in provider.

--- a/release_dashboard/lib/state/status_state.dart
+++ b/release_dashboard/lib/state/status_state.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/proto.dart' as pb;
 import 'package:flutter/material.dart';

--- a/release_dashboard/test/fakes/fake_next_context.dart
+++ b/release_dashboard/test/fakes/fake_next_context.dart
@@ -5,6 +5,7 @@
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_core/src/proto/conductor_state.pb.dart';
 import 'package:conductor_ui/services/release_dashboard_next_context.dart';
+import 'package:conductor_ui/widgets/progression.dart';
 import 'package:file/file.dart';
 import 'package:flutter/material.dart';
 
@@ -55,4 +56,7 @@ class FakeNextContext implements ReleaseDashboardNextContext {
 
   @override
   VoidCallback get syncStatusWithState => throw UnimplementedError();
+
+  @override
+  DialogPromptChanger get dialogPromptChanger => throw UnimplementedError();
 }

--- a/release_dashboard/test/fakes/fake_start_context.dart
+++ b/release_dashboard/test/fakes/fake_start_context.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:conductor_core/conductor_core.dart';
 import 'package:conductor_ui/services/release_dashboard_start_context.dart';
+import 'package:conductor_ui/widgets/progression.dart';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -37,6 +40,7 @@ class FakeStartContext extends ReleaseDashboardStartContext {
     File? stateFile,
     Future<void> Function()? runOverride,
     void Function()? syncStatusWithState,
+    DialogPromptChanger? dialogPromptChanger,
   }) {
     final FileSystem fileSystem = MemoryFileSystem.test();
     stateFile ??= fileSystem.file(kStateFileName);
@@ -54,6 +58,7 @@ class FakeStartContext extends ReleaseDashboardStartContext {
       processManager: processManager,
       stdio: stdio,
     );
+    dialogPromptChanger ??= (String? data, Completer<bool>? callback) {};
     syncStatusWithState ??= () {};
     return FakeStartContext._(
       candidateBranch: candidateBranch,
@@ -72,6 +77,7 @@ class FakeStartContext extends ReleaseDashboardStartContext {
       stateFile: stateFile,
       runOverride: runOverride,
       syncStatusWithState: syncStatusWithState,
+      dialogPromptChanger: dialogPromptChanger,
     );
   }
 
@@ -92,6 +98,7 @@ class FakeStartContext extends ReleaseDashboardStartContext {
     required File stateFile,
     this.runOverride,
     required void Function() syncStatusWithState,
+    required DialogPromptChanger dialogPromptChanger,
   }) : super(
           candidateBranch: candidateBranch,
           checkouts: checkouts,
@@ -108,6 +115,7 @@ class FakeStartContext extends ReleaseDashboardStartContext {
           releaseChannel: releaseChannel,
           stateFile: stateFile,
           syncStatusWithState: syncStatusWithState,
+          dialogPromptChanger: dialogPromptChanger,
         );
 
   /// An optional override async callback for the real [run] method.


### PR DESCRIPTION
Made a common `dialogPrompt` widget that would listen to the prompts returned by `StartContext` and `NextContext`. Whenever there is a prompt returned, the release dashboard displays a `dialogPrompt` with the prompt message as its content, and execute a completer to fulfill `StartContext` and `NextContext`'s prompts.

Main Issues:
- [x] https://github.com/flutter/flutter/issues/94072
- [x] https://github.com/flutter/flutter/issues/94222
- [x]  https://github.com/flutter/flutter/issues/93156
- [x] https://github.com/flutter/flutter/issues/93939

Screen Recording:


https://user-images.githubusercontent.com/20194490/145631743-04ce05d2-c65d-436c-ba01-9511f769e54c.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
