### PR TITLE
Add authorAssociation field in github graph query for merge bot

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -16,6 +16,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
             author {
               login
             }
+            authorAssociation
             id
             baseRepository {
               nameWithOwner


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/1434, by adding the `authorAssociation` field.

https://github.com/flutter/flutter/issues/95023