### PR TITLE
[app_dart] Move tree status check to be based on datastore algorithm

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -94,8 +94,6 @@ Future<void> main() async {
       '/api/push-build-status-to-github': PushBuildStatusToGithub(
         config,
         authProvider,
-        luciBuildService,
-        scheduler: scheduler,
       ),
       '/api/push-gold-status-to-github': PushGoldStatusToGithub(config, authProvider),
       '/api/refresh-chromebot-status': RefreshChromebotStatus(

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -18,12 +18,10 @@ import '../service/logging.dart';
 class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   const PushBuildStatusToGithub(
     Config config,
-    AuthenticationProvider authenticationProvider,
-     {
+    AuthenticationProvider authenticationProvider, {
     @visibleForTesting DatastoreServiceProvider? datastoreProvider,
     @visibleForTesting BuildStatusServiceProvider? buildStatusServiceProvider,
-  })  : 
-        datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
+  })  : datastoreProvider = datastoreProvider ?? DatastoreService.defaultProvider,
         buildStatusServiceProvider = buildStatusServiceProvider ?? BuildStatusService.defaultProvider,
         super(config: config, authenticationProvider: authenticationProvider);
 

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -167,6 +167,7 @@ class DatastoreService {
 
     if (previousStatusUpdates.isEmpty) {
       return GithubBuildStatusUpdate(
+        key: db.emptyKey.append<int>(GithubBuildStatusUpdate),
         repository: slug.fullName,
         pr: pr.number!,
         head: pr.head!.sha,

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart';
-import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/request_handlers/push_build_status_to_github.dart';
+import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:cocoon_service/src/service/luci.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
+import 'package:googleapis/bigquery/v2.dart' hide Model;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -19,38 +19,26 @@ import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
+import '../src/service/fake_build_status_provider.dart';
 import '../src/service/fake_github_service.dart';
-import '../src/service/fake_scheduler.dart';
+import '../src/utilities/entity_generators.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
   group('PushStatusToGithub', () {
+    late FakeBuildStatusService buildStatusService;
+    late FakeClientContext clientContext;
     late FakeConfig config;
     late FakeDatastoreDB db;
     late ApiRequestHandlerTester tester;
-    FakeClientContext clientContext;
-    FakeAuthenticatedContext authContext;
-    FakeTabledataResource tabledataResourceApi;
-    late MockLuciService mockLuciService;
+    late FakeAuthenticatedContext authContext;
+    late FakeTabledataResource tabledataResourceApi;
     late PushBuildStatusToGithub handler;
-    MockGitHub github;
-    MockPullRequestsService pullRequestsService;
-    MockIssuesService issuesService;
-    MockRepositoriesService repositoriesService;
-    late List<PullRequest> prsFromGitHub;
-    FakeGithubService githubService;
-    late FakeScheduler scheduler;
-    MockLuciBuildService mockLuciBuildService;
-
-    late List<LuciBuilder> builders;
-
-    PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false}) {
-      return PullRequest()
-        ..number = 123
-        ..head = (PullRequestHead()..sha = 'abc')
-        ..base = (PullRequestHead()..ref = baseRef)
-        ..draft = draft;
-    }
+    late MockGitHub github;
+    late MockPullRequestsService pullRequestsService;
+    late MockIssuesService issuesService;
+    late MockRepositoriesService repositoriesService;
+    late FakeGithubService githubService;
 
     GithubBuildStatusUpdate newStatusUpdate(PullRequest pr, BuildStatus status) {
       return GithubBuildStatusUpdate(
@@ -67,6 +55,7 @@ void main() {
       clientContext = FakeClientContext();
       authContext = FakeAuthenticatedContext(clientContext: clientContext);
       clientContext.isDevelopmentEnvironment = false;
+      buildStatusService = FakeBuildStatusService();
       githubService = FakeGithubService();
       tabledataResourceApi = FakeTabledataResource();
       db = FakeDatastoreDB();
@@ -74,7 +63,6 @@ void main() {
       pullRequestsService = MockPullRequestsService();
       issuesService = MockIssuesService();
       repositoriesService = MockRepositoriesService();
-      mockLuciBuildService = MockLuciBuildService();
       config = FakeConfig(
         tabledataResource: tabledataResourceApi,
         githubService: githubService,
@@ -82,224 +70,86 @@ void main() {
         githubClient: github,
       );
       tester = ApiRequestHandlerTester(context: authContext);
-      mockLuciService = MockLuciService();
-      scheduler = FakeScheduler(config: config, ciYaml: exampleConfig);
-      builders = await scheduler.getPostSubmitBuilders(exampleConfig);
       handler = PushBuildStatusToGithub(
         config,
         FakeAuthenticationProvider(clientContext: clientContext),
-        mockLuciBuildService,
-        luciServiceProvider: (_) => mockLuciService,
+        buildStatusServiceProvider: (_) => buildStatusService,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        scheduler: scheduler,
       );
 
       when(github.pullRequests).thenReturn(pullRequestsService);
       when(github.issues).thenReturn(issuesService);
       when(github.repositories).thenReturn(repositoriesService);
-      when(pullRequestsService.list(any, base: Config.defaultBranch(Config.flutterSlug))).thenAnswer((Invocation _) {
-        return Stream<PullRequest>.fromIterable(prsFromGitHub);
-      });
       when(repositoriesService.createStatus(any, any, any)).thenAnswer(
         (_) async => RepositoryStatus(),
       );
     });
 
-    test('Update status in datastore - success to failure', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-
-      final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
-      config.db.values[status.key] = status;
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-              commitSha: 'abc', ref: 'refs/heads/master', status: Task.statusFailed, buildNumber: 1, builderName: 'abc')
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
+    test('development environment does nothing', () async {
+      clientContext.isDevelopmentEnvironment = true;
+      config.githubClient = ThrowingGitHub();
+      db.onCommit = (List<Model<dynamic>> insert, List<Key<dynamic>> deletes) => throw AssertionError();
+      db.addOnQuery<GithubBuildStatusUpdate>((Iterable<GithubBuildStatusUpdate> results) {
+        throw AssertionError();
       });
-      expect(status.status, 'success');
-      await tester.get(handler);
-      expect(status.status, 'failure');
-      expect(status.updateTimeMillis, isNotNull);
+      final Body body = await tester.get<Body>(handler);
+      expect(body, same(Body.empty));
     });
 
-    test('update engine status in datastore for infra failure - success to failure', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-      final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
-      config.db.values[status.key] = status;
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/master',
-              status: Task.statusInfraFailure,
-              buildNumber: 1,
-              builderName: 'abc')
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
+    group('does not update anything', () {
+      setUp(() {
+        db.onCommit = (List<Model<dynamic>> insert, List<Key<dynamic>> deletes) => throw AssertionError();
+        when(repositoriesService.createStatus(any, any, any)).thenThrow(AssertionError());
       });
 
-      expect(status.status, 'success');
-      await tester.get(handler);
-      expect(status.status, 'failure');
-      expect(status.updateTimeMillis, isNotNull);
+      test('if there are no PRs', () async {
+        when(pullRequestsService.list(any, base: anyNamed('base')))
+            .thenAnswer((_) => const Stream<PullRequest>.empty());
+        buildStatusService.cumulativeStatus = BuildStatus.success();
+        final Body body = await tester.get<Body>(handler);
+        final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
+        expect(body, same(Body.empty));
+
+        // Test for BigQuery insert
+        expect(tableDataList.totalRows, '1');
+      });
+
+      test('if status has not changed since last update', () async {
+        final PullRequest pr = generatePullRequest(id: 1, sha: '1');
+        when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
+        buildStatusService.cumulativeStatus = BuildStatus.success();
+        final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
+        db.values[status.key] = status;
+        final Body body = await tester.get<Body>(handler);
+        expect(body, same(Body.empty));
+        expect(status.updates, 0);
+      });
+
+      test('if there is no pr found for a targeted branch', () async {
+        final PullRequest pr = generatePullRequest(id: 1, sha: '1');
+        when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
+        buildStatusService.cumulativeStatus = BuildStatus.success();
+        final GithubBuildStatusUpdate status =
+            newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_task_1']));
+        db.values[status.key] = status;
+        final Body body = await tester.get<Body>(handler);
+        expect(body, same(Body.empty));
+        expect(status.updates, 0);
+        expect(status.status, BuildStatus.failure().githubStatus);
+      });
     });
 
-    test('update engine status in datastore with - failure to success', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-
+    test('updates github and datastore if status has changed since last update', () async {
+      final PullRequest pr = generatePullRequest(id: 1, sha: '1');
+      when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
+      buildStatusService.cumulativeStatus = BuildStatus.success();
       final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_test_1']));
-
-      config.db.values[status.key] = status;
-
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/master',
-              status: Task.statusSucceeded,
-              buildNumber: 1,
-              builderName: 'abc')
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
-      });
-
-      expect(status.status, 'failure');
-      await tester.get(handler);
-      expect(status.status, 'success');
+      db.values[status.key] = status;
+      final Body body = await tester.get<Body>(handler);
+      expect(body, same(Body.empty));
+      expect(status.updates, 1);
       expect(status.updateTimeMillis, isNotNull);
-    });
-
-    test('update engine status in datastore with - with several tasks', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-
-      final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_test_1']));
-
-      config.db.values[status.key] = status;
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/master',
-              status: Task.statusSucceeded,
-              buildNumber: 1,
-              builderName: 'abc'),
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/master',
-              status: Task.statusFailed,
-              buildNumber: 2,
-              builderName: 'abc'),
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/master',
-              status: Task.statusSucceeded,
-              buildNumber: 3,
-              builderName: 'efg'),
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
-      });
-
-      expect(status.status, 'failure');
-      await tester.get(handler);
-      // Last build is successful.
-      expect(status.status, 'success');
-      expect(status.updateTimeMillis, isNotNull);
-    });
-
-    test('update engine status ignoring failing flaky build', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-
-      final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.failure(const <String>['failed_test_1']));
-
-      config.db.values[status.key] = status;
-      builders.add(LuciBuilder(name: 'flaky', repo: Config.engineSlug.name, flaky: true));
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-            commitSha: 'abc',
-            ref: 'refs/heads/master',
-            status: Task.statusSucceeded,
-            buildNumber: 1,
-            builderName: 'abc',
-          ),
-          const LuciTask(
-            commitSha: 'abc',
-            ref: 'refs/heads/master',
-            status: Task.statusFailed,
-            buildNumber: 1,
-            builderName: 'flaky',
-          ),
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
-      });
-
-      expect(status.status, 'failure');
-      await tester.get(handler);
-      // Last build is successful.
-      expect(status.status, 'success');
-      expect(status.updateTimeMillis, isNotNull);
-    });
-
-    test('non master tasks are ignored', () async {
-      final PullRequest pr = newPullRequest(123, 'abc', 'master');
-      prsFromGitHub = <PullRequest>[pr];
-      config.supportedBranchesValue = <String>['master'];
-
-      final GithubBuildStatusUpdate status = newStatusUpdate(pr, BuildStatus.success());
-
-      config.db.values[status.key] = status;
-      final Map<LuciBuilder, List<LuciTask>> luciTasks = Map<LuciBuilder, List<LuciTask>>.fromIterable(
-        builders,
-        key: (dynamic builder) => builder as LuciBuilder,
-        value: (dynamic builder) => <LuciTask>[
-          const LuciTask(
-              commitSha: 'abc',
-              ref: 'refs/heads/dev',
-              status: Task.statusSucceeded,
-              buildNumber: 1,
-              builderName: 'abc'),
-        ],
-      );
-      when(mockLuciService.getRecentTasks(builders: anyNamed('builders'))).thenAnswer((Invocation invocation) {
-        return Future<Map<LuciBuilder, List<LuciTask>>>.value(luciTasks);
-      });
-
-      expect(status.status, 'success');
-      await tester.get(handler);
-      // Because the task was ignored and we didn't have an update report a failure status.
-      expect(status.status, 'failure');
-      expect(status.updateTimeMillis, isNotNull);
+      expect(status.status, BuildStatus.success().githubStatus);
     });
   });
 }

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -4,7 +4,6 @@
 
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:cocoon_service/src/service/luci.dart';
 import 'package:github/github.dart';
 
 class FakeBuildStatusService implements BuildStatusService {
@@ -42,9 +41,4 @@ class FakeBuildStatusService implements BuildStatusService {
 
   @override
   DatastoreService get datastoreService => throw UnimplementedError();
-
-  @override
-  Future<String> latestLUCIStatus(List<LuciTask> tasks) {
-    throw UnimplementedError();
-  }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90569
https://github.com/flutter/flutter/issues/94522 - Enabling this to unify more of the logic in Cocoon
https://github.com/flutter/flutter/issues/94483 - More state in Cocoon makes it easier to audit why issues happen in the tree state

Reverts https://github.com/flutter/cocoon/pull/1252