### PR TITLE
Specify commit branch explicitly in pushing build status to GitHub API

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -63,6 +63,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     final Commit tipOfTreeCommit = Commit(
       sha: Config.defaultBranch(slug),
       repository: slug.fullName,
+      branch: Config.defaultBranch(slug),
     );
     final CiYaml ciYaml = await scheduler!.getCiYaml(tipOfTreeCommit);
     List<LuciBuilder> postsubmitBuilders = await scheduler!.getPostSubmitBuilders(ciYaml);


### PR DESCRIPTION
If not specified, commit will use `master` by default. However, for engine repo, we need to use `main`.

This fixes: https://github.com/flutter/flutter/issues/94483