### PR TITLE
Fix message when retargetting to default branch

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -491,9 +491,7 @@ class GithubWebhook extends RequestHandler<Body> {
     required String defaultBranch,
   }) {
     final String messageTemplate = config.wrongBaseBranchPullRequestMessage;
-    return messageTemplate
-      .replaceAll('{{target_branch}}', base)
-      .replaceAll('{{default_branch}}', defaultBranch);
+    return messageTemplate.replaceAll('{{target_branch}}', base).replaceAll('{{default_branch}}', defaultBranch);
   }
 
   Future<bool> _validateRequest(

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -445,11 +445,13 @@ class GithubWebhook extends RequestHandler<Body> {
       }
       return;
     }
-    if (Config.defaultBranch(pr.base!.repo!.slug()) == pr.base!.ref!) {
+    final String defaultBranchName = Config.defaultBranch(pr.base!.repo!.slug());
+    final String baseName = pr.base!.ref!;
+    if (baseName == defaultBranchName) {
       return;
     }
     final RegExp candidateTest = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
-    if (candidateTest.hasMatch(pr.base!.ref!) && candidateTest.hasMatch(pr.head!.ref!)) {
+    if (candidateTest.hasMatch(baseName) && candidateTest.hasMatch(pr.head!.ref!)) {
       // This is most likely a release branch
       body = config.releaseBranchPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, body)) {
@@ -459,7 +461,7 @@ class GithubWebhook extends RequestHandler<Body> {
     }
 
     // Assume this PR should be based against config.defaultBranch.
-    body = _getWrongBaseComment(pr.base!.ref!);
+    body = _getWrongBaseComment(base: baseName, defaultBranch: defaultBranchName);
     if (!await _alreadyCommented(gitHubClient, pr, body)) {
       await gitHubClient.pullRequests.edit(
         slug,
@@ -484,9 +486,14 @@ class GithubWebhook extends RequestHandler<Body> {
     return false;
   }
 
-  String _getWrongBaseComment(String base) {
+  String _getWrongBaseComment({
+    required String base,
+    required String defaultBranch,
+  }) {
     final String messageTemplate = config.wrongBaseBranchPullRequestMessage;
-    return messageTemplate.replaceAll('{{branch}}', base);
+    return messageTemplate
+      .replaceAll('{{target_branch}}', base)
+      .replaceAll('{{default_branch}}', defaultBranch);
   }
 
   Future<bool> _validateRequest(

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -138,14 +138,14 @@ class Config {
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
   String get wrongBaseBranchPullRequestMessage => 'This pull request was opened against a branch other than '
-      '_${kDefaultBranchName}_. Since Flutter pull requests should not '
-      'normally be opened against branches other than $kDefaultBranchName, I '
-      'have changed the base to $kDefaultBranchName. If this was intended, you '
-      'may modify the base back to {{branch}}. See the [Release Process]'
+      '_{{default_branch}}_. Since Flutter pull requests should not '
+      'normally be opened against branches other than {{default_branch}}, I '
+      'have changed the base to {{default_branch}}. If this was intended, you '
+      'may modify the base back to {{target_branch}}. See the [Release Process]'
       '(https://github.com/flutter/flutter/wiki/Release-process) for information '
       'about how other branches get updated.\n\n'
       '__Reviewers__: Use caution before merging pull requests to branches other '
-      'than $kDefaultBranchName, unless this is an intentional hotfix/cherrypick.';
+      'than {{default_branch}}, unless this is an intentional hotfix/cherrypick.';
 
   String wrongHeadBranchPullRequestMessage(String branch) =>
       'This pull request is trying merge the branch $branch, which is the name '


### PR DESCRIPTION
The message posted when a PR is automatically retargetted to the default
branch used a variable for the original target, but incorrectly still
hard-coded "master" as the default brach name. This means that the
message is wrong, and is particularly confusing for the (currently
common, as repos are being transitioned) case where the bot is switching
a PR from 'master' to 'main', as what it actually says is that the PR
wasn't opened against 'master' so is being switched to 'master', but if
that's not correct it can be switched back to 'master' again.

This fixes the message to get the actual default branch for the
repository, rather than assuming 'master'.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
