### PR TITLE
Fix deflake query and reference builds link

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -49,7 +49,7 @@ const String _buildDashboardPrefix = 'https://flutter-dashboard.appspot.com/#/bu
 const String _prodBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/prod/';
 const String _stagingBuildPrefix = 'https://ci.chromium.org/ui/p/flutter/builders/staging/';
 const String _flakeRecordPrefix =
-    'https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:';
+    'https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:';
 
 /// A builder to build a new issue for a flake.
 class IssueBuilder {

--- a/app_dart/lib/src/service/bigquery.dart
+++ b/app_dart/lib/src/service/bigquery.dart
@@ -74,9 +74,10 @@ where date>=date_sub(current_date(), interval 30 day) and
 group by builder_name;
 ''';
 
+// Returns builds in the past 30 days to exclude obsolete historical data.
 const String getRecordsQuery = r'''
 select sha, is_flaky, failure_count from `flutter-dashboard.datasite.luci_staging_build_status`
-where builder_name=@BUILDER_NAME
+where builder_name=@BUILDER_NAME and TIMESTAMP_DIFF(time,current_timestamp,day)<30
 order by time desc
 limit @LIMIT
 ''';

--- a/app_dart/test/request_handlers/deflake_flaky_builders_test_data.dart
+++ b/app_dart/test/request_handlers/deflake_flaky_builders_test_data.dart
@@ -195,7 +195,7 @@ const String expectedSemanticsIntegrationTestPullRequestBody = '''
   "name": "Mac_android android_semantics_integration_test"
 }
 -->
-The issue $existingIssueURL has been closed, and the test has been passing for [8 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Mac_android%20android_semantics_integration_test%22).
+The issue $existingIssueURL has been closed, and the test has been passing for [8 consecutive runs](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac_android%20android_semantics_integration_test%22).
 This test can be marked as unflaky.
 ''';
 const String expectedSemanticsIntegrationTestPullRequestBodyNoIssue = '''
@@ -204,7 +204,7 @@ const String expectedSemanticsIntegrationTestPullRequestBodyNoIssue = '''
   "name": "Mac_android android_semantics_integration_test"
 }
 -->
-The test has been passing for [8 consecutive runs](https://dashboards.corp.google.com/flutter_check_prod_test_flakiness_status_dashboard?p=BUILDER_NAME:%22Mac_android%20android_semantics_integration_test%22).
+The test has been passing for [8 consecutive runs](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac_android%20android_semantics_integration_test%22).
 This test can be marked as unflaky.
 ''';
 


### PR DESCRIPTION
This fixes: https://github.com/flutter/flutter/issues/96303 to use only recent staging builds when deflaking a test.

This PR also updates the reference link to check the flake status of a test: instead of pointing to the prod builds, the staging builds should be used and are recently available. ([example](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac%20module_test_ios%22))