### PR TITLE
Use cloud service account for FRoB.

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -243,7 +243,7 @@ class Config {
   String get luciProdAccount => 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 
   /// Internal Google service account used to surface FRoB results.
-  String get frobAccount => 'dart-sdk-rolls-jobs@system.gserviceaccount.com';
+  String get frobAccount => 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
 
   /// Service accounts used for LUCI PubSub messages.
   static const Set<String> allowedLuciPubsubServiceAccounts = <String>{


### PR DESCRIPTION
Using cloud service account allows easier impersonation and debugging.


