### PR TITLE
Fix PR merge bot when checking if a clean revert happens

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -107,7 +107,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
   ///
   /// By comparing the current commit with second TOT commit, an empty `files` in
   /// `GitHubComparison` validates a clean revert of TOT commit.
-  /// 
+  ///
   /// Note: [compareCommits] expects base commit first, and then head commit.
   Future<bool> isTOTRevert(
     String headSha,
@@ -119,11 +119,11 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     log.info('Second TOT commit is: ${secondTotCommit.sha}');
     final GitHubComparison githubComparison =
         await github.repositories.compareCommits(slug, secondTotCommit.sha!, headSha);
-    final bool emptyFiles =  githubComparison.files!.isEmpty;
-    if (emptyFiles) {
+    final bool filesIsEmpty = githubComparison.files!.isEmpty;
+    if (filesIsEmpty) {
       log.info('This is a TOT revert. Merge ignoring tests statuses.');
     }
-    return githubComparison.files!.isEmpty;
+    return filesIsEmpty;
   }
 
   Future<Map<String, dynamic>> _queryGraphQL(

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -151,11 +151,11 @@ void main() {
           .thenAnswer((Invocation invocation) {
         return Future<RepositoryCommit>.value(RepositoryCommit(sha: totSha));
       });
-      when(mockRepositoriesService.compareCommits(RepositorySlug('flutter', 'flutter'), 'deadbeef', 'abc'))
+      when(mockRepositoriesService.compareCommits(RepositorySlug('flutter', 'flutter'), 'abc', 'deadbeef'))
           .thenAnswer((Invocation invocation) {
         return Future<GitHubComparison>.value(githubComparison);
       });
-      when(mockRepositoriesService.compareCommits(RepositorySlug('flutter', 'engine'), 'deadbeef', 'abc'))
+      when(mockRepositoriesService.compareCommits(RepositorySlug('flutter', 'engine'), 'abc', 'deadbeef'))
           .thenAnswer((Invocation invocation) {
         return Future<GitHubComparison>.value(githubComparison);
       });


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/96478.

Switching the order of base and head commit (ref: https://docs.github.com/en/rest/reference/commits#compare-two-commits)