### PR TITLE
Reland "[web] Add the flutter-gold check in web engine PRs"

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -6,42 +6,55 @@ cron:
 - description: refresh chromebot build status (cocoon)
   url: /api/refresh-chromebot-status?repo=cocoon
   schedule: every 15 minutes
+
 - description: refresh chromebot build status (engine)
   url: /api/refresh-chromebot-status?repo=engine
   schedule: every 3 minutes
+
 - description: refresh chromebot build status (flutter)
   url: /api/refresh-chromebot-status?repo=flutter
   schedule: every 3 minutes
+
 - description: refresh chromebot build status (packages)
   url: /api/refresh-chromebot-status?repo=packages
   schedule: every 15 minutes
+
 - description: refresh chromebot build status (plugins)
   url: /api/refresh-chromebot-status?repo=plugins
   schedule: every 15 minutes
+
 - description: retrieve missing commits
   url: /api/vacuum-github-commits
   schedule: every 1 hours
-- description: sends build status to GitHub to annotate PRs and commits
+
+- description: sends build status to GitHub to annotate flutter PRs and commits
   url: /api/push-build-status-to-github?repo=flutter/flutter
   schedule: every 1 minutes
-- description: sends pr-specific gold status to GitHub to annotate PRs and commits
+
+- description: sends pr-specific gold status to GitHub to annotate flutter and engine PRs and commits
   url: /api/push-gold-status-to-github
   schedule: every 5 minutes
+
 - description: sends build status to GitHub to annotate engine PRs and commits
   url: /api/push-build-status-to-github?repo=flutter/engine
   schedule: every 2 minutes
+
 - description: check for mergeable commits waiting for the tree to go green
   url: /api/check-waiting-pull-requests
   schedule: every 5 minutes
+
 - description: push github rate limit history to bigquery
   url: /api/public/github-rate-limit-status
   schedule: every 1 minutes
+
 - description: detect and flag tests with high flaky rates
   url: /api/file_flaky_issue_and_pr?threshold=0.02
   schedule: every monday 16:00
+
 - description: update existing flake issues with latest statistics
   url: /api/update_existing_flaky_issues?threshold=0.02
   schedule: every monday 16:00
+
 - description: mark builders to be not flaky if they are no longer flaky
   url: /api/deflake_flaky_builders
   schedule: every monday 16:00

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -344,7 +344,7 @@ Future<Map<String, dynamic>?> _queryGraphQL(
 }
 
 const String pullRequestChecksQuery = r'''
-query ChecksForPullRequest($sPullRequest: Int!) {
+query ChecksForPullRequest($sPullRequest: Int!, $sRepoOwner: String!, $sRepoName: String!) {
   repository(owner: $sRepoOwner, name: $sRepoName) {
     pullRequest(number: $sPullRequest) {
       commits(last: 1) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -46,11 +46,21 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       return Body.empty;
     }
 
-    final RepositorySlug slug = Config.flutterSlug;
+    await _sendStatusUpdates(datastore, Config.flutterSlug);
+    await _sendStatusUpdates(datastore, Config.engineSlug);
+
+    return Body.empty;
+  }
+
+  Future<void> _sendStatusUpdates(
+    DatastoreService datastore,
+    RepositorySlug slug,
+  ) async {
     final GitHub gitHubClient = await config.createGitHubClient(slug: slug);
     final List<GithubGoldStatusUpdate> statusUpdates = <GithubGoldStatusUpdate>[];
     log.fine('Beginning Gold checks...');
     await for (PullRequest pr in gitHubClient.pullRequests.list(slug)) {
+      assert(pr.number != null);
       // Get last known Gold status from datastore.
       final GithubGoldStatusUpdate lastUpdate = await datastore.queryLastGoldUpdate(slug, pr);
       CreateStatus statusRequest;
@@ -65,8 +75,9 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         continue;
       }
 
-      if (pr.base!.ref != 'master') {
-        log.fine('This change is not staged to land on master, skipping.');
+      final String defaultBranch = Config.defaultBranch(slug);
+      if (pr.base!.ref != defaultBranch) {
+        log.fine('This change is not staged to land on $defaultBranch, skipping.');
         // This is potentially a release branch, or another change not landing
         // on master, we don't need a Gold check.
         continue;
@@ -84,7 +95,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             lastUpdate.head == pr.head!.sha &&
             !await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldDraftChange)) {
           await gitHubClient.issues
-              .createComment(slug, pr.number!, config.flutterGoldDraftChange + config.flutterGoldAlertConstant);
+              .createComment(slug, pr.number!, config.flutterGoldDraftChange + config.flutterGoldAlertConstant(slug));
         }
         continue;
       }
@@ -95,7 +106,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       bool runsGoldenFileTests = false;
       final Map<String, dynamic> data = (await _queryGraphQL(
         gitHubGraphQLClient,
-        pr.number,
+        slug,
+        pr.number!,
       ))!;
       final Map<String, dynamic> prData = data['repository']['pullRequest'] as Map<String, dynamic>;
       final Map<String, dynamic> commit = prData['commits']['nodes'].single['commit'] as Map<String, dynamic>;
@@ -109,7 +121,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       for (Map<String, dynamic> checkRun in checkRuns) {
         log.fine('Check run: $checkRun');
         final String name = checkRun['name'].toLowerCase() as String;
-        if (name.contains('framework')) {
+        if (name.contains('framework') || name.contains('web engine')) {
           runsGoldenFileTests = true;
         }
         if (checkRun['conclusion'] == null || checkRun['conclusion'].toUpperCase() != 'SUCCESS') {
@@ -129,7 +141,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           if (!await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldStalePR)) {
             log.fine('Notifying for stale PR.');
             await gitHubClient.issues
-                .createComment(slug, pr.number!, config.flutterGoldStalePR + config.flutterGoldAlertConstant);
+                .createComment(slug, pr.number!, config.flutterGoldStalePR + config.flutterGoldAlertConstant(slug));
           }
           continue;
         }
@@ -139,7 +151,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           // should just be pending. Any draft PRs are skipped
           // until marked ready for review.
           log.fine('Waiting for checks to be completed.');
-          statusRequest = _createStatus(GithubGoldStatusUpdate.statusRunning, config.flutterGoldPending, pr.number);
+          statusRequest =
+              _createStatus(GithubGoldStatusUpdate.statusRunning, config.flutterGoldPending, slug, pr.number!);
         } else {
           // We do not want to query Gold on a draft PR.
           assert(!pr.draft!);
@@ -150,7 +163,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
               goldStatus == GithubGoldStatusUpdate.statusRunning
                   ? config.flutterGoldChanges
                   : config.flutterGoldSuccess,
-              pr.number);
+              slug,
+              pr.number!);
           log.fine('New status for potential update: ${statusRequest.state}, ${statusRequest.description}');
           if (goldStatus == GithubGoldStatusUpdate.statusRunning &&
               !await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldCommentID(pr))) {
@@ -179,15 +193,13 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       }
     }
     await datastore.insert(statusUpdates);
-    log.fine('Committed all updates');
-
-    return Body.empty;
+    log.fine('Committed all updates for $slug');
   }
 
   /// Returns a GitHub Status for the given state and description.
-  CreateStatus _createStatus(String state, String description, int? prNumber) {
+  CreateStatus _createStatus(String state, String description, RepositorySlug slug, int prNumber) {
     final CreateStatus statusUpdate = CreateStatus(state)
-      ..targetUrl = _getTriageUrl(prNumber)
+      ..targetUrl = _getTriageUrl(slug, prNumber)
       ..context = 'flutter-gold'
       ..description = description;
     return statusUpdate;
@@ -214,7 +226,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
       }
       final List<dynamic> patchsets = jsonResponseTriage['patchsets'] as List<dynamic>;
       int untriaged = 0;
-      for (int i = 0; i <= patchsets.length; i++) {
+      for (int i = 0; i < patchsets.length; i++) {
         final Map<String, dynamic> patchset = patchsets[i] as Map<String, dynamic>;
         if (patchset['patchset_id'] == pr.head!.sha) {
           untriaged = patchset['new_untriaged_images'] as int;
@@ -245,8 +257,16 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     }
   }
 
-  String _getTriageUrl(int? number) {
-    return 'https://flutter-gold.skia.org/cl/github/$number';
+  String _getTriageUrl(RepositorySlug slug, int number) {
+    if (slug == Config.flutterSlug) {
+      return 'https://flutter-gold.skia.org/cl/github/$number';
+    }
+
+    if (slug == Config.engineSlug) {
+      return 'https://flutter-engine-gold.skia.org/cl/github/$number';
+    }
+
+    throw Exception('Unknown slug: $slug');
   }
 
   /// Creates a comment on a given pull request identified to have golden file
@@ -258,11 +278,11 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   ) async {
     String body;
     if (await _isFirstComment(gitHubClient, pr, slug)) {
-      body = config.flutterGoldInitialAlert(_getTriageUrl(pr.number));
+      body = config.flutterGoldInitialAlert(_getTriageUrl(slug, pr.number!));
     } else {
-      body = config.flutterGoldFollowUpAlert(_getTriageUrl(pr.number));
+      body = config.flutterGoldFollowUpAlert(_getTriageUrl(slug, pr.number!));
     }
-    body += config.flutterGoldAlertConstant + config.flutterGoldCommentID(pr);
+    body += config.flutterGoldAlertConstant(slug) + config.flutterGoldCommentID(pr);
     await gitHubClient.issues.createComment(slug, pr.number!, body);
     await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, <String>[
       'will affect goldens',
@@ -291,7 +311,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   ) async {
     final Stream<IssueComment> comments = gitHubClient.issues.listCommentsByIssue(slug, pr.number!);
     await for (IssueComment comment in comments) {
-      if (comment.body!.contains(config.flutterGoldInitialAlert(_getTriageUrl(pr.number)))) {
+      if (comment.body!.contains(config.flutterGoldInitialAlert(_getTriageUrl(slug, pr.number!)))) {
         return false;
       }
     }
@@ -299,13 +319,19 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   }
 }
 
-Future<Map<String, dynamic>?> _queryGraphQL(GraphQLClient client, int? prNumber) async {
+Future<Map<String, dynamic>?> _queryGraphQL(
+  GraphQLClient client,
+  RepositorySlug slug,
+  int prNumber,
+) async {
   final QueryResult result = await client.query(
     QueryOptions(
       document: lang.parseString(pullRequestChecksQuery),
       fetchPolicy: FetchPolicy.noCache,
       variables: <String, dynamic>{
         'sPullRequest': prNumber,
+        'sRepoOwner': slug.owner,
+        'sRepoName': slug.name,
       },
     ),
   );
@@ -319,13 +345,14 @@ Future<Map<String, dynamic>?> _queryGraphQL(GraphQLClient client, int? prNumber)
 
 const String pullRequestChecksQuery = r'''
 query ChecksForPullRequest($sPullRequest: Int!) {
-  repository(owner: "flutter", name: "flutter") {
+  repository(owner: $sRepoOwner, name: $sRepoName) {
     pullRequest(number: $sPullRequest) {
       commits(last: 1) {
         nodes {
           commit {
             # (appId: 64368) == flutter-dashboard. We only care about
             # flutter-dashboard checks.
+
             checkSuites(last: 1, filterBy: {appId: 64368}) {
               nodes {
                 checkRuns(first: 100) {

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -226,10 +226,15 @@ class Config {
   String flutterGoldFollowUpAlert(String url) => 'Golden file changes are available for triage from new commit, '
       'Click [here to view]($url).\n\n';
 
-  String get flutterGoldAlertConstant => '\n\nFor more guidance, visit '
-      '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
-      '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
-      'and make sure this patch meets those guidelines before LGTMing.\n\n';
+  String flutterGoldAlertConstant(RepositorySlug slug) {
+    if (slug == Config.flutterSlug) {
+      return '\n\nFor more guidance, visit '
+          '[Writing a golden file test for `package:flutter`](https://github.com/flutter/flutter/wiki/Writing-a-golden-file-test-for-package:flutter).\n\n'
+          '__Reviewers__: Read the [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
+          'and make sure this patch meets those guidelines before LGTMing.\n\n';
+    }
+    return '';
+  }
 
   String flutterGoldCommentID(PullRequest pr) =>
       '_Changes reported for pull request #${pr.number} at sha ${pr.head!.sha}_\n\n';

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -41,8 +41,10 @@ void main() {
     late PushGoldStatusToGithub handler;
     FakeGraphQLClient githubGraphQLClient;
     List<dynamic> checkRuns = <dynamic>[];
+    List<dynamic> engineCheckRuns = <dynamic>[];
     late MockClient mockHttpClient;
     late RepositorySlug slug;
+    late RepositorySlug engineSlug;
     late RetryOptions retryOptions;
 
     final List<LogRecord> records = <LogRecord>[];
@@ -68,7 +70,13 @@ void main() {
             source: QueryResultSource.network,
           );
       githubGraphQLClient.queryResultForOptions = (QueryOptions options) {
-        return createGithubQueryResult(checkRuns);
+        if (options.variables['sRepoName'] == slug.name) {
+          return createGithubQueryResult(checkRuns);
+        }
+        if (options.variables['sRepoName'] == engineSlug.name) {
+          return createGithubQueryResult(engineCheckRuns);
+        }
+        return createGithubQueryResult(<dynamic>[]);
       };
       config.githubGraphQLClient = githubGraphQLClient;
       config.flutterGoldPendingValue = 'pending';
@@ -95,7 +103,9 @@ void main() {
       );
 
       slug = RepositorySlug('flutter', 'flutter');
+      engineSlug = RepositorySlug('flutter', 'engine');
       checkRuns.clear();
+      engineCheckRuns.clear();
       records.clear();
       log.onRecord.listen((LogRecord record) => records.add(record));
     });
@@ -122,7 +132,8 @@ void main() {
       MockPullRequestsService pullRequestsService;
       late MockIssuesService issuesService;
       late MockRepositoriesService repositoriesService;
-      late List<PullRequest> prsFromGitHub;
+      List<PullRequest> prsFromGitHub = <PullRequest>[];
+      List<PullRequest> enginePrsFromGitHub = <PullRequest>[];
 
       setUp(() {
         github = MockGitHub();
@@ -132,9 +143,17 @@ void main() {
         when(github.pullRequests).thenReturn(pullRequestsService);
         when(github.issues).thenReturn(issuesService);
         when(github.repositories).thenReturn(repositoriesService);
-        when(pullRequestsService.list(any)).thenAnswer((Invocation _) {
+
+        prsFromGitHub.clear();
+        when(pullRequestsService.list(slug)).thenAnswer((Invocation _) {
           return Stream<PullRequest>.fromIterable(prsFromGitHub);
         });
+
+        enginePrsFromGitHub.clear();
+        when(pullRequestsService.list(engineSlug)).thenAnswer((Invocation _) {
+          return Stream<PullRequest>.fromIterable(enginePrsFromGitHub);
+        });
+
         when(repositoriesService.createStatus(any, any, any)).thenAnswer((_) async => RepositoryStatus());
         when(issuesService.createComment(any, any, any)).thenAnswer((_) async => IssueComment());
         when(issuesService.addLabelsToIssue(any, any, any)).thenAnswer((_) async => <IssueLabel>[]);
@@ -142,22 +161,23 @@ void main() {
         clientContext.isDevelopmentEnvironment = false;
       });
 
-      GithubGoldStatusUpdate newStatusUpdate(PullRequest pr, String statusUpdate, String sha, String description) {
+      GithubGoldStatusUpdate newStatusUpdate(
+          RepositorySlug slug, PullRequest pr, String statusUpdate, String sha, String description) {
         return GithubGoldStatusUpdate(
-          key: db.emptyKey.append(GithubGoldStatusUpdate),
+          key: db.emptyKey.append(GithubGoldStatusUpdate, id: pr.number),
           status: statusUpdate,
           pr: pr.number!,
           head: sha,
           updates: 0,
           description: description,
-          repository: 'flutter/flutter',
+          repository: slug.fullName,
         );
       }
 
       PullRequest newPullRequest(int number, String sha, String baseRef, {bool draft = false, DateTime? updated}) {
         return PullRequest()
-          ..number = 123
-          ..head = (PullRequestHead()..sha = 'abc')
+          ..number = number
+          ..head = (PullRequestHead()..sha = sha)
           ..base = (PullRequestHead()..ref = baseRef)
           ..draft = draft
           ..updatedAt = updated ?? DateTime.now();
@@ -178,14 +198,23 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
         });
 
-        test('if there are no framework tests for this PR', () async {
+        test('if there are no framework or web engine tests for this PR', () async {
           checkRuns = <dynamic>[
             <String, String>{'name': 'tool-test1', 'status': 'completed', 'conclusion': 'success'}
           ];
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final PullRequest flutterPr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[flutterPr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, flutterPr, '', '', '');
           db.values[status.key] = status;
+
+          engineCheckRuns = <dynamic>[
+            <String, String>{'name': 'linux-host1', 'status': 'completed', 'conclusion': 'success'}
+          ];
+          final PullRequest enginePr = newPullRequest(456, 'def', 'main');
+          enginePrsFromGitHub = <PullRequest>[enginePr];
+          final GithubGoldStatusUpdate engineStatus = newStatusUpdate(engineSlug, enginePr, '', '', '');
+          db.values[engineStatus.key] = engineStatus;
+
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
@@ -194,7 +223,14 @@ void main() {
           // Should not apply labels or make comments
           verifyNever(issuesService.addLabelsToIssue(
             slug,
-            pr.number!,
+            flutterPr.number!,
+            <String>[
+              kGoldenFileLabel,
+            ],
+          ));
+          verifyNever(issuesService.addLabelsToIssue(
+            engineSlug,
+            enginePr.number!,
             <String>[
               kGoldenFileLabel,
             ],
@@ -202,8 +238,13 @@ void main() {
 
           verifyNever(issuesService.createComment(
             slug,
-            pr.number!,
-            argThat(contains(config.flutterGoldCommentID(pr))),
+            flutterPr.number!,
+            argThat(contains(config.flutterGoldCommentID(flutterPr))),
+          ));
+          verifyNever(issuesService.createComment(
+            engineSlug,
+            enginePr.number!,
+            argThat(contains(config.flutterGoldCommentID(enginePr))),
           ));
         });
 
@@ -213,7 +254,7 @@ void main() {
           ];
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
@@ -241,6 +282,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
+            slug,
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
@@ -250,7 +292,8 @@ void main() {
 
           // Checks still running
           checkRuns = <dynamic>[
-            <String, String>{'name': 'framework', 'status': 'in_progress', 'conclusion': 'neutral'}
+            <String, String>{'name': 'framework', 'status': 'in_progress', 'conclusion': 'neutral'},
+            <String, String>{'name': 'web engine', 'status': 'in_progress', 'conclusion': 'neutral'},
           ];
 
           final Body body = await tester.get<Body>(handler);
@@ -280,6 +323,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
+            slug,
             pr,
             GithubGoldStatusUpdate.statusCompleted,
             'abc',
@@ -289,7 +333,8 @@ void main() {
 
           // Checks complete
           checkRuns = <dynamic>[
-            <String, String>{'name': 'framework', 'status': 'completed', 'conclusion': 'success'}
+            <String, String>{'name': 'framework', 'status': 'completed', 'conclusion': 'success'},
+            <String, String>{'name': 'web engine', 'status': 'completed', 'conclusion': 'success'},
           ];
 
           final Body body = await tester.get<Body>(handler);
@@ -320,6 +365,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(
+            slug,
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
@@ -329,7 +375,8 @@ void main() {
 
           // Checks complete
           checkRuns = <dynamic>[
-            <String, String>{'name': 'framework', 'status': 'completed', 'conclusion': 'success'}
+            <String, String>{'name': 'framework', 'status': 'completed', 'conclusion': 'success'},
+            <String, String>{'name': 'web engine', 'status': 'completed', 'conclusion': 'success'},
           ];
 
           // Gold status is running
@@ -383,11 +430,11 @@ void main() {
           ));
         });
 
-        test('does nothing for branches not staged to land on master', () async {
+        test('does nothing for branches not staged to land on main/master', () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'release');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // All checks completed
@@ -421,7 +468,7 @@ void main() {
           // New commit, draft PR
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -455,7 +502,7 @@ void main() {
           // New commit, draft PR
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -490,7 +537,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -532,7 +579,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -574,7 +621,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -615,27 +662,45 @@ void main() {
       group('updates GitHub and/or Datastore', () {
         test('new commit, checks running', () async {
           // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final PullRequest flutterPr = newPullRequest(123, 'f-abc', 'master');
+          prsFromGitHub = <PullRequest>[flutterPr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, flutterPr, '', '', '');
+
+          final PullRequest enginePr = newPullRequest(567, 'e-abc', 'main');
+          enginePrsFromGitHub = <PullRequest>[enginePr];
+          final GithubGoldStatusUpdate engineStatus = newStatusUpdate(engineSlug, enginePr, '', '', '');
+
           db.values[status.key] = status;
+          db.values[engineStatus.key] = engineStatus;
 
           // Checks running
           checkRuns = <dynamic>[
-            <String, String>{'name': 'framework', 'status': 'in_progress', 'conclusion': 'neutral'}
+            <String, String>{'name': 'framework', 'status': 'in_progress', 'conclusion': 'neutral'},
+          ];
+          engineCheckRuns = <dynamic>[
+            <String, String>{'name': 'web engine', 'status': 'in_progress', 'conclusion': 'neutral'},
           ];
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(status.updates, 1);
           expect(status.status, GithubGoldStatusUpdate.statusRunning);
+          expect(engineStatus.updates, 1);
+          expect(engineStatus.status, GithubGoldStatusUpdate.statusRunning);
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
           // Should not apply labels or make comments
           verifyNever(issuesService.addLabelsToIssue(
             slug,
-            pr.number!,
+            flutterPr.number!,
+            <String>[
+              kGoldenFileLabel,
+            ],
+          ));
+          verifyNever(issuesService.addLabelsToIssue(
+            engineSlug,
+            enginePr.number!,
             <String>[
               kGoldenFileLabel,
             ],
@@ -643,8 +708,13 @@ void main() {
 
           verifyNever(issuesService.createComment(
             slug,
-            pr.number!,
-            argThat(contains(config.flutterGoldCommentID(pr))),
+            flutterPr.number!,
+            argThat(contains(config.flutterGoldCommentID(flutterPr))),
+          ));
+          verifyNever(issuesService.createComment(
+            engineSlug,
+            enginePr.number!,
+            argThat(contains(config.flutterGoldCommentID(enginePr))),
           ));
         });
 
@@ -652,7 +722,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -709,7 +779,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks completed
@@ -775,7 +845,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+              newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
 
           // Checks complete
@@ -839,7 +909,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+              newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
 
           // Checks complete
@@ -913,7 +983,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+              newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
 
           // Checks completed
@@ -977,7 +1047,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+              newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
 
           // Checks completed
@@ -1017,7 +1087,7 @@ void main() {
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status =
-              newStatusUpdate(pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+              newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
 
           // Checks completed
@@ -1056,7 +1126,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(pr, '', '', '');
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
 
           // Checks failed
@@ -1096,8 +1166,8 @@ void main() {
           followUpPR,
         ];
         final GithubGoldStatusUpdate completedStatus = newStatusUpdate(
-            completedPR, GithubGoldStatusUpdate.statusCompleted, 'abc', config.flutterGoldSuccessValue!);
-        final GithubGoldStatusUpdate followUpStatus = newStatusUpdate(followUpPR, '', '', '');
+            slug, completedPR, GithubGoldStatusUpdate.statusCompleted, 'abc', config.flutterGoldSuccessValue!);
+        final GithubGoldStatusUpdate followUpStatus = newStatusUpdate(slug, followUpPR, '', '', '');
         db.values[completedStatus.key] = completedStatus;
         db.values[followUpStatus.key] = followUpStatus;
 
@@ -1153,6 +1223,7 @@ void main() {
         final PullRequest pr = newPullRequest(123, 'abc', 'master');
         prsFromGitHub = <PullRequest>[pr];
         final GithubGoldStatusUpdate status = newStatusUpdate(
+          slug,
           pr,
           GithubGoldStatusUpdate.statusRunning,
           'abc',

--- a/app_dart/test/service/config_test.dart
+++ b/app_dart/test/service/config_test.dart
@@ -5,6 +5,7 @@
 import 'dart:typed_data';
 
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:github/github.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_datastore.dart';
@@ -43,6 +44,17 @@ void main() {
 
       final String githubToken = await config.generateGithubToken(Config.flutterSlug);
       expect(githubToken, 'githubToken');
+    });
+
+    test('Returns the right flutter gold alert', () {
+      expect(
+        config.flutterGoldAlertConstant(RepositorySlug.full('flutter/flutter')),
+        contains('package:flutter'),
+      );
+      expect(
+        config.flutterGoldAlertConstant(RepositorySlug.full('flutter/engine')),
+        isNot(contains('package:flutter')),
+      );
     });
   });
 }

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -162,7 +162,7 @@ class FakeConfig implements Config {
   String flutterGoldFollowUpAlert(String url) => flutterGoldFollowUpAlertValue!;
 
   @override
-  String get flutterGoldAlertConstant => flutterGoldAlertConstantValue!;
+  String flutterGoldAlertConstant(RepositorySlug slug) => flutterGoldAlertConstantValue!;
 
   @override
   String flutterGoldCommentID(PullRequest pr) => 'PR ${pr.number}, at ${pr.head!.sha}';

--- a/app_dart/test/src/datastore/fake_datastore.dart
+++ b/app_dart/test/src/datastore/fake_datastore.dart
@@ -180,6 +180,7 @@ class FakeQuery<T extends Model<dynamic>> implements Query<T> {
       final Object? value = filter.comparisonObject;
       if (filterString.contains('branch =') ||
           filterString.contains('head =') ||
+          filterString.contains('pr =') ||
           filterString.contains('repository =')) {
         resultsView = resultsView.where((T result) => result.toString().contains(value.toString()));
       }


### PR DESCRIPTION
Relanding https://github.com/flutter/cocoon/pull/1505
Was reverted in https://github.com/flutter/cocoon/pull/1541

The entire original PR is in the first commit. All subsequent commits are the additional changes in the relanding.

The original PR was reverted because the GraphQL query was broken:
```
OperationException(
  linkException: null,
  graphqlErrors: [
    GraphQLError(message: Variable $sRepoOwner is used by ChecksForPullRequest but not declared, locations: [ErrorLocation(line: 2, column: 21)], path: [query ChecksForPullRequest, repository, owner], extensions: {code: variableNotDefined, variableName: sRepoOwner}),
    GraphQLError(message: Variable $sRepoName is used by ChecksForPullRequest but not declared, locations: [ErrorLocation(line: 2, column: 40)], path: [query ChecksForPullRequest, repository, name], extensions: {code: variableNotDefined, variableName: sRepoName})
  ]
)
```