### PR TITLE
[scheduler] Ignore runIf on release branches

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -349,8 +349,13 @@ class Scheduler {
       sha: pullRequest.head!.sha,
     );
     final CiYaml ciYaml = await getCiYaml(commit);
-    final Iterable<Target> presubmitTargets =
-        ciYaml.presubmitTargets.where((Target target) => target.value.scheduler == pb.SchedulerSystem.luci);
+    final Iterable<Target> presubmitTargets = ciYaml.presubmitTargets.where((Target target) =>
+        target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon);
+    // Release branches should run every test.
+    if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
+      return presubmitTargets.toList();
+    }
+
     // Filter builders based on the PR diff
     final GithubService githubService = await config.createGithubService(commit.slug);
     final List<String?> files = await githubService.listFiles(pullRequest);


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/96501

This will make it easier to validate release branch PRs before submitting by running everything.