### PR TITLE
[app_dart] Speed up autosubmit bot graphql queries

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -507,7 +507,12 @@ class _AutoMergeQueryResult {
 
   /// Whether the auto-merge label should be removed from this PR.
   bool get shouldRemoveLabel =>
-      !hasApprovedReview || changeRequestAuthors.isNotEmpty || failures.isNotEmpty || emptyChecks || isConflicting;
+      !hasApprovedReview ||
+      changeRequestAuthors.isNotEmpty ||
+      ciSuccessful == false ||
+      failures.isNotEmpty ||
+      emptyChecks ||
+      isConflicting;
 
   String get removalMessage {
     if (!shouldRemoveLabel) {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -264,8 +264,8 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       }
       statuses ??= <Map<String, dynamic>>[];
       String? flutterDashboardCheckSuiteConclusion;
-      if (commit['checkSuites']['nodes'] != null && (commit['checkSuites']['nodes'] as List<dynamic>).isNotEmpty) {
-        flutterDashboardCheckSuiteConclusion = commit['checkSuites']['nodes'].first['conclusion'] as String?;
+      if (commit['checkSuites']['nodes'] != null) {
+        flutterDashboardCheckSuiteConclusion = commit['checkSuites']['nodes']['conclusion'] as String?;
       }
       final Set<_FailureDetail> failures = <_FailureDetail>{};
       final bool ciSuccessful = await _checkStatuses(
@@ -352,7 +352,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     }
     log.info(
         'Validating name: $name, branch: $branch, flutterDashboardCheckSuiteConclusion: $flutterDashboardCheckSuiteConclusion');
-    if (flutterDashboardCheckSuiteConclusion == 'COMPLETED') {
+    if (flutterDashboardCheckSuiteConclusion != CheckRunConclusion.success.value) {
       allSuccess = false;
     }
 
@@ -526,6 +526,9 @@ class _AutoMergeQueryResult {
     for (String? author in changeRequestAuthors) {
       buffer.writeln('- This pull request has changes requested by @$author. Please '
           'resolve those before re-applying the label.');
+    }
+    if (ciSuccessful == false) {
+      buffer.writeln('- Some checks or statuses are failing. Ensure they are passing before re-applying.');
     }
     for (_FailureDetail detail in failures) {
       buffer.writeln('- The status or check suite ${detail.markdownLink} has failed. Please fix the '

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -146,6 +146,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       ),
     );
     log.fine('Queried GitHub\'s GraphQL API.');
+    log.fine(result.data);
 
     if (result.hasException) {
       log.severe(result.exception.toString());

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -42,14 +42,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                   # flutter-dashboard checks.
                   checkSuites(last:1, filterBy: { appId: 64368 } ) {
                     nodes {
-                      checkRuns(first:100) {
-                        nodes {
-                          name
-                          status
-                          conclusion
-                          detailsUrl
-                        }
-                      }
+                      conclusion
                     }
                   }
                 }
@@ -62,11 +55,6 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                 }
                 authorAssociation
                 state
-              }
-            }
-            labels(first: 100) {
-              nodes {
-                name
               }
             }
           }

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -48,13 +48,18 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                 }
               }
             }
-            reviews(first: 100, states: [APPROVED, CHANGES_REQUESTED]) {
+            reviews(first: 25, states: [APPROVED, CHANGES_REQUESTED]) {
               nodes {
                 author {
                   login
                 }
                 authorAssociation
                 state
+              }
+            }
+            labels(first: 25) {
+              nodes {
+                name
               }
             }
           }

--- a/app_dart/lib/src/request_handlers/query_github_graphql.dart
+++ b/app_dart/lib/src/request_handlers/query_github_graphql.dart
@@ -54,6 +54,8 @@ class QueryGithubGraphql extends ApiRequestHandler<Body> {
       ),
     );
 
+    log.info('Received result: $result');
+
     if (result.hasException) {
       log.severe(result.exception.toString());
       throw const BadRequestException('GraphQL query failed');

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -393,7 +393,6 @@ void main() {
 This pull request is not suitable for automatic merging in its current state.
 
 - Some checks or statuses are failing. Ensure they are passing before re-applying.
-- The status or check suite [Linux](https://Linux) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 ''',
           },
         ),
@@ -962,6 +961,7 @@ This pull request is not suitable for automatic merging in its current state.
               'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
 - This pull request has changes requested by @change_please. Please resolve those before re-applying the label.
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 ''',
               'labelId': base64LabelId,
             },

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -136,11 +136,14 @@ void main() {
           githubGraphQLClient: githubGraphQLClient,
           githubClient: mockGitHubClient);
       config.overrideTreeStatusLabelValue = 'warning: land on red to fix tree breakage';
+      branch = null;
+      totSha = null;
       flutterRepoPRs.clear();
       engineRepoPRs.clear();
       pluginRepoPRs.clear();
       statuses.clear();
       PullRequestHelper._counter = 0;
+      githubComparison = null;
 
       when(mockGitHubClient.repositories).thenReturn(mockRepositoriesService);
       when(mockRepositoriesService.getCommit(RepositorySlug('flutter', 'flutter'), 'HEAD~'))

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -292,6 +292,15 @@ void main() {
       );
     });
 
+    test('Does not merge PR with null checksuite', () async {
+      flutterRepoPRs.add(PullRequestHelper(checkSuiteConclusion: null));
+
+      await tester.get(handler);
+
+      _verifyQueries();
+      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
+    });
+
     test('Does not merge PR with in progress tests', () async {
       statuses = <dynamic>[
         <String, String>{'id': '1', 'status': 'EXECUTING', 'name': 'test1'},

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -307,56 +307,12 @@ void main() {
       githubGraphQLClient.verifyMutations(<MutationOptions>[]);
     });
 
-    test('Does not merge PR with in progress checks', () async {
+    test('Does not merge PR with neutral check suite', () async {
       branch = 'pull/0';
       final PullRequestHelper prInProgress = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.windowsInProgress,
-        ],
+        checkSuiteConclusion: CheckRunConclusion.neutral,
       );
       flutterRepoPRs.add(prInProgress);
-      await tester.get(handler);
-      _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
-    });
-
-    test('Does not merge PR with queued checks', () async {
-      branch = 'pull/0';
-      final PullRequestHelper prQueued = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.macQueued,
-        ],
-      );
-      flutterRepoPRs.add(prQueued);
-      await tester.get(handler);
-      _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
-    });
-
-    test('Does not merge PR with requested checks', () async {
-      branch = 'pull/0';
-      final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.linuxRequested,
-        ],
-      );
-      flutterRepoPRs.add(prRequested);
-      await tester.get(handler);
-      _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[]);
-    });
-
-    test('Does not merge PR with failed status', () async {
-      branch = 'pull/0';
-      final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.linuxRequested,
-        ],
-        lastCommitStatuses: const <StatusHelper>[
-          StatusHelper.flutterBuildFailure,
-        ],
-      );
-      flutterRepoPRs.add(prRequested);
       await tester.get(handler);
       _verifyQueries();
       githubGraphQLClient.verifyMutations(<MutationOptions>[]);
@@ -365,9 +321,6 @@ void main() {
     test('Merges PR with failed tree status if override tree status label is provided', () async {
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedSuccess,
-        ],
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildFailure,
         ],
@@ -396,37 +349,17 @@ void main() {
       ];
       branch = 'pull/0';
 
-      final PullRequestHelper prRequested = PullRequestHelper(lastCommitCheckRuns: const <CheckRunHelper>[
-        CheckRunHelper.linuxCompletedRunning,
-      ], lastCommitStatuses: const <StatusHelper>[
-        StatusHelper.flutterBuildSuccess,
-      ], lastCommitMessage: 'Revert "This is a test PR" This reverts commit abc.');
-      flutterRepoPRs.add(prRequested);
-
-      await tester.get(handler);
-
-      _verifyQueries();
-      githubGraphQLClient.verifyMutations(<MutationOptions>[
-        MutationOptions(document: mergePullRequestMutation, variables: <String, dynamic>{
-          'id': flutterRepoPRs.first.id,
-          'oid': oid,
-          'title': 'some_title (#0)',
-        }),
-      ]);
-    });
-
-    test('Merges PR with check that is successful but still considered running', () async {
-      branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.linuxCompletedRunning,
-        ],
+        checkSuiteConclusion: CheckRunConclusion.neutral,
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        lastCommitMessage: 'Revert "This is a test PR" This reverts commit abc.',
       );
       flutterRepoPRs.add(prRequested);
+
       await tester.get(handler);
+
       _verifyQueries();
       githubGraphQLClient.verifyMutations(<MutationOptions>[
         MutationOptions(document: mergePullRequestMutation, variables: <String, dynamic>{
@@ -442,10 +375,7 @@ void main() {
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedFailure,
-          CheckRunHelper.luciCompletedSuccess,
-        ],
+        checkSuiteConclusion: CheckRunConclusion.failure,
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
@@ -462,6 +392,7 @@ void main() {
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 - The status or check suite [Linux](https://Linux) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 ''',
           },
@@ -474,12 +405,11 @@ This pull request is not suitable for automatic merging in its current state.
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[],
+        checkSuiteConclusion: null,
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildFailure,
         ],
       );
-      prRequested.lastCommitCheckRuns = null;
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
       _verifyQueries();
@@ -492,6 +422,7 @@ This pull request is not suitable for automatic merging in its current state.
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 - This commit has no checks. Please check that ci.yaml validation has started and there are multiple checks. If not, try uploading an empty commit.
 ''',
           },
@@ -504,7 +435,7 @@ This pull request is not suitable for automatic merging in its current state.
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[],
+        checkSuiteConclusion: null,
         lastCommitStatuses: const <StatusHelper>[],
       );
       flutterRepoPRs.add(prRequested);
@@ -519,6 +450,7 @@ This pull request is not suitable for automatic merging in its current state.
             'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 - The status or check suite [tree status luci-flutter](https://flutter-dashboard.appspot.com/#/build) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 - This commit has no checks. Please check that ci.yaml validation has started and there are multiple checks. If not, try uploading an empty commit.
 ''',
@@ -531,9 +463,6 @@ This pull request is not suitable for automatic merging in its current state.
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
         repo: 'cocoon',
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedSuccess,
-        ],
         lastCommitStatuses: const <StatusHelper>[],
       );
       prRequested.lastCommitStatuses = null;
@@ -551,9 +480,6 @@ This pull request is not suitable for automatic merging in its current state.
     test('Merge PR with successful status and checks', () async {
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedSuccess,
-        ],
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
@@ -575,9 +501,6 @@ This pull request is not suitable for automatic merging in its current state.
       branch = 'pull/0';
       final PullRequestHelper prRequested = PullRequestHelper(
         authorAssociation: '',
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedSuccess,
-        ],
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
@@ -610,9 +533,6 @@ This pull request is not suitable for automatic merging in its current state.
         reviews: <PullRequestReviewHelper>[
           const PullRequestReviewHelper(
               authorName: 'some_rando', state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
-        ],
-        lastCommitCheckRuns: const <CheckRunHelper>[
-          CheckRunHelper.luciCompletedSuccess,
         ],
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
@@ -707,6 +627,7 @@ This pull request is not suitable for automatic merging in its current state.
               'sBody': '''
 This pull request is not suitable for automatic merging in its current state.
 
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 - The status or check suite [test1](https://cirrus-ci.com/task/1) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 ''',
             },
@@ -872,6 +793,7 @@ This pull request is not suitable for automatic merging in its current state.
             'id': prRed.id,
             'sBody': '''This pull request is not suitable for automatic merging in its current state.
 
+- Some checks or statuses are failing. Ensure they are passing before re-applying.
 - The status or check suite [other status](https://other status) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 - The status or check suite [test1](https://cirrus-ci.com/task/1) has failed. Please fix the issues identified (or deflake) before re-applying this label.
 ''',
@@ -1122,7 +1044,7 @@ class PullRequestHelper {
     ],
     this.lastCommitHash = oid,
     this.lastCommitStatuses = const <StatusHelper>[StatusHelper.flutterBuildSuccess],
-    this.lastCommitCheckRuns = const <CheckRunHelper>[CheckRunHelper.luciCompletedSuccess],
+    this.checkSuiteConclusion = CheckRunConclusion.success,
     this.lastCommitMessage = '',
     this.dateTime,
     this.labels = const <dynamic>[],
@@ -1140,7 +1062,7 @@ class PullRequestHelper {
   final List<PullRequestReviewHelper> reviews;
   final String lastCommitHash;
   List<StatusHelper>? lastCommitStatuses;
-  List<CheckRunHelper>? lastCommitCheckRuns;
+  CheckRunConclusion? checkSuiteConclusion;
   final String? lastCommitMessage;
   final DateTime? dateTime;
   List<dynamic> labels;
@@ -1185,22 +1107,11 @@ class PullRequestHelper {
                     : <dynamic>[]
               },
               'checkSuites': <String, dynamic>{
-                'nodes': lastCommitCheckRuns != null
-                    ? <dynamic>[
-                        <String, dynamic>{
-                          'checkRuns': <String, dynamic>{
-                            'nodes': lastCommitCheckRuns!.map((CheckRunHelper status) {
-                              return <String, dynamic>{
-                                'name': status.name,
-                                'status': status.status,
-                                'conclusion': status.conclusion,
-                                'detailsUrl': 'https://${status.name}',
-                              };
-                            }).toList(),
-                          }
-                        }
-                      ]
-                    : <dynamic>[]
+                'nodes': checkSuiteConclusion != null
+                    ? <String, String>{
+                        'conclusion': checkSuiteConclusion.toString(),
+                      }
+                    : <String, String>{}
               },
             },
           },


### PR DESCRIPTION
## Summary

- GitHub limits GraphQL queries to <10 seconds
- flutter/flutter has grown the number of contributors it receives, and the endpoint is timing out very frequently
- Simplify some of the operations in the GraphQL code to the bare minimum of what Cocoon needs
  - Remove check runs and instead rely on the single checksuite conclusion (fixing a bug where we only checked the first 100 check runs)

## Issues

https://github.com/flutter/flutter/issues/96503
Fixes https://github.com/flutter/flutter/issues/96540

## Future work

- Remove cirrus graphql and rely on pulling all check suite conclusions