### PR TITLE
[app_dart] Shrink auto submission graphql query pagination

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -11,7 +11,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
     labels(first: 1, query: $sLabelName) {
       nodes {
         id
-        pullRequests(first: 100, states: OPEN, orderBy: {direction: ASC, field: CREATED_AT}) {
+        pullRequests(first: 20, states: OPEN, orderBy: {direction: ASC, field: CREATED_AT}) {
           nodes {
             author {
               login
@@ -55,7 +55,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                 }
               }
             }
-            reviews(first: 100, states: [APPROVED, CHANGES_REQUESTED]) {
+            reviews(first: 5, states: [APPROVED, CHANGES_REQUESTED]) {
               nodes {
                 author {
                   login
@@ -64,7 +64,7 @@ query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLa
                 state
               }
             }
-            labels(first: 100) {
+            labels(first: 5) {
               nodes {
                 name
               }

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -136,11 +136,14 @@ void main() {
           githubGraphQLClient: githubGraphQLClient,
           githubClient: mockGitHubClient);
       config.overrideTreeStatusLabelValue = 'warning: land on red to fix tree breakage';
+      branch = null;
+      totSha = null;
       flutterRepoPRs.clear();
       engineRepoPRs.clear();
       pluginRepoPRs.clear();
       statuses.clear();
       PullRequestHelper._counter = 0;
+      githubComparison = null;
 
       when(mockGitHubClient.repositories).thenReturn(mockRepositoriesService);
       when(mockRepositoriesService.getCommit(RepositorySlug('flutter', 'flutter'), 'HEAD~'))


### PR DESCRIPTION
## Summary

These are more realistic values, and are quick fixes to the timeouts.

According to GitHub, reducing page size from 100 to 20 on the PRs would result in a speed up of a factor of 5 (even when there isn't extra data).

## Issues

https://github.com/flutter/flutter/issues/96836

## Future work

If this doesn't fix timeout issues, we'll need to split this query into smaller parts.