### PR TITLE
Skip filing a new issue when the builder is bringup: true

### DIFF
--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -113,7 +113,9 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
   }
 
   bool _shouldNotFileIssueAndPR(_BuilderDetail builderDetail, Issue? issue) {
-    // Don't create a new issue or deflake PR if the builder has been marked as flaky.
+    // Don't create a new issue or deflake PR using prod builds statuses if the builder has been marked as flaky.
+    // If the builder is `bringup: true`, but still hit flakes, a new bug will be filed in `/api/check_flaky_builders`
+    // based on staging builds statuses.
     if (builderDetail.isMarkedFlaky) {
       return true;
     }

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -464,7 +464,7 @@ void main() {
       expect(result['Status'], 'success');
     });
 
-    test('Do not create PR if the test is already flaky', () async {
+    test('Do not create an issue or PR if the test is already flaky', () async {
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
         return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
@@ -479,6 +479,8 @@ void main() {
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
           .single as Map<String, dynamic>;
+      // Verify no issue is created.
+      verifyNever(mockIssuesService.create(captureAny, captureAny));
       // Verify no pr is created.
       verifyNever(mockPullRequestsService.create(captureAny, captureAny));
 


### PR DESCRIPTION
The a builder is already `bringup: true`, it means there is a tracking issue (either open or recently closed). For either case, there is no need to create a new bug.

A deflake PR has been skipped for this case, and this PR skips issue creation as well.

https://github.com/flutter/flutter/issues/96799