### PR TITLE
Add device provisioning profile health check for ios devices

### DIFF
--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -78,7 +78,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
   }
 
   @visibleForTesting
-  Future<HealthCheckResult> deviceProvisioningProfileCheck(String deviceID, {ProcessManager processManager}) async {
+  Future<HealthCheckResult> deviceProvisioningProfileCheck(String deviceId, {ProcessManager processManager}) async {
     HealthCheckResult healthCheckResult;
     try {
       final String homeDir = Platform.environment['HOME'];
@@ -87,7 +87,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       final String provisionFileContent = await eval(
           'security', <String>['cms', '-D', '-i', '$homeDir/Library/MobileDevice/Provisioning\ Profiles/$profile'],
           processManager: processManager);
-      if (provisionFileContent.contains(deviceID)) {
+      if (provisionFileContent.contains(deviceId)) {
         healthCheckResult = HealthCheckResult.success(kDeviceProvisioningProfileCheckKey);
       } else {
         healthCheckResult = HealthCheckResult.failure(

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -55,6 +55,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       checks.add(await keychainUnlockCheck(processManager: processManager));
       checks.add(await certCheck(processManager: processManager));
       checks.add(await devicePairCheck(processManager: processManager));
+      checks.add(await deviceProvisioningProfileCheck(device.deviceId, processManager: processManager));
       checks.add(await userAutoLoginCheck(processManager: processManager));
       results['ios-device-${device.deviceId}'] = checks;
     }
@@ -74,6 +75,28 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     for (Device device in await discoverDevices()) {
       await device.recover();
     }
+  }
+
+  @visibleForTesting
+  Future<HealthCheckResult> deviceProvisioningProfileCheck(String deviceID, {ProcessManager processManager}) async {
+    HealthCheckResult healthCheckResult;
+    try {
+      final String homeDir = Platform.environment['HOME'];
+      final String profile = await eval('ls', <String>['$homeDir/Library/MobileDevice/Provisioning\ Profiles'],
+          processManager: processManager);
+      final String provisionFileContent = await eval(
+          'security', <String>['cms', '-D', '-i', '$homeDir/Library/MobileDevice/Provisioning\ Profiles/$profile'],
+          processManager: processManager);
+      if (provisionFileContent.contains(deviceID)) {
+        healthCheckResult = HealthCheckResult.success(kDeviceProvisioningProfileCheckKey);
+      } else {
+        healthCheckResult = HealthCheckResult.failure(
+            kDeviceProvisioningProfileCheckKey, 'device does not exist in the provisioning profile');
+      }
+    } on BuildFailedError catch (error) {
+      healthCheckResult = HealthCheckResult.failure(kDeviceProvisioningProfileCheckKey, error.toString());
+    }
+    return healthCheckResult;
   }
 
   @visibleForTesting

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -55,8 +55,8 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       checks.add(await keychainUnlockCheck(processManager: processManager));
       checks.add(await certCheck(processManager: processManager));
       checks.add(await devicePairCheck(processManager: processManager));
-      checks.add(await deviceProvisioningProfileCheck(device.deviceId, processManager: processManager));
       checks.add(await userAutoLoginCheck(processManager: processManager));
+      checks.add(await deviceProvisioningProfileCheck(device.deviceId, processManager: processManager));
       results['ios-device-${device.deviceId}'] = checks;
     }
     final Map<String, Map<String, dynamic>> healthCheckMap = await healthcheck(results);

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -19,6 +19,7 @@ const String kDeveloperModeCheckKey = 'developer_mode';
 const String kScreenOnCheckKey = 'screen_on';
 const String kKillAdbServerCheckKey = 'kill_adb_server';
 const String kKeychainUnlockCheckKey = 'keychain_unlock';
+const String kDeviceProvisioningProfileCheckKey = 'device_provisioning_profile';
 const String kUserAutoLoginCheckKey = 'swarming_user_auto_login';
 const String kUnlockLoginKeychain = '/usr/local/bin/unlock_login_keychain.sh';
 const String kCertCheckKey = 'codesigning_cert';

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -53,7 +53,7 @@ void main() {
       Map<String, List<HealthCheckResult>> results = await deviceDiscovery.checkDevices(processManager: processManager);
       expect(results.keys.length, equals(1));
       expect(results.keys.toList()[0], 'ios-device-abcdefg');
-      expect(results['ios-device-abcdefg'].length, 5);
+      expect(results['ios-device-abcdefg'].length, 6);
       expect(results['ios-device-abcdefg'][0].name, kDeviceAccessCheckKey);
       expect(results['ios-device-abcdefg'][0].succeeded, true);
       expect(results['ios-device-abcdefg'][1].name, kKeychainUnlockCheckKey);
@@ -64,6 +64,8 @@ void main() {
       expect(results['ios-device-abcdefg'][3].succeeded, false);
       expect(results['ios-device-abcdefg'][4].name, kUserAutoLoginCheckKey);
       expect(results['ios-device-abcdefg'][4].succeeded, false);
+      expect(results['ios-device-abcdefg'][5].name, kDeviceProvisioningProfileCheckKey);
+      expect(results['ios-device-abcdefg'][5].succeeded, false);
     });
   });
 

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -266,6 +266,7 @@ void main() {
             await deviceDiscovery.deviceProvisioningProfileCheck(deviceID, processManager: processManager);
         expect(healthCheckResult.succeeded, false);
         expect(healthCheckResult.name, kDeviceProvisioningProfileCheckKey);
+        expect(healthCheckResult.details, 'device does not exist in the provisioning profile');
       });
     });
   });


### PR DESCRIPTION
This adds the device provisioning profile health check for ios device. If the device on the test bed does not exist in the provisioning profile, the bot will be quarantined.

https://github.com/flutter/flutter/issues/95144