### PR TITLE
File flaky bug for `bringup:true` builders if no open tracking bug

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -59,7 +59,7 @@ Future<void> main() async {
       ///
       /// Response: Status 200 OK
       '/api/check-waiting-pull-requests': CheckForWaitingPullRequests(config, authProvider),
-      '/api/deflake_flaky_builders': DeflakeFlakyBuilders(config, authProvider),
+      '/api/deflake_flaky_builders': CheckFlakyBuilders(config, authProvider),
       '/api/file_flaky_issue_and_pr': FileFlakyIssueAndPR(config, authProvider),
       '/api/flush-cache': FlushCache(
         config,

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -59,7 +59,7 @@ Future<void> main() async {
       ///
       /// Response: Status 200 OK
       '/api/check-waiting-pull-requests': CheckForWaitingPullRequests(config, authProvider),
-      '/api/deflake_flaky_builders': CheckFlakyBuilders(config, authProvider),
+      '/api/check_flaky_builders': CheckFlakyBuilders(config, authProvider),
       '/api/file_flaky_issue_and_pr': FileFlakyIssueAndPR(config, authProvider),
       '/api/flush-cache': FlushCache(
         config,

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -4,8 +4,8 @@
 
 export 'src/foundation/utils.dart';
 export 'src/model/appengine/service_account_info.dart';
+export 'src/request_handlers/check_flaky_builders.dart';
 export 'src/request_handlers/check_for_waiting_pull_requests.dart';
-export 'src/request_handlers/deflake_flaky_builders.dart';
 export 'src/request_handlers/file_flaky_issue_and_pr.dart';
 export 'src/request_handlers/flush_cache.dart';
 export 'src/request_handlers/get_authentication_status.dart';

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -85,7 +85,8 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   ///   1) there is any flake in recent runs
   ///   2) there is no open flaky bug tracking the flake
   bool _shouldFileIssue(List<BuilderRecord> builderRecords, _BuilderInfo info) {
-    final bool noExistingOpenIssue = info.existingIssue == null || info.existingIssue != null && info.existingIssue!.isClosed;
+    final bool noExistingOpenIssue =
+        info.existingIssue == null || info.existingIssue != null && info.existingIssue!.isClosed;
     return builderRecords.any((BuilderRecord record) => record.isFlaky) && noExistingOpenIssue;
   }
 

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -85,9 +85,11 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   ///   1) there is any flake in recent runs
   ///   2) there is no open flaky bug tracking the flake
   bool _shouldFileIssue(List<BuilderRecord> builderRecords, _BuilderInfo info) {
-    final bool noExistingOpenIssue =
-        info.existingIssue == null || info.existingIssue != null && info.existingIssue!.isClosed;
-    return builderRecords.any((BuilderRecord record) => record.isFlaky) && noExistingOpenIssue;
+    final bool noExistingOpenIssue = info.existingIssue == null ||
+        info.existingIssue != null &&
+            info.existingIssue!.isClosed &&
+            DateTime.now().difference(info.existingIssue!.closedAt!) > const Duration(days: kGracePeriodForClosedFlake);
+    return noExistingOpenIssue && builderRecords.any((BuilderRecord record) => record.isFlaky);
   }
 
   /// A builder should be deflaked if satisfying three conditions.

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -29,8 +29,6 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
 
   static const String kThresholdKey = 'threshold';
 
-  static const int kGracePeriodForClosedFlake = 15; // days
-
   @override
   Future<Body> get() async {
     final RepositorySlug slug = Config.flutterSlug;
@@ -103,7 +101,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     await gitHub.assignReviewer(slug, reviewer: prBuilder.pullRequestReviewer, pullRequestNumber: pullRequest.number);
   }
 
-  bool _shouldNotFileIssueAndPR(_BuilderDetail builderDetail, Issue? issue) {
+  bool _shouldNotFileIssueAndPR(BuilderDetail builderDetail, Issue? issue) {
     // Don't create a new issue or deflake PR using prod builds statuses if the builder has been marked as flaky.
     // If the builder is `bringup: true`, but still hit flakes, a new bug will be filed in `/api/check_flaky_builders`
     // based on staging builds statuses.

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -43,6 +43,7 @@ const String kModifyType = 'blob';
 
 const int kSuccessBuildNumberLimit = 3;
 const int kFlayRatioBuildNumberList = 10;
+const double kDefaultFlakyRatioThreshold = 0.2;
 
 const String _commitPrefix = 'https://github.com/flutter/flutter/commit/';
 const String _buildDashboardPrefix = 'https://flutter-dashboard.appspot.com/#/build';
@@ -57,11 +58,13 @@ class IssueBuilder {
     required this.statistic,
     required this.ownership,
     required this.threshold,
+    this.bringup = false,
   });
 
   final BuilderStatistic statistic;
   final TestOwnership ownership;
   final double threshold;
+  final bool bringup;
 
   String get issueTitle {
     return '${statistic.name} is ${_formatRate(statistic.flakyRate)}% flaky';
@@ -81,7 +84,7 @@ class IssueBuilder {
   String get issueBody {
     return '''
 ${_buildHiddenMetaTags(name: statistic.name)}
-The post-submit test builder `${statistic.name}` had a flaky ratio ${_formatRate(statistic.flakyRate)}% for the past (up to) 100 commits, which is above our ${_formatRate(threshold)}% threshold.
+${_issueSummary(statistic, threshold, bringup)}
 
 One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit)}
 Commit: $_commitPrefix${statistic.recentCommit}
@@ -258,6 +261,28 @@ Future<Map<String?, PullRequest>> getExistingPRs(GithubService gitHub, Repositor
     }
   }
   return nameToExistingPRs;
+}
+
+/// File a GitHub flaky issue based on builder details in recent prod/staging runs.
+Future<Issue> fileFlakyIssue({
+  required BuilderDetail builderDetail,
+  required GithubService gitHub,
+  required RepositorySlug slug,
+  double threshold = kDefaultFlakyRatioThreshold,
+  bool bringup = false,
+}) async {
+  final IssueBuilder issueBuilder = IssueBuilder(
+      statistic: builderDetail.statistic,
+      ownership: builderDetail.ownership,
+      threshold: kDefaultFlakyRatioThreshold,
+      bringup: false);
+  return await gitHub.createIssue(
+    slug,
+    title: issueBuilder.issueTitle,
+    body: issueBuilder.issueBody,
+    labels: issueBuilder.issueLabels,
+    assignee: issueBuilder.issueAssignee,
+  );
 }
 
 /// Looks up the owner of a builder in TESTOWNERS file.
@@ -476,6 +501,18 @@ String _issueBuildLinks({String? builder, required List<String> builds, Bucket b
   return '${builds.map((String build) => _issueBuildLink(builder: builder, build: build, bucket: bucket)).join('\n')}';
 }
 
+String _issueSummary(BuilderStatistic statistic, double threshold, bool bringup) {
+  final String summary;
+  if (bringup) {
+    summary =
+        'The post-submit test builder `${statistic.name}`, which has been marked `bringup: true`, had ${statistic.flakyNumber} flakes over past ${statistic.totalNumber} commits.';
+  } else {
+    summary =
+        'The post-submit test builder `${statistic.name}` had a flaky ratio ${_formatRate(statistic.flakyRate)}% for the past (up to) 100 commits, which is above our ${_formatRate(threshold)}% threshold.';
+  }
+  return summary;
+}
+
 String _issueBuildLink({String? builder, String? build, Bucket bucket = Bucket.prod}) {
   final String buildPrefix = bucket == Bucket.staging ? _stagingBuildPrefix : _prodBuildPrefix;
   return Uri.encodeFull('$buildPrefix$builder/$build');
@@ -543,4 +580,21 @@ class TestOwnership {
   );
   String? owner;
   Team? team;
+}
+
+class BuilderDetail {
+  const BuilderDetail({
+    required this.statistic,
+    required this.existingIssue,
+    required this.existingPullRequest,
+    required this.isMarkedFlaky,
+    required this.ownership,
+    required this.type,
+  });
+  final BuilderStatistic statistic;
+  final Issue? existingIssue;
+  final PullRequest? existingPullRequest;
+  final TestOwnership ownership;
+  final bool isMarkedFlaky;
+  final BuilderType type;
 }

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -44,6 +44,7 @@ const String kModifyType = 'blob';
 const int kSuccessBuildNumberLimit = 3;
 const int kFlayRatioBuildNumberList = 10;
 const double kDefaultFlakyRatioThreshold = 0.2;
+const int kGracePeriodForClosedFlake = 15; // days
 
 const String _commitPrefix = 'https://github.com/flutter/flutter/commit/';
 const String _buildDashboardPrefix = 'https://flutter-dashboard.appspot.com/#/build';

--- a/app_dart/lib/src/service/bigquery.dart
+++ b/app_dart/lib/src/service/bigquery.dart
@@ -77,7 +77,7 @@ group by builder_name;
 // Returns builds in the past 30 days to exclude obsolete historical data.
 const String getRecordsQuery = r'''
 select sha, is_flaky, failure_count from `flutter-dashboard.datasite.luci_staging_build_status`
-where builder_name=@BUILDER_NAME and TIMESTAMP_DIFF(time,current_timestamp,day)<30
+where builder_name=@BUILDER_NAME and date>=date_sub(current_date(), interval 30 day)
 order by time desc
 limit @LIMIT
 ''';

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -354,7 +354,11 @@ void main() {
       });
       // When get issue
       when(mockIssuesService.get(captureAny, captureAny)).thenAnswer((_) {
-        return Future<Issue>.value(Issue(state: 'closed', htmlUrl: existingIssueURL));
+        return Future<Issue>.value(Issue(
+          state: 'closed',
+          htmlUrl: existingIssueURL,
+          closedAt: DateTime.now().subtract(const Duration(days: kGracePeriodForClosedFlake + 1)),
+        ));
       });
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -8,6 +8,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/request_handlers/flaky_handler_utils.dart';
 import 'package:cocoon_service/src/service/bigquery.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
+import 'package:collection/src/equality.dart';
 import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -18,7 +19,7 @@ import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/utilities/mocks.dart';
 
-import 'deflake_flaky_builders_test_data.dart';
+import 'check_flaky_builders_test_data.dart';
 
 const String kThreshold = '0.02';
 const String kCurrentMasterSHA = 'b6156fc8d1c6e992fe4ea0b9128f9aef10443bdb';
@@ -28,7 +29,7 @@ const String kCurrentUserEmail = 'login@email.com';
 
 void main() {
   group('Deflake', () {
-    late DeflakeFlakyBuilders handler;
+    late CheckFlakyBuilders handler;
     late ApiRequestHandlerTester tester;
     FakeHttpRequest request;
     late FakeConfig config;
@@ -97,7 +98,7 @@ void main() {
       );
       tester = ApiRequestHandlerTester(request: request);
 
-      handler = DeflakeFlakyBuilders(
+      handler = CheckFlakyBuilders(
         config,
         auth,
       );
@@ -131,7 +132,7 @@ void main() {
         return Future<PullRequest>.value(PullRequest(number: expectedSemanticsIntegrationTestPRNumber));
       });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -144,7 +145,7 @@ void main() {
       expect(captured.length, 3);
       expect(captured[0].toString(), kBigQueryProjectId);
       expect(captured[1] as String?, expectedSemanticsIntegrationTestBuilderName);
-      expect(captured[2] as int?, DeflakeFlakyBuilders.kRecordNumber);
+      expect(captured[2] as int?, CheckFlakyBuilders.kRecordNumber);
 
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
@@ -230,7 +231,7 @@ void main() {
         return Future<PullRequest>.value(PullRequest(number: expectedSemanticsIntegrationTestPRNumber));
       });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -243,7 +244,7 @@ void main() {
       expect(captured.length, 3);
       expect(captured[0].toString(), kBigQueryProjectId);
       expect(captured[1] as String?, expectedSemanticsIntegrationTestBuilderName);
-      expect(captured[2] as int?, DeflakeFlakyBuilders.kRecordNumber);
+      expect(captured[2] as int?, CheckFlakyBuilders.kRecordNumber);
 
       // Verify it does not get issue.
       verifyNever(mockIssuesService.get(captureAny, captureAny));
@@ -303,7 +304,7 @@ void main() {
         return Future<RepositoryContents>.value(
             RepositoryContents(file: GitHubFile(content: gitHubEncode(ciYamlContentFlakyInIgnoreList))));
       });
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -326,7 +327,7 @@ void main() {
       when(mockIssuesService.get(captureAny, captureAny)).thenAnswer((_) {
         return Future<Issue>.value(Issue(state: 'open', htmlUrl: existingIssueURL));
       });
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -344,7 +345,7 @@ void main() {
       expect(result['Status'], 'success');
     });
 
-    test('Do not create pr if the records have flaky runs', () async {
+    test('Do not create pr but do create issue if the records have flaky runs and there is no open issue', () async {
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listRecentBuildRecordsForBuilder(kBigQueryProjectId,
               builder: captureAnyNamed('builder'), limit: captureAnyNamed('limit')))
@@ -355,8 +356,13 @@ void main() {
       when(mockIssuesService.get(captureAny, captureAny)).thenAnswer((_) {
         return Future<Issue>.value(Issue(state: 'closed', htmlUrl: existingIssueURL));
       });
+      // When queries flaky data from BigQuery.
+      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
+          .thenAnswer((Invocation invocation) {
+        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+      });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsFlaky.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length + 1;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -369,7 +375,7 @@ void main() {
       expect(captured.length, 3);
       expect(captured[0].toString(), kBigQueryProjectId);
       expect(captured[1] as String?, expectedSemanticsIntegrationTestBuilderName);
-      expect(captured[2] as int?, DeflakeFlakyBuilders.kRecordNumber);
+      expect(captured[2] as int?, CheckFlakyBuilders.kRecordNumber);
 
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
@@ -379,6 +385,15 @@ void main() {
 
       // Verify pr is not created.
       verifyNever(mockPullRequestsService.create(captureAny, captureAny));
+
+      // Verify issue is created correctly.
+      captured = verify(mockIssuesService.create(captureAny, captureAny)).captured;
+      expect(captured.length, 2);
+      expect(captured[0].toString(), Config.flutterSlug.toString());
+      expect(captured[1], isA<IssueRequest>());
+      final IssueRequest issueRequest = captured[1] as IssueRequest;
+      expect(issueRequest.assignee, expectedSemanticsIntegrationTestOwner);
+      expect(const ListEquality<String>().equals(issueRequest.labels, expectedSemanticsIntegrationTestLabels), isTrue);
 
       expect(result['Status'], 'success');
     });
@@ -395,7 +410,7 @@ void main() {
         return Future<Issue>.value(Issue(state: 'closed', htmlUrl: existingIssueURL));
       });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsFailed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsFailed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -408,7 +423,7 @@ void main() {
       expect(captured.length, 3);
       expect(captured[0].toString(), kBigQueryProjectId);
       expect(captured[1] as String?, expectedSemanticsIntegrationTestBuilderName);
-      expect(captured[2] as int?, DeflakeFlakyBuilders.kRecordNumber);
+      expect(captured[2] as int?, CheckFlakyBuilders.kRecordNumber);
 
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;
@@ -438,7 +453,7 @@ void main() {
         return Future<Issue>.value(Issue(state: 'closed', htmlUrl: existingIssueURL));
       });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -462,7 +477,7 @@ void main() {
         return Future<Issue>.value(Issue(state: 'closed', htmlUrl: existingIssueURL));
       });
 
-      DeflakeFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length + 1;
+      CheckFlakyBuilders.kRecordNumber = semanticsIntegrationTestRecordsAllPassed.length + 1;
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)
@@ -475,7 +490,7 @@ void main() {
       expect(captured.length, 3);
       expect(captured[0].toString(), kBigQueryProjectId);
       expect(captured[1] as String?, expectedSemanticsIntegrationTestBuilderName);
-      expect(captured[2] as int?, DeflakeFlakyBuilders.kRecordNumber);
+      expect(captured[2] as int?, CheckFlakyBuilders.kRecordNumber);
 
       // Verify it gets the correct issue.
       captured = verify(mockIssuesService.get(captureAny, captureAny)).captured;

--- a/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
@@ -153,6 +153,13 @@ final List<BuilderRecord> semanticsIntegrationTestRecordsFailed = <BuilderRecord
   BuilderRecord(commit: 'abc', isFlaky: false, isFailed: false),
 ];
 
+const String expectedSemanticsIntegrationTestOwner = 'HansMuller';
+const List<String> expectedSemanticsIntegrationTestLabels = <String>[
+  'team: flakes',
+  'severe: flake',
+  'P1',
+  'framework',
+];
 const String expectedSemanticsIntegrationTestTreeSha = 'abcdefg';
 const int expectedSemanticsIntegrationTestPRNumber = 123;
 
@@ -207,6 +214,19 @@ const String expectedSemanticsIntegrationTestPullRequestBodyNoIssue = '''
 The test has been passing for [8 consecutive runs](https://data.corp.google.com/sites/flutter_infra_metrics_datasite/flutter_check_test_flakiness_status_dashboard/?p=BUILDER_NAME:%22Mac_android%20android_semantics_integration_test%22).
 This test can be marked as unflaky.
 ''';
+
+final List<BuilderStatistic> stagingSemanticsIntegrationTestResponse = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Mac_android android_semantics_integration_test',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+    flakyNumber: 3,
+    totalNumber: 10,
+  )
+];
 
 String gitHubEncode(String source) {
   final List<int> utf8Characters = utf8.encode(source);

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -381,7 +381,7 @@ void main() {
             title: expectedSemanticsIntegrationTestResponseTitle,
             body: expectedSemanticsIntegrationTestResponseBody,
             state: 'closed',
-            closedAt: DateTime.now().subtract(const Duration(days: FileFlakyIssueAndPR.kGracePeriodForClosedFlake - 1)),
+            closedAt: DateTime.now().subtract(const Duration(days: kGracePeriodForClosedFlake - 1)),
           )
         ]);
       });
@@ -425,7 +425,7 @@ void main() {
             title: expectedSemanticsIntegrationTestResponseTitle,
             body: expectedSemanticsIntegrationTestResponseBody,
             state: 'closed',
-            closedAt: DateTime.now().subtract(const Duration(days: FileFlakyIssueAndPR.kGracePeriodForClosedFlake + 1)),
+            closedAt: DateTime.now().subtract(const Duration(days: kGracePeriodForClosedFlake + 1)),
           )
         ]);
       });


### PR DESCRIPTION
Existing workflow is like:
1) flake bot file a flaky bug & deflake the builder
2) bug is closed due to a fix or decreased flake number
3) flake bot will file a new flaky bug still based on prod runs of this builder (INCORRECT)

This PR does:
1) file a new flaky bug based on staging runs (if there exists any flake)
2) create sharable function `fileFlakyIssue` in utils so different APIs can access
3) rename `deflake_flaky_builders` to `check_flaky_builders`.

https://github.com/flutter/flutter/issues/96799