### PR TITLE
Update cron job for `check flaky builders`

### DIFF
--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -55,6 +55,6 @@ cron:
   url: /api/update_existing_flaky_issues?threshold=0.02
   schedule: every monday 16:00
 
-- description: mark builders to be not flaky if they are no longer flaky
+- description: check flaky builders to either deflake the builder or file a new flaky bug
   url: /api/check_flaky_builders
   schedule: every monday 16:00

--- a/app_dart/cron.yaml
+++ b/app_dart/cron.yaml
@@ -56,5 +56,5 @@ cron:
   schedule: every monday 16:00
 
 - description: mark builders to be not flaky if they are no longer flaky
-  url: /api/deflake_flaky_builders
+  url: /api/check_flaky_builders
   schedule: every monday 16:00


### PR DESCRIPTION
The API has been recently updated, and this PR updates the cron job.

https://github.com/flutter/flutter/issues/96799