### PR TITLE
[app_dart] Generalize pubsub authentication

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -22,7 +22,6 @@ Future<void> main() async {
     final Config config = Config(dbService, cache);
     final AuthenticationProvider authProvider = AuthenticationProvider(config);
     final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config);
-    final AuthenticationProvider luciPubSubProvider = LuciPubsubAuthenticationProvider(config);
     final BuildBucketClient buildBucketClient = BuildBucketClient(
       accessTokenService: AccessTokenService.defaultProvider(config),
     );
@@ -79,7 +78,6 @@ Future<void> main() async {
       '/api/presubmit-luci-subscription': PresubmitLuciSubscription(
         cache,
         config,
-        luciPubSubProvider,
         buildBucketClient,
         luciBuildService,
         githubChecksService,
@@ -87,7 +85,6 @@ Future<void> main() async {
       '/api/postsubmit-luci-subscription': PostsubmitLuciSubscription(
         cache,
         config,
-        luciPubSubProvider,
       ),
       '/api/push-build-status-to-github': PushBuildStatusToGithub(
         config,
@@ -114,7 +111,6 @@ Future<void> main() async {
       '/api/scheduler/batch-request-subscription': SchedulerRequestSubscription(
         cache: cache,
         config: config,
-        authProvider: authProvider,
         buildBucketClient: buildBucketClient,
       ),
       '/api/update_existing_flaky_issues': UpdateExistingFlakyIssue(

--- a/app_dart/lib/cocoon_service.dart
+++ b/app_dart/lib/cocoon_service.dart
@@ -31,7 +31,7 @@ export 'src/request_handlers/vacuum_github_commits.dart';
 export 'src/request_handling/authentication.dart';
 export 'src/request_handling/body.dart';
 export 'src/request_handling/cache_request_handler.dart';
-export 'src/request_handling/luci_pubsub_authentication.dart';
+export 'src/request_handling/pubsub_authentication.dart';
 export 'src/request_handling/request_handler.dart';
 export 'src/request_handling/static_file_handler.dart';
 export 'src/request_handling/swarming_authentication.dart';

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -31,8 +31,8 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   /// Creates an endpoint for listening to LUCI status updates.
   const PostsubmitLuciSubscription(
     CacheService cache,
-    Config config,
-    AuthenticationProvider authProvider, {
+    Config config, {
+    AuthenticationProvider? authProvider,
     @visibleForTesting this.datastoreProvider = DatastoreService.defaultProvider,
   }) : super(
           cache: cache,

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -36,11 +36,11 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
   const PresubmitLuciSubscription(
     CacheService cache,
     Config config,
-    AuthenticationProvider authProvider,
     this.buildBucketClient,
     this.luciBuildService,
-    this.githubChecksService,
-  ) : super(
+    this.githubChecksService, {
+    AuthenticationProvider? authProvider,
+  }) : super(
           cache: cache,
           config: config,
           authProvider: authProvider,

--- a/app_dart/lib/src/request_handlers/scheduler/request_subscription.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/request_subscription.dart
@@ -28,8 +28,8 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
   const SchedulerRequestSubscription({
     required CacheService cache,
     required Config config,
-    required AuthenticationProvider authProvider,
     required this.buildBucketClient,
+    AuthenticationProvider? authProvider,
   }) : super(
           cache: cache,
           config: config,

--- a/app_dart/lib/src/request_handling/pubsub_authentication.dart
+++ b/app_dart/lib/src/request_handling/pubsub_authentication.dart
@@ -16,7 +16,7 @@ import '../foundation/typedefs.dart';
 import '../service/logging.dart';
 import 'exceptions.dart';
 
-/// Class capable of authenticating [HttpRequest]s for LUCI PubSub messages.
+/// Class capable of authenticating [HttpRequest]s for PubSub messages.
 ///
 /// This class implements an ACL on a [RequestHandler] to ensure only automated
 /// systems can access the endpoints.
@@ -27,8 +27,8 @@ import 'exceptions.dart';
 ///
 /// If there is no token, or it cannot be authenticated, [Unauthenticated] is thrown.
 @immutable
-class LuciPubsubAuthenticationProvider extends AuthenticationProvider {
-  const LuciPubsubAuthenticationProvider(
+class PubsubAuthenticationProvider extends AuthenticationProvider {
+  const PubsubAuthenticationProvider(
     Config config, {
     ClientContextProvider clientContextProvider = Providers.serviceScopeContext,
     HttpClientProvider httpClientProvider = Providers.freshHttpClient,
@@ -77,7 +77,7 @@ class LuciPubsubAuthenticationProvider extends AuthenticationProvider {
       throw const Unauthenticated('Token is expired');
     }
 
-    if (Config.allowedLuciPubsubServiceAccounts.contains(info.email)) {
+    if (Config.allowedPubsubServiceAccounts.contains(info.email)) {
       return AuthenticatedContext(clientContext: clientContext);
     }
     throw Unauthenticated('${info.email} is not in allowedLuciPubsubServiceAccounts');

--- a/app_dart/lib/src/request_handling/subscription_handler.dart
+++ b/app_dart/lib/src/request_handling/subscription_handler.dart
@@ -16,6 +16,7 @@ import 'api_request_handler.dart';
 import 'authentication.dart';
 import 'body.dart';
 import 'exceptions.dart';
+import 'pubsub_authentication.dart';
 import 'request_handler.dart';
 
 /// An [ApiRequestHandler] that handles PubSub subscription messages.
@@ -30,7 +31,7 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
   const SubscriptionHandler({
     required this.cache,
     required Config config,
-    required this.authProvider,
+    this.authProvider,
     required this.topicName,
   }) : super(
           config: config,
@@ -39,7 +40,7 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
   final CacheService cache;
 
   /// Service responsible for authenticating this [HttpRequest].
-  final AuthenticationProvider authProvider;
+  final AuthenticationProvider? authProvider;
 
   /// Unique identifier of the PubSub in this cloud project.
   final String topicName;
@@ -61,8 +62,9 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
     Future<void> Function(HttpStatusException)? onError,
   }) async {
     AuthenticatedContext authContext;
+    final AuthenticationProvider _authProvider = authProvider ?? PubsubAuthenticationProvider(config);
     try {
-      authContext = await authProvider.authenticate(request);
+      authContext = await _authProvider.authenticate(request);
     } on Unauthenticated catch (error) {
       final HttpResponse response = request.response;
       response

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -245,8 +245,8 @@ class Config {
   /// Internal Google service account used to surface FRoB results.
   String get frobAccount => 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
 
-  /// Service accounts used for LUCI PubSub messages.
-  static const Set<String> allowedLuciPubsubServiceAccounts = <String>{
+  /// Service accounts used for PubSub messages.
+  static const Set<String> allowedPubsubServiceAccounts = <String>{
     'flutter-devicelab@flutter-dashboard.iam.gserviceaccount.com',
     'flutter-dashboard@appspot.gserviceaccount.com'
   };

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -33,7 +33,7 @@ void main() {
     handler = PostsubmitLuciSubscription(
       CacheService(inMemory: true),
       config,
-      FakeAuthenticationProvider(
+      authProvider: FakeAuthenticationProvider(
         clientContext: clientContext,
       ),
       datastoreProvider: (_) => DatastoreService(config.db, 5),

--- a/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
@@ -35,10 +35,10 @@ void main() {
     handler = PresubmitLuciSubscription(
       CacheService(inMemory: true),
       config,
-      FakeAuthenticationProvider(),
       buildbucket,
       FakeLuciBuildService(config),
       mockGithubChecksService,
+      authProvider: FakeAuthenticationProvider(),
     );
     request = FakeHttpRequest();
 

--- a/app_dart/test/request_handling/pubsub_authentication_test.dart
+++ b/app_dart/test/request_handling/pubsub_authentication_test.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:cocoon_service/src/request_handling/authentication.dart' show AuthenticatedContext;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/request_handling/luci_pubsub_authentication.dart';
+import 'package:cocoon_service/src/request_handling/pubsub_authentication.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -17,25 +17,25 @@ import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 
 void main() {
-  group('LuciPubsubAuthenticationProvider', () {
+  group('PubsubAuthenticationProvider', () {
     late FakeConfig config;
     late FakeClientContext clientContext;
     late FakeHttpRequest request;
-    late LuciPubsubAuthenticationProvider auth;
+    late PubsubAuthenticationProvider auth;
     late MockClient httpClient;
 
     setUp(() {
       config = FakeConfig();
       clientContext = FakeClientContext();
       request = FakeHttpRequest();
-      auth = LuciPubsubAuthenticationProvider(
+      auth = PubsubAuthenticationProvider(
         config,
         clientContextProvider: () => clientContext,
         httpClientProvider: () => httpClient,
       );
     });
 
-    for (String allowedAccount in Config.allowedLuciPubsubServiceAccounts) {
+    for (String allowedAccount in Config.allowedPubsubServiceAccounts) {
       test('auth succeeds for $allowedAccount', () async {
         httpClient = MockClient((_) async => http.Response(
               _generateTokenResponse(allowedAccount),
@@ -44,7 +44,7 @@ void main() {
                 HttpHeaders.contentTypeHeader: 'application/json',
               },
             ));
-        auth = LuciPubsubAuthenticationProvider(
+        auth = PubsubAuthenticationProvider(
           config,
           clientContextProvider: () => clientContext,
           httpClientProvider: () => httpClient,
@@ -65,7 +65,7 @@ void main() {
               HttpHeaders.contentTypeHeader: 'application/json',
             },
           ));
-      auth = LuciPubsubAuthenticationProvider(
+      auth = PubsubAuthenticationProvider(
         config,
         clientContextProvider: () => clientContext,
         httpClientProvider: () => httpClient,
@@ -84,7 +84,7 @@ void main() {
               HttpHeaders.contentTypeHeader: 'application/json',
             },
           ));
-      auth = LuciPubsubAuthenticationProvider(
+      auth = PubsubAuthenticationProvider(
         config,
         clientContextProvider: () => clientContext,
         httpClientProvider: () => httpClient,
@@ -98,7 +98,7 @@ void main() {
     test('auth fails with expired token', () async {
       httpClient = MockClient((_) async => http.Response(
             _generateTokenResponse(
-              Config.allowedLuciPubsubServiceAccounts.first,
+              Config.allowedPubsubServiceAccounts.first,
               expiresIn: -1,
             ),
             HttpStatus.ok,
@@ -106,7 +106,7 @@ void main() {
               HttpHeaders.contentTypeHeader: 'application/json',
             },
           ));
-      auth = LuciPubsubAuthenticationProvider(
+      auth = PubsubAuthenticationProvider(
         config,
         clientContextProvider: () => clientContext,
         httpClientProvider: () => httpClient,


### PR DESCRIPTION
This is a quick fix to make writing subscriptions easier. I fell into this when I used the wrong auth for testing the scheduler batch request subscription.

## Summary
- Default `SubscriptionHandler` to use the `PubsubAuthenticationProvider`
- Rename `LuciPubsubAuthenticationProvider` to `PubsubAuthenticationProvider` and fix related names and docs

https://github.com/flutter/flutter/issues/86948 - Enabling pubsub in Cocoon