### PR TITLE
Inject bringup to distinguish bugs between staging and prod pools

### DIFF
--- a/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
@@ -120,6 +120,29 @@ const String testOwnersContent = '''
 /dev/devicelab/bin/tasks/android_semantics_integration_test.dart @HansMuller @flutter/framework
 ''';
 
+const String expectedSemanticsIntegrationTestResponseBody = '''
+<!-- meta-tags: To be used by the automation script only, DO NOT MODIFY.
+{
+  "name": "Mac_android android_semantics_integration_test"
+}
+-->
+
+The post-submit test builder `Mac_android android_semantics_integration_test`, which has been marked `bringup: true`, had 3 flakes over past 10 commits.
+
+One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_android%20android_semantics_integration_test/103
+Commit: https://github.com/flutter/flutter/commit/abc
+
+Flaky builds:
+https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_android%20android_semantics_integration_test/103
+https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_android%20android_semantics_integration_test/102
+https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_android%20android_semantics_integration_test/101
+
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
+
+Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
+''';
+
 final List<BuilderRecord> semanticsIntegrationTestRecordsAllPassed = <BuilderRecord>[
   BuilderRecord(commit: 'abc', isFlaky: false, isFailed: false),
   BuilderRecord(commit: 'abc', isFlaky: false, isFailed: false),

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
@@ -136,7 +136,7 @@ const String expectedSemanticsIntegrationTestResponseBody = '''
 }
 -->
 
-The post-submit test builder `Mac_android android_semantics_integration_test` had a flaky ratio 50.00% for the past (up to) 100 commits, which is above our 20.00% threshold.
+The post-submit test builder `Mac_android android_semantics_integration_test` had a flaky ratio 50.00% for the past (up to) 100 commits, which is above our 2.00% threshold.
 
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
 Commit: https://github.com/flutter/flutter/commit/abc
@@ -224,7 +224,7 @@ const String expectedLimitedNumberOfBuildsResponseBody = '''
 }
 -->
 
-The post-submit test builder `Mac_android android_semantics_integration_test` had a flaky ratio 25.00% for the past (up to) 100 commits, which is above our 20.00% threshold.
+The post-submit test builder `Mac_android android_semantics_integration_test` had a flaky ratio 25.00% for the past (up to) 100 commits, which is above our 2.00% threshold.
 
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
 Commit: https://github.com/flutter/flutter/commit/abc


### PR DESCRIPTION
The current flake bot files flaky bugs for two scenarios:
1) Prod builders: if any one becomes flaky and there is no existing issue to track
2) Staging builders (bringup: true): if any one hit a flake and there is no open issue to track/ there is an obsolete closed issue

This PR fixes the logic for 2). By injecting the `bringup` property, corresponding bugs will be filed accordingly.

Fixes: https://github.com/flutter/flutter/issues/97731