### PR TITLE
[dashboard] Merge columns for luci and cocoon tasks

### DIFF
--- a/dashboard/lib/logic/qualified_task.dart
+++ b/dashboard/lib/logic/qualified_task.dart
@@ -59,11 +59,23 @@ class QualifiedTask {
     if (other.runtimeType != runtimeType) {
       return false;
     }
+
+    if (isLuci) {
+      return other is QualifiedTask && other.task == task;
+    }
+
     return other is QualifiedTask && other.stage == stage && other.task == task;
   }
 
   @override
-  int get hashCode => stage.hashCode ^ task.hashCode;
+  int get hashCode {
+    // Ensure tasks from Cocoon or LUCI share the same columns.
+    if (isLuci) {
+      return StageName.cocoon.hashCode ^ task.hashCode;
+    }
+
+    return stage.hashCode ^ task.hashCode;
+  }
 }
 
 /// Get the URL for [Task] to view its log.


### PR DESCRIPTION
Tasks with `scheduler:cocoon` and `scheduler:luci` are effectively the same. They are managed by the ci.yaml tooling, but change their triggering policy and results processing.

After starting the migration, there's a few issues that shouldn't show:

https://flutter-dashboard.appspot.com/#/build?repo=cocoon&branch=master

Instead, these duplicate columns shouldn't exist.

## Issues

https://github.com/flutter/flutter/issues/92300 - Ensure a smooth migration (no disruption in the dashboard)