### PR TITLE
Add autosubmit bot support for dependabot.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -238,13 +238,15 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         continue;
       }
       final String? author = pullRequest['author']['login'] as String?;
+      final String? authorAssociation = pullRequest['authorAssociation'] as String;
       final String id = pullRequest['id'] as String;
       final String repoFullName = pullRequest['baseRepository']['nameWithOwner'] as String;
       final RepositorySlug slug = RepositorySlug.full(repoFullName);
       final String title = pullRequest['title'] as String;
 
       final Set<String?> changeRequestAuthors = <String?>{};
-      final bool hasApproval = config.rollerAccounts.contains(author) ||
+      final bool hasApproval = authorAssociation == 'dependabot[bot]' ||
+          config.rollerAccounts.contains(author) ||
           _checkApproval(
             author,
             pullRequest['authorAssociation'] as String,

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -238,7 +238,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         continue;
       }
       final String? author = pullRequest['author']['login'] as String?;
-      final String? authorAssociation = pullRequest['authorAssociation'] as String;
+      final String authorAssociation = pullRequest['authorAssociation'] as String;
       final String id = pullRequest['id'] as String;
       final String repoFullName = pullRequest['baseRepository']['nameWithOwner'] as String;
       final RepositorySlug slug = RepositorySlug.full(repoFullName);
@@ -249,7 +249,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
           config.rollerAccounts.contains(author) ||
           _checkApproval(
             author,
-            pullRequest['authorAssociation'] as String,
+            authorAssociation,
             (pullRequest['reviews']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>(),
             changeRequestAuthors,
           );

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -287,7 +287,6 @@ class Config {
   Set<String> get rollerAccounts => const <String>{
         'skia-flutter-autoroll',
         'engine-flutter-autoroll',
-        'dependabot[bot]',
       };
 
   Future<String> generateJsonWebToken() async {

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -295,6 +295,30 @@ void main() {
       );
     });
 
+    test('Merges unapproved PR from dependabot', () async {
+      flutterRepoPRs
+          .add(PullRequestHelper(authorAssociation: 'dependabot[bot]', reviews: const <PullRequestReviewHelper>[]));
+      engineRepoPRs
+          .add(PullRequestHelper(authorAssociation: 'dependabot[bot]', reviews: const <PullRequestReviewHelper>[]));
+
+      await tester.get(handler);
+
+      _verifyQueries();
+
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(engineRepoPRs.first.id),
+          ),
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(flutterRepoPRs.first.id),
+          ),
+        ],
+      );
+    });
+
     test('Does not merge PR with in progress tests', () async {
       statuses = <dynamic>[
         <String, String>{'id': '1', 'status': 'EXECUTING', 'name': 'test1'},


### PR DESCRIPTION
Dependabot uses the author association instead of login to identify the
author. This changes explicitly checks for dependabot PRs.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
