### PR TITLE
Fix prod retries on the engine.

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -45,6 +45,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
   static const String commitShaParam = 'Commit';
   static const String builderParam = 'Builder';
   static const String propertiesParam = 'Properties';
+  static const Map<String, dynamic> defaultProperties = <String, dynamic>{'force_upload': true};
 
   @override
   Future<Body> post() async {
@@ -55,7 +56,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final String repo = requestData![repoParam] as String? ?? 'flutter';
     String commitSha = requestData![commitShaParam] as String? ?? '';
     final Map<String, dynamic> properties =
-        (requestData![propertiesParam] as Map<String, dynamic>?) ?? <String, dynamic>{};
+        (requestData![propertiesParam] as Map<String, dynamic>?) ?? defaultProperties;
     final TokenInfo token = await tokenInfo(request!);
 
     RepositorySlug slug;

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -146,7 +146,7 @@ class AppEngineCocoonService implements CocoonService {
   }
 
   @override
-  Future<bool> rerunTask(Task task, String idToken) async {
+  Future<bool> rerunTask(Task task, String idToken, String repo) async {
     assert(idToken != null);
 
     final QualifiedTask qualifiedTask = QualifiedTask.fromTask(task);
@@ -160,6 +160,7 @@ class AppEngineCocoonService implements CocoonService {
         },
         body: jsonEncode(<String, String>{
           'Key': task.key.child.name,
+          'Repo': repo,
         }));
 
     return response.statusCode == HttpStatus.ok;

--- a/dashboard/lib/service/cocoon.dart
+++ b/dashboard/lib/service/cocoon.dart
@@ -52,7 +52,7 @@ abstract class CocoonService {
   /// Send rerun [Task] command to devicelab.
   ///
   /// Will not rerun tasks that are outside of devicelab.
-  Future<bool> rerunTask(Task task, String idToken);
+  Future<bool> rerunTask(Task task, String idToken, String repo);
 
   /// Force update Cocoon to get the latest commits.
   Future<bool> vacuumGitHubCommits(String idToken);

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -135,7 +135,7 @@ class DevelopmentCocoonService implements CocoonService {
   }
 
   @override
-  Future<bool> rerunTask(Task task, String accessToken) async {
+  Future<bool> rerunTask(Task task, String accessToken, String repo) async {
     return false;
   }
 

--- a/dashboard/lib/state/build.dart
+++ b/dashboard/lib/state/build.dart
@@ -344,7 +344,7 @@ class BuildState extends ChangeNotifier {
   Future<bool> refreshGitHubCommits() async => cocoonService.vacuumGitHubCommits(await authService.idToken);
 
   Future<bool> rerunTask(Task task) async {
-    return cocoonService.rerunTask(task, await authService.idToken);
+    return cocoonService.rerunTask(task, await authService.idToken, _currentRepo);
   }
 
   /// Assert that [statuses] is ordered from newest commit to oldest.

--- a/dashboard/test/service/appengine_cocoon_test.dart
+++ b/dashboard/test/service/appengine_cocoon_test.dart
@@ -141,18 +141,18 @@ void main() {
     });
 
     test('should return true if request succeeds', () async {
-      expect(await service.rerunTask(task, 'fakeAccessToken'), true);
+      expect(await service.rerunTask(task, 'fakeAccessToken', 'engine'), true);
     });
 
     test('should return false if request failed', () async {
       service = AppEngineCocoonService(client: MockClient((Request request) async {
         return Response('', 500);
       }));
-      expect(await service.rerunTask(task, 'fakeAccessToken'), false);
+      expect(await service.rerunTask(task, 'fakeAccessToken', 'engine'), false);
     });
 
     test('should return false if task key is null', () async {
-      expect(service.rerunTask(task, null), throwsA(const TypeMatcher<AssertionError>()));
+      expect(service.rerunTask(task, null, ''), throwsA(const TypeMatcher<AssertionError>()));
     });
   });
 


### PR DESCRIPTION
There were two different errors:

* Repo was not being passed to the reset-prod endpoint.
* Engine retries require force_upload property that was not being passed.

Bug: https://github.com/flutter/flutter/issues/98228
Bug: https://github.com/flutter/flutter/issues/98183

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
