### PR TITLE
Fix auto retry in repositories other than `flutter/flutter

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_chromebot_status.dart
@@ -125,6 +125,7 @@ class RefreshChromebotStatus extends ApiRequestHandler<Body> {
             luciTask: latestLuciTask,
             retries: update.attempts! - 1,
             datastore: datastore,
+            repo: slug.name,
             isFlaky: datastoreTask.task.isFlaky)) {
           update.status = Task.statusNew;
           update.attempts = (update.attempts ?? 0) + 1;

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -45,7 +45,6 @@ class ResetProdTask extends ApiRequestHandler<Body> {
   static const String commitShaParam = 'Commit';
   static const String builderParam = 'Builder';
   static const String propertiesParam = 'Properties';
-  static const Map<String, dynamic> defaultProperties = <String, dynamic>{'force_upload': true};
 
   @override
   Future<Body> post() async {
@@ -55,6 +54,8 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final String owner = requestData![ownerParam] as String? ?? 'flutter';
     final String repo = requestData![repoParam] as String? ?? 'flutter';
     String commitSha = requestData![commitShaParam] as String? ?? '';
+    final Map<String, dynamic> defaultProperties =
+        repo == 'engine' ? Config.engineDefaultProperties : const <String, dynamic>{};
     final Map<String, dynamic> properties =
         (requestData![propertiesParam] as Map<String, dynamic>?) ?? defaultProperties;
     final TokenInfo token = await tokenInfo(request!);

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -69,6 +69,9 @@ class Config {
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 
+  /// Engine default properties when rerunning a prod build.
+  static const Map<String, dynamic> engineDefaultProperties = <String, dynamic>{'force_upload': true};
+
   @visibleForTesting
   static const Duration configCacheTtl = Duration(hours: 12);
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -673,6 +673,7 @@ class LuciBuildService {
         builderName: luciTask.builderName,
         repo: repo,
         tags: tags,
+        properties: repo == 'engine' ? Config.engineDefaultProperties : const <String, dynamic>{},
         bucket: isFlaky ?? false ? 'staging' : 'prod',
       );
       return true;

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -18,14 +18,15 @@ Commit generateCommit(
   int i, {
   String? sha,
   String branch = 'master',
+  String repo = 'flutter',
 }) =>
     Commit(
       sha: sha ?? '$i',
-      repository: 'flutter/flutter',
+      repository: 'flutter/$repo',
       branch: branch,
       key: generateKey<String>(
         Commit,
-        'flutter/flutter/$branch/' + (sha ?? '$i'),
+        'flutter/$repo/$branch/' + (sha ?? '$i'),
       ),
     );
 


### PR DESCRIPTION
Engine/plugins/packages/cocoon repos are current supported in https://flutter-dashboard.appspot.com/#/build?repo=engine, however the auto retry logic when test fails is using default `flutter` repo and empty properties. 

This PR fixes the auto retry in other repos.
1) injects repo/properties when auto retry
2) moves `defaultProperties` to Config, and renames to `engineDefaultProperties`.
3) adds test to validate the logic
4) refactors other unit tests a bit to make it more clear.

Fixes: https://github.com/flutter/flutter/issues/98183