### PR TITLE
Ensure retries with checkRunEvent include the cipdVersion.

### DIFF
--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -336,7 +336,7 @@ void main() {
           return CheckRun.fromJson(const <String, dynamic>{
             'id': 1,
             'started_at': '2020-05-10T02:49:31Z',
-            'check_suite': <String, dynamic>{'id': 2}
+            'check_suite': <String, dynamic>{'id': 2},
           });
         });
         final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(

--- a/app_dart/test/src/service/fake_buildbucket.dart
+++ b/app_dart/test/src/service/fake_buildbucket.dart
@@ -49,6 +49,7 @@ class FakeBuildBucketClient extends BuildBucketClient {
                 ),
                 tags: <String, List<String>>{
                   'buildset': <String>['pr/git/12345', 'sha/git/259bcf77bd04e64ef2181caccc43eda57780cd21'],
+                  'cipd_version': <String>['refs/heads/main']
                 }),
           ],
         );


### PR DESCRIPTION
This is required to preserve the cipdVersion across re-runs. When a try
run is first scheduled the cipdVersion is added as a tag. The rerun
collects the cipdVersion tag and pass it to the cipd_exe property.

Bug: https://github.com/flutter/flutter/issues/98472

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
