### PR TITLE
[dashboard] microseconds for start time and end time (for now)

### DIFF
--- a/dashboard/lib/widgets/task_overlay.dart
+++ b/dashboard/lib/widgets/task_overlay.dart
@@ -226,7 +226,6 @@ class TaskOverlayContents extends StatelessWidget {
         task.startTimestamp == 0 ? now.difference(createTime) : startTime.difference(createTime);
     final Duration runDuration = task.endTimestamp == 0 ? now.difference(startTime) : endTime.difference(startTime);
 
-    print('queue duration is $queueDuration and runDuration is $runDuration');
     /// There are 2 possible states for queue time:
     ///   1. Task is waiting to be scheduled (in queue)
     ///   2. Task has been scheduled (out of queue)

--- a/dashboard/lib/widgets/task_overlay.dart
+++ b/dashboard/lib/widgets/task_overlay.dart
@@ -219,13 +219,14 @@ class TaskOverlayContents extends StatelessWidget {
 
     final DateTime now = Now.of(context);
     final DateTime createTime = DateTime.fromMillisecondsSinceEpoch(task.createTimestamp.toInt());
-    final DateTime startTime = DateTime.fromMillisecondsSinceEpoch(task.startTimestamp.toInt());
-    final DateTime endTime = DateTime.fromMillisecondsSinceEpoch(task.endTimestamp.toInt());
+    final DateTime startTime = DateTime.fromMicrosecondsSinceEpoch(task.startTimestamp.toInt());
+    final DateTime endTime = DateTime.fromMicrosecondsSinceEpoch(task.endTimestamp.toInt());
 
     final Duration queueDuration =
         task.startTimestamp == 0 ? now.difference(createTime) : startTime.difference(createTime);
     final Duration runDuration = task.endTimestamp == 0 ? now.difference(startTime) : endTime.difference(startTime);
 
+    print('queue duration is $queueDuration and runDuration is $runDuration');
     /// There are 2 possible states for queue time:
     ///   1. Task is waiting to be scheduled (in queue)
     ///   2. Task has been scheduled (out of queue)

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -54,6 +54,7 @@ void main() {
   final DateTime finishTime = nowTime.subtract(const Duration(minutes: 10));
 
   Int64 _int64FromDateTime(DateTime time) => Int64(time.millisecondsSinceEpoch);
+  Int64 _int64FromDateTimeMicro(DateTime time) => Int64(time.microsecondsSinceEpoch);
 
   testWidgets('TaskOverlay shows on click', (WidgetTester tester) async {
     await precacheTaskIcons(tester);
@@ -66,8 +67,8 @@ void main() {
       ..isFlaky = false // As opposed to the next test.
       ..status = TaskBox.statusFailed
       ..createTimestamp = _int64FromDateTime(createTime)
-      ..startTimestamp = _int64FromDateTime(startTime)
-      ..endTimestamp = _int64FromDateTime(finishTime);
+      ..startTimestamp = _int64FromDateTimeMicro(startTime)
+      ..endTimestamp =_int64FromDateTimeMicro(finishTime);
 
     final String expectedTaskInfoString = 'Attempts: ${expectedTask.attempts}\n'
         'Run time: 40 minutes\n'
@@ -122,8 +123,8 @@ void main() {
       ..isFlaky = true // This is the point of this test.
       ..status = TaskBox.statusFailed
       ..createTimestamp = _int64FromDateTime(createTime)
-      ..startTimestamp = _int64FromDateTime(startTime)
-      ..endTimestamp = _int64FromDateTime(finishTime);
+      ..startTimestamp = _int64FromDateTimeMicro(startTime)
+      ..endTimestamp = _int64FromDateTimeMicro(finishTime);
 
     final String flakyTaskInfoString = 'Attempts: ${flakyTask.attempts}\n'
         'Run time: 40 minutes\n'
@@ -171,8 +172,8 @@ void main() {
       ..name = 'Tasky McTaskFace'
       ..isFlaky = false
       ..createTimestamp = _int64FromDateTime(createTime)
-      ..startTimestamp = _int64FromDateTime(startTime)
-      ..endTimestamp = _int64FromDateTime(finishTime);
+      ..startTimestamp = _int64FromDateTimeMicro(startTime)
+      ..endTimestamp = _int64FromDateTimeMicro(finishTime);
 
     final String timeTaskInfoString = 'Attempts: ${timeTask.attempts}\n'
         'Run time: 8 minutes\n'
@@ -212,7 +213,7 @@ void main() {
       ..status = TaskBox.statusInProgress
       ..isFlaky = false
       ..createTimestamp = _int64FromDateTime(createTime)
-      ..startTimestamp = _int64FromDateTime(startTime);
+      ..startTimestamp = _int64FromDateTimeMicro(startTime);
 
     final String timeTaskInfoString = 'Attempts: ${timeTask.attempts}\n'
         'Running for 9 minutes\n'

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -68,7 +68,7 @@ void main() {
       ..status = TaskBox.statusFailed
       ..createTimestamp = _int64FromDateTime(createTime)
       ..startTimestamp = _int64FromDateTimeMicro(startTime)
-      ..endTimestamp =_int64FromDateTimeMicro(finishTime);
+      ..endTimestamp = _int64FromDateTimeMicro(finishTime);
 
     final String expectedTaskInfoString = 'Attempts: ${expectedTask.attempts}\n'
         'Run time: 40 minutes\n'


### PR DESCRIPTION
A maybe-not-so-good fix to circumvent https://github.com/flutter/flutter/issues/98676 and https://github.com/flutter/flutter/issues/92854. Currently the entities stored in our datastore has start time (need to verify since they are all 0s) and end time in microseconds since epoch, while create time is stored in milliseconds since epoch. In this fix, dashboard displays accordingly based on current assumptions. After infra has been migrated to a new scheduler in the future, we may need to change milli / micro seconds based on datastore again.

future work: find out root cause of start and end time being stored in microseconds in datastore.