### PR TITLE
Fix push message not processing in microseconds

### DIFF
--- a/app_dart/lib/src/model/common/json_converters.dart
+++ b/app_dart/lib/src/model/common/json_converters.dart
@@ -86,6 +86,27 @@ class Base64Converter implements JsonConverter<String, String> {
   }
 }
 
+/// A converter for "timestamp" fields encoded as microseconds since epoch.
+class MicrosecondsSinceEpochConverter implements JsonConverter<DateTime?, String?> {
+  const MicrosecondsSinceEpochConverter();
+
+  @override
+  DateTime? fromJson(String? json) {
+    if (json == null) {
+      return null;
+    }
+    return DateTime.fromMicrosecondsSinceEpoch(int.parse(json));
+  }
+
+  @override
+  String? toJson(DateTime? object) {
+    if (object == null) {
+      return null;
+    }
+    return object.microsecondsSinceEpoch.toString();
+  }
+}
+
 /// A converter for "timestamp" fields encoded as milliseconds since epoch.
 class MillisecondsSinceEpochConverter implements JsonConverter<DateTime?, String?> {
   const MillisecondsSinceEpochConverter();

--- a/app_dart/lib/src/model/luci/push_message.dart
+++ b/app_dart/lib/src/model/luci/push_message.dart
@@ -142,7 +142,7 @@ class Build extends JsonBody {
 
   /// The completion time of the build.
   @JsonKey(name: 'completed_ts')
-  @MillisecondsSinceEpochConverter()
+  @MicrosecondsSinceEpochConverter()
   final DateTime? completedTimestamp;
 
   /// The user who created the build.
@@ -151,7 +151,7 @@ class Build extends JsonBody {
 
   /// The creation time of the build.
   @JsonKey(name: 'created_ts')
-  @MillisecondsSinceEpochConverter()
+  @MicrosecondsSinceEpochConverter()
   final DateTime? createdTimestamp;
 
   /// Whether the build was experimental or not.
@@ -191,7 +191,7 @@ class Build extends JsonBody {
 
   /// The time of the build start.
   @JsonKey(name: 'started_ts')
-  @MillisecondsSinceEpochConverter()
+  @MicrosecondsSinceEpochConverter()
   final DateTime? startedTimestamp;
 
   /// The [Status] of the build.
@@ -215,7 +215,7 @@ class Build extends JsonBody {
 
   /// The time of the last update to this information.
   @JsonKey(name: 'updated_ts')
-  @MillisecondsSinceEpochConverter()
+  @MicrosecondsSinceEpochConverter()
   final DateTime? updatedTimestamp;
 
   /// The URL of the build.
@@ -223,7 +223,7 @@ class Build extends JsonBody {
 
   /// The time used as UTC now for reference to other times in this message.
   @JsonKey(name: 'utcnow_ts')
-  @MillisecondsSinceEpochConverter()
+  @MicrosecondsSinceEpochConverter()
   final DateTime? utcNowTimestamp;
 
   @override

--- a/app_dart/lib/src/model/luci/push_message.g.dart
+++ b/app_dart/lib/src/model/luci/push_message.g.dart
@@ -76,9 +76,9 @@ Build _$BuildFromJson(Map<String, dynamic> json) => Build(
       canary: json['canary'] as bool?,
       canaryPreference: $enumDecodeNullable(_$CanaryPreferenceEnumMap, json['canary_preference']),
       cancelationReason: $enumDecodeNullable(_$CancelationReasonEnumMap, json['cancelation_reason']),
-      completedTimestamp: const MillisecondsSinceEpochConverter().fromJson(json['completed_ts'] as String?),
+      completedTimestamp: const MicrosecondsSinceEpochConverter().fromJson(json['completed_ts'] as String?),
       createdBy: json['created_by'] as String?,
-      createdTimestamp: const MillisecondsSinceEpochConverter().fromJson(json['created_ts'] as String?),
+      createdTimestamp: const MicrosecondsSinceEpochConverter().fromJson(json['created_ts'] as String?),
       failureReason: $enumDecodeNullable(_$FailureReasonEnumMap, json['failure_reason']),
       experimental: json['experimental'] as bool?,
       id: json['id'] as String?,
@@ -87,11 +87,11 @@ Build _$BuildFromJson(Map<String, dynamic> json) => Build(
       result: $enumDecodeNullable(_$ResultEnumMap, json['result']),
       resultDetails: const NestedJsonConverter().fromJson(json['result_details_json'] as String?),
       serviceAccount: json['service_account'] as String?,
-      startedTimestamp: const MillisecondsSinceEpochConverter().fromJson(json['started_ts'] as String?),
+      startedTimestamp: const MicrosecondsSinceEpochConverter().fromJson(json['started_ts'] as String?),
       status: $enumDecodeNullable(_$StatusEnumMap, json['status']),
       tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      updatedTimestamp: const MillisecondsSinceEpochConverter().fromJson(json['updated_ts'] as String?),
-      utcNowTimestamp: const MillisecondsSinceEpochConverter().fromJson(json['utcnow_ts'] as String?),
+      updatedTimestamp: const MicrosecondsSinceEpochConverter().fromJson(json['updated_ts'] as String?),
+      utcNowTimestamp: const MicrosecondsSinceEpochConverter().fromJson(json['utcnow_ts'] as String?),
       url: json['url'] as String?,
     );
 
@@ -108,9 +108,9 @@ Map<String, dynamic> _$BuildToJson(Build instance) {
   writeNotNull('canary', instance.canary);
   writeNotNull('canary_preference', _$CanaryPreferenceEnumMap[instance.canaryPreference]);
   writeNotNull('cancelation_reason', _$CancelationReasonEnumMap[instance.cancelationReason]);
-  writeNotNull('completed_ts', const MillisecondsSinceEpochConverter().toJson(instance.completedTimestamp));
+  writeNotNull('completed_ts', const MicrosecondsSinceEpochConverter().toJson(instance.completedTimestamp));
   writeNotNull('created_by', instance.createdBy);
-  writeNotNull('created_ts', const MillisecondsSinceEpochConverter().toJson(instance.createdTimestamp));
+  writeNotNull('created_ts', const MicrosecondsSinceEpochConverter().toJson(instance.createdTimestamp));
   writeNotNull('experimental', instance.experimental);
   writeNotNull('failure_reason', _$FailureReasonEnumMap[instance.failureReason]);
   writeNotNull('id', instance.id);
@@ -119,12 +119,12 @@ Map<String, dynamic> _$BuildToJson(Build instance) {
   writeNotNull('result', _$ResultEnumMap[instance.result]);
   writeNotNull('result_details_json', const NestedJsonConverter().toJson(instance.resultDetails));
   writeNotNull('service_account', instance.serviceAccount);
-  writeNotNull('started_ts', const MillisecondsSinceEpochConverter().toJson(instance.startedTimestamp));
+  writeNotNull('started_ts', const MicrosecondsSinceEpochConverter().toJson(instance.startedTimestamp));
   writeNotNull('status', _$StatusEnumMap[instance.status]);
   writeNotNull('tags', instance.tags);
-  writeNotNull('updated_ts', const MillisecondsSinceEpochConverter().toJson(instance.updatedTimestamp));
+  writeNotNull('updated_ts', const MicrosecondsSinceEpochConverter().toJson(instance.updatedTimestamp));
   writeNotNull('url', instance.url);
-  writeNotNull('utcnow_ts', const MillisecondsSinceEpochConverter().toJson(instance.utcNowTimestamp));
+  writeNotNull('utcnow_ts', const MicrosecondsSinceEpochConverter().toJson(instance.utcNowTimestamp));
   return val;
 }
 

--- a/app_dart/test/model/push_message_test.dart
+++ b/app_dart/test/model/push_message_test.dart
@@ -9,10 +9,14 @@ import 'package:cocoon_service/src/model/luci/push_message.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('BuildPushMessage tagsByName', () {
+  test('BuildPushMessage.fromJson', () {
     final BuildPushMessage data = BuildPushMessage.fromJson(
       json.decode(buildPushMessageJson) as Map<String, dynamic>,
     );
+
+    expect(data.build!.createdTimestamp!.year, 2019);
+    expect(data.build!.createdTimestamp!.month, 8);
+    expect(data.build!.createdTimestamp!.day, 5);
 
     expect(data.build!.tags!.length, 11);
     expect(data.build!.tagsByName('builder').single, 'Linux Coverage');

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -80,7 +80,7 @@ void main() {
     await tester.post(handler);
 
     expect(task.status, Task.statusSucceeded);
-    expect(task.endTimestamp, 1565049193786090);
+    expect(task.endTimestamp, 1565049193786);
   });
 
   test('does not fail on empty user data', () async {


### PR DESCRIPTION
Timestamp is expected to be in microseconds from LUCI.

This is affecting the plugins, cocoon, and packages build dashboards from showing an accurate time.