### PR TITLE
[app_dart] Default null timestamps to 0

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -290,9 +290,9 @@ class Task extends Model<int> {
       buildNumberList = '$buildNumberList,$buildNumber';
     }
 
-    createTimestamp = build.createdTimestamp?.millisecondsSinceEpoch;
-    startTimestamp = build.startedTimestamp?.millisecondsSinceEpoch;
-    endTimestamp = build.completedTimestamp?.millisecondsSinceEpoch;
+    createTimestamp = build.createdTimestamp?.millisecondsSinceEpoch ?? 0;
+    startTimestamp = build.startedTimestamp?.millisecondsSinceEpoch ?? 0;
+    endTimestamp = build.completedTimestamp?.millisecondsSinceEpoch ?? 0;
 
     _setStatusFromLuciStatus(build);
   }

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -87,6 +87,21 @@ void main() {
         expect(task.endTimestamp, completed.millisecondsSinceEpoch);
       });
 
+      test('defaults timestamps to 0', () {
+        final Build build = generatePushMessageBuild(1);
+        final Task task = generateTask(1);
+
+        expect(task.endTimestamp, 0);
+        expect(task.createTimestamp, 0);
+        expect(task.startTimestamp, 0);
+
+        task.updateFromBuild(build);
+
+        expect(task.endTimestamp, 0);
+        expect(task.createTimestamp, 0);
+        expect(task.startTimestamp, 0);
+      });
+
       test('updates if buildNumber is prior to pushMessage', () {
         final Build build = generatePushMessageBuild(
           1,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98759
Fixes https://github.com/flutter/flutter/issues/98758

Issue was `completed_ts` was omitted for in progress or scheduled build updates. Datastore won't allow null, so we need to default it to 0.