### PR TITLE
Update builders value when reset_try_task with specified list

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_try_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_try_task.dart
@@ -34,7 +34,7 @@ class ResetTryTask extends ApiRequestHandler<Body> {
     final String owner = request!.uri.queryParameters[kOwnerParam] ?? 'flutter';
     final String repo = request!.uri.queryParameters[kRepoParam]!;
     final String pr = request!.uri.queryParameters[kPullRequestNumberParam]!;
-    final String? builders = requestData![kBuilderParam] as String? ?? '';
+    final String? builders = request!.uri.queryParameters[kBuilderParam] ?? '';
     // The [builders] parameter is expecting comma joined string, e.g. 'builder1, builder2'.
     final List<String> builderList = builders!.split(',').map((String builder) => builder.trim()).toList();
 


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/1617.

Updated to use `request.uri.queryParameters` instead of `json` data, as we are using `get` request to inject parameters.

cl/430741794 re doc update.