### PR TITLE
Skip branch check for cirrus CI tests

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -275,7 +275,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         statuses,
         checkRuns,
         name,
-        'pull/$number',
         labels,
       );
 
@@ -307,7 +306,6 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     List<Map<String, dynamic>> statuses,
     List<Map<String, dynamic>> checkRuns,
     String name,
-    String branch,
     List<String> labels,
   ) async {
     assert(failures.isEmpty);
@@ -337,7 +335,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
       }
     }
 
-    log.info('Validating name: $name, branch: $branch, status: $statuses');
+    log.info('Validating name: $name, status: $statuses');
     for (Map<String, dynamic> status in statuses) {
       final String? name = status['context'] as String?;
       if (status['state'] != 'SUCCESS') {
@@ -350,7 +348,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
         }
       }
     }
-    log.info('Validating name: $name, branch: $branch, checks: $checkRuns');
+    log.info('Validating name: $name, checks: $checkRuns');
     for (Map<String, dynamic> checkRun in checkRuns) {
       final String? name = checkRun['name'] as String?;
       if (checkRun['conclusion'] == 'SUCCESS') {
@@ -366,11 +364,9 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     const List<String> _succeededStates = <String>['COMPLETED', 'SKIPPED'];
     final GraphQLClient cirrusClient = await config.createCirrusGraphQLClient();
     final List<CirrusResult> cirrusResults = await queryCirrusGraphQL(sha, cirrusClient, name);
-    if (!cirrusResults.any((CirrusResult cirrusResult) => cirrusResult.branch == branch)) {
-      return allSuccess;
-    }
-    final List<Map<String, dynamic>>? cirrusStatuses =
-        cirrusResults.firstWhere((CirrusResult cirrusResult) => cirrusResult.branch == branch).tasks;
+
+    // The first build of cirrusGraphQL query always reflects the latest test statuses of the PR.
+    final List<Map<String, dynamic>>? cirrusStatuses = cirrusResults.first.tasks;
     if (cirrusStatuses == null) {
       return allSuccess;
     }

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -662,29 +662,6 @@ This pull request is not suitable for automatic merging in its current state.
       ]);
     });
 
-    test('Ignores cirrus tasks statuses when no matched branch', () async {
-      statuses = <dynamic>[
-        <String, String>{'id': '1', 'status': 'EXECUTING', 'name': 'test1'},
-        <String, String>{'id': '2', 'status': 'COMPLETED', 'name': 'test2'}
-      ];
-      branch = 'flutter-0.0-candidate.0';
-
-      flutterRepoPRs.add(PullRequestHelper());
-
-      await tester.get(handler);
-
-      _verifyQueries();
-
-      githubGraphQLClient.verifyMutations(
-        <MutationOptions>[
-          MutationOptions(
-            document: mergePullRequestMutation,
-            variables: getMergePullRequestVariables(flutterRepoPRs[0].id),
-          ),
-        ],
-      );
-    });
-
     test('Merge PR with complated tests', () async {
       statuses = <dynamic>[
         <String, String>{'id': '1', 'status': 'SKIPPED', 'name': 'test1'},


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/99077

Based on https://github.com/flutter/flutter/issues/99077#issuecomment-1051314902, the first build of the cirrus GraphQL query will always reflect the latest CI status of the PR.

This PR skips the unnecessary branch check, and directly uses the first build to check cirrus runs.