### PR TITLE
exclude rules from lint package for cocoon backend

### DIFF
--- a/app_dart/analysis_options.yaml
+++ b/app_dart/analysis_options.yaml
@@ -42,155 +42,69 @@ analyzer:
     - "**/*.pbenum.dart"
     - "test/src/utilities/mocks.mocks.dart"
 
+include: package:flutter_lints/flutter.yaml
+
 linter:
   rules:
     # these rules are documented on and in the same order as
     # the Dart Lint rules page to make maintenance easier
-    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
-    - always_specify_types
-    - annotate_overrides
-    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    # - avoid_as # incompatible with implicit-casts: false
-    - avoid_bool_literals_in_conditional_expressions
-    # - avoid_catches_without_on_clauses # we do this commonly
-    # - avoid_catching_errors # we do this commonly
-    - avoid_classes_with_only_static_members
-    # - avoid_double_and_int_checks # only useful when targeting JS runtime
-    - avoid_empty_else
-    - avoid_field_initializers_in_const_classes
-    - avoid_function_literals_in_foreach_calls
-    # - avoid_implementing_value_types # not yet tested
-    - avoid_init_to_null
-    # - avoid_js_rounded_ints # only useful when targeting JS runtime
-    - avoid_null_checks_in_equality_operators
-    # - avoid_positional_boolean_parameters # not yet tested
-    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
-    - avoid_relative_lib_imports
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    # - avoid_returning_null # there are plenty of valid reasons to return null
-    # - avoid_returning_null_for_future # not yet tested
-    - avoid_returning_null_for_void
-    # - avoid_returning_this # there are plenty of valid reasons to return this
-    # - avoid_setters_without_getters # not yet tested
-    # - avoid_shadowing_type_parameters # not yet tested
-    # - avoid_single_cascade_in_expression_statements # not yet tested
-    - avoid_slow_async_io
-    - avoid_types_as_parameter_names
-    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_types
-    - cancel_subscriptions
-    # - cascade_invocations # not yet tested
-    # - close_sinks # not reliable enough
-    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
-    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
-    - control_flow_in_finally
-    - curly_braces_in_flow_control_structures
-    # - diagnostic_describe_all_properties # not yet tested
-    - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    # - file_names # not yet tested
-    - flutter_style_todos
-    - hash_and_equals
-    - implementation_imports
-    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
-    - iterable_contains_unrelated_type
-    # - join_return_with_assignment # not yet tested
-    - library_names
-    - library_prefixes
-    # - lines_longer_than_80_chars # not yet tested
-    - list_remove_unrelated_type
-    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - non_constant_identifier_names
-    # - null_closures  # not yet tested
-    # - omit_local_variable_types # opposite of always_specify_types
-    # - one_member_abstracts # too many false positives
-    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
-    - overridden_fields
-    - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    # - parameter_assignments # we do this commonly
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    # - prefer_asserts_with_message # not yet tested
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    # - prefer_constructors_over_static_methods # not yet tested
-    - prefer_contains
-    # - prefer_double_quotes # opposite of prefer_single_quotes
-    - prefer_equal_for_default_values
-    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
-    - prefer_final_fields
-    # - prefer_final_in_for_each # not yet tested
-    - prefer_final_locals
-    # - prefer_for_elements_to_map_fromIterable # not yet tested
-    - prefer_foreach
-    # - prefer_function_declarations_over_variables # not yet tested
-    - prefer_generic_function_type_aliases
-    # - prefer_if_elements_to_conditional_expressions # not yet tested
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    # - prefer_int_literals # not yet tested
-    # - prefer_interpolation_to_compose_strings # not yet tested
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_iterable_whereType
-    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
-    # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
-    - prefer_relative_imports
-    - prefer_single_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - prefer_void_to_null
-    # - provide_deprecation_message # not yet tested
-    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
-    - recursive_getters
-    - slash_for_doc_comments
-    # - sort_child_properties_last # not yet tested
-    - sort_constructors_first
-    - sort_pub_dependencies
-    - sort_unnamed_constructors_first
-    - test_types_in_equals
-    - throw_in_finally
-    # - type_annotate_public_apis # subset of always_specify_types
-    - type_init_formals
-    - unawaited_futures
-    # - unnecessary_await_in_return # not yet tested
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_getters_setters
-    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    # - unsafe_html # not yet tested
-    - use_full_hex_values_for_flutter_colors
-    # - use_function_type_syntax_for_parameters # not yet tested
-    - use_rethrow_when_possible
-    # - use_setters_to_change_properties # not yet tested
-    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
-    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
-    - valid_regexps
-    # - void_checks # not yet tested
+    # https://dart-lang.github.io/linter/lints/index.html
+    # the rules listed below are the ones we would like to exclude from flutter_lint package
+    always_put_required_named_parameters_first: false # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    avoid_annotating_with_dynamic: false # conflicts with always_specify_types
+    avoid_as: false # required for implicit-casts: true
+    avoid_catches_without_on_clauses: false # we do this commonly
+    avoid_catching_errors: false # we do this commonly
+    avoid_double_and_int_checks: false # only useful when targeting JS runtime
+    avoid_implementing_value_types: false # not yet tested
+    avoid_js_rounded_ints: false # only useful when targeting JS runtime
+    avoid_positional_boolean_parameters: false # not yet tested
+    avoid_private_typedef_functions: false # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    avoid_returning_null: false # there are plenty of valid reasons to return null
+    avoid_returning_null_for_future: false # not yet tested
+    avoid_returning_this: false # there are plenty of valid reasons to return this
+    avoid_setters_without_getters: false # not yet tested
+    avoid_shadowing_type_parameters: false # not yet tested
+    avoid_single_cascade_in_expression_statements: false # not yet tested
+    avoid_types_on_closure_parameters: false # conflicts with always_specify_types
+    cascade_invocations: false # not yet tested
+    close_sinks: false # not reliable enough
+    comment_references: false # blocked on https://github.com/flutter/flutter/issues/20765
+    constant_identifier_names: false # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    diagnostic_describe_all_properties: false # not yet tested
+    file_names: false # not yet tested
+    invariant_booleans: false # too many false positives: https://github.com/dart-lang/linter/issues/811
+    join_return_with_assignment: false # not yet tested
+    lines_longer_than_80_chars: false # not yet tested
+    literal_only_boolean_expressions: false # too many false positives: https://github.com/dart-lang/sdk/issues/34181
+    null_closures: false  # not yet tested
+    omit_local_variable_types: false # opposite of always_specify_types
+    one_member_abstracts: false # too many false positives
+    only_throw_errors: false # https://github.com/flutter/flutter/issues/5792
+    parameter_assignments: false # we do this commonly
+    prefer_asserts_with_message: false # not yet tested
+    prefer_constructors_over_static_methods: false # not yet tested
+    prefer_double_quotes: false # opposite of prefer_single_quotes
+    prefer_expression_function_bodies: false # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    prefer_final_in_for_each: false # not yet tested
+    prefer_for_elements_to_map_fromIterable: false # not yet tested
+    prefer_function_declarations_over_variables: false # not yet tested
+    prefer_if_elements_to_conditional_expressions: false # not yet tested
+    prefer_int_literals: false # not yet tested
+    prefer_interpolation_to_compose_strings: false # not yet tested
+    prefer_mixin: false # https://github.com/dart-lang/language/issues/32
+    prefer_null_aware_operators: false # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    provide_deprecation_message: false # not yet tested
+    public_member_api_docs: false # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    sort_child_properties_last: false # not yet tested
+    type_annotate_public_apis: false # subset of always_specify_types
+    unnecessary_await_in_return: false # not yet tested
+    unnecessary_final: false # conflicts with prefer_final_locals
+    unnecessary_lambdas: false # has false positives: https://github.com/dart-lang/linter/issues/498
+    unsafe_html: false # not yet tested
+    use_function_type_syntax_for_parameters: false # not yet tested
+    use_key_in_widget_constructors: false # not yet tested
+    use_setters_to_change_properties: false # not yet tested
+    use_string_buffers: false # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    use_to_and_as_if_applicable: false # has false positives, so we prefer to catch this by code-review
+    void_checks: false # not yet tested

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -225,6 +225,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   frontend_server_client:
     dependency: transitive
     description:
@@ -400,6 +407,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.1
   fake_async: ^1.2.0
+  flutter_lints: ^1.0.4
   json_serializable: ^6.0.0
   mockito: ^5.0.14
   pedantic: ^1.11.1


### PR DESCRIPTION
migrate cocoon backend rules to use lint packages
fixes https://github.com/flutter/flutter/issues/99168