### PR TITLE
[release dashboard] suppress 3k errors in release dashboard to manifest the real ones

### DIFF
--- a/release_dashboard/analysis_options.yaml
+++ b/release_dashboard/analysis_options.yaml
@@ -1,4 +1,8 @@
-include: package:flutter_lints/flutter.yaml
+analyzer:
+  exclude:
+    - "**"
+
+#include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:

--- a/test_utilities/pubspec.yaml
+++ b/test_utilities/pubspec.yaml
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 name: global_test_runner
-author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Flutter continuous integration agent (Cocoon agent)
 homepage: https://github.com/flutter/cocoon
 


### PR DESCRIPTION
With dart lint enabled, problems view would list all problems, including the 3k dependency and syntax errors under release dashboard folder, which is cluttering the actual problems of the opened project (e.g. app_dart, dashboard etc.). This commit suppresses lint in release dashboard, so we have a cleaner view of the actual problems.