### PR TITLE
Returns first cirrus build directly instead of a list

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -363,12 +363,10 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     const List<String> _failedStates = <String>['FAILED', 'ABORTED'];
     const List<String> _succeededStates = <String>['COMPLETED', 'SKIPPED'];
     final GraphQLClient cirrusClient = await config.createCirrusGraphQLClient();
-    final List<CirrusResult> cirrusResults = await queryCirrusGraphQL(sha, cirrusClient, name);
-
-    // The first build of cirrusGraphQL query always reflects the latest test statuses of the PR.
-    final List<Map<String, dynamic>>? cirrusStatuses = cirrusResults.first.tasks;
-    log.info('First cirrus searchBuild id for flutter/$name, sha: $sha: ${cirrusResults.first.id}');
-    if (cirrusStatuses == null) {
+    // Returns the first build statues, which reflect the recent PR/commit statuses.
+    final CirrusResult cirrusResult = await queryCirrusGraphQL(sha, cirrusClient, name);
+    final List<Map<String, dynamic>> cirrusStatuses = cirrusResult.tasks;
+    if (cirrusStatuses.isEmpty) {
       return allSuccess;
     }
     for (Map<String, dynamic> runStatus in cirrusStatuses) {

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -17,6 +17,9 @@ const List<String> kCirrusFailedStates = <String>[
 ];
 const List<String> kCirrusInProgressStates = <String>['CREATED', 'TRIGGERED', 'SCHEDULED', 'EXECUTING', 'PAUSED'];
 
+/// Return the latest Cirrus build for a given [sha] by querying the cirrus graphQL.
+///
+/// API explorer: https://cirrus-ci.com/explorer
 Future<CirrusResult> queryCirrusGraphQL(
   String sha,
   GraphQLClient client,
@@ -55,6 +58,9 @@ Future<CirrusResult> queryCirrusGraphQL(
   return cirrusResult;
 }
 
+/// There may be multiple build results for a single commit.
+///
+/// This returns the first build which represents the latest test statuses.
 CirrusResult getFirstBuildResult(
   Map<String, dynamic>? data,
   List<Map<String, dynamic>> tasks, {
@@ -62,7 +68,7 @@ CirrusResult getFirstBuildResult(
   String? sha,
 }) {
   final List<dynamic> searchBuilds = data!['searchBuilds'] as List<dynamic>;
-  final dynamic searchBuild = searchBuilds.first;
+  final Map<String, dynamic> searchBuild = searchBuilds.first as Map<String, dynamic>;
   tasks.addAll((searchBuild['latestGroupTasks'] as List<dynamic>).cast<Map<String, dynamic>>());
   String? id = searchBuild['id'] as String?;
   log.info('Cirrus searchBuild id for flutter/$name, commit: $sha: $id');

--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -17,7 +17,7 @@ const List<String> kCirrusFailedStates = <String>[
 ];
 const List<String> kCirrusInProgressStates = <String>['CREATED', 'TRIGGERED', 'SCHEDULED', 'EXECUTING', 'PAUSED'];
 
-Future<List<CirrusResult>> queryCirrusGraphQL(
+Future<CirrusResult> queryCirrusGraphQL(
   String sha,
   GraphQLClient client,
   String name,
@@ -41,27 +41,33 @@ Future<List<CirrusResult>> queryCirrusGraphQL(
   }
 
   final List<Map<String, dynamic>> tasks = <Map<String, dynamic>>[];
-  final List<CirrusResult> cirrusResults = <CirrusResult>[];
-  String? branch;
-  String? id;
+  late CirrusResult cirrusResult;
+
   if (result.data == null) {
-    cirrusResults.add(CirrusResult(id, branch, tasks));
-    return cirrusResults;
+    cirrusResult = CirrusResult(null, null, tasks);
+    return cirrusResult;
   }
   try {
-    final List<dynamic> searchBuilds = result.data!['searchBuilds'] as List<dynamic>;
-    for (dynamic searchBuild in searchBuilds) {
-      tasks.clear();
-      tasks.addAll((searchBuild['latestGroupTasks'] as List<dynamic>).cast<Map<String, dynamic>>());
-      id = searchBuild['id'] as String?;
-      log.info('Cirrus searchBuild id for flutter/$name, commit: $sha: $id');
-      branch = searchBuild['branch'] as String?;
-      cirrusResults.add(CirrusResult(id, branch, tasks));
-    }
+    cirrusResult = getFirstBuildResult(result.data, tasks);
   } catch (_) {
     log.fine('Did not receive expected result from Cirrus, sha $sha may not be executing Cirrus tasks.');
   }
-  return cirrusResults;
+  return cirrusResult;
+}
+
+CirrusResult getFirstBuildResult(
+  Map<String, dynamic>? data,
+  List<Map<String, dynamic>> tasks, {
+  String? name,
+  String? sha,
+}) {
+  final List<dynamic> searchBuilds = data!['searchBuilds'] as List<dynamic>;
+  final dynamic searchBuild = searchBuilds.first;
+  tasks.addAll((searchBuild['latestGroupTasks'] as List<dynamic>).cast<Map<String, dynamic>>());
+  String? id = searchBuild['id'] as String?;
+  log.info('Cirrus searchBuild id for flutter/$name, commit: $sha: $id');
+  String? branch = searchBuild['branch'] as String?;
+  return CirrusResult(id, branch, tasks);
 }
 
 class CirrusResult {

--- a/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
+++ b/app_dart/test/request_handlers/refresh_cirrus_status_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/request_handlers/refresh_cirrus_status.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RefreshCirrusStatus', () {
+    Map<String, dynamic>? data;
+    List<Map<String, dynamic>> tasks = <Map<String, dynamic>>[];
+    setUp(() {
+      data = dataWithMultipleBuilds;
+    });
+    test('returns first build result', () async {
+      final CirrusResult cirrusResult = getFirstBuildResult(data, tasks);
+      expect(cirrusResult.id, "4532390054854656");
+      expect(cirrusResult.tasks[0]['id'] as String, "4566569471705088");
+    });
+  });
+}
+
+Map<String, dynamic> dataWithMultipleBuilds = <String, dynamic>{
+  "searchBuilds": [
+    {
+      "id": "4532390054854656",
+      "branch": "dependabot/github_actions/ossf/scorecard-action-1.0.4",
+      "latestGroupTasks": [
+        {"id": "4566569471705088", "name": "format+analyze", "status": "COMPLETED"},
+        {"id": "5692469378547712", "name": "publishable", "status": "COMPLETED"}
+      ]
+    },
+    {
+      "id": "6393714829426688",
+      "branch": "dependabot/github_actions/ossf/scorecard-action-1.0.4",
+      "latestGroupTasks": [
+        {"id": "4930474559668224", "name": "format+analyze", "status": "COMPLETED"},
+        {"id": "4971160919080960", "name": "publishable", "status": "COMPLETED"}
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
Tentative fix for https://github.com/flutter/flutter/issues/99306.

The cirrus id and test results are mixed to cause flake when checking cirrus results. This PR returns the first build results right after obtaining the cirrus GraphQL results.