### PR TITLE
[dashboard] suppress overscroll notifications elided from inner vertical scrollbar

### DIFF
--- a/dashboard/lib/widgets/lattice.dart
+++ b/dashboard/lib/widgets/lattice.dart
@@ -74,23 +74,29 @@ class LatticeScrollView extends StatelessWidget {
         controller: horizontalController,
         physics: horizontalPhysics,
         scrollBehavior: _MouseDragScrollBehavior.instance,
-        viewportBuilder: (BuildContext context, ViewportOffset horizontalOffset) => _FakeViewport(
-          child: Scrollbar(
-            thumbVisibility: true,
-            controller: verticalController,
-            child: Scrollable(
-              dragStartBehavior: dragStartBehavior,
-              axisDirection: AxisDirection.down,
+        viewportBuilder: (BuildContext context, ViewportOffset horizontalOffset) =>
+            NotificationListener<OverscrollNotification>(
+          onNotification: (notification) =>
+              notification.metrics.axisDirection != AxisDirection.right &&
+              notification.metrics.axisDirection != AxisDirection.left,
+          child: _FakeViewport(
+            child: Scrollbar(
+              thumbVisibility: true,
               controller: verticalController,
-              physics: verticalPhysics,
-              scrollBehavior: _MouseDragScrollBehavior.instance,
-              viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _FakeViewport(
-                child: _LatticeBody(
-                  textDirection: textDirection,
-                  horizontalOffset: horizontalOffset,
-                  verticalOffset: verticalOffset,
-                  cells: cells,
-                  cellSize: cellSize,
+              child: Scrollable(
+                dragStartBehavior: dragStartBehavior,
+                axisDirection: AxisDirection.down,
+                controller: verticalController,
+                physics: verticalPhysics,
+                scrollBehavior: _MouseDragScrollBehavior.instance,
+                viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _FakeViewport(
+                  child: _LatticeBody(
+                    textDirection: textDirection,
+                    horizontalOffset: horizontalOffset,
+                    verticalOffset: verticalOffset,
+                    cells: cells,
+                    cellSize: cellSize,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Might not be the best approach, I am suppressing the left and right and movement from inner vertical scrollbar to fix https://github.com/flutter/flutter/issues/99418. After flutter upgrade, the tot version is currently throwing
https://github.com/flutter/flutter/issues/99418 and blocking other PRs from landing. 