### PR TITLE
Inject repo name and sha in cirrus log

### DIFF
--- a/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
+++ b/app_dart/lib/src/request_handlers/refresh_cirrus_status.dart
@@ -51,7 +51,7 @@ Future<CirrusResult> queryCirrusGraphQL(
     return cirrusResult;
   }
   try {
-    cirrusResult = getFirstBuildResult(result.data, tasks);
+    cirrusResult = getFirstBuildResult(result.data, tasks, name: name, sha: sha);
   } catch (_) {
     log.fine('Did not receive expected result from Cirrus, sha $sha may not be executing Cirrus tasks.');
   }


### PR DESCRIPTION
PR https://github.com/flutter/cocoon/pull/1632 has fixed the problem, but from the log it shows:
```
Cirrus searchBuild id for flutter/null, commit: null: 4515354469728256
```

This PR is a nit fix to inject the repo name and sha for easy triage in the future.
