### PR TITLE
Update flaky bugs with both prod and staging stats when `bringup: true`

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -135,6 +135,8 @@ class IssueUpdateBuilder {
 
   bool get isBelow => statistic.flakyRate < threshold;
 
+  String get bucketString => bucket.toString().split('.').last;
+
   List<String> get issueLabels {
     final List<String> existingLabels = existingIssue.labels.map<String>((IssueLabel label) => label.name).toList();
     // Update the priority.
@@ -151,11 +153,11 @@ class IssueUpdateBuilder {
 
   String get issueUpdateComment {
     String result =
-        'Current flaky ratio for the past (up to) 100 commits is ${_formatRate(statistic.flakyRate)}%. Flaky number: ${statistic.flakyNumber}; total number: ${statistic.totalNumber}.\n';
+        '[$bucketString pool] current flaky ratio for the past (up to) 100 commits is ${_formatRate(statistic.flakyRate)}%. Flaky number: ${statistic.flakyNumber}; total number: ${statistic.totalNumber}.\n';
     if (statistic.flakyRate > 0.0) {
       result = result +
           '''
-One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit)}
+One recent flaky example for a same commit: ${_issueBuildLink(builder: statistic.name, build: statistic.flakyBuildOfRecentCommit, bucket: bucket)}
 Commit: $_commitPrefix${statistic.recentCommit}
 Flaky builds:
 ${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!, bucket: bucket)}

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -96,7 +96,7 @@ void main() {
       });
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
           .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+        return Future<List<BuilderStatistic>>.value(stagingCiyamlTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -214,7 +214,7 @@ void main() {
       expect(result['Status'], 'success');
     });
 
-    test('Do not add issue comment when not enough data', () async {
+    test('Can add bot staging and prod stats for a bringup: true builder', () async {
       const int existingIssueNumber = 1234;
       final List<IssueLabel> existingLabels = <IssueLabel>[
         IssueLabel(name: 'some random label'),
@@ -222,67 +222,11 @@ void main() {
       ];
       // When queries flaky data from BigQuery.
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponseNotEnoughData);
+        return Future<List<BuilderStatistic>>.value(ciyamlTestResponse);
       });
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
           .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
-      });
-      // when gets existing flaky issues.
-      when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
-          .thenAnswer((Invocation invocation) {
-        return Stream<Issue>.fromIterable(<Issue>[
-          Issue(
-            assignee: User(login: 'some dude'),
-            number: existingIssueNumber,
-            state: 'open',
-            labels: existingLabels,
-            title: expectedSemanticsIntegrationTestResponseTitle,
-            body: expectedSemanticsIntegrationTestResponseBody,
-            createdAt:
-                DateTime.now().subtract(const Duration(days: UpdateExistingFlakyIssue.kFreshPeriodForOpenFlake + 1)),
-          )
-        ]);
-      });
-      // when firing github request.
-      // This is for replacing labels.
-      when(mockGitHubClient.request(
-        captureAny,
-        captureAny,
-        body: captureAnyNamed('body'),
-      )).thenAnswer((Invocation invocation) {
-        return Future<Response>.value(Response('[]', 200));
-      });
-      final Map<String, dynamic> result = await utf8.decoder
-          .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
-          .transform(json.decoder)
-          .single as Map<String, dynamic>;
-
-      verifyNever(mockIssuesService.createComment(captureAny, captureAny, captureAny));
-
-      // Verify labels are the same.
-      verifyNever(mockGitHubClient.request(
-        captureAny,
-        captureAny,
-        body: captureAnyNamed('body'),
-      ));
-
-      expect(result['Status'], 'success');
-    });
-
-    test('Can add existing issue comment based on staging stats', () async {
-      const int existingIssueNumber = 1234;
-      final List<IssueLabel> existingLabels = <IssueLabel>[
-        IssueLabel(name: 'some random label'),
-        IssueLabel(name: 'P2'),
-      ];
-      // When queries flaky data from BigQuery.
-      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId)).thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(semanticsIntegrationTestResponse);
-      });
-      when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
-          .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+        return Future<List<BuilderStatistic>>.value(stagingCiyamlTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -316,10 +260,13 @@ void main() {
 
       // Verify comment is created correctly.
       List<dynamic> captured = verify(mockIssuesService.createComment(captureAny, captureAny, captureAny)).captured;
-      expect(captured.length, 3);
+      expect(captured.length, 6);
       expect(captured[0].toString(), Config.flutterSlug.toString());
       expect(captured[1], existingIssueNumber);
-      expect(captured[2], expectedStagingSemanticsIntegrationTestIssueComment);
+      expect(captured[2], expectedCiyamlTestIssueComment);
+      expect(captured[3].toString(), Config.flutterSlug.toString());
+      expect(captured[4], existingIssueNumber);
+      expect(captured[5], expectedStagingCiyamlTestIssueComment);
 
       // Verify labels are applied correctly.
       captured = verify(mockGitHubClient.request(
@@ -327,7 +274,7 @@ void main() {
         captureAny,
         body: captureAnyNamed('body'),
       )).captured;
-      expect(captured.length, 3);
+      expect(captured.length, 6);
       expect(captured[0].toString(), 'PUT');
       expect(captured[1], '/repos/${Config.flutterSlug.fullName}/issues/$existingIssueNumber/labels');
       expect(captured[2], GitHubJson.encode(<String>['some random label', 'P1']));
@@ -347,7 +294,7 @@ void main() {
       });
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
           .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+        return Future<List<BuilderStatistic>>.value(stagingCiyamlTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -401,7 +348,7 @@ void main() {
       });
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
           .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+        return Future<List<BuilderStatistic>>.value(stagingCiyamlTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))
@@ -466,7 +413,7 @@ void main() {
       });
       when(mockBigqueryService.listBuilderStatistic(kBigQueryProjectId, bucket: 'staging'))
           .thenAnswer((Invocation invocation) {
-        return Future<List<BuilderStatistic>>.value(stagingSemanticsIntegrationTestResponse);
+        return Future<List<BuilderStatistic>>.value(stagingCiyamlTestResponse);
       });
       // when gets existing flaky issues.
       when(mockIssuesService.listByRepo(captureAny, state: captureAnyNamed('state'), labels: captureAnyNamed('labels')))

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:cocoon_service/src/service/bigquery.dart';
 
 const String expectedSemanticsIntegrationTestIssueComment = '''
-Current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
+[prod pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
 Commit: https://github.com/flutter/flutter/commit/abc
 Flaky builds:
@@ -19,9 +19,22 @@ Recent test runs:
 https://flutter-dashboard.appspot.com/#/build?taskFilter=Mac_android%20android_semantics_integration_test
 ''';
 
-const String expectedStagingSemanticsIntegrationTestIssueComment = '''
-Current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
+const String expectedCiyamlTestIssueComment = '''
+[prod pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
+Commit: https://github.com/flutter/flutter/commit/abc
+Flaky builds:
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/103
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/102
+https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/101
+
+Recent test runs:
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller
+''';
+
+const String expectedStagingCiyamlTestIssueComment = '''
+[staging pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
+One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/103
 Commit: https://github.com/flutter/flutter/commit/abc
 Flaky builds:
 https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/103
@@ -33,7 +46,7 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutt
 ''';
 
 const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
-Current flaky ratio for the past (up to) 100 commits is 0.00%. Flaky number: 0; total number: 10.
+[prod pool] current flaky ratio for the past (up to) 100 commits is 0.00%. Flaky number: 0; total number: 10.
 ''';
 
 const String expectedSemanticsIntegrationTestNotEnoughDataComment = '''
@@ -105,7 +118,20 @@ final List<BuilderStatistic> shardSemanticsIntegrationTestResponse = <BuilderSta
   )
 ];
 
-final List<BuilderStatistic> stagingSemanticsIntegrationTestResponse = <BuilderStatistic>[
+final List<BuilderStatistic> ciyamlTestResponse = <BuilderStatistic>[
+  BuilderStatistic(
+    name: 'Linux ci_yaml flutter roller',
+    flakyRate: 0.5,
+    flakyBuilds: <String>['103', '102', '101'],
+    succeededBuilds: <String>['203', '202', '201', '200', '199', '198', '197'],
+    recentCommit: 'abc',
+    flakyBuildOfRecentCommit: '103',
+    flakyNumber: 3,
+    totalNumber: 10,
+  )
+];
+
+final List<BuilderStatistic> stagingCiyamlTestResponse = <BuilderStatistic>[
   BuilderStatistic(
     name: 'Linux ci_yaml flutter roller',
     flakyRate: 0.5,


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/99442

This PR does:
1) update flaky bugs with both prod and staging stats when the builder is `bringup: true`
2) skip build number check, it is useful to present any available test results even we have limited number
3) update tests