### PR TITLE
Set $flutter/osx_sdk to include runtime_versions

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -97,6 +97,13 @@ class Target {
         mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
       }
     }
+    // runtime_versions is a special property
+    if (mergedProperties.containsKey('runtime_versions')) {
+      // add to existing property, or create new one
+      final Object osxSdk = mergedProperties['\$flutter/osx_sdk'] ?? <String, Object>{};
+      (osxSdk as Map)['runtime_versions'] = mergedProperties['runtime_versions']!;
+      mergedProperties['\$flutter/osx_sdk'] = osxSdk;
+    }
 
     mergedProperties['bringup'] = value.bringup;
 

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -58,6 +58,117 @@ void main() {
           'xcode': '12abc',
         });
       });
+
+      test('platform properties with runtime_versions', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac',
+          platformProperties: <String, String>{
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+        );
+        expect(target.getProperties(), <String, Object>{
+          'bringup': false,
+          'dependencies': <String>[],
+          '\$flutter/osx_sdk': <String, Object>{
+            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+          },
+          'runtime_versions': ['ios-13-0', 'ios-15-0'],
+        });
+      });
+
+      test('properties with runtime_versions overrides platform properties', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+          properties: <String, String>{
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+        );
+        expect(target.getProperties(), <String, Object>{
+          'bringup': false,
+          'dependencies': <String>[],
+          '\$flutter/osx_sdk': <String, Object>{
+            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+          },
+          'runtime_versions': ['ios-13-0', 'ios-15-0'],
+        });
+      });
+
+      test('platform properties with xcode and runtime_versions', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac',
+          platformProperties: <String, String>{
+            'xcode': '12abc',
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+        );
+        expect(target.getProperties(), <String, Object>{
+          'bringup': false,
+          'dependencies': <String>[],
+          '\$flutter/osx_sdk': <String, Object>{
+            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+            'sdk_version': '12abc',
+          },
+          'xcode': '12abc',
+          'runtime_versions': ['ios-13-0', 'ios-15-0'],
+        });
+      });
+
+      test('platform properties with xcode and runtime_versions on Mac_ios', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac_ios',
+          platformProperties: <String, String>{
+            'xcode': '12abc',
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+        );
+        expect(target.getProperties(), <String, Object>{
+          'bringup': false,
+          'dependencies': <String>[],
+          '\$flutter/osx_sdk': <String, Object>{
+            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+          },
+          '\$flutter/devicelab_osx_sdk': <String, Object>{
+            'sdk_version': '12abc',
+          },
+          'xcode': '12abc',
+          'runtime_versions': ['ios-13-0', 'ios-15-0'],
+        });
+      });
+
+      test('properties with xcode and runtime_versions overrides platform properties', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'xcode': 'abc',
+            'runtime_versions': '["ios-17-0"]',
+          },
+          properties: <String, String>{
+            'xcode': '12abc',
+            'runtime_versions': '["ios-13-0", "ios-15-0"]',
+          },
+        );
+        expect(target.getProperties(), <String, Object>{
+          'bringup': false,
+          'dependencies': <String>[],
+          '\$flutter/osx_sdk': <String, Object>{
+            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+            'sdk_version': '12abc',
+          },
+          'xcode': '12abc',
+          'runtime_versions': ['ios-13-0', 'ios-15-0'],
+        });
+      });
+
     });
 
     group('dimensions', () {

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -168,7 +168,6 @@ void main() {
           'runtime_versions': ['ios-13-0', 'ios-15-0'],
         });
       });
-
     });
 
     group('dimensions', () {


### PR DESCRIPTION
Add entry into $flutter/osx_sdk dict, from runtime_versions value in
ci.yaml.

Bug:99698

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
