### PR TITLE
implement shouldMerge logic

### DIFF
--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -41,4 +41,14 @@ class GithubService {
   ) async {
     return await github.repositories.listStatuses(slug, ref).toList();
   }
+
+  /// Fetches the specified commit.
+  Future<RepositoryCommit> getRepoCommit(RepositorySlug slug, String sha) async {
+    return await github.repositories.getCommit(slug, sha);
+  }
+
+  /// Compares two commits
+  Future<GitHubComparison> compareTwoCommits(RepositorySlug slug, String refBase, String refHead) async {
+    return await github.repositories.compareCommits(slug, refBase, refHead);
+  }
 }


### PR DESCRIPTION
Here we implement the logic of check whether this pull request should merge or not.

This pr is the fifth step of https://github.com/flutter/cocoon/pull/1633.
This pr solved the issue https://github.com/flutter/flutter/issues/98707, and is intended to partly solve the issue https://github.com/flutter/flutter/issues/98707.

# Future work
If this pull request doesn't meet the requirement to be merged, we want to remove the 'autosubmit' label from it. Implement the logic of removing the label is needed.