### PR TITLE
[cloudbuild] Allow for 20 versions

### DIFF
--- a/cloud_build/deploy.sh
+++ b/cloud_build/deploy.sh
@@ -20,5 +20,5 @@ popd > /dev/null
 pushd auto_submit > /dev/null
 gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
 gcloud app services set-traffic default --splits version-$2=1 --quiet
-gcloud app versions list --format="value(version.id)" --sort-by="~version.createTime" | tail -n +11 | xargs -r gcloud app versions delete --quiet
+gcloud app versions list --format="value(version.id)" --sort-by="~version.createTime" | tail -n +20 | xargs -r gcloud app versions delete --quiet
 popd > /dev/null


### PR DESCRIPTION
Cloud build has recently been failing as we added auto_submit service, and there can be versions stored there. This allows each service to have ~5 versions (we're allotted 30 total). Doubling the limit here to prevent the timeouts.