### PR TITLE
[device doctor] Use homebrew bin

### DIFF
--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -223,9 +223,9 @@ class IosDevice implements Device {
   Future<bool> uninstall_applications({ProcessManager processManager}) async {
     processManager ??= LocalProcessManager();
     String result;
-    final String ideviceinstaller = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
+    final String fullPathIdeviceInstaller = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
     try {
-      result = await eval(ideviceinstaller, <String>['-l'], processManager: processManager);
+      result = await eval(fullPathIdeviceInstaller, <String>['-l'], processManager: processManager);
     } on BuildFailedError catch (error) {
       logger.severe('list applications fails: $error');
       stderr.write('list applications fails: $error');
@@ -240,7 +240,7 @@ class IosDevice implements Device {
     final List<String> bundleIdentifiers = results.sublist(1).map((e) => e.split(',')[0].trim()).toList();
     try {
       for (String bundleIdentifier in bundleIdentifiers) {
-        await eval(ideviceinstaller, <String>['-U', bundleIdentifier], processManager: processManager);
+        await eval(fullPathIdeviceInstaller, <String>['-U', bundleIdentifier], processManager: processManager);
       }
     } on BuildFailedError catch (error) {
       logger.severe('uninstall applications fails: $error');

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -223,8 +223,9 @@ class IosDevice implements Device {
   Future<bool> uninstall_applications({ProcessManager processManager}) async {
     processManager ??= LocalProcessManager();
     String result;
+    final String ideviceinstaller = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
     try {
-      result = await eval('ideviceinstaller', <String>['-l'], processManager: processManager);
+      result = await eval(ideviceinstaller, <String>['-l'], processManager: processManager);
     } on BuildFailedError catch (error) {
       logger.severe('list applications fails: $error');
       stderr.write('list applications fails: $error');
@@ -239,7 +240,7 @@ class IosDevice implements Device {
     final List<String> bundleIdentifiers = results.sublist(1).map((e) => e.split(',')[0].trim()).toList();
     try {
       for (String bundleIdentifier in bundleIdentifiers) {
-        await eval('ideviceinstaller', <String>['-U', bundleIdentifier], processManager: processManager);
+        await eval(ideviceinstaller, <String>['-U', bundleIdentifier], processManager: processManager);
       }
     } on BuildFailedError catch (error) {
       logger.severe('uninstall applications fails: $error');

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -28,7 +28,7 @@ const String kScreenSaverCheckKey = 'screensaver';
 const String kScreenRotationCheckKey = 'screen_rotation';
 const String kBatteryLevelCheckKey = 'battery_level';
 const String kBatteryTemperatureCheckKey = 'battery_temperature';
-const String kM1DefaultBinaryPath = '/opt/homebrew/bin';
+const String kM1BrewBinPath = '/opt/homebrew/bin';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {
@@ -133,12 +133,16 @@ void writeToFile(String results, File file) {
 
 /// Return Mac binary path.
 ///
-/// For M1 bots, binaries like `ideviceinstaller` are installed under `kM1DefaultBinaryPath`,
+/// For M1 bots, binaries like `ideviceinstaller` are installed under `kM1BrewBinPath`,
 /// where they are not visible in `$PATH` by default.
 Future<String> getMacBinaryPath(String name, {ProcessManager processManager}) async {
   String path = await eval('which', <String>[name], canFail: true, processManager: processManager);
   if (path == null || path.isEmpty) {
-    path = '$kM1DefaultBinaryPath/$name';
+    path = await eval('which', <String>['$kM1BrewBinPath/$name'], canFail: true, processManager: processManager);
+  }
+  // Throws exception when the binary doesn't exist in either location.
+  if (path == null || path.isEmpty) {
+    fail('$name not found.');
   }
   return path;
 }

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -28,6 +28,7 @@ const String kScreenSaverCheckKey = 'screensaver';
 const String kScreenRotationCheckKey = 'screen_rotation';
 const String kBatteryLevelCheckKey = 'battery_level';
 const String kBatteryTemperatureCheckKey = 'battery_temperature';
+const String kM1DefaultBinaryPath = '/opt/homebrew/bin';
 final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {
@@ -128,4 +129,16 @@ void writeToFile(String results, File file) {
     ..createSync()
     ..writeAsStringSync(results);
   return;
+}
+
+/// Return Mac binary path.
+///
+/// For M1 bots, binaries like `ideviceinstaller` are installed under `kM1DefaultBinaryPath`,
+/// where they are not visible in `$PATH` by default.
+Future<String> getMacBinaryPath(String name, {ProcessManager processManager}) async {
+  String path = await eval('which', <String>[name], canFail: true, processManager: processManager);
+  if (path == null || path.isEmpty) {
+    path = '$kM1DefaultBinaryPath/$name';
+  }
+  return path;
 }

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -314,11 +314,15 @@ void main() {
     IosDevice device;
     MockProcessManager processManager;
     Process process;
+    Process whichProcess;
     String output;
+    String ideviceinstallerPath;
 
     setUp(() {
       processManager = MockProcessManager();
       device = IosDevice(deviceId: 'abc');
+      ideviceinstallerPath = '/abc/def/ideviceinstaller';
+      whichProcess = FakeProcess(0, out: <List<int>>[utf8.encode(ideviceinstallerPath)]);
     });
     test('device restart - success', () async {
       when(processManager
@@ -345,7 +349,9 @@ void main() {
     });
 
     test('list applications - failure', () async {
-      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(whichProcess));
+      when(processManager.start(<dynamic>[ideviceinstallerPath, '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
       process = FakeProcess(1);
 
@@ -354,7 +360,9 @@ void main() {
     });
 
     test('uninstall applications - no device is available', () async {
-      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(whichProcess));
+      when(processManager.start(<dynamic>[ideviceinstallerPath, '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
       output = '''No device found.
@@ -366,7 +374,9 @@ void main() {
     });
 
     test('uninstall applications - no application exist', () async {
-      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(whichProcess));
+      when(processManager.start(<dynamic>[ideviceinstallerPath, '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
 
       output = '''CFBundleIdentifier, CFBundleVersion, CFBundleDisplayName
@@ -379,13 +389,15 @@ void main() {
 
     test('uninstall applications - applications exist with exception', () async {
       Process process_uninstall;
-      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(whichProcess));
+      when(processManager.start(<dynamic>[ideviceinstallerPath, '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
       when(processManager
-              .start(<dynamic>['ideviceinstaller', '-U', 'abc'], workingDirectory: anyNamed('workingDirectory')))
+              .start(<dynamic>[ideviceinstallerPath, '-U', 'abc'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process_uninstall));
       when(processManager
-              .start(<dynamic>['ideviceinstaller', '-U', 'jkl'], workingDirectory: anyNamed('workingDirectory')))
+              .start(<dynamic>[ideviceinstallerPath, '-U', 'jkl'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process_uninstall));
 
       output = '''CFBundleIdentifier, CFBundleVersion, CFBundleDisplayName
@@ -401,13 +413,15 @@ void main() {
 
     test('uninstall applications - applications exist', () async {
       Process process_uninstall;
-      when(processManager.start(<dynamic>['ideviceinstaller', '-l'], workingDirectory: anyNamed('workingDirectory')))
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(whichProcess));
+      when(processManager.start(<dynamic>[ideviceinstallerPath, '-l'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process));
       when(processManager
-              .start(<dynamic>['ideviceinstaller', '-U', 'abc'], workingDirectory: anyNamed('workingDirectory')))
+              .start(<dynamic>[ideviceinstallerPath, '-U', 'abc'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process_uninstall));
       when(processManager
-              .start(<dynamic>['ideviceinstaller', '-U', 'jkl'], workingDirectory: anyNamed('workingDirectory')))
+              .start(<dynamic>[ideviceinstallerPath, '-U', 'jkl'], workingDirectory: anyNamed('workingDirectory')))
           .thenAnswer((_) => Future.value(process_uninstall));
 
       output = '''CFBundleIdentifier, CFBundleVersion, CFBundleDisplayName

--- a/device_doctor/test/src/utils_test.dart
+++ b/device_doctor/test/src/utils_test.dart
@@ -80,4 +80,33 @@ void main() {
       );
     });
   });
+
+  group('getMacBinaryPath', () {
+    MockProcessManager processManager;
+    List<List<int>> output;
+
+    setUp(() {
+      processManager = MockProcessManager();
+    });
+
+    test('when binary does not exist', () async {
+      Process process = FakeProcess(1, out: null);
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      final String result = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
+      expect(result, '$kM1DefaultBinaryPath/ideviceinstaller');
+    });
+
+    test('when binary exists', () async {
+      String path = '/abc/def/ideviceinstaller';
+      output = <List<int>>[utf8.encode(path)];
+      Process process = FakeProcess(0, out: output);
+      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(process));
+
+      final String result = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
+      expect(result, path);
+    });
+  });
 }


### PR DESCRIPTION
M1 bots are installing some binaries to /opt/homebrew/bin, which is not visible to `swarming` by default. This PR checks that path to make sure binaries can run successfully, like `ideviceinstaller`.

Potentially solve: https://github.com/flutter/flutter/issues/98426#issuecomment-1063513050

