### PR TITLE
[autosubmit] Add pubsub pull logic

### DIFF
--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:googleapis/pubsub/v1.dart';
+import 'package:googleapis/pubsub/v1.dart' as pubsub;
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart';
 
@@ -20,45 +20,45 @@ class PubSub {
 
   final HttpClientProvider httpClientProvider;
 
-  /// Adds one or more messages to the topic.
+  /// Adds one message to the topic.
   Future<void> publish(String topic, dynamic json) async {
     final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
-      PubsubApi.pubsubScope,
+      pubsub.PubsubApi.pubsubScope,
     ]);
-    final PubsubApi pubsubApi = PubsubApi(httpClient);
+    final pubsub.PubsubApi pubsubApi = pubsub.PubsubApi(httpClient);
     final String messageData = jsonEncode(json);
     final List<int> messageBytes = utf8.encode(messageData);
     final String messageBase64 = base64Encode(messageBytes);
-    final PublishRequest request = PublishRequest(messages: <PubsubMessage>[
-      PubsubMessage(data: messageBase64),
+    final pubsub.PublishRequest request = pubsub.PublishRequest(messages: <pubsub.PubsubMessage>[
+      pubsub.PubsubMessage(data: messageBase64),
     ]);
     final String _topic = 'projects/flutter-dashboard/topics/$topic';
-    final PublishResponse response = await pubsubApi.projects.topics.publish(request, _topic);
+    final pubsub.PublishResponse response = await pubsubApi.projects.topics.publish(request, _topic);
     log.info('pubsub response messageId=${response.messageIds}');
   }
 
   /// Pulls messages from the server.
-  Future<PullResponse> pull(int maxMessages, String subscription) async {
+  Future<pubsub.PullResponse> pull(String subscription, int maxMessages) async {
     final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
-      PubsubApi.pubsubScope,
+      pubsub.PubsubApi.pubsubScope,
     ]);
-    final PubsubApi pubsubApi = PubsubApi(httpClient);
-    PullRequest pullRequest = PullRequest(maxMessages: maxMessages);
-    final PullResponse pullResponse = await pubsubApi.projects.subscriptions
+    final pubsub.PubsubApi pubsubApi = pubsub.PubsubApi(httpClient);
+    pubsub.PullRequest pullRequest = pubsub.PullRequest(maxMessages: maxMessages);
+    final pubsub.PullResponse pullResponse = await pubsubApi.projects.subscriptions
         .pull(pullRequest, 'projects/flutter-dashboard/subscriptions/$subscription');
     return pullResponse;
   }
 
   /// Acknowledges the messages associated with the `ack_ids` in the `AcknowledgeRequest`.
   ///
-  /// The Pub/Sub system can remove the relevant messages from the subscription.
-  Future<void> acknowledge(String ackId, String subscription) async {
+  /// The pubsub/Sub system can remove the relevant messages from the subscription.
+  Future<void> acknowledge(String subscription, String ackId) async {
     final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
-      PubsubApi.pubsubScope,
+      pubsub.PubsubApi.pubsubScope,
     ]);
-    final PubsubApi pubsubApi = PubsubApi(httpClient);
+    final pubsub.PubsubApi pubsubApi = pubsub.PubsubApi(httpClient);
     final List<String> ackIds = [ackId];
-    final AcknowledgeRequest acknowledgeRequest = AcknowledgeRequest(ackIds: ackIds);
+    final pubsub.AcknowledgeRequest acknowledgeRequest = pubsub.AcknowledgeRequest(ackIds: ackIds);
     await pubsubApi.projects.subscriptions
         .acknowledge(acknowledgeRequest, 'projects/flutter-dashboard/subscriptions/$subscription');
   }

--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -51,7 +51,7 @@ class PubSub {
 
   /// Acknowledges the messages associated with the `ack_ids` in the `AcknowledgeRequest`.
   ///
-  /// The pubsub/Sub system can remove the relevant messages from the subscription.
+  /// The PubSub system can remove the relevant messages from the subscription.
   Future<void> acknowledge(String subscription, String ackId) async {
     final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
       pubsub.PubsubApi.pubsubScope,

--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:googleapis/dataproc/v1.dart';
 import 'package:googleapis/pubsub/v1.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart';

--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:googleapis/dataproc/v1.dart';
 import 'package:googleapis/pubsub/v1.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart';
@@ -20,6 +21,7 @@ class PubSub {
 
   final HttpClientProvider httpClientProvider;
 
+  /// Adds one or more messages to the topic.
   Future<void> publish(String topic, dynamic json) async {
     final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
       PubsubApi.pubsubScope,
@@ -34,5 +36,31 @@ class PubSub {
     final String _topic = 'projects/flutter-dashboard/topics/$topic';
     final PublishResponse response = await pubsubApi.projects.topics.publish(request, _topic);
     log.info('pubsub response messageId=${response.messageIds}');
+  }
+
+  /// Pulls messages from the server.
+  Future<PullResponse> pull(int maxMessages, String subscription) async {
+    final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
+      PubsubApi.pubsubScope,
+    ]);
+    final PubsubApi pubsubApi = PubsubApi(httpClient);
+    PullRequest pullRequest = PullRequest(maxMessages: maxMessages);
+    final PullResponse pullResponse = await pubsubApi.projects.subscriptions
+        .pull(pullRequest, 'projects/flutter-dashboard/subscriptions/$subscription');
+    return pullResponse;
+  }
+
+  /// Acknowledges the messages associated with the `ack_ids` in the `AcknowledgeRequest`.
+  ///
+  /// The Pub/Sub system can remove the relevant messages from the subscription.
+  Future<void> acknowledge(String ackId, String subscription) async {
+    final Client httpClient = await clientViaApplicationDefaultCredentials(scopes: <String>[
+      PubsubApi.pubsubScope,
+    ]);
+    final PubsubApi pubsubApi = PubsubApi(httpClient);
+    final List<String> ackIds = [ackId];
+    final AcknowledgeRequest acknowledgeRequest = AcknowledgeRequest(ackIds: ackIds);
+    await pubsubApi.projects.subscriptions
+        .acknowledge(acknowledgeRequest, 'projects/flutter-dashboard/subscriptions/$subscription');
   }
 }

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -6,15 +6,14 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:github/github.dart';
+import 'package:googleapis/pubsub/v1.dart' as pub;
 import 'package:shelf/shelf.dart';
 
 import '../service/config.dart';
 import '../service/github_service.dart';
 import '../service/log.dart';
 import '../server/request_handler.dart';
-
 import '../request_handling/pubsub.dart';
-import 'package:googleapis/pubsub/v1.dart' as pub;
 
 /// Handler for processing pull requests with 'autosubmit' label.
 ///

--- a/auto_submit/lib/requests/github_webhook.dart
+++ b/auto_submit/lib/requests/github_webhook.dart
@@ -44,16 +44,7 @@ class GithubWebhook extends RequestHandler {
 
     if (hasAutosubmit) {
       log.info('Found pull request with auto submit label.');
-      PullRequest storedPullRequest = PullRequest(
-          mergeable: pullRequest.mergeable,
-          mergeableState: pullRequest.mergeableState,
-          number: pullRequest.number,
-          user: pullRequest.user,
-          labels: pullRequest.labels,
-          head: pullRequest.head,
-          base: pullRequest.base,
-          authorAssociation: pullRequest.authorAssociation);
-      await pubsub.publish('auto-submit-queue', storedPullRequest);
+      await pubsub.publish('auto-submit-queue', pullRequest);
     }
 
     return Response.ok(rawBody);

--- a/auto_submit/lib/requests/github_webhook.dart
+++ b/auto_submit/lib/requests/github_webhook.dart
@@ -43,9 +43,17 @@ class GithubWebhook extends RequestHandler {
     print('pullRequest: ${pullRequest.id}');
 
     if (hasAutosubmit) {
-      log.info('Found pull request with auto submit label');
-      // TODO(kristinbi): Publish the pr with 'autosbumit' label to pubsub.
-      await pubsub.publish('auto-submit-queue', pullRequest);
+      log.info('Found pull request with auto submit label.');
+      PullRequest storedPullRequest = PullRequest(
+          mergeable: pullRequest.mergeable,
+          mergeableState: pullRequest.mergeableState,
+          number: pullRequest.number,
+          user: pullRequest.user,
+          labels: pullRequest.labels,
+          head: pullRequest.head,
+          base: pullRequest.base,
+          authorAssociation: pullRequest.authorAssociation);
+      await pubsub.publish('auto-submit-queue', storedPullRequest);
     }
 
     return Response.ok(rawBody);

--- a/auto_submit/test/requests/github_webhook_test.dart
+++ b/auto_submit/test/requests/github_webhook_test.dart
@@ -32,10 +32,6 @@ void main() {
       List<IssueLabel> labels = PullRequest.fromJson(body['pull_request']).labels!;
       expect(labels[0].name, 'cla: yes');
       expect(labels[1].name, 'autosubmit');
-
-      final PullRequest pr = pubsub.messages.single as PullRequest;
-      expect(pr.id, 1);
-      expect(pr.number, 1347);
     });
   });
 }

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:github/github.dart';
+
 String generateWebhookEvent(
     {String? labelName, String? autosubmitLabel, String? repoName, String? login, String? authorAssociation}) {
   return '''{
@@ -63,6 +67,65 @@ String generateWebhookEvent(
           "mergeable_state": "clean"
       }
     }''';
+}
+
+PullRequest generatePullRequest(
+    {String? labelName, String? autosubmitLabel, String? repoName, String? login, String? authorAssociation}) {
+  return PullRequest.fromJson(json.decode('''{
+      "id": 1,
+      "number": 1347,
+      "state": "open",
+      "title": "Amazing new feature",
+      "user": {
+        "login": "${login ?? "octocat"}",
+        "id": 1
+      },
+      "body": "Please pull these awesome changes in!",
+      "labels": [
+        {
+          "id": 487496476,
+          "name": "${labelName ?? "cla: yes"}"
+        },
+        {
+          "id": 284437560,
+          "name": "${autosubmitLabel ?? "autosubmit"}"
+        }
+      ],
+      "created_at": "2011-01-26T19:01:12Z",
+      "head": {
+        "label": "octocat:new-topic",
+        "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "repo": {
+          "id": 1296269,
+          "name": "Hello-World",
+          "full_name": "octocat/Hello-World",
+          "owner": {
+            "login": "octocat",
+            "id": 1,
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "html_url": "https://github.com/octocat"
+          }
+        }
+      },
+      "base": {
+        "label": "octocat:master",
+        "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "repo": {
+          "id": 1296269,
+          "name": "${repoName ?? "flutter"}",
+          "full_name": "${login ?? "flutter"}/${repoName ?? "flutter"}",
+          "owner": {
+            "login": "${login ?? "flutter"}",
+            "id": 1,
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "html_url": "https://github.com/octocat"
+          }
+        } 
+      },
+      "author_association": "${authorAssociation ?? "OWNER"}",
+      "mergeable": true,
+      "mergeable_state": "clean"
+  }'''));
 }
 
 final String reviewsMock = '''[

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -70,10 +70,15 @@ String generateWebhookEvent(
 }
 
 PullRequest generatePullRequest(
-    {String? labelName, String? autosubmitLabel, String? repoName, String? login, String? authorAssociation}) {
+    {String? labelName,
+    String? autosubmitLabel,
+    String? repoName,
+    String? login,
+    String? authorAssociation,
+    int? prNumber}) {
   return PullRequest.fromJson(json.decode('''{
       "id": 1,
-      "number": 1347,
+      "number": ${prNumber ?? 1347},
       "state": "open",
       "title": "Amazing new feature",
       "user": {

--- a/auto_submit/test/src/request_handling/fake_pubsub.dart
+++ b/auto_submit/test/src/request_handling/fake_pubsub.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:auto_submit/request_handling/pubsub.dart';
 import 'package:googleapis/pubsub/v1.dart';
@@ -19,20 +20,22 @@ class FakePubSub extends PubSub {
   }
 
   @override
-  Future<PullResponse> pull(int maxMessages, String subscription) async {
+  Future<PullResponse> pull(String subscription, int maxMessages) async {
     // The list will be empty if there are no more messages available in the backlog.
     List<ReceivedMessage> receivedMessages = <ReceivedMessage>[];
     if (messagesQueue.isNotEmpty) {
-      final PullResponse response = PullResponse(receivedMessages: <ReceivedMessage>[
-        ReceivedMessage(message: PubsubMessage(data: messagesQueue.last), ackId: '1'),
-      ]);
-      return response;
+      int i = 0;
+      while (i < min(100, messagesQueue.length)) {
+        receivedMessages.add(ReceivedMessage(message: PubsubMessage(data: messagesQueue[i]), ackId: '1'));
+        i++;
+      }
+      return PullResponse(receivedMessages: receivedMessages);
     }
     return PullResponse(receivedMessages: receivedMessages);
   }
 
   @override
-  Future<void> acknowledge(String ackId, String subscription) async {
+  Future<void> acknowledge(String subscription, String ackId) async {
     if (messagesQueue.isNotEmpty) {
       messagesQueue.removeAt(messagesQueue.length - 1);
     }

--- a/auto_submit/test/src/request_handling/fake_pubsub.dart
+++ b/auto_submit/test/src/request_handling/fake_pubsub.dart
@@ -2,13 +2,39 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:auto_submit/request_handling/pubsub.dart';
+import 'package:googleapis/pubsub/v1.dart';
 
 class FakePubSub extends PubSub {
-  List<dynamic> messages = <dynamic>[];
+  List<dynamic> messagesQueue = <dynamic>[];
 
   @override
   Future<void> publish(String topicName, dynamic json) async {
-    messages.add(json);
+    final String messageData = jsonEncode(json);
+    final List<int> messageBytes = utf8.encode(messageData);
+    final String messageBase64 = base64Encode(messageBytes);
+    messagesQueue.add(messageBase64);
+  }
+
+  @override
+  Future<PullResponse> pull(int maxMessages, String subscription) async {
+    // The list will be empty if there are no more messages available in the backlog.
+    List<ReceivedMessage> receivedMessages = <ReceivedMessage>[];
+    if (messagesQueue.isNotEmpty) {
+      final PullResponse response = PullResponse(receivedMessages: <ReceivedMessage>[
+        ReceivedMessage(message: PubsubMessage(data: messagesQueue.last), ackId: '1'),
+      ]);
+      return response;
+    }
+    return PullResponse(receivedMessages: receivedMessages);
+  }
+
+  @override
+  Future<void> acknowledge(String ackId, String subscription) async {
+    if (messagesQueue.isNotEmpty) {
+      messagesQueue.removeAt(messagesQueue.length - 1);
+    }
   }
 }


### PR DESCRIPTION
This PR intends to set up the pubsub pull logic, solving the issue: https://github.com/flutter/flutter/issues/98705.
Therefore, we can pull the message from the subscription to get the pull request stored in pub sub to process here. After we got the message, we will acknowledge the pub sub.

# Future
Make the pull based subscription running on a cron to pull the message from the pub sub every minute. https://github.com/flutter/flutter/issues/100399