### PR TITLE
Update graphql query to remove a redundant query to labels and prevent the query from timing out.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -195,13 +195,13 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
   }
 
   /// Gets a labelId for a given pullRequest and label.
-  String getLabelId(Map<String, dynamic> pullRequest, String label) {
+  String? getLabelId(Map<String, dynamic> pullRequest, String label) {
     for (Map<String, dynamic> labelMap in pullRequest['labels']['nodes']) {
       if (labelMap['name'] == label) {
         return labelMap['id'] as String;
       }
     }
-    return '';
+    return null;
   }
 
   /// Parses a GraphQL query to a list of [_AutoMergeQueryResult]s.
@@ -291,7 +291,7 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
           number: number,
           title: title,
           sha: sha,
-          labelId: labelId,
+          labelId: labelId!,
           emptyChecks: checkRuns.isEmpty,
           isConflicting: isConflicting,
           unknownMergeableState: unknownMergeableState,

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests.dart
@@ -212,16 +212,8 @@ class CheckForWaitingPullRequests extends ApiRequestHandler<Body> {
     if (repository == null || repository.isEmpty) {
       throw StateError('Query did not return a repository.');
     }
-
-    //final Map<String, dynamic>? label = repository['labels']['nodes'].single as Map<String, dynamic>?;
-    //if (label == null || label.isEmpty) {
-    //  throw StateError('Query did not find information about the waitingForTreeToGoGreen label.');
-    //}
-    //final String? labelId = label['id'] as String?;
-    //log.info('LabelId of returned PRs: $labelId');
     String? labelId;
     final List<_AutoMergeQueryResult> list = <_AutoMergeQueryResult>[];
-    //final List<Map<String, dynamic>> pullRequests = (repository['pullRequests']['nodes'] as List<dynamic>).cast<Map<String, dynamic>>();
     final Iterable<Map<String, dynamic>> pullRequests =
         (repository['pullRequests']['nodes'] as List<dynamic>).map((dynamic e) => e as Map<String, dynamic>);
     for (Map<String, dynamic> pullRequest in pullRequests) {

--- a/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
+++ b/app_dart/lib/src/request_handlers/check_for_waiting_pull_requests_queries.dart
@@ -6,69 +6,65 @@ import 'package:gql/ast.dart';
 import 'package:gql/language.dart' as lang;
 
 final DocumentNode labeledPullRequestsWithReviewsQuery = lang.parseString(r'''
-query LabeledPullRequcodeestsWithReviews($sOwner: String!, $sName: String!, $sLabelName: String!) {
+query LabeledPullRequestsWithReviews($sOwner: String!, $sName: String!, $sLabelName: String!) {
   repository(owner: $sOwner, name: $sName) {
-    labels(first: 1, query: $sLabelName) {
+    pullRequests(first: 20, states: OPEN, labels: [$sLabelName], orderBy: {direction: ASC, field: CREATED_AT}) {
       nodes {
+        author {
+          login
+        }
+        authorAssociation
         id
-        pullRequests(first: 20, states: OPEN, orderBy: {direction: ASC, field: CREATED_AT}) {
+        baseRepository {
+          nameWithOwner
+        }
+        number
+        title
+        mergeable
+        commits(last:1) {
+          nodes {
+            commit {
+              abbreviatedOid
+              oid
+              committedDate
+              pushedDate
+              status {
+                contexts {
+                  context
+                  state
+                  targetUrl
+                }
+              }
+              # (appId: 64368) == flutter-dashbord. We only care about
+              # flutter-dashboard checks.
+              checkSuites(last:1, filterBy: { appId: 64368 } ) {
+                nodes {
+                  checkRuns(first:100) {
+                    nodes {
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        reviews(last: 30, states: [APPROVED, CHANGES_REQUESTED]) {
           nodes {
             author {
               login
             }
             authorAssociation
+            state
+          }
+        }
+        labels(first: 5) {
+          nodes {
+            name
             id
-            baseRepository {
-              nameWithOwner
-            }
-            number
-            title
-            mergeable
-            commits(last:1) {
-              nodes {
-                commit {
-                  abbreviatedOid
-                  oid
-                  committedDate
-                  pushedDate
-                  status {
-                    contexts {
-                      context
-                      state
-                      targetUrl
-                    }
-                  }
-                  # (appId: 64368) == flutter-dashbord. We only care about
-                  # flutter-dashboard checks.
-                  checkSuites(last:1, filterBy: { appId: 64368 } ) {
-                    nodes {
-                      checkRuns(first:100) {
-                        nodes {
-                          name
-                          status
-                          conclusion
-                          detailsUrl
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            reviews(last: 30, states: [APPROVED, CHANGES_REQUESTED]) {
-              nodes {
-                author {
-                  login
-                }
-                authorAssociation
-                state
-              }
-            }
-            labels(first: 5) {
-              nodes {
-                name
-              }
-            }
           }
         }
       }

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -23,6 +23,14 @@ import '../src/utilities/mocks.dart';
 const String base64LabelId = 'base_64_label_id';
 const String oid = 'deadbeef';
 const String title = 'some_title';
+const Map<String, dynamic> waitForGreenLabel = <String, dynamic>{
+  'name': 'waiting for tree to go green',
+  'id': base64LabelId
+};
+const Map<String, dynamic> overrideTreeStatusLabel = <String, dynamic>{
+  'name': 'warning: land on red to fix tree breakage',
+  'id': 'otherid'
+};
 const List<dynamic> waitForTreeGreenlabels = <dynamic>[
   {'name': 'waiting for tree to go green', 'id': base64LabelId}
 ];
@@ -309,8 +317,10 @@ void main() {
 
     test('Merges unapproved PR from dependabot', () async {
       config.rollerAccountsValue = <String>{'dependabot'};
-      flutterRepoPRs.add(PullRequestHelper(author: 'dependabot', reviews: const <PullRequestReviewHelper>[]));
-      engineRepoPRs.add(PullRequestHelper(author: 'dependabot', reviews: const <PullRequestReviewHelper>[]));
+      flutterRepoPRs.add(PullRequestHelper(
+          author: 'dependabot', reviews: const <PullRequestReviewHelper>[], labels: waitForTreeGreenlabels));
+      engineRepoPRs.add(PullRequestHelper(
+          author: 'dependabot', reviews: const <PullRequestReviewHelper>[], labels: waitForTreeGreenlabels));
 
       await tester.get(handler);
 
@@ -409,9 +419,7 @@ void main() {
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildFailure,
         ],
-        labels: <dynamic>[
-          <String, dynamic>{'name': 'warning: land on red to fix tree breakage'}
-        ],
+        labels: <dynamic>[waitForGreenLabel, overrideTreeStatusLabel],
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -434,11 +442,16 @@ void main() {
       ];
       branch = 'pull/0';
 
-      final PullRequestHelper prRequested = PullRequestHelper(lastCommitCheckRuns: const <CheckRunHelper>[
-        CheckRunHelper.linuxCompletedRunning,
-      ], lastCommitStatuses: const <StatusHelper>[
-        StatusHelper.flutterBuildSuccess,
-      ], lastCommitMessage: 'Revert "This is a test PR" This reverts commit abc.');
+      final PullRequestHelper prRequested = PullRequestHelper(
+        lastCommitCheckRuns: const <CheckRunHelper>[
+          CheckRunHelper.linuxCompletedRunning,
+        ],
+        lastCommitStatuses: const <StatusHelper>[
+          StatusHelper.flutterBuildSuccess,
+        ],
+        lastCommitMessage: 'Revert "This is a test PR" This reverts commit abc.',
+        labels: waitForTreeGreenlabels,
+      );
       flutterRepoPRs.add(prRequested);
 
       await tester.get(handler);
@@ -462,6 +475,7 @@ void main() {
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -575,6 +589,7 @@ This pull request is not suitable for automatic merging in its current state.
           CheckRunHelper.luciCompletedSuccess,
         ],
         lastCommitStatuses: const <StatusHelper>[],
+        labels: waitForTreeGreenlabels,
       );
       prRequested.lastCommitStatuses = null;
       flutterRepoPRs.add(prRequested);
@@ -597,6 +612,7 @@ This pull request is not suitable for automatic merging in its current state.
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -685,7 +701,7 @@ This pull request is not suitable for automatic merging in its current state.
       ];
       branch = 'pull/0';
 
-      flutterRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
 
       await tester.get(handler);
 
@@ -784,10 +800,10 @@ This pull request is not suitable for automatic merging in its current state.
     });
 
     test('Merges first 2 PRs in list, all successful', () async {
-      flutterRepoPRs.add(PullRequestHelper());
-      flutterRepoPRs.add(PullRequestHelper());
-      flutterRepoPRs.add(PullRequestHelper()); // will be ignored.
-      engineRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels)); // will be ignored.
+      engineRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
 
       await tester.get(handler);
 
@@ -814,15 +830,15 @@ This pull request is not suitable for automatic merging in its current state.
     test('Merges 1st and 3rd PR, 2nd failed', () async {
       totSha = 'abc';
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
-      flutterRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
       flutterRepoPRs.add(PullRequestHelper(
         author: 'engine-roller-hacker',
         reviews: const <PullRequestReviewHelper>[],
         labels: waitForTreeGreenlabels,
       ));
 
-      flutterRepoPRs.add(PullRequestHelper());
-      engineRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
+      engineRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
 
       await tester.get(handler);
 
@@ -866,7 +882,7 @@ This pull request is not suitable for automatic merging in its current state.
         dateTime: DateTime.now().add(const Duration(minutes: -70)),
         labels: waitForTreeGreenlabels,
       )); // ok
-      engineRepoPRs.add(PullRequestHelper()); // default is two hours for this ctor.
+      engineRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels)); // default is two hours for this ctor.
 
       await tester.get(handler);
 
@@ -927,6 +943,7 @@ This pull request is not suitable for automatic merging in its current state.
           changePleaseChange,
           changePleaseApprove,
         ],
+        labels: waitForTreeGreenlabels,
       );
 
       flutterRepoPRs.add(prChangedReview);

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -294,8 +294,18 @@ void main() {
 
     test('Merges unapproved PR from autoroller', () async {
       config.rollerAccountsValue = <String>{'engine-roller', 'skia-roller'};
-      flutterRepoPRs.add(PullRequestHelper(author: 'engine-roller', reviews: const <PullRequestReviewHelper>[]));
-      engineRepoPRs.add(PullRequestHelper(author: 'skia-roller', reviews: const <PullRequestReviewHelper>[]));
+      flutterRepoPRs.add(PullRequestHelper(
+        author: 'engine-roller',
+        reviews: const <PullRequestReviewHelper>[],
+        labels: waitForTreeGreenlabels,
+      ));
+      engineRepoPRs.add(
+        PullRequestHelper(
+          author: 'skia-roller',
+          reviews: const <PullRequestReviewHelper>[],
+          labels: waitForTreeGreenlabels,
+        ),
+      );
 
       await tester.get(handler);
 

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -23,6 +23,9 @@ import '../src/utilities/mocks.dart';
 const String base64LabelId = 'base_64_label_id';
 const String oid = 'deadbeef';
 const String title = 'some_title';
+const List<dynamic> waitForTreeGreenlabels = <dynamic>[
+  {'name': 'waiting for tree to go green', 'id': base64LabelId}
+];
 
 Map<String, dynamic> getMergePullRequestVariables(String number) {
   return <String, dynamic>{
@@ -264,7 +267,7 @@ void main() {
     }
 
     test('Errors can be logged', () async {
-      flutterRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(labels: waitForTreeGreenlabels));
       final List<GraphQLError> errors = <GraphQLError>[
         const GraphQLError(message: 'message'),
       ];
@@ -484,6 +487,7 @@ void main() {
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -508,12 +512,12 @@ This pull request is not suitable for automatic merging in its current state.
       totSha = 'abc';
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       branch = 'pull/0';
-      final PullRequestHelper prRequested = PullRequestHelper(
-        lastCommitCheckRuns: const <CheckRunHelper>[],
-        lastCommitStatuses: const <StatusHelper>[
-          StatusHelper.flutterBuildFailure,
-        ],
-      );
+      final PullRequestHelper prRequested =
+          PullRequestHelper(lastCommitCheckRuns: const <CheckRunHelper>[], lastCommitStatuses: const <StatusHelper>[
+        StatusHelper.flutterBuildFailure,
+      ], labels: <dynamic>[
+        {'name': 'waiting for tree to go green', 'id': base64LabelId}
+      ]);
       prRequested.lastCommitCheckRuns = null;
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -541,6 +545,7 @@ This pull request is not suitable for automatic merging in its current state.
       final PullRequestHelper prRequested = PullRequestHelper(
         lastCommitCheckRuns: const <CheckRunHelper>[],
         lastCommitStatuses: const <StatusHelper>[],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -616,6 +621,7 @@ This pull request is not suitable for automatic merging in its current state.
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -652,6 +658,7 @@ This pull request is not suitable for automatic merging in its current state.
         lastCommitStatuses: const <StatusHelper>[
           StatusHelper.flutterBuildSuccess,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRequested);
       await tester.get(handler);
@@ -703,7 +710,9 @@ This pull request is not suitable for automatic merging in its current state.
       ];
       branch = 'pull/0';
 
-      flutterRepoPRs.add(PullRequestHelper());
+      flutterRepoPRs.add(PullRequestHelper(
+        labels: waitForTreeGreenlabels,
+      ));
 
       await tester.get(handler);
 
@@ -731,8 +740,16 @@ This pull request is not suitable for automatic merging in its current state.
       totSha = 'abc';
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       config.rollerAccountsValue = <String>{'engine-roller', 'skia-roller'};
-      flutterRepoPRs.add(PullRequestHelper(author: 'engine-roller-hacker', reviews: const <PullRequestReviewHelper>[]));
-      engineRepoPRs.add(PullRequestHelper(author: 'skia-roller-hacker', reviews: const <PullRequestReviewHelper>[]));
+      flutterRepoPRs.add(PullRequestHelper(
+        author: 'engine-roller-hacker',
+        reviews: const <PullRequestReviewHelper>[],
+        labels: waitForTreeGreenlabels,
+      ));
+      engineRepoPRs.add(PullRequestHelper(
+        author: 'skia-roller-hacker',
+        reviews: const <PullRequestReviewHelper>[],
+        labels: waitForTreeGreenlabels,
+      ));
 
       await tester.get(handler);
 
@@ -798,7 +815,11 @@ This pull request is not suitable for automatic merging in its current state.
       totSha = 'abc';
       githubComparison = GitHubComparison('abc', 'def', 0, 0, 0, <CommitFile>[CommitFile(name: 'test')]);
       flutterRepoPRs.add(PullRequestHelper());
-      flutterRepoPRs.add(PullRequestHelper(author: 'engine-roller-hacker', reviews: const <PullRequestReviewHelper>[]));
+      flutterRepoPRs.add(PullRequestHelper(
+        author: 'engine-roller-hacker',
+        reviews: const <PullRequestReviewHelper>[],
+        labels: waitForTreeGreenlabels,
+      ));
 
       flutterRepoPRs.add(PullRequestHelper());
       engineRepoPRs.add(PullRequestHelper());
@@ -837,8 +858,14 @@ This pull request is not suitable for automatic merging in its current state.
     });
 
     test('Ignores PRs that are too new', () async {
-      flutterRepoPRs.add(PullRequestHelper(dateTime: DateTime.now().add(const Duration(minutes: -50)))); // too new
-      flutterRepoPRs.add(PullRequestHelper(dateTime: DateTime.now().add(const Duration(minutes: -70)))); // ok
+      flutterRepoPRs.add(PullRequestHelper(
+        dateTime: DateTime.now().add(const Duration(minutes: -50)),
+        labels: waitForTreeGreenlabels,
+      )); // too new
+      flutterRepoPRs.add(PullRequestHelper(
+        dateTime: DateTime.now().add(const Duration(minutes: -70)),
+        labels: waitForTreeGreenlabels,
+      )); // ok
       engineRepoPRs.add(PullRequestHelper()); // default is two hours for this ctor.
 
       await tester.get(handler);
@@ -872,6 +899,7 @@ This pull request is not suitable for automatic merging in its current state.
           StatusHelper.flutterBuildSuccess,
           StatusHelper.otherStatusFailure,
         ],
+        labels: waitForTreeGreenlabels,
       );
       flutterRepoPRs.add(prRed);
 
@@ -923,17 +951,20 @@ This pull request is not suitable for automatic merging in its current state.
         reviews: const <PullRequestReviewHelper>[
           nonMemberApprove,
         ],
+        labels: waitForTreeGreenlabels,
       );
       final PullRequestHelper prNonMemberChangeRequest = PullRequestHelper(
         reviews: const <PullRequestReviewHelper>[
           nonMemberChangeRequest,
         ],
+        labels: waitForTreeGreenlabels,
       );
       final PullRequestHelper prNonMemberChangeRequestWithMemberApprove = PullRequestHelper(
         reviews: const <PullRequestReviewHelper>[
           ownerApprove,
           nonMemberChangeRequest,
         ],
+        labels: waitForTreeGreenlabels,
       );
 
       // Ignored approval from non-member
@@ -986,19 +1017,23 @@ This pull request is not suitable for automatic merging in its current state.
         reviews: const <PullRequestReviewHelper>[
           changePleaseChange,
         ],
+        labels: waitForTreeGreenlabels,
       );
       final PullRequestHelper prOneGoodOneBadReview = PullRequestHelper(
         reviews: const <PullRequestReviewHelper>[
           memberApprove,
           changePleaseChange,
         ],
+        labels: waitForTreeGreenlabels,
       );
       final PullRequestHelper prNoReviews = PullRequestHelper(
         reviews: const <PullRequestReviewHelper>[],
+        labels: waitForTreeGreenlabels,
       );
       final PullRequestHelper prEverythingWrong = PullRequestHelper(
         lastCommitStatuses: const <StatusHelper>[StatusHelper.flutterBuildFailure],
         reviews: const <PullRequestReviewHelper>[changePleaseChange],
+        labels: waitForTreeGreenlabels,
       );
 
       flutterRepoPRs.add(prOneBadReview);
@@ -1215,7 +1250,7 @@ class PullRequestHelper {
                     : <dynamic>[]
               },
             },
-          },
+          }
         ],
       },
       'labels': <String, dynamic>{
@@ -1229,19 +1264,12 @@ QueryResult createQueryResult(List<PullRequestHelper> pullRequests) {
   return QueryResult(
     data: <String, dynamic>{
       'repository': <String, dynamic>{
-        'labels': <String, dynamic>{
-          'nodes': <dynamic>[
-            <String, dynamic>{
-              'id': base64LabelId,
-              'pullRequests': <String, dynamic>{
-                'nodes': pullRequests
-                    .map<Map<String, dynamic>>(
-                      (PullRequestHelper pullRequest) => pullRequest.toEntry(),
-                    )
-                    .toList(),
-              },
-            },
-          ],
+        'pullRequests': <String, dynamic>{
+          'nodes': pullRequests
+              .map<Map<String, dynamic>>(
+                (PullRequestHelper pullRequest) => pullRequest.toEntry(),
+              )
+              .toList(),
         },
       },
     },


### PR DESCRIPTION
Graphql queries were timing out because the query by labels is
extremelly expensive. Changing the query to filter by open PRs and then
filtering by the label is more efficient and reduces the query exection
time to 1/3.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
