### PR TITLE
Update licenses script to include Dockerfiles.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Copyright 2022 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # Flutter (https://flutter.io) Developement Environment for Linux
 # ===============================================================
 #

--- a/app_dart/Dockerfile
+++ b/app_dart/Dockerfile
@@ -1,8 +1,7 @@
-################################################################################
-#  Copyright 2016 The Flutter Authors. All rights reserved.
-#  Use of this source code is governed by a BSD-style license that can be
-#  found in the LICENSE file.
-################################################################################
+# Copyright 2016 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 # The VM service listens on port 8181
 

--- a/app_dart/Dockerfile
+++ b/app_dart/Dockerfile
@@ -1,5 +1,5 @@
 ################################################################################
-#  Copyright (c) 2016 The Flutter Authors. All rights reserved.
+#  Copyright 2016 The Flutter Authors. All rights reserved.
 #  Use of this source code is governed by a BSD-style license that can be
 #  found in the LICENSE file.
 ################################################################################

--- a/auto_submit/Dockerfile
+++ b/auto_submit/Dockerfile
@@ -1,3 +1,7 @@
+# Copyright 2022 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # Use Google's official Dart image.
 # https://hub.docker.com/r/google/dart-runtime/
 FROM google/dart-runtime

--- a/licenses/check_licenses.dart
+++ b/licenses/check_licenses.dart
@@ -116,7 +116,7 @@ Iterable<File> _allFiles(String workingDirectory, String extension, {required in
         matches += 1;
         yield entity;
       }
-      if (path.basename(entity.path) == 'Dockerfile') {
+      if (path.basename(entity.path) == 'Dockerfile' && extension == 'Dockerfile') {
         matches += 1;
         yield entity;
       }

--- a/licenses/check_licenses.dart
+++ b/licenses/check_licenses.dart
@@ -54,6 +54,8 @@ Future<void> verifyNoMissingLicense(String workingDirectory, {bool checkMinimums
   await _verifyNoMissingLicenseForExtension(
       workingDirectory, 'gn', overrideMinimumMatches ?? 0, _generateLicense('# '));
   await _verifyNoMissingLicenseForExtension(
+      workingDirectory, 'Dockerfile', overrideMinimumMatches ?? 1, _generateLicense('# '));
+  await _verifyNoMissingLicenseForExtension(
       workingDirectory, 'sh', overrideMinimumMatches ?? 1, '#!/bin/bash\n' + _generateLicense('# '));
   await _verifyNoMissingLicenseForExtension(
       workingDirectory, 'bat', overrideMinimumMatches ?? 1, _generateLicense(':: '));
@@ -111,6 +113,10 @@ Iterable<File> _allFiles(String workingDirectory, String extension, {required in
       if (path.basename(entity.path).endsWith('pbjson.dart')) continue;
       if (path.basename(entity.path).endsWith('pbserver.dart')) continue;
       if (path.extension(entity.path) == '.$extension') {
+        matches += 1;
+        yield entity;
+      }
+      if (path.basename(entity.path) == 'Dockerfile') {
         matches += 1;
         yield entity;
       }


### PR DESCRIPTION
Some dockerfiles do not include the license header but the licenses
checks have been happy. This change will make the licenses header check
fail for docker files missing the header.

Bug: https://github.com/flutter/flutter/issues/100181

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
