### PR TITLE
[device doctor] Fix `idevice_id` binary path for M1 bots

### DIFF
--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -56,7 +56,6 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     processManager ??= LocalProcessManager();
     final Map<String, List<HealthCheckResult>> results = <String, List<HealthCheckResult>>{};
     for (Device device in await discoverDevices()) {
-      print(device.deviceId);
       final List<HealthCheckResult> checks = <HealthCheckResult>[];
       checks.add(HealthCheckResult.success(kDeviceAccessCheckKey));
       checks.add(await keychainUnlockCheck(processManager: processManager));

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -44,8 +44,11 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     return LineSplitter.split(await deviceListOutput()).map((String id) => IosDevice(deviceId: id)).toList();
   }
 
-  Future<String> deviceListOutput() async {
-    return eval('idevice_id', <String>['-l']);
+  Future<String> deviceListOutput({
+    ProcessManager processManager = const LocalProcessManager(),
+  }) async {
+    final String fullPathIdeviceId = await getMacBinaryPath('idevice_id', processManager: processManager);
+    return eval(fullPathIdeviceId, <String>['-l'], processManager: processManager);
   }
 
   @override
@@ -53,6 +56,7 @@ class IosDeviceDiscovery implements DeviceDiscovery {
     processManager ??= LocalProcessManager();
     final Map<String, List<HealthCheckResult>> results = <String, List<HealthCheckResult>>{};
     for (Device device in await discoverDevices()) {
+      print(device.deviceId);
       final List<HealthCheckResult> checks = <HealthCheckResult>[];
       checks.add(HealthCheckResult.success(kDeviceAccessCheckKey));
       checks.add(await keychainUnlockCheck(processManager: processManager));

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -135,7 +135,10 @@ void writeToFile(String results, File file) {
 ///
 /// For M1 bots, binaries like `ideviceinstaller` are installed under `kM1BrewBinPath`,
 /// where they are not visible in `$PATH` by default.
-Future<String> getMacBinaryPath(String name, {ProcessManager processManager}) async {
+Future<String> getMacBinaryPath(
+  String name, {
+  ProcessManager processManager = const LocalProcessManager(),
+}) async {
   String path = await eval('which', <String>[name], canFail: true, processManager: processManager);
   if (path == null || path.isEmpty) {
     path = await eval('which', <String>['$kM1BrewBinPath/$name'], canFail: true, processManager: processManager);

--- a/device_doctor/test/src/fake_ios_device.dart
+++ b/device_doctor/test/src/fake_ios_device.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:device_doctor/src/ios_device.dart';
+import 'package:process/process.dart';
 
 class FakeIosDeviceDiscovery extends IosDeviceDiscovery {
   FakeIosDeviceDiscovery(File output) : super.testing(output);
@@ -19,7 +20,9 @@ class FakeIosDeviceDiscovery extends IosDeviceDiscovery {
   }
 
   @override
-  Future<String> deviceListOutput() async {
+  Future<String> deviceListOutput({
+    ProcessManager processManager = const LocalProcessManager(),
+  }) async {
     _pos++;
     if (_outputs[_pos - 1] is String) {
       return _outputs[_pos - 1] as String;

--- a/device_doctor/test/src/ios_device_test.dart
+++ b/device_doctor/test/src/ios_device_test.dart
@@ -435,4 +435,27 @@ void main() {
       expect(result, isTrue);
     });
   });
+
+  group('deviceListOutput', () {
+    IosDeviceDiscovery deviceDiscovery;
+    MockProcessManager processManager;
+    Process processIdeviceID;
+    Process processWhichIdeviceID;
+
+    setUp(() {
+      processManager = MockProcessManager();
+      deviceDiscovery = DeviceDiscovery('ios', MemoryFileSystem().file('output'));
+    });
+
+    test('success', () async {
+      when(processManager.start(<String>['which', 'idevice_id'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(processWhichIdeviceID));
+      when(processManager.start(<String>['/test/idevice_id', '-l'], workingDirectory: anyNamed('workingDirectory')))
+          .thenAnswer((_) => Future.value(processIdeviceID));
+      processIdeviceID = FakeProcess(0, out: <List<int>>[utf8.encode('abc')]);
+      processWhichIdeviceID = FakeProcess(0, out: <List<int>>[utf8.encode('/test/idevice_id')]);
+      String deviceId = await deviceDiscovery.deviceListOutput(processManager: processManager);
+      expect(deviceId, 'abc');
+    });
+  });
 }


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/1660, fixing the case of `idevice_id`.

https://github.com/flutter/flutter/issues/99490#issuecomment-1076889601