### PR TITLE
[autosubmit] Control numbers of PR to be merged per cycle

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -56,21 +56,18 @@ class CheckPullRequest extends RequestHandler {
     return responses;
   }
 
-  /// Check and collect the pull request we will merge this cycle.
+  /// Check and collect the pull requests to merge this cycle.
   ///
   /// The number of pull requests to be merged to each repo will not exceed
   /// the _kMergeCountPerRepo
   Future<Set> checkMerge(Set shouldMergeSet) async {
-    //The repo map stores the repo and the count of PRs we want to merge to this repo
+    //The repo map stores the repo name and the count of PRs to merge to this repo
     HashMap<String, int> repos = HashMap<String, int>();
     Set mergeSet = HashSet<PullRequest>();
     for (PullRequest pr in shouldMergeSet) {
       String repoName = pr.base!.repo!.slug().fullName;
-      if (!repos.containsKey(repoName)) {
-        repos[repoName] = 1;
-        mergeSet.add(pr);
-      } else if (repos[repoName]! < _kMergeCountPerRepo) {
-        repos[repoName] = repos[repoName]! + 1;
+      if (!repos.containsKey(repoName) || repos[repoName]! < _kMergeCountPerRepo) {
+        repos[repoName] = repos.containsKey(repoName) ? repos[repoName]! + 1 : 1;
         mergeSet.add(pr);
       } else {
         await pubsub.publish('auto-submit-queue', pr);

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -46,7 +46,7 @@ void main() {
       for (int i = 0; i < responses.length; i++) {
         final String resBody = await responses[i].readAsString();
         expect(resBody,
-            'Merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -72,7 +72,7 @@ void main() {
       for (int i = 0; i < responses.length; i++) {
         final String resBody = await responses[i].readAsString();
         expect(resBody,
-            'Merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -98,7 +98,7 @@ void main() {
       for (int i = 0; i < responses.length; i++) {
         final String resBody = await responses[i].readAsString();
         expect(resBody,
-            'Merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -120,7 +120,7 @@ void main() {
       for (Response response in responses) {
         final String resBody = await response.readAsString();
         expect(resBody,
-            'Merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -146,7 +146,7 @@ void main() {
       for (int i = 0; i < responses.length; i++) {
         final String resBody = await responses[i].readAsString();
         expect(resBody,
-            'Merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -322,6 +322,24 @@ void main() {
         expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[i].head!.sha}.');
       }
       assert(pubsub.messagesQueue.isEmpty);
+    });
+
+    test('Merges only 2 PR per cycle per repo', () async {
+      final PullRequest pr1 = generatePullRequest(prNumber: 22);
+      final PullRequest pr2 = generatePullRequest(prNumber: 23);
+      final PullRequest pr3 = generatePullRequest(prNumber: 24);
+      config = FakeConfig(githubService: githubService);
+      checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
+      Set shouldMergeSet = {pr1, pr2, pr3};
+      final Set mergeSet = await checkPullRequest.checkMerge(shouldMergeSet);
+      List<bool> mergeResult = await checkPullRequest.mergePullRequest(mergeSet);
+      expect(mergeSet.length, 2);
+      for (int i = 0; i < mergeResult.length; i++) {
+        expect(mergeResult[i], true);
+      }
+      expect(pubsub.messagesQueue.length, 1);
+      pubsub.messagesQueue.clear();
+      //assert(pubsub.messagesQueue.isEmpty);
     });
   });
 }

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -24,11 +24,12 @@ void main() {
     const String labelName = "warning: land on red to fix tree breakage";
     const String repoName = 'cocoon';
     const String autosubmitLabel = 'no_autosubmit';
+    const int _kMergeCountPerRepo = 1;
 
     test('Merges PR with successful status and checks', () async {
-      final PullRequest pr1 = generatePullRequest(prNumber: 0);
-      final PullRequest pr2 = generatePullRequest(prNumber: 1, repoName: 'flutter', login: 'cocoon');
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      final PullRequest pullRequest1 = generatePullRequest(prNumber: 0);
+      final PullRequest pullRequest2 = generatePullRequest(prNumber: 1, repoName: 'flutter', login: 'cocoon');
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -43,17 +44,17 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
         expect(resBody,
-            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[index].number} in ${pullRequests[index].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Merges unapproved PR from autoroller', () async {
-      final PullRequest pr1 = generatePullRequest(prNumber: 2, login: login);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1];
+      final PullRequest pullRequest1 = generatePullRequest(prNumber: 2, login: login);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -68,17 +69,17 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
         expect(resBody,
-            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[index].number} in ${pullRequests[index].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Merges PR with failed tree status if override tree status label is provided', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 4, labelName: labelName);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 4, labelName: labelName);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -93,10 +94,10 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
         expect(resBody,
-            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[index].number} in ${pullRequests[index].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -124,8 +125,8 @@ void main() {
     });
 
     test('Merges PR with successful checks on repo without tree status', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 7, repoName: repoName);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 7, repoName: repoName);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -140,18 +141,18 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
         expect(resBody,
-            'Should merge the pull request ${pullRequests[i].number} in ${pullRequests[i].base!.repo!.slug().fullName} repository.');
+            'Should merge the pull request ${pullRequests[index].number} in ${pullRequests[index].base!.repo!.slug().fullName} repository.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Removes the label for the PR with failed tests', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 9);
-      PullRequest pr2 = generatePullRequest(prNumber: 10);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 9);
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 10);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -166,17 +167,17 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[i].head!.sha}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[index].head!.sha}.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Removes the label for the PR with failed status', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 11);
-      PullRequest pr2 = generatePullRequest(prNumber: 12);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 11);
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 12);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -191,17 +192,17 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[i].head!.sha}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[index].head!.sha}.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Removes the label if non member does not have at least 2 member reviews', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 13, authorAssociation: '');
-      PullRequest pr2 = generatePullRequest(prNumber: 14, authorAssociation: '');
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 13, authorAssociation: '');
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 14, authorAssociation: '');
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -216,9 +217,9 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[i].head!.sha}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[index].head!.sha}.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
@@ -245,9 +246,9 @@ void main() {
     });
 
     test('Does not merge PR with in progress checks', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 16);
-      PullRequest pr2 = generatePullRequest(prNumber: 17);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 16);
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 17);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -262,18 +263,18 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Does not merge the pull request ${pullRequests[i].number}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Does not merge the pull request ${pullRequests[index].number}.');
       }
       expect(pubsub.messagesQueue.length, 2);
       pubsub.messagesQueue.clear();
     });
 
     test('Does not merge PR if no autosubmit label any more', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 18, autosubmitLabel: autosubmitLabel);
-      PullRequest pr2 = generatePullRequest(prNumber: 19, autosubmitLabel: autosubmitLabel);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 18, autosubmitLabel: autosubmitLabel);
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 19, autosubmitLabel: autosubmitLabel);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -288,18 +289,18 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Does not merge the pull request ${pullRequests[i].number}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Does not merge the pull request ${pullRequests[index].number}.');
       }
       expect(pubsub.messagesQueue.length, 2);
       pubsub.messagesQueue.clear();
     });
 
     test('Empty validations do not merge', () async {
-      PullRequest pr1 = generatePullRequest(prNumber: 20);
-      PullRequest pr2 = generatePullRequest(prNumber: 21);
-      final List<PullRequest> pullRequests = <PullRequest>[pr1, pr2];
+      PullRequest pullRequest1 = generatePullRequest(prNumber: 20);
+      PullRequest pullRequest2 = generatePullRequest(prNumber: 21);
+      final List<PullRequest> pullRequests = <PullRequest>[pullRequest1, pullRequest2];
       for (PullRequest pr in pullRequests) {
         pubsub.publish(testTopic, pr);
       }
@@ -314,34 +315,35 @@ void main() {
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
 
       final List<Response> responses = await checkPullRequest.get();
-      for (int i = 0; i < responses.length; i++) {
-        final String resBody = await responses[i].readAsString();
-        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[i].head!.sha}.');
+      for (int index = 0; index < responses.length; index++) {
+        final String resBody = await responses[index].readAsString();
+        expect(resBody, 'Remove the autosubmit label for commit: ${pullRequests[index].head!.sha}.');
       }
       assert(pubsub.messagesQueue.isEmpty);
     });
 
     test('Merges only _kMergeCountPerRepo PR per cycle per repo', () async {
-      final PullRequest pr1 = generatePullRequest(prNumber: 22, repoName: 'flutter', login: 'flutter');
-      final PullRequest pr2 = generatePullRequest(prNumber: 23, repoName: 'flutter', login: 'flutter');
-      final PullRequest pr3 = generatePullRequest(prNumber: 24, repoName: 'flutter', login: 'cocoon');
+      final PullRequest pullRequest1 = generatePullRequest(prNumber: 22, repoName: 'flutter', login: 'flutter');
+      final PullRequest pullRequest2 = generatePullRequest(prNumber: 23, repoName: 'flutter', login: 'flutter');
+      final PullRequest pullRequest3 = generatePullRequest(prNumber: 24, repoName: 'cocoon', login: 'flutter');
       config = FakeConfig(githubService: githubService);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub);
-      final Map<String, Set<PullRequest>> shouldMergeMap = <String, Set<PullRequest>>{};
-      Set<PullRequest> shouldMergeSet = {pr1, pr2, pr3};
-      for (PullRequest pr in shouldMergeSet) {
-        String repoName = pr.base!.repo!.slug().fullName;
-        if (!shouldMergeMap.containsKey(repoName)) {
-          shouldMergeMap[repoName] = <PullRequest>{};
-        }
-        shouldMergeMap[repoName]!.add(pr);
-      }
+      final Map<String, Set<PullRequest>> repoPullRequestsMap = <String, Set<PullRequest>>{
+        'flutter/flutter': <PullRequest>{pullRequest1, pullRequest2},
+        'flutter/cocoon': <PullRequest>{pullRequest3}
+      };
 
-      List<bool> mergeResult = await checkPullRequest.checkMerge(shouldMergeMap);
-      expect(mergeResult.length, 2);
-      for (int i = 0; i < mergeResult.length; i++) {
-        expect(mergeResult[i], true);
-      }
+      List<Response> mergeResult = await checkPullRequest.checkPullRequests(repoPullRequestsMap);
+      expect(mergeResult.length, 3);
+      expect(await mergeResult[0].readAsString(),
+          'Successfully merged the pull request ${pullRequest1.number} to ${pullRequest1.base!.repo!.slug().fullName} repository.');
+      expect(
+          await mergeResult[1].readAsString(),
+          'Cannot merge the pull request ${pullRequest2.number} to ${pullRequest2.base!.repo!.slug().fullName} repository'
+          'this time because we already merged $_kMergeCountPerRepo pull requests to this repository.');
+      expect(await mergeResult[2].readAsString(),
+          'Successfully merged the pull request ${pullRequest3.number} to ${pullRequest3.base!.repo!.slug().fullName} repository.');
+
       expect(pubsub.messagesQueue.length, 1);
       pubsub.messagesQueue.clear();
     });

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -24,7 +24,6 @@ void main() {
     const String labelName = "warning: land on red to fix tree breakage";
     const String repoName = 'cocoon';
     const String autosubmitLabel = 'no_autosubmit';
-    const int _kMergeCountPerRepo = 1;
 
     test('Merges PR with successful status and checks', () async {
       final PullRequest pullRequest1 = generatePullRequest(prNumber: 0);
@@ -333,17 +332,10 @@ void main() {
         'flutter/cocoon': <PullRequest>{pullRequest3}
       };
 
-      List<Response> mergeResult = await checkPullRequest.checkPullRequests(repoPullRequestsMap);
-      expect(mergeResult.length, 3);
-      expect(await mergeResult[0].readAsString(),
-          'Successfully merged the pull request ${pullRequest1.number} to ${pullRequest1.base!.repo!.slug().fullName} repository.');
-      expect(
-          await mergeResult[1].readAsString(),
-          'Cannot merge the pull request ${pullRequest2.number} to ${pullRequest2.base!.repo!.slug().fullName} repository'
-          'this time because we already merged $_kMergeCountPerRepo pull requests to this repository.');
-      expect(await mergeResult[2].readAsString(),
-          'Successfully merged the pull request ${pullRequest3.number} to ${pullRequest3.base!.repo!.slug().fullName} repository.');
-
+      List<Map<int, String>> mergeResult = await checkPullRequest.checkPullRequests(repoPullRequestsMap);
+      expect(mergeResult[0], <int, String>{22: 'merged'});
+      expect(mergeResult[1], <int, String>{23: 'queued'});
+      expect(mergeResult[2], <int, String>{24: 'merged'});
       expect(pubsub.messagesQueue.length, 1);
       pubsub.messagesQueue.clear();
     });

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -324,7 +324,7 @@ void main() {
       assert(pubsub.messagesQueue.isEmpty);
     });
 
-    test('Merges only 2 PR per cycle per repo', () async {
+    test('Merges only _kMergeCountPerRepo PR per cycle per repo', () async {
       final PullRequest pr1 = generatePullRequest(prNumber: 22);
       final PullRequest pr2 = generatePullRequest(prNumber: 23);
       final PullRequest pr3 = generatePullRequest(prNumber: 24);
@@ -339,7 +339,6 @@ void main() {
       }
       expect(pubsub.messagesQueue.length, 1);
       pubsub.messagesQueue.clear();
-      //assert(pubsub.messagesQueue.isEmpty);
     });
   });
 }


### PR DESCRIPTION
To control the number of PR to be merged to each repo per cycle, here we set a maximum threshold. Here I set it to be 2 initially, and we can change this threshold later according to the test result.

