### PR TITLE
[autosubmit] Use graphQL to get actual authorAssociation

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -165,7 +165,6 @@ class CheckPullRequest extends RequestHandler {
   Future<bool> shouldMergePullRequest(
       _AutoMergeQueryResult queryResult, RepositorySlug slug, GithubService github) async {
     // Check the label again before merge the pull request.
-    //final bool hasAutosubmitLabel = queryResult.labels.any((label) => label == config.autosubmitLabel);
     if (queryResult.shouldMerge) {
       return true;
     }

--- a/auto_submit/lib/requests/check_pull_request_queries.dart
+++ b/auto_submit/lib/requests/check_pull_request_queries.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart' as lang;
+
+final DocumentNode labeledPullRequestWithReviewsQuery = lang.parseString(r'''
+query LabeledPullRequcodeestWithReviews($sOwner: String!, $sName: String!, $sPrNumber: int!) {
+  repository(owner: $sOwner, name: $sName) { 
+    pullRequest(number: $sPrNumber) {
+      authorAssociation
+      commits(last:1) {
+        nodes {
+          commit {
+            abbreviatedOid
+            oid
+            committedDate
+            pushedDate
+            status {
+              contexts {
+                context
+                state
+                targetUrl
+              }
+            }
+          }
+        }
+      }
+      reviews(last: 30, states: [APPROVED, CHANGES_REQUESTED]) {
+        nodes {
+          author {
+            login
+          }
+          authorAssociation
+          state
+        }
+      }
+    } 
+  }
+}''');

--- a/auto_submit/lib/requests/check_pull_request_queries.dart
+++ b/auto_submit/lib/requests/check_pull_request_queries.dart
@@ -5,7 +5,7 @@
 import 'package:gql/ast.dart';
 import 'package:gql/language.dart' as lang;
 
-final DocumentNode labeledPullRequestWithReviewsQuery = lang.parseString(r'''
+final DocumentNode pullRequestWithReviewsQuery = lang.parseString(r'''
 query LabeledPullRequcodeestWithReviews($sOwner: String!, $sName: String!, $sPrNumber: int!) {
   repository(owner: $sOwner, name: $sName) { 
     pullRequest(number: $sPrNumber) {

--- a/auto_submit/lib/requests/exceptions.dart
+++ b/auto_submit/lib/requests/exceptions.dart
@@ -1,0 +1,69 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+/// An exception that may be thrown by a [RequestHandler] to trigger an error
+/// HTTP response.
+class HttpStatusException implements Exception {
+  /// Creates a new [HttpStatusException].
+  const HttpStatusException(this.statusCode, this.message);
+
+  /// The HTTP status code to return to the issuer.
+  final int statusCode;
+
+  /// The message to show to the issuer to explain the error.
+  final String message;
+
+  @override
+  String toString() => 'HTTP $statusCode: $message';
+}
+
+/// Exception that will trigger an HTTP 400 bad request.
+class BadRequestException extends HttpStatusException {
+  const BadRequestException([String message = 'Bad request']) : super(HttpStatus.badRequest, message);
+}
+
+/// Exception that will trigger an HTTP 404 not found
+class NotFoundException extends HttpStatusException {
+  const NotFoundException(String missing) : super(HttpStatus.notFound, 'Not found: $missing');
+}
+
+/// Exception that will trigger an HTTP 405 method not allowed.
+class MethodNotAllowed extends HttpStatusException {
+  const MethodNotAllowed(String method) : super(HttpStatus.methodNotAllowed, 'Unsupported method: $method');
+}
+
+/// Exception that will trigger an HTTP 409 conflict.
+class ConflictException extends HttpStatusException {
+  const ConflictException([String message = 'Request conflict with server state'])
+      : super(HttpStatus.conflict, message);
+}
+
+/// Exception that will trigger an HTTP 500 internal server error.
+class InternalServerError extends HttpStatusException {
+  const InternalServerError([String message = 'Internal server error'])
+      : super(HttpStatus.internalServerError, message);
+}
+
+/// Exception that will trigger an HTTP 401 not authorized.
+class Unauthorized extends HttpStatusException {
+  const Unauthorized([String message = 'Unauthorized']) : super(HttpStatus.unauthorized, message);
+}
+
+/// Exception that will trigger an HTTP 403 forbidden.
+class Forbidden extends HttpStatusException {
+  const Forbidden([String message = 'Forbidden']) : super(HttpStatus.forbidden, message);
+}
+
+/// Exception thrown when attempting to authenticate a request that cannot be
+/// authenticated.
+class Unauthenticated implements Exception {
+  const Unauthenticated(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'Unauthenticated: $message';
+}

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -10,28 +10,12 @@ class GithubService {
 
   final GitHub github;
 
-  /// Retrieves the reviews for a pull request.
-  Future<List<PullRequestReview>> getReviews(
-    RepositorySlug slug,
-    int prNumber,
-  ) async {
-    return await github.pullRequests.listReviews(slug, prNumber).toList();
-  }
-
   /// Retrieves check runs with the ref.
   Future<List<CheckRun>> getCheckRuns(
     RepositorySlug slug,
     String ref,
   ) async {
     return await github.checks.checkRuns.listCheckRunsForRef(slug, ref: ref).toList();
-  }
-
-  /// Retrieves the statuses of a repository at the specified reference.
-  Future<List<RepositoryStatus>> getStatuses(
-    RepositorySlug slug,
-    String ref,
-  ) async {
-    return await github.repositories.listStatuses(slug, ref).toList();
   }
 
   /// Fetches the specified commit.

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -86,7 +86,7 @@ void main() {
       }
 
       githubService.checkRunsData = checkRunsMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -111,7 +111,7 @@ void main() {
       pubsub.publish(testTopic, pullRequest);
 
       githubService.checkRunsData = checkRunsMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -140,7 +140,7 @@ void main() {
       pubsub.publish(testTopic, pullRequest);
 
       githubService.checkRunsData = checkRunsMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -167,7 +167,7 @@ void main() {
       pubsub.publish(testTopic, pullRequest);
       githubService.checkRunsData = inProgressCheckRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareToTCommitsMock;
+      githubService.compareTwoCommitsData = compareToTCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -195,7 +195,7 @@ void main() {
       pubsub.publish(testTopic, pullRequest);
 
       githubService.checkRunsData = checkRunsMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -224,7 +224,7 @@ void main() {
       }
       githubService.checkRunsData = failedCheckRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -249,7 +249,7 @@ void main() {
 
       githubService.checkRunsData = checkRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -275,7 +275,7 @@ void main() {
 
       githubService.checkRunsData = checkRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -302,7 +302,7 @@ void main() {
 
       githubService.checkRunsData = emptyCheckRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -330,7 +330,7 @@ void main() {
 
       githubService.checkRunsData = inProgressCheckRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -360,7 +360,7 @@ void main() {
       }
       githubService.checkRunsData = checkRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
@@ -388,7 +388,7 @@ void main() {
 
       githubService.checkRunsData = checkRunsMock;
       githubService.commitData = commitMock;
-      githubService.compareTowCommitsData = compareTowCommitsMock;
+      githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -86,6 +86,7 @@ void main() {
       }
 
       githubService.checkRunsData = checkRunsMock;
+      githubService.compareTowCommitsData = compareTowCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: constant_identifier_names
+
 import 'package:auto_submit/requests/check_pull_request.dart';
 import 'package:auto_submit/requests/check_pull_request_queries.dart';
 import 'package:github/github.dart';

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -277,8 +277,8 @@ final String commitMock = '''{
   }
 }''';
 
-// compareTowCOmmitsMock is from the official Github API: https://docs.github.com/en/rest/reference/commits#compare-two-commits
-final String compareTowCommitsMock = '''{
+// compareTwoCommitsMock is from the official Github API: https://docs.github.com/en/rest/reference/commits#compare-two-commits
+final String compareTwoCommitsMock = '''{
   "url": "https://api.github.com/repos/octocat/Hello-World/compare/master...topic",
   "status": "behind",
   "ahead_by": 1,

--- a/auto_submit/test/service/github_service_test.dart
+++ b/auto_submit/test/service/github_service_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:auto_submit/service/github_service.dart';
 import 'package:github/github.dart';
-import 'package:googleapis/runtimeconfig/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 

--- a/auto_submit/test/src/service/fake_config.dart
+++ b/auto_submit/test/src/service/fake_config.dart
@@ -9,6 +9,7 @@ import 'package:auto_submit/service/github_service.dart';
 import 'package:auto_submit/service/secrets.dart';
 import 'package:github/github.dart';
 import 'package:neat_cache/neat_cache.dart';
+import 'package:graphql/client.dart';
 
 import 'fake_github_service.dart';
 
@@ -16,6 +17,7 @@ import 'fake_github_service.dart';
 class FakeConfig extends Config {
   FakeConfig({
     this.githubClient,
+    this.githubGraphQLClient,
     this.githubService,
     this.rollerAccountsValue,
     this.overrideTreeStatusLabelValue,
@@ -26,6 +28,7 @@ class FakeConfig extends Config {
         );
 
   GitHub? githubClient;
+  GraphQLClient? githubGraphQLClient;
   GithubService? githubService = FakeGithubService();
   Set<String>? rollerAccountsValue;
   String? overrideTreeStatusLabelValue;
@@ -37,6 +40,8 @@ class FakeConfig extends Config {
   @override
   Future<GithubService> createGithubService() async => githubService ?? FakeGithubService();
 
+  @override
+  Future<GraphQLClient> createGitHubGraphQLClient() async => githubGraphQLClient!;
   @override
   Set<String> get rollerAccounts =>
       rollerAccountsValue ??

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -13,9 +13,7 @@ import '../../utilities/mocks.dart';
 class FakeGithubService implements GithubService {
   FakeGithubService({
     GitHub? client,
-    String? reviewsMock,
     String? checkRunsMock,
-    String? repositoryStatusesMock,
     String? commitMock,
     String? compareTowCommitsMock,
     String? successMergeMock,
@@ -25,24 +23,14 @@ class FakeGithubService implements GithubService {
   @override
   final GitHub github;
 
-  String? reviewsMock;
   String? checkRunsMock;
-  String? repositoryStatusesMock;
   String? commitMock;
   String? compareTowCommitsMock;
   String? successMergeMock;
   String? createCommentMock;
 
-  set reviewsData(String? reviewsMock) {
-    this.reviewsMock = reviewsMock;
-  }
-
   set checkRunsData(String? checkRunsMock) {
     this.checkRunsMock = checkRunsMock;
-  }
-
-  set repositoryStatusesData(String? repositoryStatusesMock) {
-    this.repositoryStatusesMock = repositoryStatusesMock;
   }
 
   set commitData(String? commitMock) {
@@ -62,14 +50,6 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<List<PullRequestReview>> getReviews(RepositorySlug slug, int prNumber) async {
-    final List<dynamic> reviews = json.decode(reviewsMock!) as List;
-    final List<PullRequestReview> prReviews =
-        reviews.map((dynamic review) => PullRequestReview.fromJson(review)).toList();
-    return prReviews;
-  }
-
-  @override
   Future<List<CheckRun>> getCheckRuns(
     RepositorySlug slug,
     String ref,
@@ -81,20 +61,6 @@ class FakeGithubService implements GithubService {
       checkRuns.addAll(checkRunsBody.map((dynamic checkRun) => CheckRun.fromJson(checkRun)).toList());
     }
     return checkRuns;
-  }
-
-  @override
-  Future<List<RepositoryStatus>> getStatuses(
-    RepositorySlug slug,
-    String ref,
-  ) async {
-    final rawBody = json.decode(repositoryStatusesMock!) as Map<String, dynamic>;
-    final List<dynamic> statusesBody = rawBody["statuses"]!;
-    List<RepositoryStatus> statuses = <RepositoryStatus>[];
-    if (statusesBody[0].isNotEmpty) {
-      statuses.addAll(statusesBody.map((dynamic state) => RepositoryStatus.fromJson(state)).toList());
-    }
-    return statuses;
   }
 
   @override

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -15,7 +15,7 @@ class FakeGithubService implements GithubService {
     GitHub? client,
     String? checkRunsMock,
     String? commitMock,
-    String? compareTowCommitsMock,
+    String? compareTwoCommitsMock,
     String? successMergeMock,
     String? createCommentMock,
   }) : github = client ?? MockGitHub();
@@ -25,7 +25,7 @@ class FakeGithubService implements GithubService {
 
   String? checkRunsMock;
   String? commitMock;
-  String? compareTowCommitsMock;
+  String? compareTwoCommitsMock;
   String? successMergeMock;
   String? createCommentMock;
 
@@ -37,8 +37,8 @@ class FakeGithubService implements GithubService {
     this.commitMock = commitMock;
   }
 
-  set compareTowCommitsData(String? compareTowCommitsMock) {
-    this.compareTowCommitsMock = compareTowCommitsMock;
+  set compareTwoCommitsData(String? compareTwoCommitsMock) {
+    this.compareTwoCommitsMock = compareTwoCommitsMock;
   }
 
   set successMergeData(String? successMergeMock) {
@@ -71,7 +71,7 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<GitHubComparison> compareTwoCommits(RepositorySlug slug, String refBase, String refHead) async {
-    final GitHubComparison githubComparison = GitHubComparison.fromJson(jsonDecode(compareTowCommitsMock!));
+    final GitHubComparison githubComparison = GitHubComparison.fromJson(jsonDecode(compareTwoCommitsMock!));
     return githubComparison;
   }
 

--- a/auto_submit/test/src/service/fake_graphql_client.dart
+++ b/auto_submit/test/src/service/fake_graphql_client.dart
@@ -1,0 +1,100 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:graphql/client.dart';
+import 'package:test/test.dart';
+
+class FakeGraphQLClient implements GraphQLClient {
+  late QueryResult Function(MutationOptions) mutateResultForOptions;
+  late QueryResult Function(QueryOptions) queryResultForOptions;
+
+  @override
+  late QueryManager queryManager;
+
+  @override
+  Link get link => throw UnimplementedError();
+
+  final List<QueryOptions> queries = <QueryOptions>[];
+  final List<MutationOptions> mutations = <MutationOptions>[];
+
+  @override
+  Future<QueryResult> mutate(MutationOptions options) async {
+    mutations.add(options);
+    return mutateResultForOptions(options);
+  }
+
+  @override
+  Future<QueryResult> query(QueryOptions options) async {
+    queries.add(options);
+    return queryResultForOptions(options);
+  }
+
+  @override
+  ObservableQuery watchQuery(WatchQueryOptions options) {
+    throw UnimplementedError();
+  }
+
+  void verifyQueries(List<QueryOptions> expected) {
+    expect(queries.length, expected.length);
+    for (int i = 0; i < queries.length; i++) {
+      expect(
+        queries[i].properties,
+        equals(expected[i].properties),
+      );
+    }
+  }
+
+  void verifyMutations(List<MutationOptions> expected) {
+    expect(mutations.length, expected.length);
+    for (int i = 0; i < mutations.length; i++) {
+      expect(
+        mutations[i].properties,
+        equals(expected[i].properties),
+      );
+    }
+  }
+
+  @override
+  late DefaultPolicies defaultPolicies;
+
+  @override
+  Future<QueryResult> fetchMore(FetchMoreOptions fetchMoreOptions,
+      {QueryOptions? originalOptions, QueryResult? previousResult}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Map<String, dynamic> readFragment(FragmentRequest fragmentRequest, {bool? optimistic = true}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Map<String, dynamic> readQuery(Request request, {bool? optimistic = true}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<QueryResult>> resetStore({bool refetchQueries = true}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  ObservableQuery watchMutation(WatchQueryOptions options) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void writeFragment(FragmentRequest fragmentRequest, {bool? broadcast = true, Map<String, dynamic>? data}) {}
+
+  @override
+  void writeQuery(Request request, {Map<String, dynamic>? data, bool? broadcast = true}) {}
+
+  @override
+  GraphQLCache get cache => throw UnimplementedError();
+
+  @override
+  Stream<QueryResult> subscribe(SubscriptionOptions options) {
+    throw UnimplementedError();
+  }
+}

--- a/auto_submit/test/utilities/mocks.dart
+++ b/auto_submit/test/utilities/mocks.dart
@@ -7,5 +7,5 @@ import 'package:mockito/annotations.dart';
 
 export 'mocks.mocks.dart';
 
-@GenerateMocks(<Type>[GitHub, PullRequestsService])
+@GenerateMocks(<Type>[GitHub, RepositoriesService])
 void main() {}

--- a/auto_submit/test/utilities/mocks.mocks.dart
+++ b/auto_submit/test/utilities/mocks.mocks.dart
@@ -50,13 +50,45 @@ class _FakeResponse_14 extends _i1.Fake implements _i2.Response {}
 
 class _FakeGitHub_15 extends _i1.Fake implements _i3.GitHub {}
 
-class _FakePullRequest_16 extends _i1.Fake implements _i3.PullRequest {}
+class _FakeRepository_16 extends _i1.Fake implements _i3.Repository {}
 
-class _FakePullRequestMerge_17 extends _i1.Fake implements _i3.PullRequestMerge {}
+class _FakeLicenseDetails_17 extends _i1.Fake implements _i3.LicenseDetails {}
 
-class _FakeIssueComment_18 extends _i1.Fake implements _i3.IssueComment {}
+class _FakeLanguageBreakdown_18 extends _i1.Fake implements _i3.LanguageBreakdown {}
 
-class _FakePullRequestReview_19 extends _i1.Fake implements _i3.PullRequestReview {}
+class _FakeBranch_19 extends _i1.Fake implements _i3.Branch {}
+
+class _FakeCommitComment_20 extends _i1.Fake implements _i3.CommitComment {}
+
+class _FakeRepositoryCommit_21 extends _i1.Fake implements _i3.RepositoryCommit {}
+
+class _FakeGitHubComparison_22 extends _i1.Fake implements _i3.GitHubComparison {}
+
+class _FakeGitHubFile_23 extends _i1.Fake implements _i3.GitHubFile {}
+
+class _FakeRepositoryContents_24 extends _i1.Fake implements _i3.RepositoryContents {}
+
+class _FakeContentCreation_25 extends _i1.Fake implements _i3.ContentCreation {}
+
+class _FakeHook_26 extends _i1.Fake implements _i3.Hook {}
+
+class _FakePublicKey_27 extends _i1.Fake implements _i3.PublicKey {}
+
+class _FakeRepositoryPages_28 extends _i1.Fake implements _i3.RepositoryPages {}
+
+class _FakePageBuild_29 extends _i1.Fake implements _i3.PageBuild {}
+
+class _FakeRelease_30 extends _i1.Fake implements _i3.Release {}
+
+class _FakeReleaseAsset_31 extends _i1.Fake implements _i3.ReleaseAsset {}
+
+class _FakeContributorParticipation_32 extends _i1.Fake implements _i3.ContributorParticipation {}
+
+class _FakeRepositoryStatus_33 extends _i1.Fake implements _i3.RepositoryStatus {}
+
+class _FakeCombinedRepositoryStatus_34 extends _i1.Fake implements _i3.CombinedRepositoryStatus {}
+
+class _FakeReleaseNotes_35 extends _i1.Fake implements _i3.ReleaseNotes {}
 
 /// A class which mocks [GitHub].
 ///
@@ -254,11 +286,11 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
 }
 
-/// A class which mocks [PullRequestsService].
+/// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock implements _i3.PullRequestsService {
-  MockPullRequestsService() {
+class MockRepositoriesService extends _i1.Mock implements _i3.RepositoriesService {
+  MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
 
@@ -266,68 +298,371 @@ class MockPullRequestsService extends _i1.Mock implements _i3.PullRequestsServic
   _i3.GitHub get github =>
       (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_15()) as _i3.GitHub);
   @override
-  _i4.Stream<_i3.PullRequest> list(_i3.RepositorySlug? slug,
-          {int? pages,
-          String? base,
-          String? direction = r'desc',
-          String? head,
-          String? sort = r'created',
-          String? state = r'open'}) =>
+  _i4.Stream<_i3.Repository> listRepositories(
+          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
+      (super.noSuchMethod(Invocation.method(#listRepositories, [], {#type: type, #sort: sort, #direction: direction}),
+          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
+  @override
+  _i4.Stream<_i3.Repository> listUserRepositories(String? user,
+          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
       (super.noSuchMethod(
-          Invocation.method(#list, [slug],
-              {#pages: pages, #base: base, #direction: direction, #head: head, #sort: sort, #state: state}),
-          returnValue: Stream<_i3.PullRequest>.empty()) as _i4.Stream<_i3.PullRequest>);
+          Invocation.method(#listUserRepositories, [user], {#type: type, #sort: sort, #direction: direction}),
+          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
   @override
-  _i4.Future<_i3.PullRequest> get(_i3.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#get, [slug, number]),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+  _i4.Stream<_i3.Repository> listOrganizationRepositories(String? org, {String? type = r'all'}) =>
+      (super.noSuchMethod(Invocation.method(#listOrganizationRepositories, [org], {#type: type}),
+          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
   @override
-  _i4.Future<_i3.PullRequest> create(_i3.RepositorySlug? slug, _i3.CreatePullRequest? request) =>
-      (super.noSuchMethod(Invocation.method(#create, [slug, request]),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+  _i4.Stream<_i3.Repository> listPublicRepositories({int? limit = 50, DateTime? since}) =>
+      (super.noSuchMethod(Invocation.method(#listPublicRepositories, [], {#limit: limit, #since: since}),
+          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
   @override
-  _i4.Future<_i3.PullRequest> edit(_i3.RepositorySlug? slug, int? number,
-          {String? title, String? body, String? state, String? base}) =>
+  _i4.Future<_i3.Repository> createRepository(_i3.CreateRepository? repository, {String? org}) =>
+      (super.noSuchMethod(Invocation.method(#createRepository, [repository], {#org: org}),
+          returnValue: Future<_i3.Repository>.value(_FakeRepository_16())) as _i4.Future<_i3.Repository>);
+  @override
+  _i4.Future<_i3.LicenseDetails> getLicense(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getLicense, [slug]),
+          returnValue: Future<_i3.LicenseDetails>.value(_FakeLicenseDetails_17())) as _i4.Future<_i3.LicenseDetails>);
+  @override
+  _i4.Future<_i3.Repository> getRepository(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getRepository, [slug]),
+          returnValue: Future<_i3.Repository>.value(_FakeRepository_16())) as _i4.Future<_i3.Repository>);
+  @override
+  _i4.Stream<_i3.Repository> getRepositories(List<_i3.RepositorySlug>? slugs) =>
+      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]), returnValue: Stream<_i3.Repository>.empty())
+          as _i4.Stream<_i3.Repository>);
+  @override
+  _i4.Future<_i3.Repository> editRepository(_i3.RepositorySlug? slug,
+          {String? name,
+          String? description,
+          String? homepage,
+          bool? private,
+          bool? hasIssues,
+          bool? hasWiki,
+          bool? hasDownloads}) =>
       (super.noSuchMethod(
-          Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+          Invocation.method(#editRepository, [
+            slug
+          ], {
+            #name: name,
+            #description: description,
+            #homepage: homepage,
+            #private: private,
+            #hasIssues: hasIssues,
+            #hasWiki: hasWiki,
+            #hasDownloads: hasDownloads
+          }),
+          returnValue: Future<_i3.Repository>.value(_FakeRepository_16())) as _i4.Future<_i3.Repository>);
   @override
-  _i4.Stream<_i3.RepositoryCommit> listCommits(_i3.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#listCommits, [slug, number]),
-          returnValue: Stream<_i3.RepositoryCommit>.empty()) as _i4.Stream<_i3.RepositoryCommit>);
-  @override
-  _i4.Stream<_i3.PullRequestFile> listFiles(_i3.RepositorySlug? slug, int? number) => (super
-          .noSuchMethod(Invocation.method(#listFiles, [slug, number]), returnValue: Stream<_i3.PullRequestFile>.empty())
-      as _i4.Stream<_i3.PullRequestFile>);
-  @override
-  _i4.Stream<_i3.PullRequestReview> listReviews(_i3.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#listReviews, [slug, number]),
-          returnValue: Stream<_i3.PullRequestReview>.empty()) as _i4.Stream<_i3.PullRequestReview>);
-  @override
-  _i4.Future<bool> isMerged(_i3.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]), returnValue: Future<bool>.value(false))
+  _i4.Future<bool> deleteRepository(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]), returnValue: Future<bool>.value(false))
           as _i4.Future<bool>);
   @override
-  _i4.Future<_i3.PullRequestMerge> merge(_i3.RepositorySlug? slug, int? number, {String? message}) =>
-      (super.noSuchMethod(Invocation.method(#merge, [slug, number], {#message: message}),
-              returnValue: Future<_i3.PullRequestMerge>.value(_FakePullRequestMerge_17()))
-          as _i4.Future<_i3.PullRequestMerge>);
+  _i4.Stream<_i3.Contributor> listContributors(_i3.RepositorySlug? slug, {bool? anon = false}) =>
+      (super.noSuchMethod(Invocation.method(#listContributors, [slug], {#anon: anon}),
+          returnValue: Stream<_i3.Contributor>.empty()) as _i4.Stream<_i3.Contributor>);
   @override
-  _i4.Stream<_i3.PullRequestComment> listCommentsByPullRequest(_i3.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#listCommentsByPullRequest, [slug, number]),
-          returnValue: Stream<_i3.PullRequestComment>.empty()) as _i4.Stream<_i3.PullRequestComment>);
+  _i4.Stream<_i3.Team> listTeams(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listTeams, [slug]), returnValue: Stream<_i3.Team>.empty())
+          as _i4.Stream<_i3.Team>);
   @override
-  _i4.Stream<_i3.PullRequestComment> listComments(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listComments, [slug]), returnValue: Stream<_i3.PullRequestComment>.empty())
-          as _i4.Stream<_i3.PullRequestComment>);
+  _i4.Future<_i3.LanguageBreakdown> listLanguages(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listLanguages, [slug]),
+              returnValue: Future<_i3.LanguageBreakdown>.value(_FakeLanguageBreakdown_18()))
+          as _i4.Future<_i3.LanguageBreakdown>);
   @override
-  _i4.Future<_i3.IssueComment> createComment(
-          _i3.RepositorySlug? slug, int? number, _i3.CreatePullRequestComment? comment) =>
-      (super.noSuchMethod(Invocation.method(#createComment, [slug, number, comment]),
-          returnValue: Future<_i3.IssueComment>.value(_FakeIssueComment_18())) as _i4.Future<_i3.IssueComment>);
+  _i4.Stream<_i3.Tag> listTags(_i3.RepositorySlug? slug, {int? page = 1, int? pages, int? perPage = 30}) =>
+      (super.noSuchMethod(Invocation.method(#listTags, [slug], {#page: page, #pages: pages, #perPage: perPage}),
+          returnValue: Stream<_i3.Tag>.empty()) as _i4.Stream<_i3.Tag>);
   @override
-  _i4.Future<_i3.PullRequestReview> createReview(_i3.RepositorySlug? slug, _i3.CreatePullRequestReview? review) =>
-      (super.noSuchMethod(Invocation.method(#createReview, [slug, review]),
-              returnValue: Future<_i3.PullRequestReview>.value(_FakePullRequestReview_19()))
-          as _i4.Future<_i3.PullRequestReview>);
+  _i4.Stream<_i3.Branch> listBranches(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listBranches, [slug]), returnValue: Stream<_i3.Branch>.empty())
+          as _i4.Stream<_i3.Branch>);
+  @override
+  _i4.Future<_i3.Branch> getBranch(_i3.RepositorySlug? slug, String? branch) =>
+      (super.noSuchMethod(Invocation.method(#getBranch, [slug, branch]),
+          returnValue: Future<_i3.Branch>.value(_FakeBranch_19())) as _i4.Future<_i3.Branch>);
+  @override
+  _i4.Stream<_i3.Collaborator> listCollaborators(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCollaborators, [slug]), returnValue: Stream<_i3.Collaborator>.empty())
+          as _i4.Stream<_i3.Collaborator>);
+  @override
+  _i4.Future<bool> isCollaborator(_i3.RepositorySlug? slug, String? user) =>
+      (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Future<bool> addCollaborator(_i3.RepositorySlug? slug, String? user) =>
+      (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Future<bool> removeCollaborator(_i3.RepositorySlug? slug, String? user) =>
+      (super.noSuchMethod(Invocation.method(#removeCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Stream<_i3.CommitComment> listSingleCommitComments(_i3.RepositorySlug? slug, _i3.RepositoryCommit? commit) =>
+      (super.noSuchMethod(Invocation.method(#listSingleCommitComments, [slug, commit]),
+          returnValue: Stream<_i3.CommitComment>.empty()) as _i4.Stream<_i3.CommitComment>);
+  @override
+  _i4.Stream<_i3.CommitComment> listCommitComments(_i3.RepositorySlug? slug) => (super
+          .noSuchMethod(Invocation.method(#listCommitComments, [slug]), returnValue: Stream<_i3.CommitComment>.empty())
+      as _i4.Stream<_i3.CommitComment>);
+  @override
+  _i4.Future<_i3.CommitComment> createCommitComment(_i3.RepositorySlug? slug, _i3.RepositoryCommit? commit,
+          {String? body, String? path, int? position, int? line}) =>
+      (super.noSuchMethod(
+          Invocation.method(
+              #createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}),
+          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_20())) as _i4.Future<_i3.CommitComment>);
+  @override
+  _i4.Future<_i3.CommitComment> getCommitComment(_i3.RepositorySlug? slug, {int? id}) =>
+      (super.noSuchMethod(Invocation.method(#getCommitComment, [slug], {#id: id}),
+          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_20())) as _i4.Future<_i3.CommitComment>);
+  @override
+  _i4.Future<_i3.CommitComment> updateCommitComment(_i3.RepositorySlug? slug, {int? id, String? body}) =>
+      (super.noSuchMethod(Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}),
+          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_20())) as _i4.Future<_i3.CommitComment>);
+  @override
+  _i4.Future<bool> deleteCommitComment(_i3.RepositorySlug? slug, {int? id}) =>
+      (super.noSuchMethod(Invocation.method(#deleteCommitComment, [slug], {#id: id}),
+          returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
+  @override
+  _i4.Stream<_i3.RepositoryCommit> listCommits(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCommits, [slug]), returnValue: Stream<_i3.RepositoryCommit>.empty())
+          as _i4.Stream<_i3.RepositoryCommit>);
+  @override
+  _i4.Future<_i3.RepositoryCommit> getCommit(_i3.RepositorySlug? slug, String? sha) => (super.noSuchMethod(
+      Invocation.method(#getCommit, [slug, sha]),
+      returnValue: Future<_i3.RepositoryCommit>.value(_FakeRepositoryCommit_21())) as _i4.Future<_i3.RepositoryCommit>);
+  @override
+  _i4.Future<String> getCommitDiff(_i3.RepositorySlug? slug, String? sha) =>
+      (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]), returnValue: Future<String>.value(''))
+          as _i4.Future<String>);
+  @override
+  _i4.Future<_i3.GitHubComparison> compareCommits(_i3.RepositorySlug? slug, String? refBase, String? refHead) =>
+      (super.noSuchMethod(Invocation.method(#compareCommits, [slug, refBase, refHead]),
+              returnValue: Future<_i3.GitHubComparison>.value(_FakeGitHubComparison_22()))
+          as _i4.Future<_i3.GitHubComparison>);
+  @override
+  _i4.Future<_i3.GitHubFile> getReadme(_i3.RepositorySlug? slug, {String? ref}) =>
+      (super.noSuchMethod(Invocation.method(#getReadme, [slug], {#ref: ref}),
+          returnValue: Future<_i3.GitHubFile>.value(_FakeGitHubFile_23())) as _i4.Future<_i3.GitHubFile>);
+  @override
+  _i4.Future<_i3.RepositoryContents> getContents(_i3.RepositorySlug? slug, String? path, {String? ref}) =>
+      (super.noSuchMethod(Invocation.method(#getContents, [slug, path], {#ref: ref}),
+              returnValue: Future<_i3.RepositoryContents>.value(_FakeRepositoryContents_24()))
+          as _i4.Future<_i3.RepositoryContents>);
+  @override
+  _i4.Future<_i3.ContentCreation> createFile(_i3.RepositorySlug? slug, _i3.CreateFile? file) => (super.noSuchMethod(
+      Invocation.method(#createFile, [slug, file]),
+      returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_25())) as _i4.Future<_i3.ContentCreation>);
+  @override
+  _i4.Future<_i3.ContentCreation> updateFile(
+          _i3.RepositorySlug? slug, String? path, String? message, String? content, String? sha, {String? branch}) =>
+      (super.noSuchMethod(Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}),
+              returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_25()))
+          as _i4.Future<_i3.ContentCreation>);
+  @override
+  _i4.Future<_i3.ContentCreation> deleteFile(
+          _i3.RepositorySlug? slug, String? path, String? message, String? sha, String? branch) =>
+      (super.noSuchMethod(Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
+              returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_25()))
+          as _i4.Future<_i3.ContentCreation>);
+  @override
+  _i4.Future<String?> getArchiveLink(_i3.RepositorySlug? slug, String? ref, {String? format = r'tarball'}) =>
+      (super.noSuchMethod(Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
+          returnValue: Future<String?>.value()) as _i4.Future<String?>);
+  @override
+  _i4.Stream<_i3.Repository> listForks(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listForks, [slug]), returnValue: Stream<_i3.Repository>.empty())
+          as _i4.Stream<_i3.Repository>);
+  @override
+  _i4.Future<_i3.Repository> createFork(_i3.RepositorySlug? slug, [_i3.CreateFork? fork]) =>
+      (super.noSuchMethod(Invocation.method(#createFork, [slug, fork]),
+          returnValue: Future<_i3.Repository>.value(_FakeRepository_16())) as _i4.Future<_i3.Repository>);
+  @override
+  _i4.Stream<_i3.Hook> listHooks(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listHooks, [slug]), returnValue: Stream<_i3.Hook>.empty())
+          as _i4.Stream<_i3.Hook>);
+  @override
+  _i4.Future<_i3.Hook> getHook(_i3.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#getHook, [slug, id]), returnValue: Future<_i3.Hook>.value(_FakeHook_26()))
+          as _i4.Future<_i3.Hook>);
+  @override
+  _i4.Future<_i3.Hook> createHook(_i3.RepositorySlug? slug, _i3.CreateHook? hook) =>
+      (super.noSuchMethod(Invocation.method(#createHook, [slug, hook]),
+          returnValue: Future<_i3.Hook>.value(_FakeHook_26())) as _i4.Future<_i3.Hook>);
+  @override
+  _i4.Future<_i3.Hook> editHook(_i3.RepositorySlug? slug, _i3.Hook? hookToEdit,
+          {String? configUrl,
+          String? configContentType,
+          String? configSecret,
+          bool? configInsecureSsl,
+          List<String>? events,
+          List<String>? addEvents,
+          List<String>? removeEvents,
+          bool? active}) =>
+      (super.noSuchMethod(
+          Invocation.method(#editHook, [
+            slug,
+            hookToEdit
+          ], {
+            #configUrl: configUrl,
+            #configContentType: configContentType,
+            #configSecret: configSecret,
+            #configInsecureSsl: configInsecureSsl,
+            #events: events,
+            #addEvents: addEvents,
+            #removeEvents: removeEvents,
+            #active: active
+          }),
+          returnValue: Future<_i3.Hook>.value(_FakeHook_26())) as _i4.Future<_i3.Hook>);
+  @override
+  _i4.Future<bool> testPushHook(_i3.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Future<bool> pingHook(_i3.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Future<bool> deleteHook(_i3.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Stream<_i3.PublicKey> listDeployKeys(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]), returnValue: Stream<_i3.PublicKey>.empty())
+          as _i4.Stream<_i3.PublicKey>);
+  @override
+  _i4.Future<_i3.PublicKey> getDeployKey(_i3.RepositorySlug? slug, {int? id}) =>
+      (super.noSuchMethod(Invocation.method(#getDeployKey, [slug], {#id: id}),
+          returnValue: Future<_i3.PublicKey>.value(_FakePublicKey_27())) as _i4.Future<_i3.PublicKey>);
+  @override
+  _i4.Future<_i3.PublicKey> createDeployKey(_i3.RepositorySlug? slug, _i3.CreatePublicKey? key) =>
+      (super.noSuchMethod(Invocation.method(#createDeployKey, [slug, key]),
+          returnValue: Future<_i3.PublicKey>.value(_FakePublicKey_27())) as _i4.Future<_i3.PublicKey>);
+  @override
+  _i4.Future<bool> deleteDeployKey({_i3.RepositorySlug? slug, _i3.PublicKey? key}) =>
+      (super.noSuchMethod(Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
+          returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
+  @override
+  _i4.Future<_i3.RepositoryCommit> merge(_i3.RepositorySlug? slug, _i3.CreateMerge? merge) => (super.noSuchMethod(
+      Invocation.method(#merge, [slug, merge]),
+      returnValue: Future<_i3.RepositoryCommit>.value(_FakeRepositoryCommit_21())) as _i4.Future<_i3.RepositoryCommit>);
+  @override
+  _i4.Future<_i3.RepositoryPages> getPagesInfo(_i3.RepositorySlug? slug) => (super.noSuchMethod(
+      Invocation.method(#getPagesInfo, [slug]),
+      returnValue: Future<_i3.RepositoryPages>.value(_FakeRepositoryPages_28())) as _i4.Future<_i3.RepositoryPages>);
+  @override
+  _i4.Stream<_i3.PageBuild> listPagesBuilds(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]), returnValue: Stream<_i3.PageBuild>.empty())
+          as _i4.Stream<_i3.PageBuild>);
+  @override
+  _i4.Future<_i3.PageBuild> getLatestPagesBuild(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getLatestPagesBuild, [slug]),
+          returnValue: Future<_i3.PageBuild>.value(_FakePageBuild_29())) as _i4.Future<_i3.PageBuild>);
+  @override
+  _i4.Stream<_i3.Release> listReleases(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listReleases, [slug]), returnValue: Stream<_i3.Release>.empty())
+          as _i4.Stream<_i3.Release>);
+  @override
+  _i4.Future<_i3.Release> getLatestRelease(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getLatestRelease, [slug]),
+          returnValue: Future<_i3.Release>.value(_FakeRelease_30())) as _i4.Future<_i3.Release>);
+  @override
+  _i4.Future<_i3.Release> getReleaseById(_i3.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#getReleaseById, [slug, id]),
+          returnValue: Future<_i3.Release>.value(_FakeRelease_30())) as _i4.Future<_i3.Release>);
+  @override
+  _i4.Future<_i3.Release> getReleaseByTagName(_i3.RepositorySlug? slug, String? tagName) =>
+      (super.noSuchMethod(Invocation.method(#getReleaseByTagName, [slug, tagName]),
+          returnValue: Future<_i3.Release>.value(_FakeRelease_30())) as _i4.Future<_i3.Release>);
+  @override
+  _i4.Future<_i3.Release> createRelease(_i3.RepositorySlug? slug, _i3.CreateRelease? createRelease,
+          {bool? getIfExists = true}) =>
+      (super.noSuchMethod(Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}),
+          returnValue: Future<_i3.Release>.value(_FakeRelease_30())) as _i4.Future<_i3.Release>);
+  @override
+  _i4.Future<_i3.Release> editRelease(_i3.RepositorySlug? slug, _i3.Release? releaseToEdit,
+          {String? tagName, String? targetCommitish, String? name, String? body, bool? draft, bool? preRelease}) =>
+      (super.noSuchMethod(
+          Invocation.method(#editRelease, [
+            slug,
+            releaseToEdit
+          ], {
+            #tagName: tagName,
+            #targetCommitish: targetCommitish,
+            #name: name,
+            #body: body,
+            #draft: draft,
+            #preRelease: preRelease
+          }),
+          returnValue: Future<_i3.Release>.value(_FakeRelease_30())) as _i4.Future<_i3.Release>);
+  @override
+  _i4.Future<bool> deleteRelease(_i3.RepositorySlug? slug, _i3.Release? release) =>
+      (super.noSuchMethod(Invocation.method(#deleteRelease, [slug, release]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Stream<_i3.ReleaseAsset> listReleaseAssets(_i3.RepositorySlug? slug, _i3.Release? release) =>
+      (super.noSuchMethod(Invocation.method(#listReleaseAssets, [slug, release]),
+          returnValue: Stream<_i3.ReleaseAsset>.empty()) as _i4.Stream<_i3.ReleaseAsset>);
+  @override
+  _i4.Future<_i3.ReleaseAsset> getReleaseAsset(_i3.RepositorySlug? slug, _i3.Release? release, {int? assetId}) =>
+      (super.noSuchMethod(Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}),
+          returnValue: Future<_i3.ReleaseAsset>.value(_FakeReleaseAsset_31())) as _i4.Future<_i3.ReleaseAsset>);
+  @override
+  _i4.Future<_i3.ReleaseAsset> editReleaseAsset(_i3.RepositorySlug? slug, _i3.ReleaseAsset? assetToEdit,
+          {String? name, String? label}) =>
+      (super.noSuchMethod(Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}),
+          returnValue: Future<_i3.ReleaseAsset>.value(_FakeReleaseAsset_31())) as _i4.Future<_i3.ReleaseAsset>);
+  @override
+  _i4.Future<bool> deleteReleaseAsset(_i3.RepositorySlug? slug, _i3.ReleaseAsset? asset) =>
+      (super.noSuchMethod(Invocation.method(#deleteReleaseAsset, [slug, asset]), returnValue: Future<bool>.value(false))
+          as _i4.Future<bool>);
+  @override
+  _i4.Future<List<_i3.ReleaseAsset>> uploadReleaseAssets(
+          _i3.Release? release, Iterable<_i3.CreateReleaseAsset>? createReleaseAssets) =>
+      (super.noSuchMethod(Invocation.method(#uploadReleaseAssets, [release, createReleaseAssets]),
+              returnValue: Future<List<_i3.ReleaseAsset>>.value(<_i3.ReleaseAsset>[]))
+          as _i4.Future<List<_i3.ReleaseAsset>>);
+  @override
+  _i4.Future<List<_i3.ContributorStatistics>> listContributorStats(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listContributorStats, [slug]),
+              returnValue: Future<List<_i3.ContributorStatistics>>.value(<_i3.ContributorStatistics>[]))
+          as _i4.Future<List<_i3.ContributorStatistics>>);
+  @override
+  _i4.Stream<_i3.YearCommitCountWeek> listCommitActivity(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCommitActivity, [slug]),
+          returnValue: Stream<_i3.YearCommitCountWeek>.empty()) as _i4.Stream<_i3.YearCommitCountWeek>);
+  @override
+  _i4.Stream<_i3.WeeklyChangesCount> listCodeFrequency(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCodeFrequency, [slug]),
+          returnValue: Stream<_i3.WeeklyChangesCount>.empty()) as _i4.Stream<_i3.WeeklyChangesCount>);
+  @override
+  _i4.Future<_i3.ContributorParticipation> getParticipation(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getParticipation, [slug]),
+              returnValue: Future<_i3.ContributorParticipation>.value(_FakeContributorParticipation_32()))
+          as _i4.Future<_i3.ContributorParticipation>);
+  @override
+  _i4.Stream<_i3.PunchcardEntry> listPunchcard(_i3.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listPunchcard, [slug]), returnValue: Stream<_i3.PunchcardEntry>.empty())
+          as _i4.Stream<_i3.PunchcardEntry>);
+  @override
+  _i4.Stream<_i3.RepositoryStatus> listStatuses(_i3.RepositorySlug? slug, String? ref) =>
+      (super.noSuchMethod(Invocation.method(#listStatuses, [slug, ref]),
+          returnValue: Stream<_i3.RepositoryStatus>.empty()) as _i4.Stream<_i3.RepositoryStatus>);
+  @override
+  _i4.Future<_i3.RepositoryStatus> createStatus(_i3.RepositorySlug? slug, String? ref, _i3.CreateStatus? request) =>
+      (super.noSuchMethod(Invocation.method(#createStatus, [slug, ref, request]),
+              returnValue: Future<_i3.RepositoryStatus>.value(_FakeRepositoryStatus_33()))
+          as _i4.Future<_i3.RepositoryStatus>);
+  @override
+  _i4.Future<_i3.CombinedRepositoryStatus> getCombinedStatus(_i3.RepositorySlug? slug, String? ref) =>
+      (super.noSuchMethod(Invocation.method(#getCombinedStatus, [slug, ref]),
+              returnValue: Future<_i3.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_34()))
+          as _i4.Future<_i3.CombinedRepositoryStatus>);
+  @override
+  _i4.Future<_i3.ReleaseNotes> generateReleaseNotes(_i3.CreateReleaseNotes? crn) =>
+      (super.noSuchMethod(Invocation.method(#generateReleaseNotes, [crn]),
+          returnValue: Future<_i3.ReleaseNotes>.value(_FakeReleaseNotes_35())) as _i4.Future<_i3.ReleaseNotes>);
 }


### PR DESCRIPTION
To solve the issue https://github.com/flutter/flutter/issues/101012 to get the real author association, this PR changed the rest api to graphQL to query reviews and statuses. 
For checks, since we can use Rest Api to get all checks and graphQL query has a limitation on the numbers of checks we can get, we will keep using Rest Api for checks.