### PR TITLE
Revert "[app_flutter] wrap AppBar.title in a Tooltip"

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -326,16 +326,11 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
 
     final BuildState _buildState = Provider.of<BuildState>(context);
     _buildState.updateCurrentRepoBranch(repo!, branch!);
-    final String statusTitle = _getStatusTitle(_buildState);
-    final Widget titleWidget = Tooltip(
-      message: statusTitle,
-      child: Text(statusTitle),
-    );
     return AnimatedBuilder(
       animation: _buildState,
       builder: (BuildContext context, Widget? child) => Scaffold(
         appBar: CocoonAppBar(
-          title: titleWidget,
+          title: Text(_getStatusTitle(_buildState)),
           backgroundColor: colorTable[_buildState.isTreeBuilding],
           actions: <Widget>[
             if (!_smallScreen) ..._slugSelection(context, _buildState),

--- a/dashboard/linux/flutter/CMakeLists.txt
+++ b/dashboard/linux/flutter/CMakeLists.txt
@@ -82,7 +82,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+      linux-x64 ${CMAKE_BUILD_TYPE}
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -140,7 +140,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   file:
     dependency: transitive
     description:
@@ -589,5 +589,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"
   flutter: ">=2.8.0"

--- a/dashboard/test/build_dashboard_page_test.dart
+++ b/dashboard/test/build_dashboard_page_test.dart
@@ -240,11 +240,7 @@ void main() {
       ),
     );
 
-    // Verify the "Tree is Closed" message is wrapped in a [Tooltip].
-    final Finder tooltipFinder = find.byWidgetPredicate((Widget widget) {
-      return widget is Tooltip && (widget.message?.contains('Tree is Closed') ?? false);
-    });
-    expect(tooltipFinder, findsOneWidget);
+    expect(find.textContaining('Tree is Closed'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
     expect(appbarWidget.backgroundColor, Colors.red);
@@ -269,11 +265,7 @@ void main() {
       ),
     );
 
-    // Verify the "Tree is Closed" message is wrapped in a [Tooltip].
-    final Finder tooltipFinder = find.byWidgetPredicate((Widget widget) {
-      return widget is Tooltip && (widget.message?.contains('Tree is Closed') ?? false);
-    });
-    expect(tooltipFinder, findsOneWidget);
+    expect(find.textContaining('Tree is Closed'), findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
     expect(appbarWidget.backgroundColor, Colors.red[800]);


### PR DESCRIPTION
Reverts flutter/cocoon#1696

There appears to be a bug in this that causes the text to not always be updated (missing key in tooltip?)

Fixes https://github.com/flutter/flutter/issues/101311