### PR TITLE
[autosubmit] Get correct installation id

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -108,8 +108,8 @@ class CheckPullRequest extends RequestHandler {
     log.info('Got the Pull Request ${pullRequest.number} from pubsub.');
 
     final RepositorySlug slug = pullRequest.base!.repo!.slug();
-    final GithubService gitHub = await config.createGithubService();
-    final GraphQLClient graphQLClient = await config.createGitHubGraphQLClient();
+    final GithubService gitHub = await config.createGithubService(slug);
+    final GraphQLClient graphQLClient = await config.createGitHubGraphQLClient(slug);
     final _AutoMergeQueryResult queryResult = await _parseQueryData(pullRequest, gitHub, graphQLClient);
     if (await shouldMergePullRequest(queryResult, slug, gitHub)) {
       final bool hasAutosubmitLabel = queryResult.labels.any((label) => label == config.autosubmitLabel);

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -56,7 +56,7 @@ class Config {
     return String.fromCharCodes(cacheValue!);
   }
 
-  Future<String?> getInstallationId() async {
+  Future<String> getInstallationId() async {
     final String jwt = await _generateGithubJwt();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jwt',
@@ -70,14 +70,14 @@ class Config {
       githubInstallationUri,
       headers: headers,
     );
-    final list = json.decode(response.body).map((data) => (data) as Map<String, dynamic>).toList();
-    String? installatinId;
+    final List<dynamic> list = json.decode(response.body).map((data) => (data) as Map<String, dynamic>).toList();
+    late String installationId;
     for (Map<String, dynamic> installData in list) {
       if (installData['account']!['login']!.toString() == 'flutter') {
-        installatinId = installData['id']!.toString();
+        installationId = installData['id']!.toString();
       }
     }
-    return installatinId;
+    return installationId;
   }
 
   Future<GraphQLClient> createGitHubGraphQLClient() async {
@@ -106,7 +106,7 @@ class Config {
       'Authorization': 'Bearer $jwt',
       'Accept': 'application/vnd.github.machine-man-preview+json'
     };
-    final String? installationId = await getInstallationId();
+    final String installationId = await getInstallationId();
     final Uri githubAccessTokensUri = Uri.https('api.github.com', 'app/installations/$installationId/access_tokens');
     final http.Client client = httpProvider();
     final http.Response response = await client.post(

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -47,7 +47,7 @@ class Config {
 
   Future<String> generateGithubToken(RepositorySlug slug) async {
     // GitHub's secondary rate limits are run into very frequently when making auth tokens.
-    final Uint8List? cacheValue = await cache['githubToken'].get(
+    final Uint8List? cacheValue = await cache['githubToken-${slug.owner}'].get(
       () => _generateGithubToken(slug),
       // Tokens have a TTL of 10 minutes. AppEngine requests have a TTL of 1 minute.
       // To ensure no expired tokens are used, set this to 10 - 1, with an extra buffer of a duplicate request.

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -35,20 +35,20 @@ class Config {
 
   Cache get cache => Cache(cacheProvider).withPrefix('config');
 
-  Future<GithubService> createGithubService() async {
-    final GitHub github = await createGithubClient();
+  Future<GithubService> createGithubService(RepositorySlug slug) async {
+    final GitHub github = await createGithubClient(slug);
     return GithubService(github);
   }
 
-  Future<GitHub> createGithubClient() async {
-    String token = await generateGithubToken();
+  Future<GitHub> createGithubClient(RepositorySlug slug) async {
+    String token = await generateGithubToken(slug);
     return GitHub(auth: Authentication.withToken(token));
   }
 
-  Future<String> generateGithubToken() async {
+  Future<String> generateGithubToken(RepositorySlug slug) async {
     // GitHub's secondary rate limits are run into very frequently when making auth tokens.
     final Uint8List? cacheValue = await cache['githubToken'].get(
-      _generateGithubToken,
+      () => _generateGithubToken(slug),
       // Tokens have a TTL of 10 minutes. AppEngine requests have a TTL of 1 minute.
       // To ensure no expired tokens are used, set this to 10 - 1, with an extra buffer of a duplicate request.
       const Duration(minutes: 8),
@@ -56,7 +56,7 @@ class Config {
     return String.fromCharCodes(cacheValue!);
   }
 
-  Future<String> getInstallationId() async {
+  Future<String> getInstallationId(RepositorySlug slug) async {
     final String jwt = await _generateGithubJwt();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jwt',
@@ -73,14 +73,14 @@ class Config {
     final List<dynamic> list = json.decode(response.body).map((data) => (data) as Map<String, dynamic>).toList();
     late String installationId;
     for (Map<String, dynamic> installData in list) {
-      if (installData['account']!['login']!.toString() == 'flutter') {
+      if (installData['account']!['login']!.toString() == slug.owner) {
         installationId = installData['id']!.toString();
       }
     }
     return installationId;
   }
 
-  Future<GraphQLClient> createGitHubGraphQLClient() async {
+  Future<GraphQLClient> createGitHubGraphQLClient(RepositorySlug slug) async {
     final HttpLink httpLink = HttpLink(
       'https://api.github.com/graphql',
       defaultHeaders: <String, String>{
@@ -88,7 +88,7 @@ class Config {
       },
     );
 
-    final String token = await generateGithubToken();
+    final String token = await generateGithubToken(slug);
 
     final AuthLink _authLink = AuthLink(
       getToken: () async => 'Bearer $token',
@@ -100,13 +100,13 @@ class Config {
     );
   }
 
-  Future<Uint8List> _generateGithubToken() async {
+  Future<Uint8List> _generateGithubToken(RepositorySlug slug) async {
     final String jwt = await _generateGithubJwt();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jwt',
       'Accept': 'application/vnd.github.machine-man-preview+json'
     };
-    final String installationId = await getInstallationId();
+    final String installationId = await getInstallationId(slug);
     final Uri githubAccessTokensUri = Uri.https('api.github.com', 'app/installations/$installationId/access_tokens');
     final http.Client client = httpProvider();
     final http.Response response = await client.post(

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -56,7 +56,7 @@ class Config {
     return String.fromCharCodes(cacheValue!);
   }
 
-  Future<String> getInstallationId() async {
+  Future<String?> getInstallationId() async {
     final String jwt = await _generateGithubJwt();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jwt',
@@ -71,7 +71,12 @@ class Config {
       headers: headers,
     );
     final list = json.decode(response.body).map((data) => (data) as Map<String, dynamic>).toList();
-    final String installatinId = list[0]['id'].toString();
+    String? installatinId;
+    for (Map<String, dynamic> installData in list) {
+      if (installData['account']!['login']!.toString() == 'flutter') {
+        installatinId = installData['id']!.toString();
+      }
+    }
     return installatinId;
   }
 
@@ -83,7 +88,7 @@ class Config {
       },
     );
 
-    String token = await generateGithubToken();
+    final String token = await generateGithubToken();
 
     final AuthLink _authLink = AuthLink(
       getToken: () async => 'Bearer $token',
@@ -101,7 +106,7 @@ class Config {
       'Authorization': 'Bearer $jwt',
       'Accept': 'application/vnd.github.machine-man-preview+json'
     };
-    final String installationId = await getInstallationId();
+    final String? installationId = await getInstallationId();
     final Uri githubAccessTokensUri = Uri.https('api.github.com', 'app/installations/$installationId/access_tokens');
     final http.Client client = httpProvider();
     final http.Response response = await client.post(

--- a/auto_submit/test/service/config_test.dart
+++ b/auto_submit/test/service/config_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'package:auto_submit/service/config.dart';
 import 'package:auto_submit/service/secrets.dart';
+import 'package:github/github.dart';
 import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
 import 'package:neat_cache/cache_provider.dart';
@@ -25,6 +26,7 @@ void main() {
     late Config config;
     late MockClient mockClient;
     final SecretManager secretManager = LocalSecretManager();
+    final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
     const int kCacheSize = 1024;
 
     setUp(() {
@@ -54,7 +56,7 @@ void main() {
         const Duration(minutes: 1),
       );
 
-      final String githubToken = await config.generateGithubToken();
+      final String githubToken = await config.generateGithubToken(slug);
       expect(githubToken, 'githubToken');
     });
   });

--- a/auto_submit/test/service/config_test.dart
+++ b/auto_submit/test/service/config_test.dart
@@ -26,7 +26,8 @@ void main() {
     late Config config;
     late MockClient mockClient;
     final SecretManager secretManager = LocalSecretManager();
-    final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
+    final RepositorySlug flutterSlug = RepositorySlug('flutter', 'flutter');
+    final RepositorySlug testSlug = RepositorySlug('test', 'test');
     const int kCacheSize = 1024;
 
     setUp(() {
@@ -39,7 +40,7 @@ void main() {
       );
     });
 
-    test('verify github App InstallationId ', () async {
+    test('verify github App Installation Id ', () async {
       final Uri githubInstallationUri = Uri.https('api.github.com', 'app/installations');
       final http.Response response = await mockClient.get(githubInstallationUri);
       final list = json.decode(response.body).map((data) => (data) as Map<String, dynamic>).toList();
@@ -51,13 +52,34 @@ void main() {
       const String configValue = 'githubToken';
       final Uint8List cachedValue = Uint8List.fromList(configValue.codeUnits);
       Cache cache = Cache(cacheProvider).withPrefix('config');
-      await cache['githubToken'].set(
+      await cache['githubToken-${flutterSlug.owner}'].set(
         cachedValue,
         const Duration(minutes: 1),
       );
 
-      final String githubToken = await config.generateGithubToken(slug);
-      expect(githubToken, 'githubToken');
+      final String githubToken = await config.generateGithubToken(flutterSlug);
+      expect(githubToken, configValue);
+    });
+
+    test('Github clients are created with correct token', () async {
+      const String flutterToken = 'flutterToken';
+      final Uint8List flutterValue = Uint8List.fromList(flutterToken.codeUnits);
+      const String testToken = 'testToken';
+      final Uint8List testValue = Uint8List.fromList(testToken.codeUnits);
+      Cache cache = Cache(cacheProvider).withPrefix('config');
+      await cache['githubToken-${flutterSlug.owner}'].set(
+        flutterValue,
+        const Duration(minutes: 1),
+      );
+      await cache['githubToken-${testSlug.owner}'].set(
+        testValue,
+        const Duration(minutes: 1),
+      );
+
+      GitHub flutterClient = await config.createGithubClient(flutterSlug);
+      GitHub testClient = await config.createGithubClient(testSlug);
+      expect(flutterClient.auth!.token!, flutterToken);
+      expect(testClient.auth!.token!, testToken);
     });
   });
 }

--- a/auto_submit/test/src/service/fake_config.dart
+++ b/auto_submit/test/src/service/fake_config.dart
@@ -35,13 +35,13 @@ class FakeConfig extends Config {
   String? autosubmitLabelValue;
 
   @override
-  Future<GitHub> createGithubClient() async => githubClient!;
+  Future<GitHub> createGithubClient(RepositorySlug slug) async => githubClient!;
 
   @override
-  Future<GithubService> createGithubService() async => githubService ?? FakeGithubService();
+  Future<GithubService> createGithubService(RepositorySlug slug) async => githubService ?? FakeGithubService();
 
   @override
-  Future<GraphQLClient> createGitHubGraphQLClient() async => githubGraphQLClient!;
+  Future<GraphQLClient> createGitHubGraphQLClient(RepositorySlug slug) async => githubGraphQLClient!;
   @override
   Set<String> get rollerAccounts =>
       rollerAccountsValue ??


### PR DESCRIPTION
For the installation Id used to generate github token, we should pick the one belongs to flutter to get the write permission.
This PR also solves the issue: https://github.com/flutter/flutter/issues/100808. So now we can track the installation Id by repo to ensure every repo's quota is independent.