### PR TITLE
[app_dart] Add flutter-2.13-candidate.0 to release branches

### DIFF
--- a/app_dart/dev/branches.txt
+++ b/app_dart/dev/branches.txt
@@ -1,1 +1,3 @@
 master
+main
+flutter-2.13-candidate.0

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -144,10 +144,16 @@ class Config {
 
   /// Retrieve the supported branches for a repository.
   Future<List<String>> getSupportedBranches(RepositorySlug slug) async {
-    if (slug.name == 'flutter') {
-      return flutterBranches;
+    final List<String> branches = await flutterBranches;
+    if (slug == Config.flutterSlug) {
+      branches.remove('main');
+      return branches;
+    } else if (slug == Config.engineSlug) {
+      branches.remove('master');
+      return branches;
     }
-    return <String>['master'];
+
+    return <String>['main'];
   }
 
   Future<List<String>> get flutterBranches => _getFlutterBranches();

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -144,6 +144,7 @@ class Config {
 
   /// Retrieve the supported branches for a repository.
   Future<List<String>> getSupportedBranches(RepositorySlug slug) async {
+    // TODO(xilaizhang): Switch this to query datastore once branch entities are being written. https://github.com/flutter/flutter/issues/100491
     final List<String> branches = await flutterBranches;
     if (slug == Config.flutterSlug) {
       branches.remove('main');

--- a/app_dart/test/service/config_test.dart
+++ b/app_dart/test/service/config_test.dart
@@ -25,7 +25,7 @@ void main() {
       final Uint8List cachedValue = Uint8List.fromList(configValue.codeUnits);
 
       await cacheService.set(
-        'config',
+        Config.configCacheName,
         'githubapp_installations',
         cachedValue,
       );
@@ -37,7 +37,7 @@ void main() {
       const String configValue = 'githubToken';
       final Uint8List cachedValue = Uint8List.fromList(configValue.codeUnits);
       await cacheService.set(
-        'config',
+        Config.configCacheName,
         'githubToken-${Config.flutterSlug}',
         cachedValue,
       );
@@ -55,6 +55,15 @@ void main() {
         config.flutterGoldAlertConstant(RepositorySlug.full('flutter/engine')),
         isNot(contains('package:flutter')),
       );
+    });
+
+    test('flutter branches', () async {
+      final List<String> branches = <String>['master', 'main', 'flutter-2.13-candidate.0'];
+      final Uint8List branchesBytes = Uint8List.fromList(branches.join(',').codeUnits);
+      await cacheService.set(Config.configCacheName, 'flutterBranches', branchesBytes);
+      expect(await config.getSupportedBranches(Config.flutterSlug), <String>['master', 'flutter-2.13-candidate.0']);
+      expect(await config.getSupportedBranches(Config.engineSlug), <String>['main', 'flutter-2.13-candidate.0']);
+      expect(await config.getSupportedBranches(Config.cocoonSlug), <String>['main']);
     });
   });
 }


### PR DESCRIPTION
This is necessary as next engine beta will use the Cocoon scheduler. As a hack, you can add the branch manually in the URL encode, this is to make it easier to surface these results to the rest of the team.

This is temporary until https://github.com/flutter/flutter/issues/100491 is implemented