### PR TITLE
Refactor cronjob deploy to include auto-submit bot

### DIFF
--- a/cloud_build/deploy_app_dart.sh
+++ b/cloud_build/deploy_app_dart.sh
@@ -9,7 +9,6 @@ pushd app_dart > /dev/null
 set -e
 # app_dart
 gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
-gcloud app deploy --project "$1" cron.yaml
 gcloud app services set-traffic default --splits version-$2=1 --quiet
 # Google Cloud quota only allows 30 versions.
 # For daily builds, this will keep the 10 most recent versions, but wipe the rest.

--- a/cloud_build/deploy_cron_jobs.sh
+++ b/cloud_build/deploy_cron_jobs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright 2020 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Deploy latest cron jobs to google cloud.
+# This includes cron jobs for both app_dart and auto_submit.
+
+gcloud app deploy --project "$1" cron.yaml

--- a/cloudbuild_cron.yaml
+++ b/cloudbuild_cron.yaml
@@ -1,0 +1,22 @@
+# Provide instructions for google Cloud Build to deploy cron jobs
+# to flutter-dashboard project. It will be triggered
+# by daily schedule on `main` branch.
+#
+# The deploy will be skipped if no new commits since last deployment.
+
+steps:
+  # Deploy a new version to google cloud.
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: '/bin/bash'
+    args:  
+      - '-c'
+      - |-
+        gcloud config set project $PROJECT_ID
+        latest_version=$(gcloud app versions list --hide-no-traffic --format 'value(version.id)')
+        if [ "$latest_version" = "version-$SHORT_SHA" ]; then
+          echo "No updates since last deployment."
+        else
+          bash cloud_build/deploy_cron_jobs.sh $PROJECT_ID
+        fi
+
+timeout: 600s

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,4 +1,4 @@
-# This config is automatically deployed by cloudbuild/deploy.sh.
+# This config is automatically deployed by cloudbuild/deploy_cron_jobs.sh.
 #
 # To manually deploy this config, run:
 #   gcloud app deploy --project flutter-dashboard cron.yaml
@@ -58,3 +58,8 @@ cron:
 - description: check flaky builders to either deflake the builder or file a new flaky bug
   url: /api/check_flaky_builders
   schedule: every wednesday 16:00
+
+- description: check pull request in auto submit bot
+  url: /check-pull-request
+  target: auto-submit
+  schedule: every 1 hours


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/1717 enforced authentication of APIs to cronjob only.

Considering gcloud project supports only one cron.yaml, this PR generalize existing cron job deployment to include both app_dart and auto_submit.