### PR TITLE
[autosubmit] Add valid merge PR

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -76,7 +76,6 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
         final PullRequest pullRequest = repoPullRequestsMap[repoName]!.elementAt(index);
         if (index < _kMergeCountPerRepo) {
           final bool mergeResult = await _processMerge(pullRequest);
-          log.info('Finished merge pull request.');
           if (mergeResult) {
             responses.add(<int, String>{pullRequest.number!: 'merged'});
           } else {
@@ -110,7 +109,6 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
 
   Future<Response> _processMessage(
       pub.ReceivedMessage receivedMessage, Map<String, Set<PullRequest>> repoPullRequestsMap) async {
-    log.info('Comes to merge PR');
     final String messageData = receivedMessage.message!.data!;
     final rawBody = json.decode(String.fromCharCodes(base64.decode(messageData))) as Map<String, dynamic>;
     final PullRequest pullRequest = PullRequest.fromJson(rawBody);
@@ -180,7 +178,6 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
   /// 2) Not all tests finish but this is a clean revert of the Tip of Tree (TOT) commit.
   Future<bool> shouldMergePullRequest(
       _AutoMergeQueryResult queryResult, RepositorySlug slug, GithubService github) async {
-    log.info('Before checking should merge logic');
     // Check the label again before merge the pull request.
     if (queryResult.shouldMerge) {
       return true;

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -46,10 +46,9 @@ class GithubService {
   }
 
   /// Merge a pull request
-  Future<PullRequestMerge> merge(
-    RepositorySlug slug,
-    int number,
-  ) async {
-    return await github.pullRequests.merge(slug, number);
+  Future<bool> merge(RepositorySlug slug, String base, String head) async {
+    final response = await github.request('POST', '/repos/${slug.fullName}/merges',
+        body: GitHubJson.encode({'base': base, 'head': head}));
+    return response.statusCode == StatusCodes.CREATED;
   }
 }

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -92,7 +92,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -120,7 +120,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -149,7 +149,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -176,7 +176,7 @@ void main() {
       githubService.compareTwoCommitsData = compareToTCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -204,7 +204,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -232,7 +232,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -259,7 +259,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -285,7 +285,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -312,7 +312,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -340,7 +340,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -373,7 +373,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -402,7 +402,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -428,7 +428,7 @@ void main() {
       final PullRequest pullRequest1 = generatePullRequest(prNumber: 0, repoName: 'flutter', login: 'flutter');
       final PullRequest pullRequest2 = generatePullRequest(prNumber: 1, repoName: 'flutter', login: 'flutter');
       final PullRequest pullRequest3 = generatePullRequest(prNumber: 2, repoName: cocoonRepo, login: 'flutter');
-      githubService.pullRequestMergeData = pullRequestMergeMock;
+
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       final Map<String, Set<PullRequest>> repoPullRequestsMap = <String, Set<PullRequest>>{

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -100,6 +100,7 @@ PullRequest generatePullRequest(
       "created_at": "2011-01-26T19:01:12Z",
       "head": {
         "label": "octocat:new-topic",
+        "ref": "new-topic",
         "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
         "repo": {
           "id": 1296269,
@@ -115,6 +116,8 @@ PullRequest generatePullRequest(
       },
       "base": {
         "label": "octocat:master",
+        "label": "octocat:main",
+        "ref": "main",
         "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
         "repo": {
           "id": 1296269,

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -93,8 +93,7 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<PullRequestMerge> merge(RepositorySlug slug, int number) async {
-    final PullRequestMerge mergeResult = PullRequestMerge.fromJson(jsonDecode(pullRequestMergeMock!));
-    return mergeResult;
+  Future<bool> merge(RepositorySlug slug, String base, String head) async {
+    return true;
   }
 }


### PR DESCRIPTION
Previously we have already added and merged the codes that call Rest API to merge the pull request ( #1719). 
However, even though we are granted the merge permission to the flutter/cocoon repo, we still cannot successfully merge the pull request and continue to get the error `Can not merge the pull request 1723. Merge commits are not allowed on this repository..`.

To implement a valid way to merge the pull request, we found another Rest API here (https://docs.github.com/en/rest/reference/branches#merge-a-branch). Though this API is typically used for merging branch, we can use commit sha as head to merge commit as well.
Since the github dart package doesn't contain an existing API for this, I referred to https://github.com/SpinlockLabs/github.dart/blob/master/lib/src/common/issues_service.dart#L365 to write the POST request here.

With this API, now we can successfully merge the pull request. Check #1726 for a successful merge done by autosubmit bot.