### PR TITLE
[autosubmit] Auto update pull request branch

### DIFF
--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -51,4 +51,11 @@ class GithubService {
         body: GitHubJson.encode({'base': base, 'head': head}));
     return response.statusCode == StatusCodes.CREATED;
   }
+
+  /// Update a pull request branch
+  Future<bool> updateBranch(RepositorySlug slug, int number, String headSha) async {
+    final response = await github.request('PUT', '/repos/${slug.fullName}/pulls/$number/update-branch',
+        body: GitHubJson.encode({'expected_head_sha': headSha}));
+    return response.statusCode == StatusCodes.ACCEPTED;
+  }
 }

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -92,7 +92,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
+      githubService.commitData = commitMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -120,7 +120,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
+      githubService.commitData = commitMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -149,7 +149,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
+      githubService.commitData = commitMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -176,7 +176,6 @@ void main() {
       githubService.compareTwoCommitsData = compareToTCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -204,7 +203,7 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
+      githubService.commitData = commitMock;
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -232,7 +231,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -259,7 +257,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -285,7 +282,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -312,7 +308,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -340,7 +335,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -373,7 +367,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
       flutterRequest = PullRequestHelper(prNumber: 0);
@@ -402,7 +395,6 @@ void main() {
       githubService.compareTwoCommitsData = compareTwoCommitsMock;
       githubService.successMergeData = successMergeMock;
       githubService.createCommentData = createCommentMock;
-
       config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
       checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
 
@@ -442,6 +434,17 @@ void main() {
       expect(mergeResult[2], <int, String>{2: 'merged'});
       expect(pubsub.messagesQueue.length, 1);
       pubsub.messagesQueue.clear();
+    });
+
+    test('Auto Merges the branch if it was behind the ToT by _kBehindToT commits', () async {
+      final PullRequest pullRequest = generatePullRequest(prNumber: 0);
+
+      githubService.commitData = commitMock;
+      githubService.compareTwoCommitsData = shouldRebaseMock;
+      config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
+      checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
+      Response response = await checkPullRequest.autoMergeBranch(pullRequest, githubService);
+      expect(await response.readAsString(), 'Successfully updated the pull request ${pullRequest.number} branch.');
     });
   });
 }

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -280,6 +280,22 @@ final String commitMock = '''{
   }
 }''';
 
+final String shouldRebaseMock = '''{
+  "url": "https://api.github.com/repos/octocat/Hello-World/compare/master...topic",
+  "status": "behind",
+  "ahead_by": 1,
+  "behind_by": 11,
+  "total_commits": 1,
+  "files": [
+    {
+      "sha": "bbcd538c8e72b8c175046e27cc8f907076331401",
+      "filename": "file1.txt",
+      "status": "added",
+      "changes": 124
+    }
+  ]
+}''';
+
 // compareTwoCommitsMock is from the official Github API: https://docs.github.com/en/rest/reference/commits#compare-two-commits
 final String compareTwoCommitsMock = '''{
   "url": "https://api.github.com/repos/octocat/Hello-World/compare/master...topic",

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -96,4 +96,9 @@ class FakeGithubService implements GithubService {
   Future<bool> merge(RepositorySlug slug, String base, String head) async {
     return true;
   }
+
+  @override
+  Future<bool> updateBranch(RepositorySlug slug, int number, String headSha) async {
+    return true;
+  }
 }


### PR DESCRIPTION
To implement auto merge branch, I first referred to github graphQL doc (https://docs.github.com/en/graphql/reference/input-objects#mergebranchinput) and wrote the correct codes by using graphQL mutation in #1727. 
However, I continued to receive `GraphQLError(message: Resource not accessible by integration)` error when I tested the code, even though flutter/cocoon has given the write permission to content. 
This is because the repositoryId parameter we used to merge branch is the Node ID of the Repository containing the base branch, that is, Kristin/cocoon, instead of flutter/cocoon. And for the Kristin/cocoon repo, I didn't install the app into my github, let alone changed the settings to give the write permission to allow merging branch.
One possible way to solve this issue is to install the app into my own github and give myself the write permission, but this is not scalable because we cannot require all other engineers to install the app on their own github to allow auto merge branch.

To implement a valid method to auto merge the pull request branch, I finally used a Rest API which updates a pull request branch (Please check the doc here: https://docs.github.com/en/rest/reference/pulls#update-a-pull-request-branch). This API will update the pull request branch with the latest upstream changes by merging HEAD from the base branch into the pull request branch. With this method, we don't need to worry about the permission in our fork repo, and can successfully auto merge the branch with flutter/cocoon write permission to content.

Here is a success example of auto merging branch: #1710.