### PR TITLE
Add cpu dimension support when parsing ci yaml

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -36,7 +36,7 @@ class Target {
   static const List<String> iosPlatforms = <String>['mac_ios', 'mac_ios32'];
 
   /// Dimension list defined in .ci.yaml.
-  static List<String> dimensionList = <String>['os', 'device_os', 'device_type', 'mac_model', 'cores'];
+  static List<String> dimensionList = <String>['os', 'device_os', 'device_type', 'mac_model', 'cores', 'cpu'];
 
   /// Gets dimensions for this [pb.Target].
   ///

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -179,11 +179,13 @@ void main() {
       });
 
       test('dimensions exit', () {
-        final Target target = generateTarget(1, properties: <String, String>{'os': 'abc'});
+        final Target target = generateTarget(1, properties: <String, String>{'os': 'abc', 'cpu': 'x64'});
         final List<RequestedDimension> dimensions = target.getDimensions();
-        expect(dimensions.length, 1);
+        expect(dimensions.length, 2);
         expect(dimensions[0].key, 'os');
         expect(dimensions[0].value, 'abc');
+        expect(dimensions[1].key, 'cpu');
+        expect(dimensions[1].value, 'x64');
       });
 
       test('properties are evaluated as string', () {


### PR DESCRIPTION
Instead of using `mac_model`, it is recommended to use `cpu`+`os`. This PR adds `cpu` dimension support defined in .ci.yaml config, which will help validate changes in pre-submit.

Related: https://flutter-review.googlesource.com/c/infra/+/29061

context: https://github.com/flutter/flutter/pull/101871, https://github.com/flutter/flutter/issues/101861