### PR TITLE
[autosubmit] GraphQL merge PR

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -126,7 +126,6 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
     final rawBody = json.decode(String.fromCharCodes(base64.decode(messageData))) as Map<String, dynamic>;
     final PullRequest pullRequest = PullRequest.fromJson(rawBody);
     log.info('Got the Pull Request ${pullRequest.number} from pubsub.');
-    //await pubsub.acknowledge('auto-submit-queue-sub', receivedMessage.ackId!);
 
     final RepositorySlug slug = pullRequest.base!.repo!.slug();
     final GithubService gitHub = await config.createGithubService(slug);

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -54,7 +54,7 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
     }
     final List<Future<Response>> futures = <Future<Response>>[];
     //The repoPullRequestsMap stores the repo name and the set of PRs ready to merge to this repo
-    final Map<String, Set<PullRequest>> repoPullRequestsMap = <String, Set<PullRequest>>{};
+    final Map<String, Set<_AutoMergeQueryResult>> repoPullRequestsMap = <String, Set<_AutoMergeQueryResult>>{};
     for (pub.ReceivedMessage message in receivedMessages) {
       futures.add(_processMessage(message, repoPullRequestsMap));
     }
@@ -72,52 +72,61 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
   ///
   /// The number of pull requests to be merged to each repo will not exceed
   /// the _kMergeCountPerRepo
-  Future<List<Map<int, String>>> checkPullRequests(Map<String, Set<PullRequest>> repoPullRequestsMap) async {
+  Future<List<Map<int, String>>> checkPullRequests(Map<String, Set<_AutoMergeQueryResult>> repoPullRequestsMap) async {
     final List<Map<int, String>> responses = <Map<int, String>>[];
     for (String repoName in repoPullRequestsMap.keys) {
       // Merge first _kMergeCountPerRepo counts of pull requests to each repo
       log.info('Merge first $_kMergeCountPerRepo counts of pull requests to each repo');
       for (int index = 0; index < repoPullRequestsMap[repoName]!.length; index++) {
-        final PullRequest pullRequest = repoPullRequestsMap[repoName]!.elementAt(index);
+        final _AutoMergeQueryResult queryResult = repoPullRequestsMap[repoName]!.elementAt(index);
         if (index < _kMergeCountPerRepo) {
-          final bool mergeResult = await _processMerge(pullRequest);
+          final bool mergeResult = await _processMerge(
+              queryResult.graphQLId, queryResult.sha!, queryResult.number!, queryResult.title, queryResult.slug);
           if (mergeResult) {
-            responses.add(<int, String>{pullRequest.number!: 'merged'});
+            responses.add(<int, String>{queryResult.number!: 'merged'});
           } else {
-            responses.add(<int, String>{pullRequest.number!: 'unmerged'});
+            responses.add(<int, String>{queryResult.number!: 'unmerged'});
           }
         } else {
           await pubsub.publish('auto-submit-queue', repoPullRequestsMap[repoName]!.elementAt(index));
-          responses.add(<int, String>{pullRequest.number!: 'queued'});
+          responses.add(<int, String>{queryResult.number!: 'queued'});
         }
       }
     }
     return responses;
   }
 
-  Future<bool> _processMerge(PullRequest pullRequest) async {
-    String base = pullRequest.base!.ref!;
-    String head = pullRequest.head!.sha!;
-    RepositorySlug slug = pullRequest.base!.repo!.slug();
-    final GithubService gitHub = await config.createGithubService(slug);
-    bool merged = await gitHub.merge(slug, base, head);
-    final int number = pullRequest.number!;
-    if (merged) {
-      log.info('Merged the pull request $number in ${slug.fullName} repository.');
-      return true;
-    } else {
-      log.warning('Failed to merge the pull request $number.');
-      await pubsub.publish('auto-submit-queue', pullRequest);
+  Future<bool> _processMerge(
+    String id,
+    String sha,
+    int number,
+    String title,
+    RepositorySlug slug,
+  ) async {
+    final GraphQLClient client = await config.createGitHubGraphQLClient(slug);
+    final QueryResult result = await client.mutate(MutationOptions(
+      document: mergePullRequestMutation,
+      variables: <String, dynamic>{
+        'id': id,
+        'oid': sha,
+        'title': '$title (#$number)',
+      },
+    ));
+
+    if (result.hasException) {
+      log.severe('Failed to merge pr#: $number with ${result.exception.toString()}');
+      return false;
     }
-    return false;
+    return true;
   }
 
   Future<Response> _processMessage(
-      pub.ReceivedMessage receivedMessage, Map<String, Set<PullRequest>> repoPullRequestsMap) async {
+      pub.ReceivedMessage receivedMessage, Map<String, Set<_AutoMergeQueryResult>> repoPullRequestsMap) async {
     final String messageData = receivedMessage.message!.data!;
     final rawBody = json.decode(String.fromCharCodes(base64.decode(messageData))) as Map<String, dynamic>;
     final PullRequest pullRequest = PullRequest.fromJson(rawBody);
     log.info('Got the Pull Request ${pullRequest.number} from pubsub.');
+    //await pubsub.acknowledge('auto-submit-queue-sub', receivedMessage.ackId!);
 
     final RepositorySlug slug = pullRequest.base!.repo!.slug();
     final GithubService gitHub = await config.createGithubService(slug);
@@ -130,9 +139,9 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
       final bool hasAutosubmitLabel = queryResult.labels.any((label) => label == config.autosubmitLabel);
       if (hasAutosubmitLabel) {
         if (!repoPullRequestsMap.containsKey(slug.fullName)) {
-          repoPullRequestsMap[slug.fullName] = <PullRequest>{};
+          repoPullRequestsMap[slug.fullName] = <_AutoMergeQueryResult>{};
         }
-        repoPullRequestsMap[slug.fullName]!.add(pullRequest);
+        repoPullRequestsMap[slug.fullName]!.add(queryResult);
         await pubsub.acknowledge('auto-submit-queue-sub', receivedMessage.ackId!);
         return Response.ok('Should merge the pull request ${queryResult.number} in ${slug.fullName} repository.');
       } else {
@@ -309,7 +318,14 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
       slug.name,
       labelNames,
     );
+
+    final String id = pullRequest['id'] as String;
+    final String title = pullRequest['title'] as String;
+
     return _AutoMergeQueryResult(
+      slug: slug,
+      graphQLId: id,
+      title: title,
       ciSuccessful: ciSuccessful,
       failures: failures,
       hasApprovedReview: hasApproval,
@@ -446,6 +462,8 @@ bool _checkApproval(
 // TODO(Kristin): Simplify the _AutoMergeQueryResult class. https://github.com/flutter/flutter/issues/99717.
 class _AutoMergeQueryResult {
   const _AutoMergeQueryResult({
+    required this.graphQLId,
+    required this.title,
     required this.hasApprovedReview,
     required this.changeRequestAuthors,
     required this.ciSuccessful,
@@ -456,7 +474,14 @@ class _AutoMergeQueryResult {
     required this.isConflicting,
     required this.unknownMergeableState,
     required this.labels,
+    required this.slug,
   });
+
+  /// The GitHub GraphQL ID of this pull request.
+  final String graphQLId;
+
+  /// The pull request title.
+  final String title;
 
   /// Whether the pull request has at least one approved review.
   final bool hasApprovedReview;
@@ -487,6 +512,9 @@ class _AutoMergeQueryResult {
 
   /// List of labels associated with the PR.
   final List<String> labels;
+
+  /// The slug of the repository
+  final RepositorySlug slug;
 
   /// Whether it is sane to automatically merge this PR.
   bool get shouldMerge =>

--- a/auto_submit/lib/requests/check_pull_request_queries.dart
+++ b/auto_submit/lib/requests/check_pull_request_queries.dart
@@ -10,6 +10,8 @@ query LabeledPullRequcodeestWithReviews($sOwner: String!, $sName: String!, $sPrN
   repository(owner: $sOwner, name: $sName) { 
     pullRequest(number: $sPrNumber) {
       authorAssociation
+      id
+      title
       commits(last:1) {
         nodes {
           commit {
@@ -37,5 +39,18 @@ query LabeledPullRequcodeestWithReviews($sOwner: String!, $sName: String!, $sPrN
         }
       }
     } 
+  }
+}''');
+
+final DocumentNode mergePullRequestMutation = lang.parseString(r'''
+mutation MergePR($id: ID!, $oid: GitObjectID!, $title: String) {
+  mergePullRequest(input: {
+    pullRequestId: $id,
+    expectedHeadOid: $oid,
+    mergeMethod: SQUASH,
+    commitBody: "",
+    commitHeadline: $title
+  }) {
+    clientMutationId
   }
 }''');

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'package:github/github.dart';
 
 /// [GithubService] handles communication with the GitHub API.
@@ -43,13 +45,6 @@ class GithubService {
     String body,
   ) async {
     return await github.issues.createComment(slug, issueNumber, body);
-  }
-
-  /// Merge a pull request
-  Future<bool> merge(RepositorySlug slug, String base, String head) async {
-    final response = await github.request('POST', '/repos/${slug.fullName}/merges',
-        body: GitHubJson.encode({'base': base, 'head': head}));
-    return response.statusCode == StatusCodes.CREATED;
   }
 
   /// Update a pull request branch

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -416,26 +416,6 @@ void main() {
       assert(pubsub.messagesQueue.isEmpty);
     });
 
-    test('Merges only _kMergeCountPerRepo PR per cycle per repo', () async {
-      final PullRequest pullRequest1 = generatePullRequest(prNumber: 0, repoName: 'flutter', login: 'flutter');
-      final PullRequest pullRequest2 = generatePullRequest(prNumber: 1, repoName: 'flutter', login: 'flutter');
-      final PullRequest pullRequest3 = generatePullRequest(prNumber: 2, repoName: cocoonRepo, login: 'flutter');
-
-      config = FakeConfig(githubService: githubService, githubGraphQLClient: githubGraphQLClient);
-      checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
-      final Map<String, Set<PullRequest>> repoPullRequestsMap = <String, Set<PullRequest>>{
-        'flutter/flutter': <PullRequest>{pullRequest1, pullRequest2},
-        'flutter/cocoon': <PullRequest>{pullRequest3}
-      };
-
-      List<Map<int, String>> mergeResult = await checkPullRequest.checkPullRequests(repoPullRequestsMap);
-      expect(mergeResult[0], <int, String>{0: 'merged'});
-      expect(mergeResult[1], <int, String>{1: 'queued'});
-      expect(mergeResult[2], <int, String>{2: 'merged'});
-      expect(pubsub.messagesQueue.length, 1);
-      pubsub.messagesQueue.clear();
-    });
-
     test('Auto Merges the branch if it was behind the ToT by _kBehindToT commits', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0);
 

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -20,6 +20,9 @@ import '../src/service/fake_config.dart';
 import '../src/service/fake_github_service.dart';
 import '../src/service/fake_graphql_client.dart';
 
+const String oid = '6dcb09b5b57875f334f61aebed695e2e4193db5e';
+const String title = 'some_title';
+
 void main() {
   group('Check CheckPullRequest', () {
     late CheckPullRequest checkPullRequest;
@@ -43,6 +46,9 @@ void main() {
       githubGraphQLClient = FakeGraphQLClient();
       auth = FakeCronAuthProvider();
       expectedOptions = <QueryOptions>[];
+
+      githubGraphQLClient.mutateResultForOptions =
+          (MutationOptions options) => QueryResult(source: QueryResultSource.network);
 
       githubGraphQLClient.queryResultForOptions = (QueryOptions options) {
         expect(options.variables['sOwner'], 'flutter');
@@ -102,6 +108,18 @@ void main() {
       expectedOptions.add(flutterOption);
       expectedOptions.add(cocoonOption);
       _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest1.number!.toString(), pullRequest1.number!.toString()),
+          ),
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest2.number!.toString(), pullRequest2.number!.toString()),
+          ),
+        ],
+      );
       final StringBuffer responseMessages = StringBuffer();
       for (PullRequest pullRequest in pullRequests) {
         responseMessages.write(
@@ -136,6 +154,14 @@ void main() {
       final Response response = await checkPullRequest.get();
       expectedOptions.add(flutterOption);
       _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest.number!.toString(), pullRequest.number!.toString()),
+          ),
+        ],
+      );
       expect(await response.readAsString(),
           'Should merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
       assert(pubsub.messagesQueue.isEmpty);
@@ -163,6 +189,14 @@ void main() {
       final Response response = await checkPullRequest.get();
       expectedOptions.add(flutterOption);
       _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest.number!.toString(), pullRequest.number!.toString()),
+          ),
+        ],
+      );
       expect(await response.readAsString(),
           'Should merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
       assert(pubsub.messagesQueue.isEmpty);
@@ -190,6 +224,14 @@ void main() {
       final Response response = await checkPullRequest.get();
       expectedOptions.add(flutterOption);
       _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest.number!.toString(), pullRequest.number!.toString()),
+          ),
+        ],
+      );
       expect(await response.readAsString(),
           'Should merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
       assert(pubsub.messagesQueue.isEmpty);
@@ -214,6 +256,14 @@ void main() {
       final Response response = await checkPullRequest.get();
       expectedOptions.add(cocoonOption);
       _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables('0', pullRequest.number!.toString()),
+          ),
+        ],
+      );
       expect(await response.readAsString(),
           'Should merge the pull request ${pullRequest.number} in ${pullRequest.base!.repo!.slug().fullName} repository.');
       assert(pubsub.messagesQueue.isEmpty);
@@ -470,6 +520,7 @@ class PullRequestHelper {
     this.prNumber = 0,
     this.repo = 'flutter',
     this.authorAssociation = 'MEMBER',
+    this.title = 'some_title',
     this.reviews = const <PullRequestReviewHelper>[
       PullRequestReviewHelper(authorName: 'member', state: ReviewState.APPROVED, memberType: MemberType.MEMBER)
     ],
@@ -477,12 +528,7 @@ class PullRequestHelper {
     this.lastCommitStatuses = const <StatusHelper>[StatusHelper.flutterBuildSuccess],
     this.lastCommitMessage = '',
     this.dateTime,
-  }) : _count = _counter++;
-
-  static int _counter = 0;
-
-  final int _count;
-  String get id => _count.toString();
+  });
 
   final int prNumber;
   final String repo;
@@ -492,12 +538,15 @@ class PullRequestHelper {
   List<StatusHelper>? lastCommitStatuses;
   final String? lastCommitMessage;
   final DateTime? dateTime;
+  final String title;
 
   RepositorySlug get slug => RepositorySlug('flutter', repo);
 
   Map<String, dynamic> toEntry() {
     return <String, dynamic>{
       'authorAssociation': authorAssociation,
+      'id': prNumber.toString(),
+      'title': title,
       'reviews': <String, dynamic>{
         'nodes': reviews.map((PullRequestReviewHelper review) {
           return <String, dynamic>{
@@ -542,4 +591,12 @@ QueryResult createQueryResult(PullRequestHelper pullRequest) {
     },
     source: QueryResultSource.network,
   );
+}
+
+Map<String, dynamic> getMergePullRequestVariables(String id, String number) {
+  return <String, dynamic>{
+    'id': id,
+    'oid': oid,
+    'title': '$title (#$number)',
+  };
 }


### PR DESCRIPTION
This PR continues to solve the issue https://github.com/flutter/flutter/issues/101803.
In our autosubmit bot, after we processed to check a pull request should be merged, we want to add a method autoMergePR() that can help us auto merge this pull request to our main branch.

I first used the Rest API [#merge-a-pull-request](https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request)  in the github official doc, (you can check this part of codes in https://github.com/flutter/flutter/issues/1719). However, I continued to get the error `Can not merge the pull request 1723. Merge commits are not allowed on this repository..` even we granted the write permission.

Then I used the Rest API [#merge-a-branch](https://docs.github.com/en/rest/reference/branches#merge-a-branch) to merge the PR. However, this way cannot meet the requirement to squash and merge the PR.

This PR switched to use graphQL mutation and successfully squash and merge the PR.