### PR TITLE
issue #102000, making cocoon dashboard task name filter case insensitive

### DIFF
--- a/dashboard/lib/logic/task_grid_filter.dart
+++ b/dashboard/lib/logic/task_grid_filter.dart
@@ -42,7 +42,8 @@ class TaskGridFilter extends FilterPropertySource {
     }
   }
 
-  final RegExpFilterProperty _taskProperty = RegExpFilterProperty(fieldName: 'taskFilter', label: 'Task Name', caseSensitive: false);
+  final RegExpFilterProperty _taskProperty =
+      RegExpFilterProperty(fieldName: 'taskFilter', label: 'Task Name', caseSensitive: false);
   final RegExpFilterProperty _authorProperty = RegExpFilterProperty(fieldName: 'authorFilter', label: 'Commit Author');
   final RegExpFilterProperty _messageProperty =
       RegExpFilterProperty(fieldName: 'messageFilter', label: 'Commit Message');

--- a/dashboard/lib/logic/task_grid_filter.dart
+++ b/dashboard/lib/logic/task_grid_filter.dart
@@ -42,7 +42,7 @@ class TaskGridFilter extends FilterPropertySource {
     }
   }
 
-  final RegExpFilterProperty _taskProperty = RegExpFilterProperty(fieldName: 'taskFilter', label: 'Task Name');
+  final RegExpFilterProperty _taskProperty = RegExpFilterProperty(fieldName: 'taskFilter', label: 'Task Name', caseSensitive: false);
   final RegExpFilterProperty _authorProperty = RegExpFilterProperty(fieldName: 'authorFilter', label: 'Commit Author');
   final RegExpFilterProperty _messageProperty =
       RegExpFilterProperty(fieldName: 'messageFilter', label: 'Commit Message');

--- a/dashboard/lib/widgets/filter_property_sheet.dart
+++ b/dashboard/lib/widgets/filter_property_sheet.dart
@@ -76,11 +76,12 @@ abstract class ValueFilterProperty<T> extends ValueListenable<T> with FilterProp
 
 /// A class used to represent a Regular Expression property in the filter object.
 class RegExpFilterProperty extends ValueFilterProperty<String?> {
-  RegExpFilterProperty({required String fieldName, String? label, String? value})
-      : _value = value,
+  RegExpFilterProperty({required String fieldName, String? label, String? value, bool caseSensitive = true})
+      : _value = value, _caseSensitive = caseSensitive,
         super(fieldName: fieldName, label: label);
 
   String? _value;
+  final bool _caseSensitive;
   @override
   String? get value => _value;
   set value(String? newValue) {
@@ -125,7 +126,7 @@ class RegExpFilterProperty extends ValueFilterProperty<String?> {
   /// The value of this property as a [RegExp] object, useful for matching its pattern
   /// against candidate values in the list being filtered.
   RegExp? _regExp;
-  RegExp? get regExp => _regExp ??= _value == null ? null : RegExp(_value!);
+  RegExp? get regExp => _regExp ??= _value == null ? null : RegExp(_value!, caseSensitive: _caseSensitive);
   set regExp(RegExp? newRegExp) => value = newRegExp == null || newRegExp.pattern == '' ? null : newRegExp.pattern;
 
   /// True iff the value, interpreted as a regular expression, matches the candidate [String].

--- a/dashboard/lib/widgets/filter_property_sheet.dart
+++ b/dashboard/lib/widgets/filter_property_sheet.dart
@@ -77,7 +77,8 @@ abstract class ValueFilterProperty<T> extends ValueListenable<T> with FilterProp
 /// A class used to represent a Regular Expression property in the filter object.
 class RegExpFilterProperty extends ValueFilterProperty<String?> {
   RegExpFilterProperty({required String fieldName, String? label, String? value, bool caseSensitive = true})
-      : _value = value, _caseSensitive = caseSensitive,
+      : _value = value,
+        _caseSensitive = caseSensitive,
         super(fieldName: fieldName, label: label);
 
   String? _value;


### PR DESCRIPTION
This is a commit regarding issue #102000 here:

https://github.com/flutter/flutter/issues/102000

I have added _caseSensitive property to RegExpFilterProperty, I've set it to true by default so it doesn't affect anything else. Then for the task name filter, I set caseSensitive to false.