### PR TITLE
[cron] Increase autosubmit frequency to 2 minutes

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -62,4 +62,4 @@ cron:
 - description: check pull request in auto submit bot
   url: /check-pull-request
   target: auto-submit
-  schedule: every 1 hours
+  schedule: every 2 minutes


### PR DESCRIPTION
I've been using the bot. It would be nice if it was every 2 minutes, which roughly matches the existing logic.

This would allow 2 PRs to be submitted every 4 minutes versus the 2 PRs every 5 minutes today.