### PR TITLE
[app_dart] Add remedy for ci.yaml validation failures by rebasing PR

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -144,7 +144,8 @@ class CiYaml {
         // a new build without "bringup: true"
         // link to wiki - https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#adding-a-new-devicelab-test
         if (totTargets.isNotEmpty && !totTargets.contains(target.name) && target.bringup != true) {
-          exceptions.add('ERROR: ${target.name} is a new builder added. it needs to be marked bringup: true');
+          exceptions.add(
+              'ERROR: ${target.name} is a new builder added. it needs to be marked bringup: true\nIf ci.yaml wasn\'t changed, try `git fetch upstream && git merge upstream/master`');
           continue;
         }
         targetGraph[target.name] = <pb.Target>[];


### PR DESCRIPTION
Sometimes the ci.yaml validation fails as PRs aren't up to date with tip of tree. This gives an actionable message to users to rebase their PRs with the master to get unblocked.