### PR TITLE
Support platform `mac_arm64_ios` when injecting devicelab xcode property

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -33,7 +33,7 @@ class Target {
   final RepositorySlug slug;
 
   /// Target prefixes that indicate it will run on an ios device.
-  static const List<String> iosPlatforms = <String>['mac_ios', 'mac_ios32'];
+  static const List<String> iosPlatforms = <String>['mac_ios', 'mac_arm64_ios'];
 
   /// Dimension list defined in .ci.yaml.
   static List<String> dimensionList = <String>['os', 'device_os', 'device_type', 'mac_model', 'cores', 'cpu'];


### PR DESCRIPTION
Related https://flutter-review.googlesource.com/c/infra/+/29261
Issue: https://github.com/flutter/flutter/issues/87508