### PR TITLE
[test_utilities] Migrate pub to use dart pub

### DIFF
--- a/test_utilities/bin/prepare_environment.sh
+++ b/test_utilities/bin/prepare_environment.sh
@@ -8,6 +8,6 @@
 
 set -ex
 
-pub global activate tuneup
+dart pub global activate tuneup
 flutter channel master
 flutter upgrade


### PR DESCRIPTION
This is to fix the Cocoon post-submit failures in go/cocoon-build