### PR TITLE
[app_dart] Fix release auto-approvals to only work on branches

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -190,7 +190,9 @@ class GithubWebhook extends RequestHandler<Body> {
     final PullRequest pr = pullRequestEvent.pullRequest!;
     final RepositorySlug slug = pullRequestEvent.repository!.slug();
 
-    if (pr.head?.ref == null && pr.head!.ref!.contains(Config.defaultBranch(slug))) {
+    final String defaultBranch = Config.defaultBranch(slug);
+    final String? branch = pr.base?.ref;
+    if (branch == null || branch.contains(defaultBranch)) {
       // This isn't a release branch PR
       return;
     }


### PR DESCRIPTION
Fixes the issues with:
1. Was looking at HEAD and not the base (base is what the PR wants to merge into)
2. The check was looking for a null branch AND the branch to contain the default branch to skip reviewing it

Fixes https://github.com/flutter/flutter/issues/102017