### PR TITLE
Avoid duplicated auto-approvals.

### DIFF
--- a/auto_submit/lib/service/approver_service.dart
+++ b/auto_submit/lib/service/approver_service.dart
@@ -19,8 +19,17 @@ class ApproverService {
       log.info('Auto-review ignored for $author');
       return;
     }
+
     final RepositorySlug slug = pullRequest.base!.repo!.slug();
     final GitHub botClient = await config.createFlutterGitHubBotClient(slug);
+
+    Stream<PullRequestReview> reviews = botClient.pullRequests.listReviews(slug, pullRequest.number!);
+    await for (PullRequestReview review in reviews) {
+      if (review.user.login == 'fluttergithubbot' && review.state == 'APPROVED') {
+        // Already approved.
+        return;
+      }
+    }
 
     final CreatePullRequestReview review =
         CreatePullRequestReview(slug.owner, slug.name, pullRequest.number!, 'APPROVE');

--- a/auto_submit/test/service/approver_service_test.dart
+++ b/auto_submit/test/service/approver_service_test.dart
@@ -7,6 +7,7 @@ import 'package:github/github.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import '../requests/check_pull_request_test.dart';
 import '../requests/github_webhook_test_data.dart';
 import '../src/service/fake_config.dart';
 import '../utilities/mocks.dart';
@@ -33,11 +34,20 @@ void main() {
   });
 
   test('Verify approve', () async {
+    when(pullRequests.listReviews(any, any)).thenAnswer((_) => const Stream<PullRequestReview>.empty());
     PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
     await service.approve(pr);
     final List<dynamic> reviews = verify(pullRequests.createReview(any, captureAny)).captured;
     expect(reviews.length, 1);
     final CreatePullRequestReview review = reviews.single as CreatePullRequestReview;
     expect(review.event, 'APPROVE');
+  });
+
+  test('Already approved', () async {
+    PullRequestReview review = PullRequestReview(id: 123, user: User(login: 'fluttergithubbot'), state: 'APPROVED');
+    when(pullRequests.listReviews(any, any)).thenAnswer((_) => Stream<PullRequestReview>.value(review));
+    PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
+    await service.approve(pr);
+    verifyNever(pullRequests.createReview(any, captureAny));
   });
 }


### PR DESCRIPTION
This is fixing the logic to auto-approve PRs to approve just once.

Bug: https://github.com/flutter/flutter/issues/102712

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
