### PR TITLE
Adds logic to deal with duplicated messages and closed PRs.

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -145,9 +145,6 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
 
   Future<Response> _processMessage(
       PullRequest pullRequest, Map<String, Set<_AutoMergeQueryResult>> repoPullRequestsMap, String ackId) async {
-    //final String messageData = receivedMessage.message!.data!;
-    //final rawBody = json.decode(String.fromCharCodes(base64.decode(messageData))) as Map<String, dynamic>;
-    //final PullRequest pullRequest = PullRequest.fromJson(rawBody);
     log.info('Got the Pull Request ${pullRequest.number} from pubsub.');
 
     final RepositorySlug slug = pullRequest.base!.repo!.slug();

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -76,11 +76,12 @@ PullRequest generatePullRequest(
     String? login,
     String? authorAssociation,
     String? author,
-    int? prNumber}) {
+    int? prNumber,
+    String? state}) {
   return PullRequest.fromJson(json.decode('''{
       "id": 1,
       "number": ${prNumber ?? 1347},
-      "state": "open",
+      "state": "${state ?? "open"}",
       "title": "Amazing new feature",
       "user": {
         "login": "${author ?? "octocat"}",


### PR DESCRIPTION
A new message is published to the topic everytime a new label is added
to a PR. If the first message is used to land the PR or somebody
manually merge the PR the bot will keep trying to merge the PR and
failing.

Bug: https://github.com/flutter/flutter/issues/102944

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
