### PR TITLE
Impeller was merged into engine so removing impeller repos

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -50,7 +50,6 @@ class Config {
         cocoonSlug,
         engineSlug,
         flutterSlug,
-        impellerSlug,
         packagesSlug,
         pluginsSlug,
       };
@@ -72,7 +71,6 @@ class Config {
       engineSlug: 'main',
       pluginsSlug: 'main',
       packagesSlug: 'main',
-      impellerSlug: 'main',
     };
 
     return defaultBranches[slug] ?? kDefaultBranchName;
@@ -307,7 +305,6 @@ class Config {
   static RepositorySlug get flutterSlug => RepositorySlug('flutter', 'flutter');
   static RepositorySlug get packagesSlug => RepositorySlug('flutter', 'packages');
   static RepositorySlug get pluginsSlug => RepositorySlug('flutter', 'plugins');
-  static RepositorySlug get impellerSlug => RepositorySlug('flutter', 'impeller');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
 

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -74,7 +74,6 @@ void main() {
             Config.flutterSlug,
             Config.packagesSlug,
             Config.pluginsSlug,
-            Config.impellerSlug,
           });
       flutterRepoPRs.clear();
       statuses.clear();
@@ -160,7 +159,6 @@ void main() {
             Config.flutterSlug,
             Config.packagesSlug,
             Config.pluginsSlug,
-            Config.impellerSlug,
           });
       config.overrideTreeStatusLabelValue = 'warning: land on red to fix tree breakage';
       branch = null;
@@ -281,15 +279,6 @@ void main() {
             variables: <String, dynamic>{
               'sOwner': 'flutter',
               'sName': 'plugins',
-              'sLabelName': config.waitingForTreeToGoGreenLabelNameValue,
-            },
-          ),
-          QueryOptions(
-            document: labeledPullRequestsWithReviewsQuery,
-            fetchPolicy: FetchPolicy.noCache,
-            variables: <String, dynamic>{
-              'sOwner': 'flutter',
-              'sName': 'impeller',
               'sLabelName': config.waitingForTreeToGoGreenLabelNameValue,
             },
           ),

--- a/app_dart/test/request_handlers/vacuum_github_commits_test.dart
+++ b/app_dart/test/request_handlers/vacuum_github_commits_test.dart
@@ -83,7 +83,6 @@ void main() {
           Config.flutterSlug,
           Config.packagesSlug,
           Config.pluginsSlug,
-          Config.impellerSlug,
         },
       );
 


### PR DESCRIPTION
Impeller was merged into engine so removing impeller repos everywhere from cocoon

Bug: flutter/flutter#103016

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
