### PR TITLE
Revert "[scheduler] Process build messages with null task key (#1698)"

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -69,33 +69,21 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final Map<String, dynamic> userData = jsonDecode(buildPushMessage.userData!) as Map<String, dynamic>;
     final String? rawTaskKey = userData['task_key'] as String?;
     final String? rawCommitKey = userData['commit_key'] as String?;
-    if (rawCommitKey == null) {
-      throw const BadRequestException('userData does not contain commit_key');
+    if (rawTaskKey == null || rawCommitKey == null) {
+      throw const BadRequestException('userData does not contain task_key');
     }
+    log.fine('Looking up key...');
+    final int taskId = int.parse(rawTaskKey);
+    final Key<String> commitKey = Key<String>(Key<dynamic>.emptyKey(Partition(null)), Commit, rawCommitKey);
+    final Key<int> taskKey = Key<int>(commitKey, Task, taskId);
+    final Task task = await datastore.lookupByValue<Task>(taskKey);
+    log.fine('Found $task');
+
     final Build? build = buildPushMessage.build;
     if (build == null) {
       log.warning('Build is null');
       return Body.empty;
     }
-    final Key<String> commitKey = Key<String>(Key<dynamic>.emptyKey(Partition(null)), Commit, rawCommitKey);
-    Task? task;
-    if (rawTaskKey == null || rawTaskKey.isEmpty || rawTaskKey == 'null') {
-      log.fine('Pulling builder name from parameters_json...');
-      log.fine(build.buildParameters);
-      final String? taskName = build.buildParameters?['builder_name'] as String?;
-      if (taskName == null) {
-        throw const BadRequestException('task_key is null and parameters_json does not contain the builder name');
-      }
-      final List<Task> tasks = await datastore.queryRecentTasksByName(name: taskName).toList();
-      task = tasks.singleWhere((Task task) => task.parentKey?.id == commitKey.id);
-    } else {
-      log.fine('Looking up key...');
-      final int taskId = int.parse(rawTaskKey);
-      final Key<int> taskKey = Key<int>(commitKey, Task, taskId);
-      task = await datastore.lookupByValue<Task>(taskKey);
-    }
-    log.fine('Found $task');
-
     task.updateFromBuild(build);
     await datastore.insert(<Task>[task]);
     log.fine('Updated datastore');
@@ -104,7 +92,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       log.fine('Trying to auto-retry...');
       final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
       final CiYaml ciYaml = await scheduler.getCiYaml(commit);
-      final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task!.name);
+      final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task.name);
       final bool retried = await luciBuildService.checkRerunBuilder(
         commit: commit,
         target: target,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -141,8 +141,8 @@ class Scheduler {
         toBeScheduled.add(Tuple<Target, Task, int>(target, task, priority));
       }
     }
+    await luciBuildService.schedulePostsubmitBuilds(commit: commit, toBeScheduled: toBeScheduled);
 
-    // Datastore must be written to generate task keys
     try {
       await datastore.withTransaction<void>((Transaction transaction) async {
         transaction.queueMutations(inserts: <Commit>[commit]);
@@ -153,8 +153,6 @@ class Scheduler {
     } catch (error) {
       log.severe('Failed to add commit ${commit.sha!}: $error');
     }
-
-    await luciBuildService.schedulePostsubmitBuilds(commit: commit, toBeScheduled: toBeScheduled);
 
     await _uploadToBigQuery(commit);
   }

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -121,26 +121,4 @@ void main() {
     expect(await tester.post(handler), Body.empty);
     expect(task.status, Task.statusNew);
   });
-
-  test('fallback to build parameters if task_key is not present', () async {
-    final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
-    final Task task = generateTask(
-      4507531199512576,
-      name: 'Linux A',
-      parent: commit,
-      status: Task.statusInProgress,
-    );
-    config.db.values[task.key] = task;
-    config.db.values[commit.key] = commit;
-    tester.message = createBuildbucketPushMessage(
-      'COMPLETED',
-      builderName: 'Linux A',
-      result: 'FAILURE',
-      userData: '{\\"task_key\\":\\"null\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
-    );
-
-    expect(task.status, Task.statusInProgress);
-    expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusNew);
-  });
 }

--- a/app_dart/test/src/utilities/push_message.dart
+++ b/app_dart/test/src/utilities/push_message.dart
@@ -10,15 +10,13 @@ import 'package:cocoon_service/src/model/luci/push_message.dart';
 
 const String ref = 'deadbeef';
 
-PushMessage createBuildbucketPushMessage(
-  String status, {
-  String? result,
-  String builderName = 'Linux Coverage',
-  String urlParam = '',
-  int retries = 0,
-  String? failureReason,
-  String? userData = '',
-}) {
+PushMessage createBuildbucketPushMessage(String status,
+    {String? result,
+    String builderName = 'Linux Coverage',
+    String urlParam = '',
+    int retries = 0,
+    String? failureReason,
+    String? userData = ''}) {
   return PushMessage(
     data: buildPushMessageJson(
       status,
@@ -54,15 +52,13 @@ PushMessage pushMessageJsonNoBuildset(
   );
 }
 
-String buildPushMessageJson(
-  String status, {
-  String? result,
-  String builderName = 'Linux Coverage',
-  String urlParam = '',
-  int retries = 0,
-  String? failureReason,
-  String? userData,
-}) =>
+String buildPushMessageJson(String status,
+        {String? result,
+        String builderName = 'Linux Coverage',
+        String urlParam = '',
+        int retries = 0,
+        String? failureReason,
+        String? userData}) =>
     base64.encode(utf8.encode(buildPushMessageString(
       status,
       result: result,


### PR DESCRIPTION
This was temporarily added to recover from an outage. Removing as it seems to be causing some bugs in the release builds on go/engine-build

Fixes https://github.com/flutter/flutter/issues/102998