### PR TITLE
Adding a filter for staging tasks

### DIFF
--- a/dashboard/lib/logic/task_grid_filter.dart
+++ b/dashboard/lib/logic/task_grid_filter.dart
@@ -53,6 +53,8 @@ class TaskGridFilter extends FilterPropertySource {
   final BoolFilterProperty _iosProperty = BoolFilterProperty(fieldName: 'showiOS', label: 'iOS');
   final BoolFilterProperty _linuxPorperty = BoolFilterProperty(fieldName: 'showLinux', label: 'Linux');
   final BoolFilterProperty _androidProperty = BoolFilterProperty(fieldName: 'showAndroid', label: 'Android');
+  final BoolFilterProperty _stagingProperty =
+      BoolFilterProperty(fieldName: 'showStaging', label: 'Staging', value: false);
 
   // [_allProperties] is a LinkedHashMap so we can trust its iteration order
   LinkedHashMap<String, ValueFilterProperty<dynamic>>? _allPropertiesMap;
@@ -67,7 +69,8 @@ class TaskGridFilter extends FilterPropertySource {
         ..[_windowsPorperty.fieldName] = _windowsPorperty
         ..[_iosProperty.fieldName] = _iosProperty
         ..[_linuxPorperty.fieldName] = _linuxPorperty
-        ..[_androidProperty.fieldName] = _androidProperty) as LinkedHashMap<String, ValueFilterProperty<dynamic>>?)!;
+        ..[_androidProperty.fieldName] = _androidProperty
+        ..[_stagingProperty.fieldName] = _stagingProperty) as LinkedHashMap<String, ValueFilterProperty<dynamic>>?)!;
 
   /// The [taskFilter] property is a regular expression that must match the name of the
   /// task in the grid. This property will filter out columns on the build dashboard.
@@ -133,6 +136,15 @@ class TaskGridFilter extends FilterPropertySource {
 
   set showAndroid(bool? value) => _androidProperty.value = value;
 
+  /// The [showStaging] property is a boolean
+  ///
+  /// it indicates whether to display staging tasks (tasks with name prefixed
+  /// with linux_staging_build).
+  /// This property will filter out columns on the build dashboard.
+  bool? get showStaging => _stagingProperty.value;
+
+  set showStaging(bool? value) => _stagingProperty.value = value;
+
   /// Check the values in the [CommitStatus] for compatibility with the properties of this
   /// filter and return [true] iff the commit row should be displayed.
   bool matchesCommit(CommitStatus commitStatus) {
@@ -152,6 +164,10 @@ class TaskGridFilter extends FilterPropertySource {
   /// properties of this filter and return [true] iff the commit column should be displayed.
   bool matchesTask(QualifiedTask qualifiedTask) {
     if (!_taskProperty.matches(qualifiedTask.task!)) {
+      return false;
+    }
+
+    if ((!_allProperties['showStaging']?.value) && qualifiedTask.task!.toLowerCase().startsWith('staging_build_')) {
       return false;
     }
 
@@ -198,6 +214,7 @@ class TaskGridFilter extends FilterPropertySource {
           label: 'Stages',
           members: <BoolFilterProperty>[
             _androidProperty,
+            _stagingProperty,
             _iosProperty,
             _linuxPorperty,
             _macProperty,

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -12,12 +12,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   void testDefault(TaskGridFilter filter) {
-    expect(filter.toMap(includeDefaults: false).length, 0);
+    expect(filter.toMap(includeDefaults: false).length, 1);
     expect(filter.taskFilter, null);
     expect(filter.authorFilter, null);
     expect(filter.messageFilter, null);
     expect(filter.hashFilter, null);
     expect(filter.showiOS, true);
+    expect(filter.showStaging, false);
 
     expect(filter.matchesTask(QualifiedTask.fromTask(Task())), true);
     expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'foo')), true);

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -56,6 +56,7 @@ void main() {
         TaskGridFilter()..messageFilter = RegExp('foo'));
     expect(TaskGridFilter.fromMap(<String, String>{'hashFilter': 'foo'}), TaskGridFilter()..hashFilter = RegExp('foo'));
     expect(TaskGridFilter.fromMap(<String, String>{'showMac': 'false'}), TaskGridFilter()..showMac = false);
+    expect(TaskGridFilter.fromMap(<String, String>{'showStaging': 'false'}), TaskGridFilter()..showStaging = false);
   });
 
   test('cross check on inequality', () {
@@ -79,6 +80,43 @@ void main() {
           expect(nonDefaultFilters[i], isNot(equals(nonDefaultFilters[j])));
         }
       }
+    }
+  });
+
+  test('staging filter show all tasks', () {
+    final List<TaskGridFilter> filters = <TaskGridFilter>[
+      TaskGridFilter()..showStaging = true,
+    ];
+    for (final TaskGridFilter filter in filters) {
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Staging_build_linux task')), true);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'staging_build_mac task')), true);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android task')), true);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'linux_android task')), true);
+    }
+  });
+
+  test('staging filter staging tasks', () {
+    final List<TaskGridFilter> filters = <TaskGridFilter>[
+      TaskGridFilter()..showStaging = false,
+    ];
+    for (final TaskGridFilter filter in filters) {
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Staging_build_linux task')), false);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'staging_build_mac task')), false);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android task')), true);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'linux_android task')), true);
+    }
+  });
+
+  test('staging filter name matches', () {
+    final List<TaskGridFilter> filters = <TaskGridFilter>[
+      TaskGridFilter()..showStaging = false,
+    ];
+    for (final TaskGridFilter filter in filters) {
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Staging_build_linux task')), false);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Staging_build_mac task')), false);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android staging_build')), true);
+      expect(filter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'linux_android_staging_build_linux task')),
+          true);
     }
   });
 


### PR DESCRIPTION
Adding a checkbox to menu for staging tasks (tasks whose names
are prefixed with 'Staging_build_').
By default staging tasks are not displayed.
Should have no other visible changes/functionality of the dashboard.

Bug:103081

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
