### PR TITLE
[signing bot] add bot_type for existing post submit builds

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -12,26 +12,27 @@ platform_properties:
   linux:
     properties:
       os: Linux
+      bot_type: "regular"
   mac:
     properties:
       os: Mac-10.15
+      bot_type: "regular"
   windows:
     properties:
       os: Windows
+      bot_type: "regular"
 
 targets:
   - name: Linux Cocoon
     recipe: cocoon/cocoon
     properties:
       add_recipes_cq: "true"
-      bot_type: "regular"
 
   - name: Linux device_doctor
     postsubmit: false
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
-      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -40,7 +41,6 @@ targets:
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
-      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -49,7 +49,6 @@ targets:
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
-      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -57,4 +56,3 @@ targets:
     recipe: infra/ci_yaml
     properties:
       add_recipes_cq: "true"
-      bot_type: "regular"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -12,15 +12,15 @@ platform_properties:
   linux:
     properties:
       os: Linux
-      bot_type: "regular"
+      signing_certs: "none"
   mac:
     properties:
       os: Mac-10.15
-      bot_type: "regular"
+      signing_certs: "none"
   windows:
     properties:
       os: Windows
-      bot_type: "regular"
+      signing_certs: "none"
 
 targets:
   - name: Linux Cocoon

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -24,12 +24,14 @@ targets:
     recipe: cocoon/cocoon
     properties:
       add_recipes_cq: "true"
+      bot_type: "regular"
 
   - name: Linux device_doctor
     postsubmit: false
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
+      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -38,6 +40,7 @@ targets:
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
+      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -46,6 +49,7 @@ targets:
     recipe: cocoon/device_doctor
     properties:
       add_recipes_cq: "true"
+      bot_type: "regular"
     runIf:
       - device_doctor/**
 
@@ -53,3 +57,4 @@ targets:
     recipe: infra/ci_yaml
     properties:
       add_recipes_cq: "true"
+      bot_type: "regular"


### PR DESCRIPTION
This is to distinguish regular building bots from code signing bots. 

Regular building bots and code signing bots will have different value for `bot_type`.

Context: go/code-signing-bot. Context of planned introduction of code signing bot: https://chrome-internal-review.googlesource.com/c/infradata/config/+/4685734/7