### PR TITLE
[app_dart] Remove branches.txt

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -168,8 +168,3 @@ For more options run:
 $ dart dev/deploy.dart --help
 ```
 
-### Branching support for flutter repo
-
-Add targeted branches in `dev/branches.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).
-
-Once the PR has merged, go to https://flutter-dashboard.appspot.com/api/flush-cache?key=flutterBranches to flush the cache and have the latest change take effect. Otherwise, it can take 12 hours for it to propagate. Ensure you are signed into [cocoon dashboard](https://flutter-dashboard.appspot.com) otherwise it will throw a 403.

--- a/app_dart/dev/branches.txt
+++ b/app_dart/dev/branches.txt
@@ -1,4 +1,0 @@
-master
-main
-flutter-2.13-candidate.0
-fuchsia_r48


### PR DESCRIPTION
This is no longer used as we're storing them in datastore