### PR TITLE
removing hardcode true in BoolFilterProperty.

### DIFF
--- a/dashboard/lib/widgets/filter_property_sheet.dart
+++ b/dashboard/lib/widgets/filter_property_sheet.dart
@@ -168,14 +168,10 @@ class BoolFilterProperty extends ValueFilterProperty<bool?> {
   }
 
   @override
-  bool get isDefault {
-    return value == _defaultValue;
-  }
+  bool get isDefault => value == _defaultValue;
 
   @override
-  void reset() {
-    value = _defaultValue;
-  }
+  void reset() => value = _defaultValue;
 }
 
 /// A class used to enclose a group of other [BoolFilterProperty] properties to be

--- a/dashboard/lib/widgets/filter_property_sheet.dart
+++ b/dashboard/lib/widgets/filter_property_sheet.dart
@@ -136,11 +136,12 @@ class RegExpFilterProperty extends ValueFilterProperty<String?> {
 
 /// A class used to represent a boolean property in the filter object.
 class BoolFilterProperty extends ValueFilterProperty<bool?> {
-  BoolFilterProperty({required String fieldName, String? label, bool value = true})
-      : _value = value,
+  BoolFilterProperty({required String fieldName, String? label, bool value = true })
+      : _value = value, _defaultValue = value,
         super(fieldName: fieldName, label: label);
 
   bool? _value;
+  bool? _defaultValue;
 
   @override
   bool? get value => _value;
@@ -166,10 +167,14 @@ class BoolFilterProperty extends ValueFilterProperty<bool?> {
   }
 
   @override
-  bool get isDefault => _value == true;
+  bool get isDefault {
+    return value == _defaultValue;
+  }
 
   @override
-  void reset() => value = true;
+  void reset() {
+    value = _defaultValue;
+  }
 }
 
 /// A class used to enclose a group of other [BoolFilterProperty] properties to be

--- a/dashboard/lib/widgets/filter_property_sheet.dart
+++ b/dashboard/lib/widgets/filter_property_sheet.dart
@@ -136,12 +136,13 @@ class RegExpFilterProperty extends ValueFilterProperty<String?> {
 
 /// A class used to represent a boolean property in the filter object.
 class BoolFilterProperty extends ValueFilterProperty<bool?> {
-  BoolFilterProperty({required String fieldName, String? label, bool value = true })
-      : _value = value, _defaultValue = value,
+  BoolFilterProperty({required String fieldName, String? label, bool value = true})
+      : _value = value,
+        _defaultValue = value,
         super(fieldName: fieldName, label: label);
 
   bool? _value;
-  bool? _defaultValue;
+  final bool? _defaultValue;
 
   @override
   bool? get value => _value;

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   void testDefault(TaskGridFilter filter) {
-    expect(filter.toMap(includeDefaults: false).length, 1);
+    expect(filter.toMap(includeDefaults: false).length, 0);
     expect(filter.taskFilter, null);
     expect(filter.authorFilter, null);
     expect(filter.messageFilter, null);

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   void testDefault(TaskGridFilter filter) {
-    expect(filter.toMap(includeDefaults: false).length, 0);
+    expect(filter.toMap(includeDefaults: false), isEmpty);
     expect(filter.taskFilter, null);
     expect(filter.authorFilter, null);
     expect(filter.messageFilter, null);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/103372

the BoolPropertyFilter was considered as having true as default all the time, so everything was hardcoded as true.

Changed that.