### PR TITLE
Catch exception to ack pub/sub message

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/request_subscription.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/request_subscription.dart
@@ -57,16 +57,25 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
       throw BadRequestException(e.toString());
     }
 
-    await retryOptions.retry(
-      () async {
-        final List<Request> requestsToRetry = await _sendBatchRequest(request);
-        request = BatchRequest(requests: requestsToRetry);
-        if (requestsToRetry.isNotEmpty) {
-          throw const InternalServerError('Failed to schedule builds');
-        }
-      },
-      retryIf: (Exception e) => e is InternalServerError,
-    );
+    /// Retry scheduling builds upto 3 times.
+    ///
+    /// Log error message when still failing after retry. Avoid endless rescheduling
+    /// by acking the pub/sub message without throwing an exception.
+    try {
+      await retryOptions.retry(
+        () async {
+          final List<Request> requestsToRetry = await _sendBatchRequest(request);
+          request = BatchRequest(requests: requestsToRetry);
+          if (requestsToRetry.isNotEmpty) {
+            throw const InternalServerError('Failed to schedule builds.');
+          }
+        },
+        retryIf: (Exception e) => e is InternalServerError,
+      );
+    } catch (e) {
+      log.warning('Failed to schedule builds.');
+      return Body.forString('Failed to schedule builds.');
+    }
 
     return Body.empty;
   }

--- a/app_dart/test/request_handlers/scheduler/request_subscription_test.dart
+++ b/app_dart/test/request_handlers/scheduler/request_subscription_test.dart
@@ -87,4 +87,23 @@ void main() {
     expect(body, Body.empty);
     expect(verify(buildBucketClient.batch(any)).callCount, 2);
   });
+
+  test('acking message and loging error when no response comes back after retry limit', () async {
+    when(buildBucketClient.batch(any)).thenAnswer((_) async {
+      return const BatchResponse();
+    });
+    const BatchRequest request = BatchRequest(requests: <Request>[
+      Request(
+        scheduleBuild: ScheduleBuildRequest(
+          builderId: BuilderId(
+            builder: 'Linux A',
+          ),
+        ),
+      ),
+    ]);
+    tester.message = push_message.PushMessage(data: base64Encode(utf8.encode(jsonEncode(request))));
+    final Body body = await tester.post(handler);
+    expect(body, isNotNull);
+    expect(verify(buildBucketClient.batch(any)).callCount, 3);
+  });
 }


### PR DESCRIPTION
Fix: https://github.com/flutter/flutter/issues/103168

This PR catches exception when retry limit is hit to batch schedule builds.