### PR TITLE
Prevent multiple approvals.

### DIFF
--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -69,7 +69,7 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
         await pubsub.acknowledge('auto-submit-queue-sub', message.ackId!);
         continue;
       } else {
-        approver.approve(pullRequest);
+        await approver.approve(pullRequest);
         processingLog.add(pullRequest.number!);
       }
       if (!await shouldProcess(pullRequest)) {

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:auto_submit/service/approver_service.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/pubsub/v1.dart' as pub;
 import 'package:shelf/shelf.dart';
@@ -36,10 +37,12 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
   const CheckPullRequest({
     required Config config,
     required CronAuthProvider cronAuthProvider,
+    this.approverProvider = ApproverService.defaultProvider,
     this.pubsub = const PubSub(),
   }) : super(config: config, cronAuthProvider: cronAuthProvider);
 
   final PubSub pubsub;
+  final ApproverServiceProvider approverProvider;
 
   static const int kPullMesssageBatchSize = 100;
 
@@ -48,6 +51,7 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
     final List<Response> responses = <Response>[];
     final Set<int> processingLog = <int>{};
     final pub.PullResponse pullResponse = await pubsub.pull('auto-submit-queue-sub', kPullMesssageBatchSize);
+    final ApproverService approver = approverProvider(config);
     final List<pub.ReceivedMessage>? receivedMessages = pullResponse.receivedMessages;
     if (receivedMessages == null) {
       log.info('There are no requests in the queue');
@@ -65,6 +69,7 @@ class CheckPullRequest extends AuthenticatedRequestHandler {
         await pubsub.acknowledge('auto-submit-queue-sub', message.ackId!);
         continue;
       } else {
+        approver.approve(pullRequest);
         processingLog.add(pullRequest.number!);
       }
       if (!await shouldProcess(pullRequest)) {

--- a/auto_submit/lib/requests/github_webhook.dart
+++ b/auto_submit/lib/requests/github_webhook.dart
@@ -10,7 +10,6 @@ import 'package:shelf/shelf.dart';
 import 'package:crypto/crypto.dart';
 
 import '../request_handling/pubsub.dart';
-import '../service/approver_service.dart';
 import '../service/config.dart';
 import '../service/log.dart';
 import '../server/request_handler.dart';
@@ -58,8 +57,6 @@ class GithubWebhook extends RequestHandler {
 
     if (hasAutosubmit) {
       log.info('Found pull request with auto submit label.');
-      ApproverService approver = ApproverService(config);
-      approver.approve(pullRequest);
       await pubsub.publish('auto-submit-queue', pullRequest);
     }
 

--- a/auto_submit/lib/service/approver_service.dart
+++ b/auto_submit/lib/service/approver_service.dart
@@ -7,10 +7,19 @@ import 'package:github/github.dart';
 
 import '../service/config.dart';
 
+/// Function signature for a [ApproverService] provider.
+typedef ApproverServiceProvider = ApproverService Function(Config config);
+
+/// Provides github PR approval services.
 class ApproverService {
-  ApproverService(this.config);
+  const ApproverService(this.config);
 
   final Config config;
+
+  /// Creates and returns a [ApproverService] using [config].
+  static ApproverService defaultProvider(Config config) {
+    return ApproverService(config);
+  }
 
   Future<void> approve(PullRequest pullRequest) async {
     final String? author = pullRequest.user!.login;

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 // ignore_for_file: constant_identifier_names
+import 'package:auto_submit/service/config.dart';
 import 'package:auto_submit/service/log.dart';
 import 'package:logging/logging.dart';
 import 'package:auto_submit/requests/check_pull_request.dart';
@@ -219,7 +220,12 @@ void main() {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, author: rollorAuthor);
       pubsub.publish(testTopic, pullRequest);
 
-      checkPullRequest = CheckPullRequest(config: config, pubsub: pubsub, cronAuthProvider: auth);
+      checkPullRequest = CheckPullRequest(
+        config: config,
+        pubsub: pubsub,
+        cronAuthProvider: auth,
+        approverProvider: (Config config) => MockApproverService(),
+      );
 
       flutterRequest = PullRequestHelper(
         prNumber: 0,

--- a/auto_submit/test/utilities/mocks.dart
+++ b/auto_submit/test/utilities/mocks.dart
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:auto_submit/service/approver_service.dart';
 import 'package:github/github.dart';
 import 'package:mockito/annotations.dart';
 
 export 'mocks.mocks.dart';
 
 @GenerateMocks(<Type>[
+  ApproverService,
   GitHub,
   PullRequestsService,
   RepositoriesService,

--- a/auto_submit/test/utilities/mocks.mocks.dart
+++ b/auto_submit/test/utilities/mocks.mocks.dart
@@ -2,10 +2,12 @@
 // in auto_submit/test/utilities/mocks.dart.
 // Do not manually edit this file.
 
-import 'dart:async' as _i4;
+import 'dart:async' as _i6;
 
-import 'package:github/src/common.dart' as _i3;
-import 'package:http/http.dart' as _i2;
+import 'package:auto_submit/service/approver_service.dart' as _i5;
+import 'package:auto_submit/service/config.dart' as _i2;
+import 'package:github/github.dart' as _i4;
+import 'package:http/http.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -18,152 +20,170 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
-class _FakeClient_0 extends _i1.Fake implements _i2.Client {}
+class _FakeConfig_0 extends _i1.Fake implements _i2.Config {}
 
-class _FakeActivityService_1 extends _i1.Fake implements _i3.ActivityService {}
+class _FakeClient_1 extends _i1.Fake implements _i3.Client {}
 
-class _FakeAuthorizationsService_2 extends _i1.Fake implements _i3.AuthorizationsService {}
+class _FakeActivityService_2 extends _i1.Fake implements _i4.ActivityService {}
 
-class _FakeGistsService_3 extends _i1.Fake implements _i3.GistsService {}
+class _FakeAuthorizationsService_3 extends _i1.Fake implements _i4.AuthorizationsService {}
 
-class _FakeGitService_4 extends _i1.Fake implements _i3.GitService {}
+class _FakeGistsService_4 extends _i1.Fake implements _i4.GistsService {}
 
-class _FakeIssuesService_5 extends _i1.Fake implements _i3.IssuesService {}
+class _FakeGitService_5 extends _i1.Fake implements _i4.GitService {}
 
-class _FakeMiscService_6 extends _i1.Fake implements _i3.MiscService {}
+class _FakeIssuesService_6 extends _i1.Fake implements _i4.IssuesService {}
 
-class _FakeOrganizationsService_7 extends _i1.Fake implements _i3.OrganizationsService {}
+class _FakeMiscService_7 extends _i1.Fake implements _i4.MiscService {}
 
-class _FakePullRequestsService_8 extends _i1.Fake implements _i3.PullRequestsService {}
+class _FakeOrganizationsService_8 extends _i1.Fake implements _i4.OrganizationsService {}
 
-class _FakeRepositoriesService_9 extends _i1.Fake implements _i3.RepositoriesService {}
+class _FakePullRequestsService_9 extends _i1.Fake implements _i4.PullRequestsService {}
 
-class _FakeSearchService_10 extends _i1.Fake implements _i3.SearchService {}
+class _FakeRepositoriesService_10 extends _i1.Fake implements _i4.RepositoriesService {}
 
-class _FakeUrlShortenerService_11 extends _i1.Fake implements _i3.UrlShortenerService {}
+class _FakeSearchService_11 extends _i1.Fake implements _i4.SearchService {}
 
-class _FakeUsersService_12 extends _i1.Fake implements _i3.UsersService {}
+class _FakeUrlShortenerService_12 extends _i1.Fake implements _i4.UrlShortenerService {}
 
-class _FakeChecksService_13 extends _i1.Fake implements _i3.ChecksService {}
+class _FakeUsersService_13 extends _i1.Fake implements _i4.UsersService {}
 
-class _FakeResponse_14 extends _i1.Fake implements _i2.Response {}
+class _FakeChecksService_14 extends _i1.Fake implements _i4.ChecksService {}
 
-class _FakeGitHub_15 extends _i1.Fake implements _i3.GitHub {}
+class _FakeResponse_15 extends _i1.Fake implements _i3.Response {}
 
-class _FakePullRequest_16 extends _i1.Fake implements _i3.PullRequest {}
+class _FakeGitHub_16 extends _i1.Fake implements _i4.GitHub {}
 
-class _FakePullRequestMerge_17 extends _i1.Fake implements _i3.PullRequestMerge {}
+class _FakePullRequest_17 extends _i1.Fake implements _i4.PullRequest {}
 
-class _FakePullRequestComment_18 extends _i1.Fake implements _i3.PullRequestComment {}
+class _FakePullRequestMerge_18 extends _i1.Fake implements _i4.PullRequestMerge {}
 
-class _FakePullRequestReview_19 extends _i1.Fake implements _i3.PullRequestReview {}
+class _FakePullRequestComment_19 extends _i1.Fake implements _i4.PullRequestComment {}
 
-class _FakeRepository_20 extends _i1.Fake implements _i3.Repository {}
+class _FakePullRequestReview_20 extends _i1.Fake implements _i4.PullRequestReview {}
 
-class _FakeLicenseDetails_21 extends _i1.Fake implements _i3.LicenseDetails {}
+class _FakeRepository_21 extends _i1.Fake implements _i4.Repository {}
 
-class _FakeLanguageBreakdown_22 extends _i1.Fake implements _i3.LanguageBreakdown {}
+class _FakeLicenseDetails_22 extends _i1.Fake implements _i4.LicenseDetails {}
 
-class _FakeBranch_23 extends _i1.Fake implements _i3.Branch {}
+class _FakeLanguageBreakdown_23 extends _i1.Fake implements _i4.LanguageBreakdown {}
 
-class _FakeCommitComment_24 extends _i1.Fake implements _i3.CommitComment {}
+class _FakeBranch_24 extends _i1.Fake implements _i4.Branch {}
 
-class _FakeRepositoryCommit_25 extends _i1.Fake implements _i3.RepositoryCommit {}
+class _FakeCommitComment_25 extends _i1.Fake implements _i4.CommitComment {}
 
-class _FakeGitHubComparison_26 extends _i1.Fake implements _i3.GitHubComparison {}
+class _FakeRepositoryCommit_26 extends _i1.Fake implements _i4.RepositoryCommit {}
 
-class _FakeGitHubFile_27 extends _i1.Fake implements _i3.GitHubFile {}
+class _FakeGitHubComparison_27 extends _i1.Fake implements _i4.GitHubComparison {}
 
-class _FakeRepositoryContents_28 extends _i1.Fake implements _i3.RepositoryContents {}
+class _FakeGitHubFile_28 extends _i1.Fake implements _i4.GitHubFile {}
 
-class _FakeContentCreation_29 extends _i1.Fake implements _i3.ContentCreation {}
+class _FakeRepositoryContents_29 extends _i1.Fake implements _i4.RepositoryContents {}
 
-class _FakeHook_30 extends _i1.Fake implements _i3.Hook {}
+class _FakeContentCreation_30 extends _i1.Fake implements _i4.ContentCreation {}
 
-class _FakePublicKey_31 extends _i1.Fake implements _i3.PublicKey {}
+class _FakeHook_31 extends _i1.Fake implements _i4.Hook {}
 
-class _FakeRepositoryPages_32 extends _i1.Fake implements _i3.RepositoryPages {}
+class _FakePublicKey_32 extends _i1.Fake implements _i4.PublicKey {}
 
-class _FakePageBuild_33 extends _i1.Fake implements _i3.PageBuild {}
+class _FakeRepositoryPages_33 extends _i1.Fake implements _i4.RepositoryPages {}
 
-class _FakeRelease_34 extends _i1.Fake implements _i3.Release {}
+class _FakePageBuild_34 extends _i1.Fake implements _i4.PageBuild {}
 
-class _FakeReleaseAsset_35 extends _i1.Fake implements _i3.ReleaseAsset {}
+class _FakeRelease_35 extends _i1.Fake implements _i4.Release {}
 
-class _FakeContributorParticipation_36 extends _i1.Fake implements _i3.ContributorParticipation {}
+class _FakeReleaseAsset_36 extends _i1.Fake implements _i4.ReleaseAsset {}
 
-class _FakeRepositoryStatus_37 extends _i1.Fake implements _i3.RepositoryStatus {}
+class _FakeContributorParticipation_37 extends _i1.Fake implements _i4.ContributorParticipation {}
 
-class _FakeCombinedRepositoryStatus_38 extends _i1.Fake implements _i3.CombinedRepositoryStatus {}
+class _FakeRepositoryStatus_38 extends _i1.Fake implements _i4.RepositoryStatus {}
 
-class _FakeReleaseNotes_39 extends _i1.Fake implements _i3.ReleaseNotes {}
+class _FakeCombinedRepositoryStatus_39 extends _i1.Fake implements _i4.CombinedRepositoryStatus {}
+
+class _FakeReleaseNotes_40 extends _i1.Fake implements _i4.ReleaseNotes {}
+
+/// A class which mocks [ApproverService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockApproverService extends _i1.Mock implements _i5.ApproverService {
+  MockApproverService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i2.Config get config => (super.noSuchMethod(Invocation.getter(#config), returnValue: _FakeConfig_0()) as _i2.Config);
+  @override
+  _i6.Future<void> approve(_i4.PullRequest? pullRequest) =>
+      (super.noSuchMethod(Invocation.method(#approve, [pullRequest]),
+          returnValue: Future<void>.value(), returnValueForMissingStub: Future<void>.value()) as _i6.Future<void>);
+}
 
 /// A class which mocks [GitHub].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGitHub extends _i1.Mock implements _i3.GitHub {
+class MockGitHub extends _i1.Mock implements _i4.GitHub {
   MockGitHub() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set auth(_i3.Authentication? _auth) =>
+  set auth(_i4.Authentication? _auth) =>
       super.noSuchMethod(Invocation.setter(#auth, _auth), returnValueForMissingStub: null);
   @override
   String get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint), returnValue: '') as String);
   @override
-  _i2.Client get client => (super.noSuchMethod(Invocation.getter(#client), returnValue: _FakeClient_0()) as _i2.Client);
+  _i3.Client get client => (super.noSuchMethod(Invocation.getter(#client), returnValue: _FakeClient_1()) as _i3.Client);
   @override
-  _i3.ActivityService get activity =>
-      (super.noSuchMethod(Invocation.getter(#activity), returnValue: _FakeActivityService_1()) as _i3.ActivityService);
+  _i4.ActivityService get activity =>
+      (super.noSuchMethod(Invocation.getter(#activity), returnValue: _FakeActivityService_2()) as _i4.ActivityService);
   @override
-  _i3.AuthorizationsService get authorizations =>
-      (super.noSuchMethod(Invocation.getter(#authorizations), returnValue: _FakeAuthorizationsService_2())
-          as _i3.AuthorizationsService);
+  _i4.AuthorizationsService get authorizations =>
+      (super.noSuchMethod(Invocation.getter(#authorizations), returnValue: _FakeAuthorizationsService_3())
+          as _i4.AuthorizationsService);
   @override
-  _i3.GistsService get gists =>
-      (super.noSuchMethod(Invocation.getter(#gists), returnValue: _FakeGistsService_3()) as _i3.GistsService);
+  _i4.GistsService get gists =>
+      (super.noSuchMethod(Invocation.getter(#gists), returnValue: _FakeGistsService_4()) as _i4.GistsService);
   @override
-  _i3.GitService get git =>
-      (super.noSuchMethod(Invocation.getter(#git), returnValue: _FakeGitService_4()) as _i3.GitService);
+  _i4.GitService get git =>
+      (super.noSuchMethod(Invocation.getter(#git), returnValue: _FakeGitService_5()) as _i4.GitService);
   @override
-  _i3.IssuesService get issues =>
-      (super.noSuchMethod(Invocation.getter(#issues), returnValue: _FakeIssuesService_5()) as _i3.IssuesService);
+  _i4.IssuesService get issues =>
+      (super.noSuchMethod(Invocation.getter(#issues), returnValue: _FakeIssuesService_6()) as _i4.IssuesService);
   @override
-  _i3.MiscService get misc =>
-      (super.noSuchMethod(Invocation.getter(#misc), returnValue: _FakeMiscService_6()) as _i3.MiscService);
+  _i4.MiscService get misc =>
+      (super.noSuchMethod(Invocation.getter(#misc), returnValue: _FakeMiscService_7()) as _i4.MiscService);
   @override
-  _i3.OrganizationsService get organizations =>
-      (super.noSuchMethod(Invocation.getter(#organizations), returnValue: _FakeOrganizationsService_7())
-          as _i3.OrganizationsService);
+  _i4.OrganizationsService get organizations =>
+      (super.noSuchMethod(Invocation.getter(#organizations), returnValue: _FakeOrganizationsService_8())
+          as _i4.OrganizationsService);
   @override
-  _i3.PullRequestsService get pullRequests =>
-      (super.noSuchMethod(Invocation.getter(#pullRequests), returnValue: _FakePullRequestsService_8())
-          as _i3.PullRequestsService);
+  _i4.PullRequestsService get pullRequests =>
+      (super.noSuchMethod(Invocation.getter(#pullRequests), returnValue: _FakePullRequestsService_9())
+          as _i4.PullRequestsService);
   @override
-  _i3.RepositoriesService get repositories =>
-      (super.noSuchMethod(Invocation.getter(#repositories), returnValue: _FakeRepositoriesService_9())
-          as _i3.RepositoriesService);
+  _i4.RepositoriesService get repositories =>
+      (super.noSuchMethod(Invocation.getter(#repositories), returnValue: _FakeRepositoriesService_10())
+          as _i4.RepositoriesService);
   @override
-  _i3.SearchService get search =>
-      (super.noSuchMethod(Invocation.getter(#search), returnValue: _FakeSearchService_10()) as _i3.SearchService);
+  _i4.SearchService get search =>
+      (super.noSuchMethod(Invocation.getter(#search), returnValue: _FakeSearchService_11()) as _i4.SearchService);
   @override
-  _i3.UrlShortenerService get urlShortener =>
-      (super.noSuchMethod(Invocation.getter(#urlShortener), returnValue: _FakeUrlShortenerService_11())
-          as _i3.UrlShortenerService);
+  _i4.UrlShortenerService get urlShortener =>
+      (super.noSuchMethod(Invocation.getter(#urlShortener), returnValue: _FakeUrlShortenerService_12())
+          as _i4.UrlShortenerService);
   @override
-  _i3.UsersService get users =>
-      (super.noSuchMethod(Invocation.getter(#users), returnValue: _FakeUsersService_12()) as _i3.UsersService);
+  _i4.UsersService get users =>
+      (super.noSuchMethod(Invocation.getter(#users), returnValue: _FakeUsersService_13()) as _i4.UsersService);
   @override
-  _i3.ChecksService get checks =>
-      (super.noSuchMethod(Invocation.getter(#checks), returnValue: _FakeChecksService_13()) as _i3.ChecksService);
+  _i4.ChecksService get checks =>
+      (super.noSuchMethod(Invocation.getter(#checks), returnValue: _FakeChecksService_14()) as _i4.ChecksService);
   @override
-  _i4.Future<T> getJSON<S, T>(String? path,
+  _i6.Future<T> getJSON<S, T>(String? path,
           {int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           Map<String, String>? headers,
           Map<String, String>? params,
-          _i3.JSONConverter<S, T>? convert,
+          _i4.JSONConverter<S, T>? convert,
           String? preview}) =>
       (super.noSuchMethod(
           Invocation.method(#getJSON, [
@@ -176,14 +196,14 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #convert: convert,
             #preview: preview
           }),
-          returnValue: Future<T>.value(null)) as _i4.Future<T>);
+          returnValue: Future<T>.value(null)) as _i6.Future<T>);
   @override
-  _i4.Future<T> postJSON<S, T>(String? path,
+  _i6.Future<T> postJSON<S, T>(String? path,
           {int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           Map<String, String>? headers,
           Map<String, dynamic>? params,
-          _i3.JSONConverter<S, T>? convert,
+          _i4.JSONConverter<S, T>? convert,
           dynamic body,
           String? preview}) =>
       (super.noSuchMethod(
@@ -198,14 +218,14 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #body: body,
             #preview: preview
           }),
-          returnValue: Future<T>.value(null)) as _i4.Future<T>);
+          returnValue: Future<T>.value(null)) as _i6.Future<T>);
   @override
-  _i4.Future<T> putJSON<S, T>(String? path,
+  _i6.Future<T> putJSON<S, T>(String? path,
           {int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           Map<String, String>? headers,
           Map<String, dynamic>? params,
-          _i3.JSONConverter<S, T>? convert,
+          _i4.JSONConverter<S, T>? convert,
           dynamic body,
           String? preview}) =>
       (super.noSuchMethod(
@@ -220,14 +240,14 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #body: body,
             #preview: preview
           }),
-          returnValue: Future<T>.value(null)) as _i4.Future<T>);
+          returnValue: Future<T>.value(null)) as _i6.Future<T>);
   @override
-  _i4.Future<T> patchJSON<S, T>(String? path,
+  _i6.Future<T> patchJSON<S, T>(String? path,
           {int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           Map<String, String>? headers,
           Map<String, dynamic>? params,
-          _i3.JSONConverter<S, T>? convert,
+          _i4.JSONConverter<S, T>? convert,
           dynamic body,
           String? preview}) =>
       (super.noSuchMethod(
@@ -242,14 +262,14 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #body: body,
             #preview: preview
           }),
-          returnValue: Future<T>.value(null)) as _i4.Future<T>);
+          returnValue: Future<T>.value(null)) as _i6.Future<T>);
   @override
-  _i4.Future<T> requestJson<S, T>(String? method, String? path,
+  _i6.Future<T> requestJson<S, T>(String? method, String? path,
           {int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           Map<String, String>? headers,
           Map<String, dynamic>? params,
-          _i3.JSONConverter<S, T?>? convert,
+          _i4.JSONConverter<S, T?>? convert,
           dynamic body,
           String? preview}) =>
       (super.noSuchMethod(
@@ -265,14 +285,14 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #body: body,
             #preview: preview
           }),
-          returnValue: Future<T>.value(null)) as _i4.Future<T>);
+          returnValue: Future<T>.value(null)) as _i6.Future<T>);
   @override
-  _i4.Future<_i2.Response> request(String? method, String? path,
+  _i6.Future<_i3.Response> request(String? method, String? path,
           {Map<String, String>? headers,
           Map<String, dynamic>? params,
           dynamic body,
           int? statusCode,
-          void Function(_i2.Response)? fail,
+          void Function(_i3.Response)? fail,
           String? preview}) =>
       (super.noSuchMethod(
           Invocation.method(#request, [
@@ -286,9 +306,9 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
             #fail: fail,
             #preview: preview
           }),
-          returnValue: Future<_i2.Response>.value(_FakeResponse_14())) as _i4.Future<_i2.Response>);
+          returnValue: Future<_i3.Response>.value(_FakeResponse_15())) as _i6.Future<_i3.Response>);
   @override
-  void handleStatusCode(_i2.Response? response) =>
+  void handleStatusCode(_i3.Response? response) =>
       super.noSuchMethod(Invocation.method(#handleStatusCode, [response]), returnValueForMissingStub: null);
   @override
   void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
@@ -297,16 +317,16 @@ class MockGitHub extends _i1.Mock implements _i3.GitHub {
 /// A class which mocks [PullRequestsService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock implements _i3.PullRequestsService {
+class MockPullRequestsService extends _i1.Mock implements _i4.PullRequestsService {
   MockPullRequestsService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.GitHub get github =>
-      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_15()) as _i3.GitHub);
+  _i4.GitHub get github =>
+      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16()) as _i4.GitHub);
   @override
-  _i4.Stream<_i3.PullRequest> list(_i3.RepositorySlug? slug,
+  _i6.Stream<_i4.PullRequest> list(_i4.RepositorySlug? slug,
           {int? pages,
           String? base,
           String? direction = r'desc',
@@ -316,111 +336,111 @@ class MockPullRequestsService extends _i1.Mock implements _i3.PullRequestsServic
       (super.noSuchMethod(
           Invocation.method(#list, [slug],
               {#pages: pages, #base: base, #direction: direction, #head: head, #sort: sort, #state: state}),
-          returnValue: Stream<_i3.PullRequest>.empty()) as _i4.Stream<_i3.PullRequest>);
+          returnValue: Stream<_i4.PullRequest>.empty()) as _i6.Stream<_i4.PullRequest>);
   @override
-  _i4.Future<_i3.PullRequest> get(_i3.RepositorySlug? slug, int? number) =>
+  _i6.Future<_i4.PullRequest> get(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#get, [slug, number]),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+          returnValue: Future<_i4.PullRequest>.value(_FakePullRequest_17())) as _i6.Future<_i4.PullRequest>);
   @override
-  _i4.Future<_i3.PullRequest> create(_i3.RepositorySlug? slug, _i3.CreatePullRequest? request) =>
+  _i6.Future<_i4.PullRequest> create(_i4.RepositorySlug? slug, _i4.CreatePullRequest? request) =>
       (super.noSuchMethod(Invocation.method(#create, [slug, request]),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+          returnValue: Future<_i4.PullRequest>.value(_FakePullRequest_17())) as _i6.Future<_i4.PullRequest>);
   @override
-  _i4.Future<_i3.PullRequest> edit(_i3.RepositorySlug? slug, int? number,
+  _i6.Future<_i4.PullRequest> edit(_i4.RepositorySlug? slug, int? number,
           {String? title, String? body, String? state, String? base}) =>
       (super.noSuchMethod(
           Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
-          returnValue: Future<_i3.PullRequest>.value(_FakePullRequest_16())) as _i4.Future<_i3.PullRequest>);
+          returnValue: Future<_i4.PullRequest>.value(_FakePullRequest_17())) as _i6.Future<_i4.PullRequest>);
   @override
-  _i4.Stream<_i3.RepositoryCommit> listCommits(_i3.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listCommits, [slug, number]),
-          returnValue: Stream<_i3.RepositoryCommit>.empty()) as _i4.Stream<_i3.RepositoryCommit>);
+          returnValue: Stream<_i4.RepositoryCommit>.empty()) as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i4.Stream<_i3.PullRequestFile> listFiles(_i3.RepositorySlug? slug, int? number) => (super
-          .noSuchMethod(Invocation.method(#listFiles, [slug, number]), returnValue: Stream<_i3.PullRequestFile>.empty())
-      as _i4.Stream<_i3.PullRequestFile>);
+  _i6.Stream<_i4.PullRequestFile> listFiles(_i4.RepositorySlug? slug, int? number) => (super
+          .noSuchMethod(Invocation.method(#listFiles, [slug, number]), returnValue: Stream<_i4.PullRequestFile>.empty())
+      as _i6.Stream<_i4.PullRequestFile>);
   @override
-  _i4.Stream<_i3.PullRequestReview> listReviews(_i3.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestReview> listReviews(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listReviews, [slug, number]),
-          returnValue: Stream<_i3.PullRequestReview>.empty()) as _i4.Stream<_i3.PullRequestReview>);
+          returnValue: Stream<_i4.PullRequestReview>.empty()) as _i6.Stream<_i4.PullRequestReview>);
   @override
-  _i4.Future<bool> isMerged(_i3.RepositorySlug? slug, int? number) =>
+  _i6.Future<bool> isMerged(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<_i3.PullRequestMerge> merge(_i3.RepositorySlug? slug, int? number, {String? message}) =>
+  _i6.Future<_i4.PullRequestMerge> merge(_i4.RepositorySlug? slug, int? number, {String? message}) =>
       (super.noSuchMethod(Invocation.method(#merge, [slug, number], {#message: message}),
-              returnValue: Future<_i3.PullRequestMerge>.value(_FakePullRequestMerge_17()))
-          as _i4.Future<_i3.PullRequestMerge>);
+              returnValue: Future<_i4.PullRequestMerge>.value(_FakePullRequestMerge_18()))
+          as _i6.Future<_i4.PullRequestMerge>);
   @override
-  _i4.Stream<_i3.PullRequestComment> listCommentsByPullRequest(_i3.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestComment> listCommentsByPullRequest(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listCommentsByPullRequest, [slug, number]),
-          returnValue: Stream<_i3.PullRequestComment>.empty()) as _i4.Stream<_i3.PullRequestComment>);
+          returnValue: Stream<_i4.PullRequestComment>.empty()) as _i6.Stream<_i4.PullRequestComment>);
   @override
-  _i4.Stream<_i3.PullRequestComment> listComments(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listComments, [slug]), returnValue: Stream<_i3.PullRequestComment>.empty())
-          as _i4.Stream<_i3.PullRequestComment>);
+  _i6.Stream<_i4.PullRequestComment> listComments(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listComments, [slug]), returnValue: Stream<_i4.PullRequestComment>.empty())
+          as _i6.Stream<_i4.PullRequestComment>);
   @override
-  _i4.Future<_i3.PullRequestComment> createComment(
-          _i3.RepositorySlug? slug, int? number, _i3.CreatePullRequestComment? comment) =>
+  _i6.Future<_i4.PullRequestComment> createComment(
+          _i4.RepositorySlug? slug, int? number, _i4.CreatePullRequestComment? comment) =>
       (super.noSuchMethod(Invocation.method(#createComment, [slug, number, comment]),
-              returnValue: Future<_i3.PullRequestComment>.value(_FakePullRequestComment_18()))
-          as _i4.Future<_i3.PullRequestComment>);
+              returnValue: Future<_i4.PullRequestComment>.value(_FakePullRequestComment_19()))
+          as _i6.Future<_i4.PullRequestComment>);
   @override
-  _i4.Future<_i3.PullRequestReview> createReview(_i3.RepositorySlug? slug, _i3.CreatePullRequestReview? review) =>
+  _i6.Future<_i4.PullRequestReview> createReview(_i4.RepositorySlug? slug, _i4.CreatePullRequestReview? review) =>
       (super.noSuchMethod(Invocation.method(#createReview, [slug, review]),
-              returnValue: Future<_i3.PullRequestReview>.value(_FakePullRequestReview_19()))
-          as _i4.Future<_i3.PullRequestReview>);
+              returnValue: Future<_i4.PullRequestReview>.value(_FakePullRequestReview_20()))
+          as _i6.Future<_i4.PullRequestReview>);
 }
 
 /// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRepositoriesService extends _i1.Mock implements _i3.RepositoriesService {
+class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesService {
   MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.GitHub get github =>
-      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_15()) as _i3.GitHub);
+  _i4.GitHub get github =>
+      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16()) as _i4.GitHub);
   @override
-  _i4.Stream<_i3.Repository> listRepositories(
+  _i6.Stream<_i4.Repository> listRepositories(
           {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
       (super.noSuchMethod(Invocation.method(#listRepositories, [], {#type: type, #sort: sort, #direction: direction}),
-          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
+          returnValue: Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Stream<_i3.Repository> listUserRepositories(String? user,
+  _i6.Stream<_i4.Repository> listUserRepositories(String? user,
           {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
       (super.noSuchMethod(
           Invocation.method(#listUserRepositories, [user], {#type: type, #sort: sort, #direction: direction}),
-          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
+          returnValue: Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Stream<_i3.Repository> listOrganizationRepositories(String? org, {String? type = r'all'}) =>
+  _i6.Stream<_i4.Repository> listOrganizationRepositories(String? org, {String? type = r'all'}) =>
       (super.noSuchMethod(Invocation.method(#listOrganizationRepositories, [org], {#type: type}),
-          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
+          returnValue: Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Stream<_i3.Repository> listPublicRepositories({int? limit = 50, DateTime? since}) =>
+  _i6.Stream<_i4.Repository> listPublicRepositories({int? limit = 50, DateTime? since}) =>
       (super.noSuchMethod(Invocation.method(#listPublicRepositories, [], {#limit: limit, #since: since}),
-          returnValue: Stream<_i3.Repository>.empty()) as _i4.Stream<_i3.Repository>);
+          returnValue: Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Future<_i3.Repository> createRepository(_i3.CreateRepository? repository, {String? org}) =>
+  _i6.Future<_i4.Repository> createRepository(_i4.CreateRepository? repository, {String? org}) =>
       (super.noSuchMethod(Invocation.method(#createRepository, [repository], {#org: org}),
-          returnValue: Future<_i3.Repository>.value(_FakeRepository_20())) as _i4.Future<_i3.Repository>);
+          returnValue: Future<_i4.Repository>.value(_FakeRepository_21())) as _i6.Future<_i4.Repository>);
   @override
-  _i4.Future<_i3.LicenseDetails> getLicense(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.LicenseDetails> getLicense(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLicense, [slug]),
-          returnValue: Future<_i3.LicenseDetails>.value(_FakeLicenseDetails_21())) as _i4.Future<_i3.LicenseDetails>);
+          returnValue: Future<_i4.LicenseDetails>.value(_FakeLicenseDetails_22())) as _i6.Future<_i4.LicenseDetails>);
   @override
-  _i4.Future<_i3.Repository> getRepository(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.Repository> getRepository(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getRepository, [slug]),
-          returnValue: Future<_i3.Repository>.value(_FakeRepository_20())) as _i4.Future<_i3.Repository>);
+          returnValue: Future<_i4.Repository>.value(_FakeRepository_21())) as _i6.Future<_i4.Repository>);
   @override
-  _i4.Stream<_i3.Repository> getRepositories(List<_i3.RepositorySlug>? slugs) =>
-      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]), returnValue: Stream<_i3.Repository>.empty())
-          as _i4.Stream<_i3.Repository>);
+  _i6.Stream<_i4.Repository> getRepositories(List<_i4.RepositorySlug>? slugs) =>
+      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]), returnValue: Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Future<_i3.Repository> editRepository(_i3.RepositorySlug? slug,
+  _i6.Future<_i4.Repository> editRepository(_i4.RepositorySlug? slug,
           {String? name,
           String? description,
           String? homepage,
@@ -440,147 +460,147 @@ class MockRepositoriesService extends _i1.Mock implements _i3.RepositoriesServic
             #hasWiki: hasWiki,
             #hasDownloads: hasDownloads
           }),
-          returnValue: Future<_i3.Repository>.value(_FakeRepository_20())) as _i4.Future<_i3.Repository>);
+          returnValue: Future<_i4.Repository>.value(_FakeRepository_21())) as _i6.Future<_i4.Repository>);
   @override
-  _i4.Future<bool> deleteRepository(_i3.RepositorySlug? slug) =>
+  _i6.Future<bool> deleteRepository(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Stream<_i3.Contributor> listContributors(_i3.RepositorySlug? slug, {bool? anon = false}) =>
+  _i6.Stream<_i4.Contributor> listContributors(_i4.RepositorySlug? slug, {bool? anon = false}) =>
       (super.noSuchMethod(Invocation.method(#listContributors, [slug], {#anon: anon}),
-          returnValue: Stream<_i3.Contributor>.empty()) as _i4.Stream<_i3.Contributor>);
+          returnValue: Stream<_i4.Contributor>.empty()) as _i6.Stream<_i4.Contributor>);
   @override
-  _i4.Stream<_i3.Team> listTeams(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listTeams, [slug]), returnValue: Stream<_i3.Team>.empty())
-          as _i4.Stream<_i3.Team>);
+  _i6.Stream<_i4.Team> listTeams(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listTeams, [slug]), returnValue: Stream<_i4.Team>.empty())
+          as _i6.Stream<_i4.Team>);
   @override
-  _i4.Future<_i3.LanguageBreakdown> listLanguages(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.LanguageBreakdown> listLanguages(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listLanguages, [slug]),
-              returnValue: Future<_i3.LanguageBreakdown>.value(_FakeLanguageBreakdown_22()))
-          as _i4.Future<_i3.LanguageBreakdown>);
+              returnValue: Future<_i4.LanguageBreakdown>.value(_FakeLanguageBreakdown_23()))
+          as _i6.Future<_i4.LanguageBreakdown>);
   @override
-  _i4.Stream<_i3.Tag> listTags(_i3.RepositorySlug? slug, {int? page = 1, int? pages, int? perPage = 30}) =>
+  _i6.Stream<_i4.Tag> listTags(_i4.RepositorySlug? slug, {int? page = 1, int? pages, int? perPage = 30}) =>
       (super.noSuchMethod(Invocation.method(#listTags, [slug], {#page: page, #pages: pages, #perPage: perPage}),
-          returnValue: Stream<_i3.Tag>.empty()) as _i4.Stream<_i3.Tag>);
+          returnValue: Stream<_i4.Tag>.empty()) as _i6.Stream<_i4.Tag>);
   @override
-  _i4.Stream<_i3.Branch> listBranches(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listBranches, [slug]), returnValue: Stream<_i3.Branch>.empty())
-          as _i4.Stream<_i3.Branch>);
+  _i6.Stream<_i4.Branch> listBranches(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listBranches, [slug]), returnValue: Stream<_i4.Branch>.empty())
+          as _i6.Stream<_i4.Branch>);
   @override
-  _i4.Future<_i3.Branch> getBranch(_i3.RepositorySlug? slug, String? branch) =>
+  _i6.Future<_i4.Branch> getBranch(_i4.RepositorySlug? slug, String? branch) =>
       (super.noSuchMethod(Invocation.method(#getBranch, [slug, branch]),
-          returnValue: Future<_i3.Branch>.value(_FakeBranch_23())) as _i4.Future<_i3.Branch>);
+          returnValue: Future<_i4.Branch>.value(_FakeBranch_24())) as _i6.Future<_i4.Branch>);
   @override
-  _i4.Stream<_i3.Collaborator> listCollaborators(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listCollaborators, [slug]), returnValue: Stream<_i3.Collaborator>.empty())
-          as _i4.Stream<_i3.Collaborator>);
+  _i6.Stream<_i4.Collaborator> listCollaborators(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCollaborators, [slug]), returnValue: Stream<_i4.Collaborator>.empty())
+          as _i6.Stream<_i4.Collaborator>);
   @override
-  _i4.Future<bool> isCollaborator(_i3.RepositorySlug? slug, String? user) =>
+  _i6.Future<bool> isCollaborator(_i4.RepositorySlug? slug, String? user) =>
       (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<bool> addCollaborator(_i3.RepositorySlug? slug, String? user) =>
+  _i6.Future<bool> addCollaborator(_i4.RepositorySlug? slug, String? user) =>
       (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<bool> removeCollaborator(_i3.RepositorySlug? slug, String? user) =>
+  _i6.Future<bool> removeCollaborator(_i4.RepositorySlug? slug, String? user) =>
       (super.noSuchMethod(Invocation.method(#removeCollaborator, [slug, user]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Stream<_i3.CommitComment> listSingleCommitComments(_i3.RepositorySlug? slug, _i3.RepositoryCommit? commit) =>
+  _i6.Stream<_i4.CommitComment> listSingleCommitComments(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit) =>
       (super.noSuchMethod(Invocation.method(#listSingleCommitComments, [slug, commit]),
-          returnValue: Stream<_i3.CommitComment>.empty()) as _i4.Stream<_i3.CommitComment>);
+          returnValue: Stream<_i4.CommitComment>.empty()) as _i6.Stream<_i4.CommitComment>);
   @override
-  _i4.Stream<_i3.CommitComment> listCommitComments(_i3.RepositorySlug? slug) => (super
-          .noSuchMethod(Invocation.method(#listCommitComments, [slug]), returnValue: Stream<_i3.CommitComment>.empty())
-      as _i4.Stream<_i3.CommitComment>);
+  _i6.Stream<_i4.CommitComment> listCommitComments(_i4.RepositorySlug? slug) => (super
+          .noSuchMethod(Invocation.method(#listCommitComments, [slug]), returnValue: Stream<_i4.CommitComment>.empty())
+      as _i6.Stream<_i4.CommitComment>);
   @override
-  _i4.Future<_i3.CommitComment> createCommitComment(_i3.RepositorySlug? slug, _i3.RepositoryCommit? commit,
+  _i6.Future<_i4.CommitComment> createCommitComment(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit,
           {String? body, String? path, int? position, int? line}) =>
       (super.noSuchMethod(
           Invocation.method(
               #createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}),
-          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_24())) as _i4.Future<_i3.CommitComment>);
+          returnValue: Future<_i4.CommitComment>.value(_FakeCommitComment_25())) as _i6.Future<_i4.CommitComment>);
   @override
-  _i4.Future<_i3.CommitComment> getCommitComment(_i3.RepositorySlug? slug, {int? id}) =>
+  _i6.Future<_i4.CommitComment> getCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
       (super.noSuchMethod(Invocation.method(#getCommitComment, [slug], {#id: id}),
-          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_24())) as _i4.Future<_i3.CommitComment>);
+          returnValue: Future<_i4.CommitComment>.value(_FakeCommitComment_25())) as _i6.Future<_i4.CommitComment>);
   @override
-  _i4.Future<_i3.CommitComment> updateCommitComment(_i3.RepositorySlug? slug, {int? id, String? body}) =>
+  _i6.Future<_i4.CommitComment> updateCommitComment(_i4.RepositorySlug? slug, {int? id, String? body}) =>
       (super.noSuchMethod(Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}),
-          returnValue: Future<_i3.CommitComment>.value(_FakeCommitComment_24())) as _i4.Future<_i3.CommitComment>);
+          returnValue: Future<_i4.CommitComment>.value(_FakeCommitComment_25())) as _i6.Future<_i4.CommitComment>);
   @override
-  _i4.Future<bool> deleteCommitComment(_i3.RepositorySlug? slug, {int? id}) =>
+  _i6.Future<bool> deleteCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
       (super.noSuchMethod(Invocation.method(#deleteCommitComment, [slug], {#id: id}),
-          returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i4.Stream<_i3.RepositoryCommit> listCommits(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listCommits, [slug]), returnValue: Stream<_i3.RepositoryCommit>.empty())
-          as _i4.Stream<_i3.RepositoryCommit>);
+  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCommits, [slug]), returnValue: Stream<_i4.RepositoryCommit>.empty())
+          as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i4.Future<_i3.RepositoryCommit> getCommit(_i3.RepositorySlug? slug, String? sha) => (super.noSuchMethod(
+  _i6.Future<_i4.RepositoryCommit> getCommit(_i4.RepositorySlug? slug, String? sha) => (super.noSuchMethod(
       Invocation.method(#getCommit, [slug, sha]),
-      returnValue: Future<_i3.RepositoryCommit>.value(_FakeRepositoryCommit_25())) as _i4.Future<_i3.RepositoryCommit>);
+      returnValue: Future<_i4.RepositoryCommit>.value(_FakeRepositoryCommit_26())) as _i6.Future<_i4.RepositoryCommit>);
   @override
-  _i4.Future<String> getCommitDiff(_i3.RepositorySlug? slug, String? sha) =>
+  _i6.Future<String> getCommitDiff(_i4.RepositorySlug? slug, String? sha) =>
       (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]), returnValue: Future<String>.value(''))
-          as _i4.Future<String>);
+          as _i6.Future<String>);
   @override
-  _i4.Future<_i3.GitHubComparison> compareCommits(_i3.RepositorySlug? slug, String? refBase, String? refHead) =>
+  _i6.Future<_i4.GitHubComparison> compareCommits(_i4.RepositorySlug? slug, String? refBase, String? refHead) =>
       (super.noSuchMethod(Invocation.method(#compareCommits, [slug, refBase, refHead]),
-              returnValue: Future<_i3.GitHubComparison>.value(_FakeGitHubComparison_26()))
-          as _i4.Future<_i3.GitHubComparison>);
+              returnValue: Future<_i4.GitHubComparison>.value(_FakeGitHubComparison_27()))
+          as _i6.Future<_i4.GitHubComparison>);
   @override
-  _i4.Future<_i3.GitHubFile> getReadme(_i3.RepositorySlug? slug, {String? ref}) =>
+  _i6.Future<_i4.GitHubFile> getReadme(_i4.RepositorySlug? slug, {String? ref}) =>
       (super.noSuchMethod(Invocation.method(#getReadme, [slug], {#ref: ref}),
-          returnValue: Future<_i3.GitHubFile>.value(_FakeGitHubFile_27())) as _i4.Future<_i3.GitHubFile>);
+          returnValue: Future<_i4.GitHubFile>.value(_FakeGitHubFile_28())) as _i6.Future<_i4.GitHubFile>);
   @override
-  _i4.Future<_i3.RepositoryContents> getContents(_i3.RepositorySlug? slug, String? path, {String? ref}) =>
+  _i6.Future<_i4.RepositoryContents> getContents(_i4.RepositorySlug? slug, String? path, {String? ref}) =>
       (super.noSuchMethod(Invocation.method(#getContents, [slug, path], {#ref: ref}),
-              returnValue: Future<_i3.RepositoryContents>.value(_FakeRepositoryContents_28()))
-          as _i4.Future<_i3.RepositoryContents>);
+              returnValue: Future<_i4.RepositoryContents>.value(_FakeRepositoryContents_29()))
+          as _i6.Future<_i4.RepositoryContents>);
   @override
-  _i4.Future<_i3.ContentCreation> createFile(_i3.RepositorySlug? slug, _i3.CreateFile? file) => (super.noSuchMethod(
+  _i6.Future<_i4.ContentCreation> createFile(_i4.RepositorySlug? slug, _i4.CreateFile? file) => (super.noSuchMethod(
       Invocation.method(#createFile, [slug, file]),
-      returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_29())) as _i4.Future<_i3.ContentCreation>);
+      returnValue: Future<_i4.ContentCreation>.value(_FakeContentCreation_30())) as _i6.Future<_i4.ContentCreation>);
   @override
-  _i4.Future<_i3.ContentCreation> updateFile(
-          _i3.RepositorySlug? slug, String? path, String? message, String? content, String? sha, {String? branch}) =>
+  _i6.Future<_i4.ContentCreation> updateFile(
+          _i4.RepositorySlug? slug, String? path, String? message, String? content, String? sha, {String? branch}) =>
       (super.noSuchMethod(Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}),
-              returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_29()))
-          as _i4.Future<_i3.ContentCreation>);
+              returnValue: Future<_i4.ContentCreation>.value(_FakeContentCreation_30()))
+          as _i6.Future<_i4.ContentCreation>);
   @override
-  _i4.Future<_i3.ContentCreation> deleteFile(
-          _i3.RepositorySlug? slug, String? path, String? message, String? sha, String? branch) =>
+  _i6.Future<_i4.ContentCreation> deleteFile(
+          _i4.RepositorySlug? slug, String? path, String? message, String? sha, String? branch) =>
       (super.noSuchMethod(Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
-              returnValue: Future<_i3.ContentCreation>.value(_FakeContentCreation_29()))
-          as _i4.Future<_i3.ContentCreation>);
+              returnValue: Future<_i4.ContentCreation>.value(_FakeContentCreation_30()))
+          as _i6.Future<_i4.ContentCreation>);
   @override
-  _i4.Future<String?> getArchiveLink(_i3.RepositorySlug? slug, String? ref, {String? format = r'tarball'}) =>
+  _i6.Future<String?> getArchiveLink(_i4.RepositorySlug? slug, String? ref, {String? format = r'tarball'}) =>
       (super.noSuchMethod(Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
-          returnValue: Future<String?>.value()) as _i4.Future<String?>);
+          returnValue: Future<String?>.value()) as _i6.Future<String?>);
   @override
-  _i4.Stream<_i3.Repository> listForks(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listForks, [slug]), returnValue: Stream<_i3.Repository>.empty())
-          as _i4.Stream<_i3.Repository>);
+  _i6.Stream<_i4.Repository> listForks(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listForks, [slug]), returnValue: Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
-  _i4.Future<_i3.Repository> createFork(_i3.RepositorySlug? slug, [_i3.CreateFork? fork]) =>
+  _i6.Future<_i4.Repository> createFork(_i4.RepositorySlug? slug, [_i4.CreateFork? fork]) =>
       (super.noSuchMethod(Invocation.method(#createFork, [slug, fork]),
-          returnValue: Future<_i3.Repository>.value(_FakeRepository_20())) as _i4.Future<_i3.Repository>);
+          returnValue: Future<_i4.Repository>.value(_FakeRepository_21())) as _i6.Future<_i4.Repository>);
   @override
-  _i4.Stream<_i3.Hook> listHooks(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listHooks, [slug]), returnValue: Stream<_i3.Hook>.empty())
-          as _i4.Stream<_i3.Hook>);
+  _i6.Stream<_i4.Hook> listHooks(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listHooks, [slug]), returnValue: Stream<_i4.Hook>.empty())
+          as _i6.Stream<_i4.Hook>);
   @override
-  _i4.Future<_i3.Hook> getHook(_i3.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#getHook, [slug, id]), returnValue: Future<_i3.Hook>.value(_FakeHook_30()))
-          as _i4.Future<_i3.Hook>);
+  _i6.Future<_i4.Hook> getHook(_i4.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#getHook, [slug, id]), returnValue: Future<_i4.Hook>.value(_FakeHook_31()))
+          as _i6.Future<_i4.Hook>);
   @override
-  _i4.Future<_i3.Hook> createHook(_i3.RepositorySlug? slug, _i3.CreateHook? hook) =>
+  _i6.Future<_i4.Hook> createHook(_i4.RepositorySlug? slug, _i4.CreateHook? hook) =>
       (super.noSuchMethod(Invocation.method(#createHook, [slug, hook]),
-          returnValue: Future<_i3.Hook>.value(_FakeHook_30())) as _i4.Future<_i3.Hook>);
+          returnValue: Future<_i4.Hook>.value(_FakeHook_31())) as _i6.Future<_i4.Hook>);
   @override
-  _i4.Future<_i3.Hook> editHook(_i3.RepositorySlug? slug, _i3.Hook? hookToEdit,
+  _i6.Future<_i4.Hook> editHook(_i4.RepositorySlug? slug, _i4.Hook? hookToEdit,
           {String? configUrl,
           String? configContentType,
           String? configSecret,
@@ -603,74 +623,74 @@ class MockRepositoriesService extends _i1.Mock implements _i3.RepositoriesServic
             #removeEvents: removeEvents,
             #active: active
           }),
-          returnValue: Future<_i3.Hook>.value(_FakeHook_30())) as _i4.Future<_i3.Hook>);
+          returnValue: Future<_i4.Hook>.value(_FakeHook_31())) as _i6.Future<_i4.Hook>);
   @override
-  _i4.Future<bool> testPushHook(_i3.RepositorySlug? slug, int? id) =>
+  _i6.Future<bool> testPushHook(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<bool> pingHook(_i3.RepositorySlug? slug, int? id) =>
+  _i6.Future<bool> pingHook(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<bool> deleteHook(_i3.RepositorySlug? slug, int? id) =>
+  _i6.Future<bool> deleteHook(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Stream<_i3.PublicKey> listDeployKeys(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]), returnValue: Stream<_i3.PublicKey>.empty())
-          as _i4.Stream<_i3.PublicKey>);
+  _i6.Stream<_i4.PublicKey> listDeployKeys(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]), returnValue: Stream<_i4.PublicKey>.empty())
+          as _i6.Stream<_i4.PublicKey>);
   @override
-  _i4.Future<_i3.PublicKey> getDeployKey(_i3.RepositorySlug? slug, {int? id}) =>
+  _i6.Future<_i4.PublicKey> getDeployKey(_i4.RepositorySlug? slug, {int? id}) =>
       (super.noSuchMethod(Invocation.method(#getDeployKey, [slug], {#id: id}),
-          returnValue: Future<_i3.PublicKey>.value(_FakePublicKey_31())) as _i4.Future<_i3.PublicKey>);
+          returnValue: Future<_i4.PublicKey>.value(_FakePublicKey_32())) as _i6.Future<_i4.PublicKey>);
   @override
-  _i4.Future<_i3.PublicKey> createDeployKey(_i3.RepositorySlug? slug, _i3.CreatePublicKey? key) =>
+  _i6.Future<_i4.PublicKey> createDeployKey(_i4.RepositorySlug? slug, _i4.CreatePublicKey? key) =>
       (super.noSuchMethod(Invocation.method(#createDeployKey, [slug, key]),
-          returnValue: Future<_i3.PublicKey>.value(_FakePublicKey_31())) as _i4.Future<_i3.PublicKey>);
+          returnValue: Future<_i4.PublicKey>.value(_FakePublicKey_32())) as _i6.Future<_i4.PublicKey>);
   @override
-  _i4.Future<bool> deleteDeployKey({_i3.RepositorySlug? slug, _i3.PublicKey? key}) =>
+  _i6.Future<bool> deleteDeployKey({_i4.RepositorySlug? slug, _i4.PublicKey? key}) =>
       (super.noSuchMethod(Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
-          returnValue: Future<bool>.value(false)) as _i4.Future<bool>);
+          returnValue: Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i4.Future<_i3.RepositoryCommit> merge(_i3.RepositorySlug? slug, _i3.CreateMerge? merge) => (super.noSuchMethod(
+  _i6.Future<_i4.RepositoryCommit> merge(_i4.RepositorySlug? slug, _i4.CreateMerge? merge) => (super.noSuchMethod(
       Invocation.method(#merge, [slug, merge]),
-      returnValue: Future<_i3.RepositoryCommit>.value(_FakeRepositoryCommit_25())) as _i4.Future<_i3.RepositoryCommit>);
+      returnValue: Future<_i4.RepositoryCommit>.value(_FakeRepositoryCommit_26())) as _i6.Future<_i4.RepositoryCommit>);
   @override
-  _i4.Future<_i3.RepositoryPages> getPagesInfo(_i3.RepositorySlug? slug) => (super.noSuchMethod(
+  _i6.Future<_i4.RepositoryPages> getPagesInfo(_i4.RepositorySlug? slug) => (super.noSuchMethod(
       Invocation.method(#getPagesInfo, [slug]),
-      returnValue: Future<_i3.RepositoryPages>.value(_FakeRepositoryPages_32())) as _i4.Future<_i3.RepositoryPages>);
+      returnValue: Future<_i4.RepositoryPages>.value(_FakeRepositoryPages_33())) as _i6.Future<_i4.RepositoryPages>);
   @override
-  _i4.Stream<_i3.PageBuild> listPagesBuilds(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]), returnValue: Stream<_i3.PageBuild>.empty())
-          as _i4.Stream<_i3.PageBuild>);
+  _i6.Stream<_i4.PageBuild> listPagesBuilds(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]), returnValue: Stream<_i4.PageBuild>.empty())
+          as _i6.Stream<_i4.PageBuild>);
   @override
-  _i4.Future<_i3.PageBuild> getLatestPagesBuild(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.PageBuild> getLatestPagesBuild(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLatestPagesBuild, [slug]),
-          returnValue: Future<_i3.PageBuild>.value(_FakePageBuild_33())) as _i4.Future<_i3.PageBuild>);
+          returnValue: Future<_i4.PageBuild>.value(_FakePageBuild_34())) as _i6.Future<_i4.PageBuild>);
   @override
-  _i4.Stream<_i3.Release> listReleases(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listReleases, [slug]), returnValue: Stream<_i3.Release>.empty())
-          as _i4.Stream<_i3.Release>);
+  _i6.Stream<_i4.Release> listReleases(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listReleases, [slug]), returnValue: Stream<_i4.Release>.empty())
+          as _i6.Stream<_i4.Release>);
   @override
-  _i4.Future<_i3.Release> getLatestRelease(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.Release> getLatestRelease(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLatestRelease, [slug]),
-          returnValue: Future<_i3.Release>.value(_FakeRelease_34())) as _i4.Future<_i3.Release>);
+          returnValue: Future<_i4.Release>.value(_FakeRelease_35())) as _i6.Future<_i4.Release>);
   @override
-  _i4.Future<_i3.Release> getReleaseById(_i3.RepositorySlug? slug, int? id) =>
+  _i6.Future<_i4.Release> getReleaseById(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#getReleaseById, [slug, id]),
-          returnValue: Future<_i3.Release>.value(_FakeRelease_34())) as _i4.Future<_i3.Release>);
+          returnValue: Future<_i4.Release>.value(_FakeRelease_35())) as _i6.Future<_i4.Release>);
   @override
-  _i4.Future<_i3.Release> getReleaseByTagName(_i3.RepositorySlug? slug, String? tagName) =>
+  _i6.Future<_i4.Release> getReleaseByTagName(_i4.RepositorySlug? slug, String? tagName) =>
       (super.noSuchMethod(Invocation.method(#getReleaseByTagName, [slug, tagName]),
-          returnValue: Future<_i3.Release>.value(_FakeRelease_34())) as _i4.Future<_i3.Release>);
+          returnValue: Future<_i4.Release>.value(_FakeRelease_35())) as _i6.Future<_i4.Release>);
   @override
-  _i4.Future<_i3.Release> createRelease(_i3.RepositorySlug? slug, _i3.CreateRelease? createRelease,
+  _i6.Future<_i4.Release> createRelease(_i4.RepositorySlug? slug, _i4.CreateRelease? createRelease,
           {bool? getIfExists = true}) =>
       (super.noSuchMethod(Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}),
-          returnValue: Future<_i3.Release>.value(_FakeRelease_34())) as _i4.Future<_i3.Release>);
+          returnValue: Future<_i4.Release>.value(_FakeRelease_35())) as _i6.Future<_i4.Release>);
   @override
-  _i4.Future<_i3.Release> editRelease(_i3.RepositorySlug? slug, _i3.Release? releaseToEdit,
+  _i6.Future<_i4.Release> editRelease(_i4.RepositorySlug? slug, _i4.Release? releaseToEdit,
           {String? tagName, String? targetCommitish, String? name, String? body, bool? draft, bool? preRelease}) =>
       (super.noSuchMethod(
           Invocation.method(#editRelease, [
@@ -684,72 +704,72 @@ class MockRepositoriesService extends _i1.Mock implements _i3.RepositoriesServic
             #draft: draft,
             #preRelease: preRelease
           }),
-          returnValue: Future<_i3.Release>.value(_FakeRelease_34())) as _i4.Future<_i3.Release>);
+          returnValue: Future<_i4.Release>.value(_FakeRelease_35())) as _i6.Future<_i4.Release>);
   @override
-  _i4.Future<bool> deleteRelease(_i3.RepositorySlug? slug, _i3.Release? release) =>
+  _i6.Future<bool> deleteRelease(_i4.RepositorySlug? slug, _i4.Release? release) =>
       (super.noSuchMethod(Invocation.method(#deleteRelease, [slug, release]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Stream<_i3.ReleaseAsset> listReleaseAssets(_i3.RepositorySlug? slug, _i3.Release? release) =>
+  _i6.Stream<_i4.ReleaseAsset> listReleaseAssets(_i4.RepositorySlug? slug, _i4.Release? release) =>
       (super.noSuchMethod(Invocation.method(#listReleaseAssets, [slug, release]),
-          returnValue: Stream<_i3.ReleaseAsset>.empty()) as _i4.Stream<_i3.ReleaseAsset>);
+          returnValue: Stream<_i4.ReleaseAsset>.empty()) as _i6.Stream<_i4.ReleaseAsset>);
   @override
-  _i4.Future<_i3.ReleaseAsset> getReleaseAsset(_i3.RepositorySlug? slug, _i3.Release? release, {int? assetId}) =>
+  _i6.Future<_i4.ReleaseAsset> getReleaseAsset(_i4.RepositorySlug? slug, _i4.Release? release, {int? assetId}) =>
       (super.noSuchMethod(Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}),
-          returnValue: Future<_i3.ReleaseAsset>.value(_FakeReleaseAsset_35())) as _i4.Future<_i3.ReleaseAsset>);
+          returnValue: Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36())) as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i4.Future<_i3.ReleaseAsset> editReleaseAsset(_i3.RepositorySlug? slug, _i3.ReleaseAsset? assetToEdit,
+  _i6.Future<_i4.ReleaseAsset> editReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? assetToEdit,
           {String? name, String? label}) =>
       (super.noSuchMethod(Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}),
-          returnValue: Future<_i3.ReleaseAsset>.value(_FakeReleaseAsset_35())) as _i4.Future<_i3.ReleaseAsset>);
+          returnValue: Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36())) as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i4.Future<bool> deleteReleaseAsset(_i3.RepositorySlug? slug, _i3.ReleaseAsset? asset) =>
+  _i6.Future<bool> deleteReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? asset) =>
       (super.noSuchMethod(Invocation.method(#deleteReleaseAsset, [slug, asset]), returnValue: Future<bool>.value(false))
-          as _i4.Future<bool>);
+          as _i6.Future<bool>);
   @override
-  _i4.Future<List<_i3.ReleaseAsset>> uploadReleaseAssets(
-          _i3.Release? release, Iterable<_i3.CreateReleaseAsset>? createReleaseAssets) =>
+  _i6.Future<List<_i4.ReleaseAsset>> uploadReleaseAssets(
+          _i4.Release? release, Iterable<_i4.CreateReleaseAsset>? createReleaseAssets) =>
       (super.noSuchMethod(Invocation.method(#uploadReleaseAssets, [release, createReleaseAssets]),
-              returnValue: Future<List<_i3.ReleaseAsset>>.value(<_i3.ReleaseAsset>[]))
-          as _i4.Future<List<_i3.ReleaseAsset>>);
+              returnValue: Future<List<_i4.ReleaseAsset>>.value(<_i4.ReleaseAsset>[]))
+          as _i6.Future<List<_i4.ReleaseAsset>>);
   @override
-  _i4.Future<List<_i3.ContributorStatistics>> listContributorStats(_i3.RepositorySlug? slug) =>
+  _i6.Future<List<_i4.ContributorStatistics>> listContributorStats(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listContributorStats, [slug]),
-              returnValue: Future<List<_i3.ContributorStatistics>>.value(<_i3.ContributorStatistics>[]))
-          as _i4.Future<List<_i3.ContributorStatistics>>);
+              returnValue: Future<List<_i4.ContributorStatistics>>.value(<_i4.ContributorStatistics>[]))
+          as _i6.Future<List<_i4.ContributorStatistics>>);
   @override
-  _i4.Stream<_i3.YearCommitCountWeek> listCommitActivity(_i3.RepositorySlug? slug) =>
+  _i6.Stream<_i4.YearCommitCountWeek> listCommitActivity(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCommitActivity, [slug]),
-          returnValue: Stream<_i3.YearCommitCountWeek>.empty()) as _i4.Stream<_i3.YearCommitCountWeek>);
+          returnValue: Stream<_i4.YearCommitCountWeek>.empty()) as _i6.Stream<_i4.YearCommitCountWeek>);
   @override
-  _i4.Stream<_i3.WeeklyChangesCount> listCodeFrequency(_i3.RepositorySlug? slug) =>
+  _i6.Stream<_i4.WeeklyChangesCount> listCodeFrequency(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCodeFrequency, [slug]),
-          returnValue: Stream<_i3.WeeklyChangesCount>.empty()) as _i4.Stream<_i3.WeeklyChangesCount>);
+          returnValue: Stream<_i4.WeeklyChangesCount>.empty()) as _i6.Stream<_i4.WeeklyChangesCount>);
   @override
-  _i4.Future<_i3.ContributorParticipation> getParticipation(_i3.RepositorySlug? slug) =>
+  _i6.Future<_i4.ContributorParticipation> getParticipation(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getParticipation, [slug]),
-              returnValue: Future<_i3.ContributorParticipation>.value(_FakeContributorParticipation_36()))
-          as _i4.Future<_i3.ContributorParticipation>);
+              returnValue: Future<_i4.ContributorParticipation>.value(_FakeContributorParticipation_37()))
+          as _i6.Future<_i4.ContributorParticipation>);
   @override
-  _i4.Stream<_i3.PunchcardEntry> listPunchcard(_i3.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listPunchcard, [slug]), returnValue: Stream<_i3.PunchcardEntry>.empty())
-          as _i4.Stream<_i3.PunchcardEntry>);
+  _i6.Stream<_i4.PunchcardEntry> listPunchcard(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listPunchcard, [slug]), returnValue: Stream<_i4.PunchcardEntry>.empty())
+          as _i6.Stream<_i4.PunchcardEntry>);
   @override
-  _i4.Stream<_i3.RepositoryStatus> listStatuses(_i3.RepositorySlug? slug, String? ref) =>
+  _i6.Stream<_i4.RepositoryStatus> listStatuses(_i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#listStatuses, [slug, ref]),
-          returnValue: Stream<_i3.RepositoryStatus>.empty()) as _i4.Stream<_i3.RepositoryStatus>);
+          returnValue: Stream<_i4.RepositoryStatus>.empty()) as _i6.Stream<_i4.RepositoryStatus>);
   @override
-  _i4.Future<_i3.RepositoryStatus> createStatus(_i3.RepositorySlug? slug, String? ref, _i3.CreateStatus? request) =>
+  _i6.Future<_i4.RepositoryStatus> createStatus(_i4.RepositorySlug? slug, String? ref, _i4.CreateStatus? request) =>
       (super.noSuchMethod(Invocation.method(#createStatus, [slug, ref, request]),
-              returnValue: Future<_i3.RepositoryStatus>.value(_FakeRepositoryStatus_37()))
-          as _i4.Future<_i3.RepositoryStatus>);
+              returnValue: Future<_i4.RepositoryStatus>.value(_FakeRepositoryStatus_38()))
+          as _i6.Future<_i4.RepositoryStatus>);
   @override
-  _i4.Future<_i3.CombinedRepositoryStatus> getCombinedStatus(_i3.RepositorySlug? slug, String? ref) =>
+  _i6.Future<_i4.CombinedRepositoryStatus> getCombinedStatus(_i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#getCombinedStatus, [slug, ref]),
-              returnValue: Future<_i3.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_38()))
-          as _i4.Future<_i3.CombinedRepositoryStatus>);
+              returnValue: Future<_i4.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_39()))
+          as _i6.Future<_i4.CombinedRepositoryStatus>);
   @override
-  _i4.Future<_i3.ReleaseNotes> generateReleaseNotes(_i3.CreateReleaseNotes? crn) =>
+  _i6.Future<_i4.ReleaseNotes> generateReleaseNotes(_i4.CreateReleaseNotes? crn) =>
       (super.noSuchMethod(Invocation.method(#generateReleaseNotes, [crn]),
-          returnValue: Future<_i3.ReleaseNotes>.value(_FakeReleaseNotes_39())) as _i4.Future<_i3.ReleaseNotes>);
+          returnValue: Future<_i4.ReleaseNotes>.value(_FakeReleaseNotes_40())) as _i6.Future<_i4.ReleaseNotes>);
 }


### PR DESCRIPTION
This was happening because the webhook was getting multiple parallel
requests with the same PR. Moving the approval logic to the message
processing allows us to avoid the multiple approvals caused by the race
condition.

Bug: https://github.com/flutter/flutter/issues/102712

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
