### PR TITLE
[app_dart] Remove package:pedantic

### DIFF
--- a/app_dart/dev/deploy.dart
+++ b/app_dart/dev/deploy.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:pedantic/pedantic.dart';
 
 const String cloudbuildDirectory = 'cloud_build';
 const String workspaceDirectory = '../';

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -477,13 +477,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
-  pedantic:
-    dependency: "direct dev"
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   platform:
     dependency: "direct dev"
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -38,7 +38,6 @@ dev_dependencies:
   flutter_lints: ^1.0.4
   json_serializable: ^6.1.6
   mockito: ^5.1.0
-  pedantic: ^1.11.1
   platform: ^3.1.0
   process: ^4.2.4
   test: ^1.21.1


### PR DESCRIPTION
No longer needed as `unawaited` is in `dart:async` now
