### PR TITLE
wrapping AppBar.title in a Tooltip

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -347,7 +347,12 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
       animation: _buildState,
       builder: (BuildContext context, Widget? child) => Scaffold(
         appBar: CocoonAppBar(
-          title: Text(_getStatusTitle(_buildState)),
+          title: Tooltip(
+            message: _getStatusTitle(_buildState),
+            child: Text(
+              _getStatusTitle(_buildState),
+            ),
+          ),
           backgroundColor: colorTable[_buildState.isTreeBuilding],
           actions: <Widget>[
             if (!_smallScreen) ..._slugSelection(context, _buildState),

--- a/dashboard/test/build_dashboard_page_test.dart
+++ b/dashboard/test/build_dashboard_page_test.dart
@@ -259,7 +259,11 @@ void main() {
       ),
     );
 
-    expect(find.textContaining('Tree is Closed'), findsOneWidget);
+    // Verify the "Tree is Closed" message is wrapped in a [Tooltip].
+    final Finder tooltipFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is Tooltip && (widget.message?.contains('Tree is Closed') ?? false);
+    });
+    expect(tooltipFinder, findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
     expect(appbarWidget.backgroundColor, Colors.red);
@@ -284,7 +288,11 @@ void main() {
       ),
     );
 
-    expect(find.textContaining('Tree is Closed'), findsOneWidget);
+    // Verify the "Tree is Closed" message is wrapped in a [Tooltip].
+    final Finder tooltipFinder = find.byWidgetPredicate((Widget widget) {
+      return widget is Tooltip && (widget.message?.contains('Tree is Closed') ?? false);
+    });
+    expect(tooltipFinder, findsOneWidget);
 
     final AppBar appbarWidget = find.byType(AppBar).evaluate().first.widget as AppBar;
     expect(appbarWidget.backgroundColor, Colors.red[800]);


### PR DESCRIPTION
Closes flutter/flutter#101311

@christopherfujino I am reusing your code, the only difference is that I am calling `_getStatusTitle` inside the animation builder, I guess that's why it was being stuck on Loading... 