### PR TITLE
remove package logging

### DIFF
--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -130,14 +130,14 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     Map<String, String> properties = <String, String>{};
     if (devices.isEmpty) {
       writeToFile(json.encode(properties), _outputFilePath!);
-      logger.info('No device is available.');
+      stdout.writeln('No devices available.');
       return properties;
     }
     properties = await getDeviceProperties(devices[0], processManager: processManager);
     final String propertiesJson = json.encode(properties);
 
     writeToFile(propertiesJson, _outputFilePath!);
-    logger.info('Properties for deviceID ${devices[0].deviceId}: $propertiesJson');
+    stdout.writeln('Properties for deviceID ${devices[0].deviceId}: $propertiesJson');
     return properties;
   }
 

--- a/device_doctor/lib/src/health.dart
+++ b/device_doctor/lib/src/health.dart
@@ -42,7 +42,6 @@ Future<HealthCheckResult> closeIosDialog({
       command.add("PROVISIONING_PROFILE_SPECIFIER=${pl.environment['FLUTTER_XCODE_PROVISIONING_PROFILE_SPECIFIER']}");
     }
     Process proc = await pm.start(command, workingDirectory: dialogDir.path);
-    logger.info('Executing: $command');
     int exitCode = await proc.exitCode;
     if (exitCode != 0) {
       fail('Command "$command" failed with exit code $exitCode.');

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -212,7 +212,6 @@ class IosDevice implements Device {
           await getMacBinaryPath('idevicediagnostics', processManager: processManager);
       await eval(fullPathIdevicediagnostics, <String>['restart'], processManager: processManager);
     } on BuildFailedError catch (error) {
-      logger.severe('device restart fails: $error');
       stderr.write('device restart fails: $error');
       return false;
     }
@@ -232,7 +231,6 @@ class IosDevice implements Device {
     try {
       result = await eval(fullPathIdeviceInstaller, <String>['-l'], processManager: processManager);
     } on BuildFailedError catch (error) {
-      logger.severe('list applications fails: $error');
       stderr.write('list applications fails: $error');
       return false;
     }
@@ -248,7 +246,6 @@ class IosDevice implements Device {
         await eval(fullPathIdeviceInstaller, <String>['-U', bundleIdentifier], processManager: processManager);
       }
     } on BuildFailedError catch (error) {
-      logger.severe('uninstall applications fails: $error');
       stderr.write('uninstall applications fails: $error');
       return false;
     }

--- a/device_doctor/lib/src/utils.dart
+++ b/device_doctor/lib/src/utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
@@ -29,7 +28,6 @@ const String kScreenRotationCheckKey = 'screen_rotation';
 const String kBatteryLevelCheckKey = 'battery_level';
 const String kBatteryTemperatureCheckKey = 'battery_temperature';
 const String kM1BrewBinPath = '/opt/homebrew/bin';
-final Logger logger = Logger('DeviceDoctor');
 
 void fail(String message) {
   throw BuildFailedError(message);
@@ -79,8 +77,6 @@ Future<Process> startProcess(String executable, List<String> arguments,
     {Map<String, String>? env,
     bool silent = false,
     ProcessManager? processManager = const LocalProcessManager()}) async {
-  String command = '$executable ${arguments.join(" ")}';
-  if (!silent) logger.info('Executing: $command');
   late Process proc;
   try {
     proc = await processManager!

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -219,7 +219,7 @@ packages:
     source: hosted
     version: "4.4.0"
   logging:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"

--- a/device_doctor/pubspec.yaml
+++ b/device_doctor/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   analyzer: ">=2.3.0 <5.0.0"
   args: ^2.3.0
-  logging: ^1.0.1
   meta: ^1.7.0
   path: ^1.8.1
   process: ^4.2.4


### PR DESCRIPTION
this was not actually logging anywhere anyway, so remove the package. some of the logs were redundant to what was printed to stderr, I simply deleted these. Some seemed useful diagnostics to show, I ported these to `stdout.writeln()`. And printing the executed command seemed unimportant so I simply deleted (I can port it to stdout.writeln() if it would be useful).

No tests were affected by this change.