### PR TITLE
do not re-trigger builds when marking ready for review

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -130,7 +130,6 @@ class GithubWebhook extends RequestHandler<Body> {
         await _checkForLabelsAndTests(pullRequestEvent);
         break;
       case 'opened':
-      case 'ready_for_review':
       case 'reopened':
         // These cases should trigger LUCI jobs.
         await _checkForLabelsAndTests(pullRequestEvent);
@@ -145,6 +144,7 @@ class GithubWebhook extends RequestHandler<Body> {
         await _scheduleIfMergeable(pullRequestEvent);
         break;
       // Ignore the rest of the events.
+      case 'ready_for_review':
       case 'unlabeled':
       case 'assigned':
       case 'locked':

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -273,6 +273,80 @@ void main() {
       )).called(1);
     });
 
+    // We already schedule checks when a draft is opened, don't need to re-test
+    // just because it was marked ready for review
+    test('Does nothing on ready_for_review', () async {
+      const int issueNumber = 123;
+      request.headers.set('X-GitHub-Event', 'pull_request');
+      request.body = generatePullRequestEvent(
+        'ready_for_review',
+        issueNumber,
+        kDefaultBranchName,
+      );
+      final Uint8List body = utf8.encode(request.body!) as Uint8List;
+      final Uint8List key = utf8.encode(keyString) as Uint8List;
+      final String hmac = getHmac(body, key);
+      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
+
+      bool batchRequestCalled = false;
+
+      Future<BatchResponse> _getBatchResponse() async {
+        batchRequestCalled = true;
+        fail('Marking a draft ready for review should not trigger new builds');
+      }
+
+      fakeBuildBucketClient.batchResponse = _getBatchResponse;
+
+      await tester.post(webhook);
+
+      expect(batchRequestCalled, isFalse);
+    });
+
+    test('Triggers builds when opening a draft PR', () async {
+      const int issueNumber = 123;
+      request.headers.set('X-GitHub-Event', 'pull_request');
+      request.body = generatePullRequestEvent(
+        'opened',
+        issueNumber,
+        kDefaultBranchName,
+        isDraft: true,
+      );
+      final Uint8List body = utf8.encode(request.body!) as Uint8List;
+      final Uint8List key = utf8.encode(keyString) as Uint8List;
+      final String hmac = getHmac(body, key);
+      request.headers.set('X-Hub-Signature', 'sha1=$hmac');
+
+      bool batchRequestCalled = false;
+
+      Future<BatchResponse> _getBatchResponse() async {
+        batchRequestCalled = true;
+        return BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  generateBuild(999, name: 'Linux', status: Status.ended),
+                ],
+              ),
+            ),
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[
+                  generateBuild(998, name: 'Linux', status: Status.ended),
+                ],
+              ),
+            ),
+          ],
+        );
+      }
+
+      fakeBuildBucketClient.batchResponse = _getBatchResponse;
+
+      await tester.post(webhook);
+
+      expect(batchRequestCalled, isTrue);
+    });
+
     test('Does nothing against cherry pick PR', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
@@ -2051,8 +2125,7 @@ void foo() {
       expect(db.values.values.whereType<Commit>().length, 1);
     });
 
-    test('Does not test pest draft pull requests.', () async {
-      //FOR REVIEW : umm is pest a typo here or maybe some form of pr
+    test('Does not comment about needing tests on draft pull requests.', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
       request.body = generatePullRequestEvent(
@@ -2188,7 +2261,7 @@ void foo() {
         );
       }
 
-      fakeBuildBucketClient.batchResponse = _getBatchResponse();
+      fakeBuildBucketClient.batchResponse = _getBatchResponse;
 
       request.body = generatePullRequestEvent('synchronize', issueNumber, kDefaultBranchName, includeCqLabel: true);
       final Uint8List body = utf8.encode(request.body!) as Uint8List;
@@ -2217,7 +2290,7 @@ void foo() {
           ]);
         });
 
-        fakeBuildBucketClient.batchResponse = Future<BatchResponse>.value(
+        fakeBuildBucketClient.batchResponse = () => Future<BatchResponse>.value(
           const BatchResponse(
             responses: <Response>[
               Response(
@@ -2288,7 +2361,7 @@ void foo() {
       });
 
       test('When synchronized, cancels existing builds and schedules new ones', () async {
-        fakeBuildBucketClient.batchResponse = Future<BatchResponse>.value(
+        fakeBuildBucketClient.batchResponse = () => Future<BatchResponse>.value(
           BatchResponse(
             responses: <Response>[
               Response(

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -2291,21 +2291,21 @@ void foo() {
         });
 
         fakeBuildBucketClient.batchResponse = () => Future<BatchResponse>.value(
-          const BatchResponse(
-            responses: <Response>[
-              Response(
-                searchBuilds: SearchBuildsResponse(
-                  builds: <Build>[],
-                ),
+              const BatchResponse(
+                responses: <Response>[
+                  Response(
+                    searchBuilds: SearchBuildsResponse(
+                      builds: <Build>[],
+                    ),
+                  ),
+                  Response(
+                    searchBuilds: SearchBuildsResponse(
+                      builds: <Build>[],
+                    ),
+                  ),
+                ],
               ),
-              Response(
-                searchBuilds: SearchBuildsResponse(
-                  builds: <Build>[],
-                ),
-              ),
-            ],
-          ),
-        );
+            );
 
         request.body = generatePullRequestEvent(action, 1, 'master');
 
@@ -2362,25 +2362,25 @@ void foo() {
 
       test('When synchronized, cancels existing builds and schedules new ones', () async {
         fakeBuildBucketClient.batchResponse = () => Future<BatchResponse>.value(
-          BatchResponse(
-            responses: <Response>[
-              Response(
-                searchBuilds: SearchBuildsResponse(
-                  builds: <Build>[
-                    generateBuild(999, name: 'Linux', status: Status.ended),
-                  ],
-                ),
+              BatchResponse(
+                responses: <Response>[
+                  Response(
+                    searchBuilds: SearchBuildsResponse(
+                      builds: <Build>[
+                        generateBuild(999, name: 'Linux', status: Status.ended),
+                      ],
+                    ),
+                  ),
+                  Response(
+                    searchBuilds: SearchBuildsResponse(
+                      builds: <Build>[
+                        generateBuild(998, name: 'Linux', status: Status.ended),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              Response(
-                searchBuilds: SearchBuildsResponse(
-                  builds: <Build>[
-                    generateBuild(998, name: 'Linux', status: Status.ended),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        );
+            );
 
         request.body = generatePullRequestEvent('synchronize', issueNumber, kDefaultBranchName, includeCqLabel: true);
         final Uint8List body = utf8.encode(request.body!) as Uint8List;

--- a/app_dart/test/src/service/fake_buildbucket.dart
+++ b/app_dart/test/src/service/fake_buildbucket.dart
@@ -22,7 +22,7 @@ class FakeBuildBucketClient extends BuildBucketClient {
 
   Future<Build>? scheduleBuildResponse;
   Future<SearchBuildsResponse>? searchBuildsResponse;
-  Future<BatchResponse>? batchResponse;
+  Future<BatchResponse> Function()? batchResponse;
   Future<Build>? cancelBuildResponse;
   Future<Build>? getBuildResponse;
 
@@ -60,6 +60,9 @@ class FakeBuildBucketClient extends BuildBucketClient {
 
   @override
   Future<BatchResponse> batch(BatchRequest request) async {
+    if (batchResponse != null) {
+      return batchResponse!();
+    }
     final List<Response> responses = <Response>[];
     for (Request request in request.requests!) {
       if (request.cancelBuild != null) {


### PR DESCRIPTION
We already test when drafts are opened, so we don't need to re-trigger when marked ready for review.