### PR TITLE
Remove unused import to fix cocoon

### DIFF
--- a/dashboard/test/utils/golden.dart
+++ b/dashboard/test/utils/golden.dart
@@ -4,7 +4,6 @@
 
 import 'dart:developer';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Flutter upstream https://github.com/flutter/flutter/pull/105648 caused cocoon builder breakage: https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/flutter-try-builder_chops-service-accounts.iam.gserviceaccount.com/4080afd105c86723c951472336133b98c312107c022060d4761ea8d4cf7b9c94/+/build.proto?server=chromium-swarm.appspot.com

This PR fixes forward.