### PR TITLE
Update dart beta hash to fix 'dart pub get' step failing with an olde…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,19 @@ updates:
       - "team"
       - "team: infra"
       - "autosubmit"
+  - package-ecosystem: "docker"
+    directory: "/app_dart"
+    schedule:
+      interval: "daily"
+    labels:
+      - "team"
+      - "team: infra"
+      - "autosubmit"
+  - package-ecosystem: "docker"
+    directory: "/auto_submit"
+    schedule:
+      interval: "daily"
+    labels:
+      - "team"
+      - "team: infra"
+      - "autosubmit"

--- a/app_dart/Dockerfile
+++ b/app_dart/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Dart Docker official images can be found here: https://hub.docker.com/_/dart
-FROM dart:beta@sha256:63ff60883736b48f179d795bbe555054a131ed0bc9b3e67185cd860bc3bf1e4a
+FROM dart:beta@sha256:5ace16f585cf5ad434a603a8e9a6dd4937a907308fd16c6f5c059cd1e3971c8d
 
 WORKDIR /app
 

--- a/auto_submit/Dockerfile
+++ b/auto_submit/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # Dart Docker official images can be found here: https://hub.docker.com/_/dart
-FROM dart:beta@sha256:63ff60883736b48f179d795bbe555054a131ed0bc9b3e67185cd860bc3bf1e4a
+FROM dart:beta@sha256:5ace16f585cf5ad434a603a8e9a6dd4937a907308fd16c6f5c059cd1e3971c8d
 
 WORKDIR /app
 


### PR DESCRIPTION
* Addresses issue https://github.com/flutter/flutter/issues/106144
* Updates the image hash to the latest hash uploaded 3 days ago
* Docker image obtained from: https://hub.docker.com/layers/dart/library/dart/beta-sdk/images/sha256-5ace16f585cf5ad434a603a8e9a6dd4937a907308fd16c6f5c059cd1e3971c8d?context=explore

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
