### PR TITLE
Auto-roller accounts do not get labeled/commented with needs tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -262,6 +262,7 @@ class GithubWebhook extends RequestHandler<Body> {
         needsTests = !_allChangesAreCodeComments(file);
       }
 
+      // Check to see if tests were submitted with this PR.
       if (_isATest(filename)) {
         hasTests = true;
       }
@@ -275,6 +276,11 @@ class GithubWebhook extends RequestHandler<Body> {
 
     if (labels.isNotEmpty) {
       await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, labels.toList());
+    }
+
+    // We do not need to add test labels if this is an auto roller author.
+    if (config.rollerAccounts.contains(pr.user!.login)) {
+      return;
     }
 
     if (!hasTests && needsTests && !pr.draft! && !_isReleaseBranch(pr)) {
@@ -383,9 +389,11 @@ class GithubWebhook extends RequestHandler<Body> {
   }
 
   Future<void> _applyEngineRepoLabels(GitHub gitHubClient, String? eventAction, PullRequest pr) async {
+    // Do not apply the test labels for the autoroller accounts.
     if (pr.user!.login == 'skia-flutter-autoroll') {
       return;
     }
+
     final RepositorySlug slug = pr.base!.repo!.slug();
     final Stream<PullRequestFile> files = gitHubClient.pullRequests.listFiles(slug, pr.number!);
     final Set<String> labels = <String>{};
@@ -411,6 +419,11 @@ class GithubWebhook extends RequestHandler<Body> {
 
     if (labels.isNotEmpty) {
       await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, labels.toList());
+    }
+
+    // We do not need to add test labels if this is an auto roller author.
+    if (config.rollerAccounts.contains(pr.user!.login)) {
+      return;
     }
 
     if (!hasTests && needsTests && !pr.draft! && !_isReleaseBranch(pr)) {
@@ -464,6 +477,11 @@ class GithubWebhook extends RequestHandler<Body> {
           filename.endsWith('_test.cpp')) {
         hasTests = true;
       }
+    }
+
+    // We do not need to add test labels if this is an auto roller author.
+    if (config.rollerAccounts.contains(pr.user!.login)) {
+      return;
     }
 
     if (!hasTests && needsTests && !pr.draft! && !_isReleaseBranch(pr)) {

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -710,12 +710,12 @@ void main() {
     });
 
     group("Auto-roller accounts do not label Framework PR with test label or comment.", () {
-      var inputs = {
+      Set<String> inputs = {
         'skia-flutter-autoroll',
         'dependabot',
       };
 
-      for (var element in inputs) {
+      for (String element in inputs) {
         test('Framework does not label PR with no tests label if author is $element', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
@@ -1372,12 +1372,12 @@ void foo() {
     });
 
     group("Auto-roller accounts do not label Engine PR with test label or comment.", () {
-      var inputs = {
+      Set<String> inputs = {
         'engine-flutter-autoroll',
         'dependabot',
       };
 
-      for (var element in inputs) {
+      for (String element in inputs) {
         test('Engine does not label PR for no tests if author is $element', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
@@ -1743,13 +1743,13 @@ void foo() {
     });
 
     group('Plugins does not comment and label if author is an autoroller account.', () {
-      var inputs = {
+      Set<String> inputs = {
         'engine-flutter-autoroll',
         'skia-flutter-autoroll',
         'dependabot',
       };
 
-      for (var element in inputs) {
+      for (String element in inputs) {
         test('Plugins does not comment and label if author is $element.', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -114,10 +114,10 @@ void main() {
     config.githubClient = gitHubClient;
     config.deviceLabServiceAccountValue = const ServiceAccountInfo(email: serviceAccountEmail);
     config.rollerAccountsValue = const <String>{
-        'skia-flutter-autoroll',
-        'engine-flutter-autoroll',
-        'dependabot',
-      };
+      'skia-flutter-autoroll',
+      'engine-flutter-autoroll',
+      'dependabot',
+    };
   });
 
   group('github webhook pull_request event', () {
@@ -753,12 +753,13 @@ void main() {
           ));
         });
       });
-    }); 
+    });
 
     test('Framework does not label PR with no tests label if author is engine-flutter-autoroll', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = generatePullRequestEvent('opened', issueNumber, kDefaultBranchName, login: 'engine-flutter-autoroll');
+      request.body =
+          generatePullRequestEvent('opened', issueNumber, kDefaultBranchName, login: 'engine-flutter-autoroll');
       final Uint8List body = utf8.encode(request.body!) as Uint8List;
       final Uint8List key = utf8.encode(keyString) as Uint8List;
       final String hmac = getHmac(body, key);
@@ -1376,18 +1377,12 @@ void foo() {
         'dependabot',
       };
 
-      inputs.forEach((element) { 
+      inputs.forEach((element) {
         test('Engine does not label PR for no tests if author is $element', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
-          request.body = generatePullRequestEvent(
-            'opened',
-            issueNumber,
-            kDefaultBranchName,
-            repoName: 'engine',
-            repoFullName: 'flutter/engine',
-            login: element
-          );
+          request.body = generatePullRequestEvent('opened', issueNumber, kDefaultBranchName,
+              repoName: 'engine', repoFullName: 'flutter/engine', login: element);
 
           final Uint8List body = utf8.encode(request.body!) as Uint8List;
           final Uint8List key = utf8.encode(keyString) as Uint8List;
@@ -1433,14 +1428,8 @@ void foo() {
     test('Engine does not label PR for no tests if author is skia-flutter-autoroll', () async {
       const int issueNumber = 123;
       request.headers.set('X-GitHub-Event', 'pull_request');
-      request.body = generatePullRequestEvent(
-        'opened',
-        issueNumber,
-        kDefaultBranchName,
-        repoName: 'engine',
-        repoFullName: 'flutter/engine',
-        login: 'skia-flutter-autoroll'
-      );
+      request.body = generatePullRequestEvent('opened', issueNumber, kDefaultBranchName,
+          repoName: 'engine', repoFullName: 'flutter/engine', login: 'skia-flutter-autoroll');
 
       final Uint8List body = utf8.encode(request.body!) as Uint8List;
       final Uint8List key = utf8.encode(keyString) as Uint8List;
@@ -1760,7 +1749,7 @@ void foo() {
         'dependabot',
       };
 
-      inputs.forEach((element) { 
+      inputs.forEach((element) {
         test('Plugins does not comment and label if author is $element.', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');

--- a/app_dart/test/request_handlers/github_webhook_test.dart
+++ b/app_dart/test/request_handlers/github_webhook_test.dart
@@ -715,7 +715,7 @@ void main() {
         'dependabot',
       };
 
-      inputs.forEach((element) {
+      for (var element in inputs) {
         test('Framework does not label PR with no tests label if author is $element', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
@@ -752,7 +752,7 @@ void main() {
             argThat(contains(config.missingTestsPullRequestMessageValue)),
           ));
         });
-      });
+      }
     });
 
     test('Framework does not label PR with no tests label if author is engine-flutter-autoroll', () async {
@@ -1377,7 +1377,7 @@ void foo() {
         'dependabot',
       };
 
-      inputs.forEach((element) {
+      for (var element in inputs) {
         test('Engine does not label PR for no tests if author is $element', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
@@ -1422,7 +1422,7 @@ void foo() {
             <String>['needs tests'],
           ));
         });
-      });
+      }
     });
 
     test('Engine does not label PR for no tests if author is skia-flutter-autoroll', () async {
@@ -1749,7 +1749,7 @@ void foo() {
         'dependabot',
       };
 
-      inputs.forEach((element) {
+      for (var element in inputs) {
         test('Plugins does not comment and label if author is $element.', () async {
           const int issueNumber = 123;
           request.headers.set('X-GitHub-Event', 'pull_request');
@@ -1793,7 +1793,7 @@ void foo() {
             <String>['needs tests'],
           ));
         });
-      });
+      }
     });
 
     test('Plugins apply no label or comment if pr is for release branches', () async {


### PR DESCRIPTION
## Change Description
Dependabot and auto-roller account PRs are exempt from `needs tests` label and the "It looks like this pull request may not have tests." comments.  

## Issue
Fix https://github.com/flutter/flutter/issues/105180

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
