### PR TITLE
Autosubmit bot logs for #106914

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -273,6 +273,7 @@ class Scheduler {
       pullRequest: pullRequest,
       reason: reason,
     );
+
     final github.CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
       config,
       pullRequest.base!.repo!.slug(),
@@ -283,6 +284,7 @@ class Scheduler {
         summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
+    
     final github.RepositorySlug slug = pullRequest.base!.repo!.slug();
     dynamic exception;
     try {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -284,7 +284,7 @@ class Scheduler {
         summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
-    
+
     final github.RepositorySlug slug = pullRequest.base!.repo!.slug();
     dynamic exception;
     try {

--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -245,7 +245,7 @@ packages:
       name: github
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   glob:
     dependency: transitive
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   file: ^6.1.2
   fixnum: ^1.0.1
   gcloud: ^0.8.4
-  github: ^9.3.0
+  github: ^9.4.0
   googleapis: ^7.0.0
   googleapis_auth: ^1.3.1
   gql: ^0.13.1

--- a/auto_submit/lib/model/auto_submit_query_result.dart
+++ b/auto_submit/lib/model/auto_submit_query_result.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:json_annotation/json_annotation.dart';
 
 part 'auto_submit_query_result.g.dart';
@@ -88,6 +90,9 @@ class ContextNode {
   factory ContextNode.fromJson(Map<String, dynamic> json) => _$ContextNodeFromJson(json);
 
   Map<String, dynamic> toJson() => _$ContextNodeToJson(this);
+
+  @override
+  String toString() => jsonEncode(_$ContextNodeToJson(this));
 }
 
 @JsonSerializable()

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -159,7 +159,7 @@ class CiSuccessful extends Validation {
 
     return allSuccess;
   }
-  
+
   List<String> _checkRunListToStringList(List<github.CheckRun> checkRuns) {
     List<String> checkRunStrings = [];
     for (int i = 0; i < checkRuns.length; i++) {

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -151,7 +151,6 @@ class CiSuccessful extends Validation {
   /// Returns allSuccess unmodified if there were no failures, false otherwise.
   bool validateCheckRuns(
       github.RepositorySlug slug, List<github.CheckRun> checkRuns, Set<FailureDetail> failures, bool allSuccess) {
-    
     List<String> checkRunsStringList = _checkRunListToStringList(checkRuns);
     log.info('Validating name: ${slug.name}, checkRuns: $checkRunsStringList');
 

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -6,7 +6,6 @@ import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/service/github_service.dart';
 import 'package:auto_submit/validations/validation.dart';
 import 'package:github/github.dart' as github;
-import 'dart:convert';
 
 import '../service/config.dart';
 import '../service/log.dart';

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -86,7 +86,6 @@ class CiSuccessful extends Validation {
     if (Config.reposWithTreeStatus.contains(slug)) {
       bool treeStatusExists = false;
       final String treeStatusName = 'luci-${slug.name}';
-
       log.info('Validating tree status: ${slug.name}, statuses: $statuses');
 
       /// Scan list of statuses to see if the tree status exists (this list is expected to be <5 items)
@@ -111,7 +110,6 @@ class CiSuccessful extends Validation {
   bool validateStatuses(github.RepositorySlug slug, List<String> labelNames, List<ContextNode> statuses,
       Set<FailureDetail> failures, bool allSuccess) {
     final String overrideTreeStatusLabel = config.overrideTreeStatusLabel;
-
     log.info('Validating name: ${slug.name}, statuses: $statuses');
 
     for (ContextNode status in statuses) {
@@ -138,8 +136,7 @@ class CiSuccessful extends Validation {
   /// Returns allSuccess unmodified if there were no failures, false otherwise.
   bool validateCheckRuns(
       github.RepositorySlug slug, List<github.CheckRun> checkRuns, Set<FailureDetail> failures, bool allSuccess) {
-    List<String> checkRunsStringList = _checkRunListToStringList(checkRuns);
-    log.info('Validating name: ${slug.name}, checkRuns: $checkRunsStringList');
+    log.info('Validating name: ${slug.name}, checkRuns: $checkRuns');
 
     for (github.CheckRun checkRun in checkRuns) {
       final String? name = checkRun.name;
@@ -158,17 +155,5 @@ class CiSuccessful extends Validation {
     }
 
     return allSuccess;
-  }
-
-  List<String> _checkRunListToStringList(List<github.CheckRun> checkRuns) {
-    List<String> checkRunStrings = [];
-    for (int i = 0; i < checkRuns.length; i++) {
-      checkRunStrings.add(_checkRunToString(checkRuns[i]));
-    }
-    return checkRunStrings;
-  }
-
-  String _checkRunToString(github.CheckRun checkRun) {
-    return json.encode(checkRun.toJson());
   }
 }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -138,7 +138,6 @@ class CiSuccessful extends Validation {
     for (int i = 0; i < contextNodeList.length; i++) {
       contextNodeStrings.add(_contextNodeToString(contextNodeList[i]));
     }
-    print(contextNodeStrings);
     return contextNodeStrings;
   }
 

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -6,6 +6,7 @@ import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/service/github_service.dart';
 import 'package:auto_submit/validations/validation.dart';
 import 'package:github/github.dart' as github;
+import 'dart:convert';
 
 import '../service/config.dart';
 import '../service/log.dart';
@@ -142,7 +143,7 @@ class CiSuccessful extends Validation {
   }
 
   String _contextNodeToString(ContextNode contextNode) {
-    return '{ContextNode: context=${contextNode.context}, state=${contextNode.state}, targetUrl=${contextNode.targetUrl}}';
+    return json.encode(contextNode.toJson());
   }
 
   /// Validate the checkRuns to see if all have completed successfully or not.
@@ -182,6 +183,6 @@ class CiSuccessful extends Validation {
   }
 
   String _checkRunToString(github.CheckRun checkRun) {
-    return '{CheckRun: id=${checkRun.id}, headSha=${checkRun.headSha}, checkSuiteId=${checkRun.checkSuiteId}, name=${checkRun.name}, status=${checkRun.status}, conclusion=${checkRun.conclusion.value}}';
+    return json.encode(checkRun.toJson());
   }
 }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -87,8 +87,7 @@ class CiSuccessful extends Validation {
       bool treeStatusExists = false;
       final String treeStatusName = 'luci-${slug.name}';
 
-      List<String> contextNodeStrings = _contextNodeListToStringList(statuses);
-      log.info('Validating tree status: ${slug.name}, statuses: $contextNodeStrings');
+      log.info('Validating tree status: ${slug.name}, statuses: $statuses');
 
       /// Scan list of statuses to see if the tree status exists (this list is expected to be <5 items)
       for (ContextNode status in statuses) {
@@ -113,8 +112,7 @@ class CiSuccessful extends Validation {
       Set<FailureDetail> failures, bool allSuccess) {
     final String overrideTreeStatusLabel = config.overrideTreeStatusLabel;
 
-    List<String> contextNodeStrings = _contextNodeListToStringList(statuses);
-    log.info('Validating name: ${slug.name}, statuses: $contextNodeStrings');
+    log.info('Validating name: ${slug.name}, statuses: $statuses');
 
     for (ContextNode status in statuses) {
       // How can name be null but presumed to not be null below when added to failure?
@@ -132,18 +130,6 @@ class CiSuccessful extends Validation {
     }
 
     return allSuccess;
-  }
-
-  List<String> _contextNodeListToStringList(List<ContextNode> contextNodeList) {
-    List<String> contextNodeStrings = [];
-    for (int i = 0; i < contextNodeList.length; i++) {
-      contextNodeStrings.add(_contextNodeToString(contextNodeList[i]));
-    }
-    return contextNodeStrings;
-  }
-
-  String _contextNodeToString(ContextNode contextNode) {
-    return json.encode(contextNode.toJson());
   }
 
   /// Validate the checkRuns to see if all have completed successfully or not.
@@ -173,7 +159,7 @@ class CiSuccessful extends Validation {
 
     return allSuccess;
   }
-
+  
   List<String> _checkRunListToStringList(List<github.CheckRun> checkRuns) {
     List<String> checkRunStrings = [];
     for (int i = 0; i < checkRuns.length; i++) {

--- a/auto_submit/pubspec.lock
+++ b/auto_submit/pubspec.lock
@@ -224,7 +224,7 @@ packages:
       name: github
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   glob:
     dependency: transitive
     description:

--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   appengine: ^0.13.2
   corsac_jwt: ^1.0.0-nullsafety.1
   flutter_lints: ^1.0.4
-  github: ^9.3.0
+  github: ^9.4.0
   googleapis: ^7.0.0
   googleapis_auth: ^1.3.1
   graphql: ^5.1.1

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -371,6 +371,7 @@ const String inprogressAndNotFailedCheckRunMock = '''{
 const String emptyCheckRunsMock = '''{"check_runs": [{}]}''';
 
 // repositoryStatusesMock is from the official Github API: https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+// state can be error, failure, pending, success
 const String repositoryStatusesMock = '''{
   "state": "success",
   "statuses": [

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -221,7 +221,7 @@ void main() {
     test('Validate tree status is set contains slug.', () {
       slug = github.RepositorySlug('octocat', 'flutter');
       final List<ContextNode> contextNodeList = _getContextNodeListFromJson(repositoryStatusesMock);
-
+      expect(contextNodeList.isEmpty, false);
       /// The status must be uppercase as the original code is expecting this.
       _convertContextNodeStatuses(contextNodeList);
       ciSuccessful.validateTreeStatusIsSet(slug, contextNodeList, failures);
@@ -231,7 +231,7 @@ void main() {
     test('Validate tree status is set does not contain slug.', () {
       slug = github.RepositorySlug('octocat', 'infra');
       final List<ContextNode> contextNodeList = _getContextNodeListFromJson(repositoryStatusesMock);
-
+      expect(contextNodeList.isEmpty, false);
       /// The status must be uppercase as the original code is expecting this.
       _convertContextNodeStatuses(contextNodeList);
       ciSuccessful.validateTreeStatusIsSet(slug, contextNodeList, failures);

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -222,6 +222,7 @@ void main() {
       slug = github.RepositorySlug('octocat', 'flutter');
       final List<ContextNode> contextNodeList = _getContextNodeListFromJson(repositoryStatusesMock);
       expect(contextNodeList.isEmpty, false);
+
       /// The status must be uppercase as the original code is expecting this.
       _convertContextNodeStatuses(contextNodeList);
       ciSuccessful.validateTreeStatusIsSet(slug, contextNodeList, failures);
@@ -232,6 +233,7 @@ void main() {
       slug = github.RepositorySlug('octocat', 'infra');
       final List<ContextNode> contextNodeList = _getContextNodeListFromJson(repositoryStatusesMock);
       expect(contextNodeList.isEmpty, false);
+
       /// The status must be uppercase as the original code is expecting this.
       _convertContextNodeStatuses(contextNodeList);
       ciSuccessful.validateTreeStatusIsSet(slug, contextNodeList, failures);

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -323,14 +323,14 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -365,7 +365,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   pedantic:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
This isn't a fix but it does add more logging so we can see what information is coming into the CiSuccessful Validator so we can determine why it is causing the autosubmit label to be removed in certain circumstances.

## Issues
https://github.com/flutter/flutter/issues/106916

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
