### PR TITLE
Upgraded url_launcher and build_runner dependencies manually.

### DIFF
--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.0"
   build_runner_core:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.6.0"
   lints:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   url_launcher_android:
     dependency: transitive
     description:

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -30,11 +30,11 @@ dependencies:
   http: ^0.13.4
   protobuf: ^2.0.1
   provider: ^6.0.2
-  url_launcher: ^6.1.4
+  url_launcher: ^6.1.5
   flutter_app_icons: ^0.0.3
 
 dev_dependencies:
-  build_runner: ^2.1.1
+  build_runner: ^2.2.0
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Description

dependabot had downgraded some of the dependencies included here with the upgrad to build_runner and url_launcher dependencies.

## Issues

https://github.com/flutter/cocoon/pull/1973
https://github.com/flutter/cocoon/pull/1983

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
