### PR TITLE
Send batch requests when scheduling new commit builds

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -143,6 +143,9 @@ class Config {
   /// Size of the shards to send to buildBucket when scheduling builds.
   int get schedulingShardSize => 5;
 
+  /// Batch size of builds to schedule in each swarming request.
+  int get batchSize => 5;
+
   /// Max retries when scheduling builds.
   static const RetryOptions schedulerRetry = RetryOptions(maxAttempts: 3);
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -161,7 +161,7 @@ class Scheduler {
 
   /// Schedule all builds in batch requests instead of a single request.
   ///
-  /// Each batch request contains `kBatchSize` builds to be scheduled.
+  /// Each batch request contains [Config.batchSize] builds to be scheduled.
   Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final List<Future> futures = <Future>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:cocoon_service/src/service/build_status_provider.dart';
@@ -154,9 +155,22 @@ class Scheduler {
       log.severe('Failed to add commit ${commit.sha!}: $error');
     }
 
-    await luciBuildService.schedulePostsubmitBuilds(commit: commit, toBeScheduled: toBeScheduled);
-
+    await _bactchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
+  }
+
+  /// Schedule all builds in batch requests instead of a single request.
+  ///
+  /// Each batch request contains `kBatchSize` builds to be scheduled.
+  Future<void> _bactchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+    final List<Future> futures = <Future>[];
+    for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
+      futures.add(luciBuildService.schedulePostsubmitBuilds(
+        commit: commit,
+        toBeScheduled: toBeScheduled.sublist(i, min(i + config.batchSize, toBeScheduled.length)),
+      ));
+    }
+    await Future.wait<void>(futures);
   }
 
   /// Return subset of [commits] not stored in Datastore.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -155,14 +155,14 @@ class Scheduler {
       log.severe('Failed to add commit ${commit.sha!}: $error');
     }
 
-    await _bactchScheduleBuilds(commit, toBeScheduled);
+    await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
   }
 
   /// Schedule all builds in batch requests instead of a single request.
   ///
   /// Each batch request contains `kBatchSize` builds to be scheduled.
-  Future<void> _bactchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+  Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final List<Future> futures = <Future>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
       futures.add(luciBuildService.schedulePostsubmitBuilds(

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -56,6 +56,7 @@ class FakeConfig implements Config {
     this.supportedBranchesValue,
     this.luciBuildersValue,
     this.supportedReposValue,
+    this.batchSizeValue,
     FakeDatastoreDB? dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -69,6 +70,7 @@ class FakeConfig implements Config {
   ServiceAccountInfo? deviceLabServiceAccountValue;
   int? maxTaskRetriesValue;
   int? maxLuciTaskRetriesValue;
+  int? batchSizeValue;
   FakeKeyHelper? keyHelperValue;
   String? oauthClientIdValue;
   String? githubOAuthTokenValue;
@@ -131,6 +133,9 @@ class FakeConfig implements Config {
   /// Size of the shards to send to buildBucket when scheduling builds.
   @override
   int get schedulingShardSize => 5;
+
+  @override
+  int get batchSize => batchSizeValue ?? 5;
 
   @override
   int get maxLuciTaskRetries => maxLuciTaskRetriesValue!;


### PR DESCRIPTION
With cocoon scheduling, a single schedule request of all builds will be created. This causes unpredicted builds schedule failure.

This PR use batch requests instead of a single request of ~300 builds: each batch is with default 5 builds.

Validation: a test version of cocoon wit this change has been running since yesterday.

Related: https://github.com/flutter/flutter/issues/103443, https://github.com/flutter/flutter/issues/92300