### PR TITLE
Rerun failed build with a higher priority

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -554,6 +554,7 @@ class LuciBuildService {
       ),
       tags: tags,
       properties: processedProperties,
+      priority: priority,
     );
   }
 

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -665,6 +665,7 @@ void main() {
       for (String key in Config.engineDefaultProperties.keys) {
         expect(properties.containsKey(key), true);
       }
+      expect(scheduleBuildRequest.priority, LuciBuildService.kRerunPriority);
       expect(scheduleBuildRequest.gitilesCommit?.project, 'mirrors/engine');
       expect(rerunFlag, isTrue);
       expect(task.attempts, 2);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/108183.

We have the logic to prepare high priority, but fail to inject it to `ScheduleBuildRequest`. This PR fixes it.