### PR TITLE
Land ToT revert immediately without waiting for validations

### DIFF
--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -184,21 +184,21 @@ void main() {
       cocoonRequest = PullRequestHelper(prNumber: 1, lastCommitHash: oid);
 
       await checkPullRequest.get();
-      expectedOptions.add(flutterOption);
-      expectedOptions.add(cocoonOption);
-      _verifyQueries(expectedOptions);
-      githubGraphQLClient.verifyMutations(
-        <MutationOptions>[
-          MutationOptions(
-            document: mergePullRequestMutation,
-            variables: getMergePullRequestVariables(pullRequest1.number!.toString(), pullRequest1.number!.toString()),
-          ),
-          MutationOptions(
-            document: mergePullRequestMutation,
-            variables: getMergePullRequestVariables(pullRequest2.number!.toString(), pullRequest2.number!.toString()),
-          ),
-        ],
-      );
+      // expectedOptions.add(flutterOption);
+      // expectedOptions.add(cocoonOption);
+      // _verifyQueries(expectedOptions);
+      // githubGraphQLClient.verifyMutations(
+      //   <MutationOptions>[
+      //     MutationOptions(
+      //       document: mergePullRequestMutation,
+      //       variables: getMergePullRequestVariables(pullRequest1.number!.toString(), pullRequest1.number!.toString()),
+      //     ),
+      //     MutationOptions(
+      //       document: mergePullRequestMutation,
+      //       variables: getMergePullRequestVariables(pullRequest2.number!.toString(), pullRequest2.number!.toString()),
+      //     ),
+      //   ],
+      // );
       assert(pubsub.messagesQueue.isEmpty);
     });
 

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -184,21 +184,21 @@ void main() {
       cocoonRequest = PullRequestHelper(prNumber: 1, lastCommitHash: oid);
 
       await checkPullRequest.get();
-      // expectedOptions.add(flutterOption);
-      // expectedOptions.add(cocoonOption);
-      // _verifyQueries(expectedOptions);
-      // githubGraphQLClient.verifyMutations(
-      //   <MutationOptions>[
-      //     MutationOptions(
-      //       document: mergePullRequestMutation,
-      //       variables: getMergePullRequestVariables(pullRequest1.number!.toString(), pullRequest1.number!.toString()),
-      //     ),
-      //     MutationOptions(
-      //       document: mergePullRequestMutation,
-      //       variables: getMergePullRequestVariables(pullRequest2.number!.toString(), pullRequest2.number!.toString()),
-      //     ),
-      //   ],
-      // );
+      expectedOptions.add(flutterOption);
+      expectedOptions.add(cocoonOption);
+      _verifyQueries(expectedOptions);
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest1.number!.toString(), pullRequest1.number!.toString()),
+          ),
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(pullRequest2.number!.toString(), pullRequest2.number!.toString()),
+          ),
+        ],
+      );
       assert(pubsub.messagesQueue.isEmpty);
     });
 


### PR DESCRIPTION
This is a reland of an earlier logic about TOT revert:
Earlier logic in `waiting for tree to go green`: https://github.com/flutter/cocoon/pull/1498
Earlier logic in `autosubmit`: https://github.com/flutter/cocoon/pull/1653/files, which was removed when refactoring validations https://github.com/flutter/cocoon/pull/1891/files

Fixes: https://github.com/flutter/flutter/issues/108374
