### PR TITLE
[scheduler] Run guranteed policy on release branches and engine PRs

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -80,13 +80,13 @@ class Target {
   ///
   /// Targets not triggered by Cocoon will not be triggered.
   ///
-  /// Targets by default run on a [GuranteedPolicy], but targets in the devicelab run with [BatchPolicy].
+  /// Targets by default run on a [GuaranteedPolicy], but targets in the devicelab run with [BatchPolicy].
   SchedulerPolicy get schedulerPolicy {
     if (value.scheduler != pb.SchedulerSystem.cocoon) {
       return OmitPolicy();
     }
 
-    return shouldBatchSchedule ? BatchPolicy() : GuranteedPolicy();
+    return shouldBatchSchedule ? BatchPolicy() : GuaranteedPolicy();
   }
 
   /// Gets the assembled properties for this [pb.Target].

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -134,7 +134,11 @@ class Scheduler {
     final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
     for (Target target in initialTargets) {
       final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
-      final SchedulerPolicy policy = target.schedulerPolicy;
+      SchedulerPolicy policy = target.schedulerPolicy;
+      // Engine repo and release branches should always run every task
+      if (commit.slug == Config.engineSlug || Config.defaultBranch(commit.slug) != commit.branch) {
+        policy = GuranteedPolicy();
+      }
       final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -135,9 +135,9 @@ class Scheduler {
     for (Target target in initialTargets) {
       final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
       SchedulerPolicy policy = target.schedulerPolicy;
-      // Engine repo and release branches should always run every task
+      // Engine repo and release branches should run every task
       if (commit.slug == Config.engineSlug || Config.defaultBranch(commit.slug) != commit.branch) {
-        policy = GuranteedPolicy();
+        policy = GuaranteedPolicy();
       }
       final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {

--- a/app_dart/lib/src/service/scheduler/policy.dart
+++ b/app_dart/lib/src/service/scheduler/policy.dart
@@ -20,7 +20,7 @@ abstract class SchedulerPolicy {
 }
 
 /// Every [Task] is triggered to run.
-class GuranteedPolicy implements SchedulerPolicy {
+class GuaranteedPolicy implements SchedulerPolicy {
   @override
   Future<int?> triggerPriority({
     required Task task,

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -332,7 +332,7 @@ void main() {
       });
 
       test('vm cocoon targets return guranteed policy', () {
-        expect(generateTarget(1, platform: 'Linux').schedulerPolicy, isA<GuranteedPolicy>());
+        expect(generateTarget(1, platform: 'Linux').schedulerPolicy, isA<GuaranteedPolicy>());
       });
     });
   });


### PR DESCRIPTION
Release branches are currently blocked as they will use batch scheduling for the engine on mac, which isn't expected.

I assume this is similar logic we also want for the engine repo.