### PR TITLE
add fluttergithubbot to list of allow-listed autoroller accounts

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -323,6 +323,8 @@ class Config {
         'skia-flutter-autoroll',
         'engine-flutter-autoroll',
         'dependabot',
+        // for pub package autorolls https://github.com/flutter/flutter/issues/106371
+        'fluttergithubbot',
       };
 
   Future<String> generateJsonWebToken() async {

--- a/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
+++ b/app_dart/test/request_handlers/check_for_waiting_pull_requests_test.dart
@@ -371,6 +371,35 @@ void main() {
       );
     });
 
+    test('Merges unapproved pub autoroll PR from fluttergithubbot', () async {
+      // Ensure there is at least one cirrus status.
+      statuses = <dynamic>[
+        <String, String>{'id': '3', 'status': 'COMPLETED', 'name': 'test2'}
+      ];
+      config.rollerAccountsValue = <String>{'fluttergithubbot'};
+      flutterRepoPRs.add(PullRequestHelper(
+          author: 'fluttergithubbot', reviews: const <PullRequestReviewHelper>[], labels: waitForTreeGreenlabels));
+      engineRepoPRs.add(PullRequestHelper(
+          author: 'fluttergithubbot', reviews: const <PullRequestReviewHelper>[], labels: waitForTreeGreenlabels));
+
+      await tester.get(handler);
+
+      _verifyQueries();
+
+      githubGraphQLClient.verifyMutations(
+        <MutationOptions>[
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(engineRepoPRs.first.id),
+          ),
+          MutationOptions(
+            document: mergePullRequestMutation,
+            variables: getMergePullRequestVariables(flutterRepoPRs.first.id),
+          ),
+        ],
+      );
+    });
+
     test('Does not merge PR with in progress tests', () async {
       statuses = <dynamic>[
         <String, String>{'id': '1', 'status': 'EXECUTING', 'name': 'test1'},


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/pull/108635
Part of https://github.com/flutter/flutter/issues/106371

@keyonghan is it ok to add this user to this list? I know this account is also used for the flaky bot PRs.

@CaseyHillers this seems like a silly test I've added, since I'm setting `config.rollerAccountsValue` in the test. Should I refactor this code so I can actually test the prod value?