### PR TITLE
[app_dart] Add retries to GitHub.listCommits

### DIFF
--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -534,7 +534,7 @@ packages:
     source: hosted
     version: "1.2.0"
   retry:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: retry
       url: "https://pub.dartlang.org"

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   neat_cache: ^2.0.2
   process_runner: ^4.1.2
   protobuf: ^2.1.0
+  retry: ^3.1.0
   truncate: ^3.0.1
 
 dev_dependencies:

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -125,11 +125,11 @@ void main() {
           throwsExceptionWith<InternalServerError>('Failed to find a revision to branch Flutter recipes for $branch'));
     });
 
-    test('creates branch when GitHub requires retries', () async {
+    test('creates branch', () async {
       await branchService.branchFlutterRecipes(branch);
     });
 
-    test('creates branch', () async {
+    test('creates branch when GitHub requires retries', () async {
       int attempts = 0;
       githubService.listCommitsBranch = (String branch, int ts) {
         attempts++;


### PR DESCRIPTION
When GitHub has a newly created branches, the commit list hasn't finished replicating for the new branch. This adds a retry around it.

Additionally, explicitly add `package:retry` to the pubspec dependencies.

https://github.com/flutter/flutter/issues/102325