### PR TITLE
Bump mockito version to 5.3.0

### DIFF
--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -441,7 +441,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.3.0"
   neat_cache:
     dependency: "direct main"
     description:
@@ -737,4 +737,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   fake_async: ^1.3.1
   flutter_lints: ^1.0.4
   json_serializable: ^6.3.1
-  mockito: ^5.2.0
+  mockito: ^5.3.0
   platform: ^3.1.0
   process: ^4.2.4
   test: ^1.21.4

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -344,7 +344,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.15"
+    version: "5.3.0"
   nested:
     dependency: transitive
     description:

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.14
+  mockito: ^5.3.0
   path: ^1.8.1
   url_launcher_platform_interface: ^2.1.0
 

--- a/device_doctor/pubspec.lock
+++ b/device_doctor/pubspec.lock
@@ -266,7 +266,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.3.0"
   node_preamble:
     dependency: transitive
     description:

--- a/device_doctor/pubspec.yaml
+++ b/device_doctor/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.1
   fake_async: ^1.3.0
-  mockito: ">=4.1.0 <6.0.0"
+  mockito: ^5.3.0
   test: ^1.17.12


### PR DESCRIPTION
Manual roll of:
https://github.com/flutter/cocoon/pull/2019
https://github.com/flutter/cocoon/pull/2018
https://github.com/flutter/cocoon/pull/2021