### PR TITLE
[codesign] Logic to visit a binary file

### DIFF
--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -90,11 +90,11 @@ class FileCodesignVisitor {
   static const String fixItInstructions = '''
 Codesign test failed.
 
-We compared binary files in engine artifacts with those listed in 
-entilement.txt and withoutEntitlements.txt, and the binary files do not match. 
-*entitlements.txt is the configuartion file encoded in engine artifact zip, 
+We compared binary files in engine artifacts with those listed in
+entilement.txt and withoutEntitlements.txt, and the binary files do not match.
+*entitlements.txt is the configuartion file encoded in engine artifact zip,
 built by BUID.gn and Ninja, to detail the list of entitlement files.
-Either an expected file was not found in *entitlements.txt, or an unexpected 
+Either an expected file was not found in *entitlements.txt, or an unexpected
 file was found in entitlements.txt.
 
 This usually happens either during an engine roll.
@@ -149,8 +149,7 @@ entitlements applied during codesigning.
           zipEntity: entity,
           entitlementParentPath: entitlementParentPath,
         );
-      }
-      else if (childType == FileType.binary){
+      } else if (childType == FileType.binary) {
         await visitBinaryFile(binaryEntity: entity, entitlementParentPath: entitlementParentPath);
       }
       log.info('Child file of direcotry ${directory.basename} is ${entity.basename}\n');
@@ -184,7 +183,6 @@ entitlements applied during codesigning.
       processManager: processManager,
     );
   }
-
 
   /// Visit and codesign a binary with / without entilement.
   ///
@@ -232,5 +230,4 @@ entitlements applied during codesigning.
     }
     fileConsumed.add(entitlementCurrentPath);
   }
-
 }

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -87,7 +87,24 @@ class FileCodesignVisitor {
 </plist>
 ''';
 
-  void _initialize() {
+  static const String fixItInstructions = '''
+Codesign test failed.
+
+We compared binary files in engine artifacts with those listed in 
+entilement.txt and withoutEntitlements.txt, and the binary files do not match. 
+*entitlements.txt is the configuartion file encoded in engine artifact zip, 
+built by BUID.gn and Ninja, to detail the list of entitlement files.
+Either an expected file was not found in *entitlements.txt, or an unexpected 
+file was found in entitlements.txt.
+
+This usually happens either during an engine roll.
+If this is a valid change, then BUILD.gn needs to be changed.
+Specifically, update [entitlements.txt] or
+[withoutEntitlements.txt] lists, depending on if the file should have macOS
+entitlements applied during codesigning.
+''';
+
+  void initialize() {
     entitlementsFile = tempDir.childFile('Entitlements.plist')..writeAsStringSync(_entitlementsFileContents);
     remoteDownloadsDir = tempDir.childDirectory('downloads')..createSync();
     codesignedZipsDir = tempDir.childDirectory('codesigned_zips')..createSync();
@@ -95,7 +112,7 @@ class FileCodesignVisitor {
 
   /// The entrance point of examining and code signing an engine artifact.
   Future<void> validateAll() async {
-    _initialize();
+    initialize();
 
     await Future<void>.value(null);
     log.info('Codesigned all binaries in ${tempDir.path}');
@@ -133,6 +150,9 @@ class FileCodesignVisitor {
           entitlementParentPath: entitlementParentPath,
         );
       }
+      else if (childType == FileType.binary){
+        await visitBinaryFile(binaryEntity: entity, entitlementParentPath: entitlementParentPath);
+      }
       log.info('Child file of direcotry ${directory.basename} is ${entity.basename}\n');
     }
   }
@@ -164,4 +184,53 @@ class FileCodesignVisitor {
       processManager: processManager,
     );
   }
+
+
+  /// Visit and codesign a binary with / without entilement.
+  ///
+  /// At this stage, the virtual [entitlementCurrentPath] accumulated through the recursive visit, is compared
+  /// against the paths extracted from [fileWithEntitlements], to help determine if this file should be signed
+  /// with entitlements.
+  Future<void> visitBinaryFile({required FileSystemEntity binaryEntity, required String entitlementParentPath}) async {
+    if (await isSymlink(binaryEntity.absolute.path, processManager)) {
+      return;
+    }
+
+    final String currentFileName = binaryEntity.absolute.path.split('/').last;
+    final String entitlementCurrentPath = '$entitlementParentPath/$currentFileName';
+
+    if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
+        !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
+      log.severe('The system has detected a binary file at $entitlementCurrentPath\n'
+          'but it is not in the entitlements configuartion files your provided \n'
+          'if this is a new engine artifact, please add it to one of the entilements.txt files\n');
+      throw CodesignException(fixItInstructions);
+    }
+    log.info('\n signing file at path ${binaryEntity.absolute.path}');
+    log.info('\n the virtual entitlement path associated with file is $entitlementCurrentPath');
+    log.info('\n the decision to sign with entitlement is ${fileWithEntitlements.contains(entitlementCurrentPath)}');
+    final List<String> args = <String>[
+      'codesign',
+      '-f', // force
+      '-s', // use the cert provided by next argument
+      codesignCertName,
+      binaryEntity.absolute.path,
+      '--timestamp', // add a secure timestamp
+      '--options=runtime', // hardened runtime
+      if (fileWithEntitlements.contains(entitlementCurrentPath)) ...<String>[
+        '--entitlements',
+        entitlementsFile.absolute.path
+      ],
+    ];
+    final io.ProcessResult result = await processManager.run(args);
+    if (result.exitCode != 0) {
+      throw CodesignException(
+        'Failed to codesign ${binaryEntity.absolute.path} with args: ${args.join(' ')}\n'
+        'stdout:\n${(result.stdout as String).trim()}\n'
+        'stderr:\n${(result.stderr as String).trim()}',
+      );
+    }
+    fileConsumed.add(entitlementCurrentPath);
+  }
+
 }

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -103,9 +103,11 @@ file was found in entitlements.txt.
 
 This usually happens during an engine roll.
 If this is a valid change, then BUILD.gn needs to be changed.
-For example, If this is a new binary that need to be code signed with entitlements, add it
+Binaries that will run on a macOS host require entitlements, and
+binaries that run on an iOS device must NOT have entitlements.
+For example, If this is a new binarythat runs on macOS host, add it
 to [entitlements.txt] file inside the zip artifact produced by BUILD.gn.
-If this is a new binary that need to be code signed without entitlements, add it
+If this is a new binary that need to be run on iOS device, add it
 to [withoutEntitlements.txt].
 If there are obsolete binaries in entitlements configuration files, please delete or
 update these file paths accordingly.

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -135,9 +135,6 @@ update these file paths accordingly.
     final List<FileSystemEntity> entities = await directory.list().toList();
     for (FileSystemEntity entity in entities) {
       if (entity is io.Directory) {
-        if (io.FileSystemEntity.isLinkSync(entity.absolute.path)) {
-          return;
-        }
         await visitDirectory(
           directory: directory.childDirectory(entity.basename),
           entitlementParentPath: entitlementParentPath,

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -95,7 +95,7 @@ class FileCodesignVisitor {
 Codesign test failed.
 
 We compared binary files in engine artifacts with those listed in
-entilement.txt and withoutEntitlements.txt, and the binary files do not match.
+entitlement.txt and withoutEntitlements.txt, and the binary files do not match.
 *entitlements.txt is the configuartion file encoded in engine artifact zip,
 built by BUILD.gn and Ninja, to detail the list of entitlement files.
 Either an expected file was not found in *entitlements.txt, or an unexpected
@@ -162,7 +162,7 @@ update these file paths accordingly.
     required FileSystemEntity zipEntity,
     required String entitlementParentPath,
   }) async {
-    log.info('This embedded file is ${zipEntity.path} and entilementParentPath is $entitlementParentPath');
+    log.info('This embedded file is ${zipEntity.path} and entitlementParentPath is $entitlementParentPath');
     final String currentFileName = zipEntity.basename;
     final Directory newDir = tempDir.childDirectory('embedded_zip_${zipEntity.absolute.path.hashCode}');
     await unzip(
@@ -195,14 +195,14 @@ update these file paths accordingly.
       return;
     }
 
-    final String currentFileName = binaryFile.absolute.path.split('/').last;
+    final String currentFileName = binaryFile.basename;
     final String entitlementCurrentPath = '$entitlementParentPath/$currentFileName';
 
     if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
         !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
       log.severe('The system has detected a binary file at $entitlementCurrentPath.'
           'but it is not in the entitlements configuartion files you provided.'
-          'if this is a new engine artifact, please add it to one of the entilements.txt files');
+          'if this is a new engine artifact, please add it to one of the entitlements.txt files');
       throw CodesignException(fixItInstructions);
     }
     log.info('signing file at path ${binaryFile.absolute.path}');

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -135,6 +135,9 @@ update these file paths accordingly.
     final List<FileSystemEntity> entities = await directory.list().toList();
     for (FileSystemEntity entity in entities) {
       if (entity is io.Directory) {
+        if (io.FileSystemEntity.isLinkSync(entity.absolute.path)) {
+          return;
+        }
         await visitDirectory(
           directory: directory.childDirectory(entity.basename),
           entitlementParentPath: entitlementParentPath,
@@ -191,10 +194,6 @@ update these file paths accordingly.
   /// against the paths extracted from [fileWithEntitlements], to help determine if this file should be signed
   /// with entitlements.
   Future<void> visitBinaryFile({required File binaryFile, required String entitlementParentPath}) async {
-    if (io.FileSystemEntity.isLinkSync(binaryFile.absolute.path)) {
-      return;
-    }
-
     final String currentFileName = binaryFile.basename;
     final String entitlementCurrentPath = '$entitlementParentPath/$currentFileName';
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -153,7 +153,7 @@ update these file paths accordingly.
       } else if (childType == FileType.binary) {
         await visitBinaryFile(binaryFile: entity as File, entitlementParentPath: entitlementParentPath);
       }
-      log.info('Child file of direcotry ${directory.basename} is ${entity.basename}');
+      log.info('Child file of directory ${directory.basename} is ${entity.basename}');
     }
   }
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -189,7 +189,7 @@ update these file paths accordingly.
   /// against the paths extracted from [fileWithEntitlements], to help determine if this file should be signed
   /// with entitlements.
   Future<void> visitBinaryFile({required File binaryFile, required String entitlementParentPath}) async {
-    if (await isSymlink(binaryFile.absolute.path, processManager)) {
+    if (io.FileSystemEntity.isLinkSync(binaryFile.absolute.path)) {
       return;
     }
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -105,9 +105,9 @@ This usually happens during an engine roll.
 If this is a valid change, then BUILD.gn needs to be changed.
 Binaries that will run on a macOS host require entitlements, and
 binaries that run on an iOS device must NOT have entitlements.
-For example, If this is a new binarythat runs on macOS host, add it
+For example, if this is a new binary that runs on macOS host, add it
 to [entitlements.txt] file inside the zip artifact produced by BUILD.gn.
-If this is a new binary that need to be run on iOS device, add it
+If this is a new binary that needs to be run on iOS device, add it
 to [withoutEntitlements.txt].
 If there are obsolete binaries in entitlements configuration files, please delete or
 update these file paths accordingly.

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -29,6 +29,21 @@ enum FileType {
   }
 }
 
+Future<bool> isSymlink(String fileOrFolderPath, ProcessManager processManager) async {
+  final ProcessResult result = processManager.runSync(
+    <String>[
+      'ls',
+      '-alhf',
+      fileOrFolderPath,
+    ],
+  );
+
+  return (result.stdout as String)
+      .split('\n')
+      .where((String s) => !s.split(' ').contains('->') && s.trim().isNotEmpty)
+      .isEmpty;
+}
+
 Future<void> unzip({
   required FileSystemEntity inputZip,
   required Directory outDir,

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -57,7 +57,7 @@ Future<void> unzip({
       outDir.absolute.path,
     ],
   );
-  log.info('The downloaded file is unzipped from ${inputZip.absolute.path} to ${outDir.absolute.path}\n');
+  log.info('The downloaded file is unzipped from ${inputZip.absolute.path} to ${outDir.absolute.path}');
 }
 
 Future<void> zip({

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -29,21 +29,6 @@ enum FileType {
   }
 }
 
-Future<bool> isSymlink(String fileOrFolderPath, ProcessManager processManager) async {
-  final ProcessResult result = processManager.runSync(
-    <String>[
-      'ls',
-      '-alhf',
-      fileOrFolderPath,
-    ],
-  );
-
-  return (result.stdout as String)
-      .split('\n')
-      .where((String s) => !s.split(' ').contains('->') && s.trim().isNotEmpty)
-      .isEmpty;
-}
-
 Future<void> unzip({
   required FileSystemEntity inputZip,
   required Directory outDir,

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -85,9 +85,9 @@ void main() {
           .map((LogRecord record) => record.message)
           .toList();
       expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_0'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_a'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_b'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_c'));
+      expect(messages, contains('Child file of directory remote_zip_0 is file_a'));
+      expect(messages, contains('Child file of directory remote_zip_0 is file_b'));
+      expect(messages, contains('Child file of directory remote_zip_0 is file_c'));
     });
 
     test('visitDirectory recursively visits directory', () async {
@@ -125,8 +125,8 @@ void main() {
           .toList();
       expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1'));
       expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1/folder_a'));
-      expect(messages, contains('Child file of direcotry remote_zip_1 is file_a'));
-      expect(messages, contains('Child file of direcotry folder_a is file_b'));
+      expect(messages, contains('Child file of directory remote_zip_1 is file_a'));
+      expect(messages, contains('Child file of directory folder_a is file_b'));
     });
 
     test('visit directory inside a zip', () async {
@@ -188,8 +188,8 @@ void main() {
           contains(
               'The downloaded file is unzipped from ${tempDir.path}/remote_zip_2/zip_1 to ${tempDir.path}/embedded_zip_${zipFileName.hashCode}'));
       expect(messages, contains('Visiting directory ${tempDir.path}/embedded_zip_${zipFileName.hashCode}'));
-      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_1'));
-      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_2'));
+      expect(messages, contains('Child file of directory embedded_zip_${zipFileName.hashCode} is file_1'));
+      expect(messages, contains('Child file of directory embedded_zip_${zipFileName.hashCode} is file_2'));
     });
 
     test('visit zip inside a directory', () async {

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -37,7 +37,6 @@ void main() {
         tempDir: tempDir,
       );
       codesignVisitor.directoriesVisited.clear();
-      codesignVisitor.initialize();
       records.clear();
       log.onRecord.listen((LogRecord record) => records.add(record));
     });
@@ -85,10 +84,10 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_0\n'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_a\n'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_b\n'));
-      expect(messages, contains('Child file of direcotry remote_zip_0 is file_c\n'));
+      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_0'));
+      expect(messages, contains('Child file of direcotry remote_zip_0 is file_a'));
+      expect(messages, contains('Child file of direcotry remote_zip_0 is file_b'));
+      expect(messages, contains('Child file of direcotry remote_zip_0 is file_c'));
     });
 
     test('visitDirectory recursively visits directory', () async {
@@ -124,10 +123,10 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1\n'));
-      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1/folder_a\n'));
-      expect(messages, contains('Child file of direcotry remote_zip_1 is file_a\n'));
-      expect(messages, contains('Child file of direcotry folder_a is file_b\n'));
+      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1'));
+      expect(messages, contains('Visiting directory ${tempDir.path}/remote_zip_1/folder_a'));
+      expect(messages, contains('Child file of direcotry remote_zip_1 is file_a'));
+      expect(messages, contains('Child file of direcotry folder_a is file_b'));
     });
 
     test('visit directory inside a zip', () async {
@@ -187,10 +186,10 @@ void main() {
       expect(
           messages,
           contains(
-              'The downloaded file is unzipped from ${tempDir.path}/remote_zip_2/zip_1 to ${tempDir.path}/embedded_zip_${zipFileName.hashCode}\n'));
-      expect(messages, contains('Visiting directory ${tempDir.path}/embedded_zip_${zipFileName.hashCode}\n'));
-      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_1\n'));
-      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_2\n'));
+              'The downloaded file is unzipped from ${tempDir.path}/remote_zip_2/zip_1 to ${tempDir.path}/embedded_zip_${zipFileName.hashCode}'));
+      expect(messages, contains('Visiting directory ${tempDir.path}/embedded_zip_${zipFileName.hashCode}'));
+      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_1'));
+      expect(messages, contains('Child file of direcotry embedded_zip_${zipFileName.hashCode} is file_2'));
     });
 
     test('visit zip inside a directory', () async {
@@ -235,13 +234,13 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/remote_zip_4\n'));
-      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/remote_zip_4/folder_1\n'));
+      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/remote_zip_4'));
+      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/remote_zip_4/folder_1'));
       expect(
           messages,
           contains(
-              'The downloaded file is unzipped from ${tempDir.path}/remote_zip_4/folder_1/zip_1 to ${tempDir.path}/embedded_zip_${zipFileName.hashCode}\n'));
-      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/embedded_zip_${zipFileName.hashCode}\n'));
+              'The downloaded file is unzipped from ${tempDir.path}/remote_zip_4/folder_1/zip_1 to ${tempDir.path}/embedded_zip_${zipFileName.hashCode}'));
+      expect(messages, contains('Visiting directory ${tempDir.absolute.path}/embedded_zip_${zipFileName.hashCode}'));
     });
 
     test('throw exception when the same directory is visited', () async {
@@ -366,13 +365,13 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('\n signing file at path ${tempDir.absolute.path}/remote_zip_1/file_a'));
-      expect(messages, contains('\n the virtual entitlement path associated with file is root/file_a'));
-      expect(messages, contains('\n the decision to sign with entitlement is true'));
+      expect(messages, contains('signing file at path ${tempDir.absolute.path}/remote_zip_1/file_a'));
+      expect(messages, contains('the virtual entitlement path associated with file is root/file_a'));
+      expect(messages, contains('the decision to sign with entitlement is true'));
 
-      expect(messages, contains('\n signing file at path ${tempDir.absolute.path}/remote_zip_1/file_b'));
-      expect(messages, contains('\n the virtual entitlement path associated with file is root/file_b'));
-      expect(messages, contains('\n the decision to sign with entitlement is false'));
+      expect(messages, contains('signing file at path ${tempDir.absolute.path}/remote_zip_1/file_b'));
+      expect(messages, contains('the virtual entitlement path associated with file is root/file_b'));
+      expect(messages, contains('the decision to sign with entitlement is false'));
     });
   });
 }

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -309,14 +309,6 @@ void main() {
         ),
         FakeCommand(
           command: <String>[
-            'ls',
-            '-alhf',
-            '${tempDir.absolute.path}/remote_zip_1/file_a',
-          ],
-          stdout: 'no_arrow_output',
-        ),
-        FakeCommand(
-          command: <String>[
             'codesign',
             '-f',
             '-s',
@@ -336,14 +328,6 @@ void main() {
             '${tempDir.absolute.path}/remote_zip_1/file_b',
           ],
           stdout: 'application/x-mach-binary',
-        ),
-        FakeCommand(
-          command: <String>[
-            'ls',
-            '-alhf',
-            '${tempDir.absolute.path}/remote_zip_1/file_b',
-          ],
-          stdout: 'no_arrow_output',
         ),
         FakeCommand(
           command: <String>[

--- a/codesign/test/file_codesing_visitor_test.dart
+++ b/codesign/test/file_codesing_visitor_test.dart
@@ -374,6 +374,5 @@ void main() {
       expect(messages, contains('\n the virtual entitlement path associated with file is root/file_b'));
       expect(messages, contains('\n the decision to sign with entitlement is false'));
     });
-
   });
 }


### PR DESCRIPTION
context: this is the fourth split (a smaller split) of https://github.com/flutter/cocoon/pull/1861.

prior splits (merged, excluding abandoned) : https://github.com/flutter/cocoon/pull/1972, https://github.com/flutter/cocoon/pull/1899, https://github.com/flutter/cocoon/pull/2003.

This split adds in logic to visit a binary file, and code sign it with or without entitlement, based on the configuration file.

-------
Thanks for reviewing! Incorporated feedbacks from Christopher