### PR TITLE
Manually bump `google_sign_in` from 5.2.3 to 5.4.1 in /dashboard

### DIFF
--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -232,14 +232,28 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.3"
+    version: "5.4.1"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.4.0"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   google_sign_in_web:
     dependency: transitive
     description:

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   fixnum: ^1.0.0
   flutter:
     sdk: flutter
-  google_sign_in: ^5.2.3
+  google_sign_in: ^5.4.1
   http: ^0.13.4
   protobuf: ^2.0.1
   provider: ^6.0.2

--- a/dashboard/test/utils/fake_google_account.dart
+++ b/dashboard/test/utils/fake_google_account.dart
@@ -25,7 +25,7 @@ class FakeGoogleSignInAccount implements GoogleSignInAccount {
   Future<Map<String, String>> get authHeaders => Future<Map<String, String>>.value(<String, String>{});
 
   @override
-  late Future<GoogleSignInAuthentication> authentication;
+  late final Future<GoogleSignInAuthentication> authentication;
 
   @override
   Future<void> clearAuthCache() => Future<void>.value(null);


### PR DESCRIPTION
Manually land: https://github.com/flutter/cocoon/pull/2042 with fixes.