### PR TITLE
Change Image Name to Use Artifact Registry

### DIFF
--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -6,7 +6,7 @@
 
 steps:
   # Build dashboard.
-  - name: us-docker.pkg.dev/$PROJECT_ID/gcr.io/flutter
+  - name: us-docker.pkg.dev/$PROJECT_ID/flutter/flutter
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']
 

--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -6,7 +6,7 @@
 
 steps:
   # Build dashboard.
-  - name: gcr.io/$PROJECT_ID/flutter
+  - name: us-docker.pkg.dev/$PROJECT_ID/gcr.io/$PROJECT_ID/flutter
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']
 

--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -6,7 +6,7 @@
 
 steps:
   # Build dashboard.
-  - name: us-docker.pkg.dev/$PROJECT_ID/gcr.io/$PROJECT_ID/flutter
+  - name: us-docker.pkg.dev/$PROJECT_ID/gcr.io/flutter
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']
 

--- a/flutter_image_build.yaml
+++ b/flutter_image_build.yaml
@@ -1,10 +1,10 @@
 # Builds a new flutter image, which is used to build cocoon dashboard.
 
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/flutter', '.']
+  - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/flutter/flutter', '.']
 
 timeout: 1200s
 
-images: ['gcr.io/$PROJECT_ID/flutter']
+images: ['us-docker.pkg.dev/$PROJECT_ID/flutter/flutter']
 tags: ['cloud-builders-community']


### PR DESCRIPTION
In order to generate provenance and increase SLSA level, images are being routed to Artifact Registry instead of Container Registry. The transition has been tested for both autosubmit and app-dart. It is also necessary for the flutter image build prerequisite to be pushed to Artifact Registry.

 As part of this, the build configurations for app-dart and flutter image build need to be updated to point to the correct Artifact Registry location.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
