### PR TITLE
Establish Docker Image build provenance and move to artifact registry

### DIFF
--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -1,8 +1,10 @@
 # Provide instructions for google Cloud Build to auto-build flutter
 # dashboard to flutter-dashboard project. Auto-build will be triggered
 # by daily schedule on `main` branch. This cloudbuild calls two cloudbuild
-# configurations. One is for generating the docker image with build provenance,
-# and the other uses the generated docker image and deploys it to app engine.
+# configurations.
+#
+# The first job is for generating the docker image with build provenance,
+# and the second uses the generated docker image and deploys it to app engine.
 
 steps:
   - name: gcr.io/cloud-builders/gcloud
@@ -10,7 +12,9 @@ steps:
     args:
       - '-c'
       - |-
-        gcloud builds submit --config app_dart/cloudbuild_app_dart_docker.yaml
-        gcloud builds submit --config app_dart/cloudbuild_app_dart_deploy.yaml
+        gcloud builds submit --config app_dart/cloudbuild_app_dart_docker.yaml \
+          --substitutions="SHORT_SHA=$SHORT_SHA"
+        gcloud builds submit --config app_dart/cloudbuild_app_dart_deploy.yaml \
+          --substitutions="_GAE_PROMOTE=$_GAE_PROMOTE,SHORT_SHA=$SHORT_SHA"
 
 timeout: 1200s

--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -10,6 +10,12 @@ steps:
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']
 
+
+  # Build docker image
+  - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', 'app_dart']
+
+
   # Deploy a new version to google cloud.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: '/bin/bash'
@@ -25,3 +31,5 @@ steps:
         fi
 
 timeout: 1200s
+
+images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA']

--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -1,0 +1,16 @@
+# Provide instructions for google Cloud Build to auto-build flutter
+# dashboard to flutter-dashboard project. Auto-build will be triggered
+# by daily schedule on `main` branch. This cloudbuild calls two cloudbuild
+# configurations. One is for generating the docker image with build provenance,
+# and the other uses the generated docker image and deploys it to app engine.
+
+steps:
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |-
+        gcloud builds submit --config app_dart/cloudbuild_app_dart_docker.yaml
+        gcloud builds submit --config app_dart/cloudbuild_app_dart_deploy.yaml
+
+timeout: 1200s

--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -20,5 +20,3 @@ steps:
         fi
 
 timeout: 1200s
-
-images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA']

--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -5,17 +5,6 @@
 # The auto-build will be skipped if no new commits since last deployment.
 
 steps:
-  # Build dashboard.
-  - name: us-docker.pkg.dev/$PROJECT_ID/flutter/flutter
-    entrypoint: '/bin/bash'
-    args: ['cloud_build/dashboard_build.sh']
-
-
-  # Build docker image
-  - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
-    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', 'app_dart']
-
-
   # Deploy a new version to google cloud.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: '/bin/bash'

--- a/app_dart/cloudbuild_app_dart_docker.yaml
+++ b/app_dart/cloudbuild_app_dart_docker.yaml
@@ -1,8 +1,5 @@
-# Provide instructions for google Cloud Build to auto-build flutter
-# dashboard to flutter-dashboard project. Auto-build will be triggered
-# by daily schedule on `main` branch.
-#
-# The auto-build will be skipped if no new commits since last deployment.
+# Provide instructions for google Cloud Build to build and upload the flutter
+# dashboard docker image to artifact registry.
 
 steps:
   # Build dashboard.

--- a/app_dart/cloudbuild_app_dart_docker.yaml
+++ b/app_dart/cloudbuild_app_dart_docker.yaml
@@ -3,6 +3,9 @@
 
 steps:
   # Build dashboard.
+  # This step generates the dashboard files using flutter, then moves the
+  # generated files into the app_dart folder, where a docker image is then
+  # created in the next step.
   - name: us-docker.pkg.dev/$PROJECT_ID/flutter/flutter
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']

--- a/app_dart/cloudbuild_app_dart_docker.yaml
+++ b/app_dart/cloudbuild_app_dart_docker.yaml
@@ -1,0 +1,20 @@
+# Provide instructions for google Cloud Build to auto-build flutter
+# dashboard to flutter-dashboard project. Auto-build will be triggered
+# by daily schedule on `main` branch.
+#
+# The auto-build will be skipped if no new commits since last deployment.
+
+steps:
+  # Build dashboard.
+  - name: us-docker.pkg.dev/$PROJECT_ID/flutter/flutter
+    entrypoint: '/bin/bash'
+    args: ['cloud_build/dashboard_build.sh']
+
+
+  # Build docker image
+  - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', 'app_dart']
+
+timeout: 1200s
+
+images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA']

--- a/auto_submit/cloudbuild_auto_submit.yaml
+++ b/auto_submit/cloudbuild_auto_submit.yaml
@@ -1,22 +1,20 @@
 # Provide instructions for google Cloud Build to auto-build flutter
-# auto submit to flutter-dashboard project. Auto-build will be triggered
-# by daily schedule on `main` branch.
+# auto-submit bot to flutter-dashboard project. Auto-build will be triggered
+# by daily schedule on `main` branch. This cloudbuild calls two cloudbuild
+# configurations.
 #
-# The auto-build will be skipped if no new commits since last deployment.
+# The first job is for generating the docker image with build provenance,
+# and the second uses the generated docker image and deploys it to app engine.
 
 steps:
-  # Deploy a new version to google cloud.
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: '/bin/bash'
     args:
       - '-c'
       - |-
-        gcloud config set project $PROJECT_ID
-        latest_version=$(gcloud app versions list --hide-no-traffic --format 'value(version.id)')
-        if [ "$latest_version" = "version-$SHORT_SHA" ]; then
-          echo "No updates since last deployment."
-        else
-          bash cloud_build/deploy_auto_submit.sh $PROJECT_ID $SHORT_SHA $_GAE_PROMOTE
-        fi
+        gcloud builds submit --config auto_submit/cloudbuild_auto_submit_docker.yaml \
+          --substitutions="SHORT_SHA=$SHORT_SHA"
+        gcloud builds submit --config auto_submit/cloudbuild_auto_submit_deploy.yaml \
+          --substitutions="_GAE_PROMOTE=$_GAE_PROMOTE,SHORT_SHA=$SHORT_SHA"
 
 timeout: 1200s

--- a/auto_submit/cloudbuild_auto_submit_deploy.yaml
+++ b/auto_submit/cloudbuild_auto_submit_deploy.yaml
@@ -1,0 +1,22 @@
+# Provide instructions for google Cloud Build to auto-build flutter
+# auto submit to flutter-dashboard project. Auto-build will be triggered
+# by daily schedule on `main` branch.
+#
+# The auto-build will be skipped if no new commits since last deployment.
+
+steps:
+  # Deploy a new version to google cloud.
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: '/bin/bash'
+    args:
+      - '-c'
+      - |-
+        gcloud config set project $PROJECT_ID
+        latest_version=$(gcloud app versions list --hide-no-traffic --format 'value(version.id)')
+        if [ "$latest_version" = "version-$SHORT_SHA" ]; then
+          echo "No updates since last deployment."
+        else
+          bash cloud_build/deploy_auto_submit.sh $PROJECT_ID $SHORT_SHA $_GAE_PROMOTE
+        fi
+
+timeout: 1200s

--- a/auto_submit/cloudbuild_auto_submit_docker.yaml
+++ b/auto_submit/cloudbuild_auto_submit_docker.yaml
@@ -1,0 +1,11 @@
+# Provide instructions for google Cloud Build to build and upload the flutter
+# auto-submit docker image to artifact registry.
+
+steps:
+  # Build docker image
+  - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA', 'auto_submit']
+
+timeout: 1200s
+
+images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA']

--- a/cloud_build/deploy_app_dart.sh
+++ b/cloud_build/deploy_app_dart.sh
@@ -8,7 +8,7 @@
 pushd app_dart > /dev/null
 set -e
 # app_dart
-gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
+gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/default.version-$2"
 gcloud app services set-traffic default --splits version-$2=1 --quiet
 # Google Cloud quota only allows 30 versions.
 # For daily builds, this will keep the 10 most recent versions, but wipe the rest.

--- a/cloud_build/deploy_auto_submit.sh
+++ b/cloud_build/deploy_auto_submit.sh
@@ -5,9 +5,11 @@
 
 # Deploy a new auto submit version to google cloud.
 
-# auto_submit
 pushd auto_submit > /dev/null
-gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version
+# auto_submit
+gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/auto-submit.version-$2"
 gcloud app services set-traffic auto-submit --splits version-$2=1 --quiet
+# Google Cloud quota only allows 30 versions.
+# For daily builds, this will keep the 10 most recent versions, but wipe the rest.
 gcloud app versions list --format="value(version.id)" --sort-by="~version.createTime"  --service=auto-submit | tail -n +20 | xargs -r gcloud app versions delete --quiet
 popd > /dev/null


### PR DESCRIPTION
Bug: b/242225018

Creates build provenance for the following docker images:
* Docker image utilized by the flutter dashboard
* Flutter dashboard
* Flutter autosubmit

This required a couple of significant changes:
* Docker images are now deployed to artifact registry instead of container registry.
  * This change was necessary because provenance is able to be generated in artifact registry easily, but not in container registry.
* Originally,`gcloud app deploy` automatically generated the docker image and uploaded it.
  * In order to generate provenance, we needed to create the images ourselves. Therefore, the build and deploy have been split into different cloud builds, with a main cloud build configuration executing the build and deploy cloudbuild configs in order.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
