### PR TITLE
Support fuchsia release branches.

### DIFF
--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -89,7 +89,7 @@ class BranchService {
   Future<void> branchFlutterRecipes(String branch) async {
     final RepositorySlug recipesSlug = RepositorySlug('flutter', 'recipes');
     if ((await gerritService.branches('${recipesSlug.owner}-review.googlesource.com', recipesSlug.name,
-            subString: branch))
+            filterRegex: branch))
         .contains(branch)) {
       // subString is a regex, and can return multiple matches
       log.warning('$branch already exists for $recipesSlug');

--- a/app_dart/lib/src/service/gerrit_service.dart
+++ b/app_dart/lib/src/service/gerrit_service.dart
@@ -37,13 +37,14 @@ class GerritService {
 
   /// Gets the branches from a remote git repository using the gerrit APIs.
   ///
-  /// [subString] allows to filter branches with this text (not case sensitive).
+  /// [filterRegex] a regular expression string to filter the branches list to
+  /// the ones matching the regex.
   ///
   /// See more:
   ///   * https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-branches
-  Future<List<String>> branches(String repo, String project, {String? subString}) async {
+  Future<List<String>> branches(String repo, String project, {String? filterRegex}) async {
     final Map<String, String> queryParameters = <String, String>{
-      if (subString != null && subString.isNotEmpty) 'm': subString,
+      if (filterRegex != null && filterRegex.isNotEmpty) 'r': filterRegex,
     };
     final Uri url = Uri.https(repo, 'projects/$project/branches', queryParameters);
     final List<dynamic> response = await _get(url) as List<dynamic>;

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -219,6 +219,7 @@ class LuciBuildService {
       'recipes',
       filterRegex: 'flutter-*|fuchsia*',
     );
+    log.info('Available release branches: $branches');
 
     final String sha = pullRequest.head!.sha!;
     String cipdVersion = 'refs/heads/${pullRequest.base!.ref!}';

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -217,7 +217,7 @@ class LuciBuildService {
     final List<String> branches = await gerritService.branches(
       'flutter-review.googlesource.com',
       'recipes',
-      filterRegex: 'flutter-*|fuchsia*',
+      filterRegex: 'flutter-.*|fuchsia.*',
     );
     log.info('Available release branches: $branches');
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -217,7 +217,7 @@ class LuciBuildService {
     final List<String> branches = await gerritService.branches(
       'flutter-review.googlesource.com',
       'recipes',
-      subString: 'flutter-',
+      filterRegex: 'flutter-*|fuchsia*',
     );
 
     final String sha = pullRequest.head!.sha!;

--- a/app_dart/test/service/gerrit_service_test.dart
+++ b/app_dart/test/service/gerrit_service_test.dart
@@ -12,6 +12,7 @@ import 'package:cocoon_service/src/service/gerrit_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/service/fake_auth_client.dart';
@@ -35,16 +36,21 @@ void main() {
       }
     });
     test('Returns a list of branches', () async {
+      Request? requestAux;
       const String body =
           ')]}\'\n[{"web_links":[{"name":"browse","url":"https://a.com/branch_a","target":"_blank"}],"ref":"refs/heads/branch_a","revision":"0bc"}]';
-      mockHttpClient = MockClient((_) async => http.Response(body, HttpStatus.ok));
+      mockHttpClient = MockClient((Request request) async {
+        requestAux = request;
+        return http.Response(body, HttpStatus.ok);
+      });
       gerritService = GerritService(httpClient: mockHttpClient);
       final List<String> branches = await gerritService.branches(
         'myhost',
         'a/b/c',
-        filterRegex: 'flutter-*',
+        filterRegex: 'flutter-*|fuchsia*',
       );
       expect(branches, equals(<String>['refs/heads/branch_a']));
+      expect(requestAux!.url.queryParameters, equals(<dynamic, dynamic>{'r': 'flutter-*|fuchsia*'}));
     });
 
     test('No results return an empty list', () async {

--- a/app_dart/test/service/gerrit_service_test.dart
+++ b/app_dart/test/service/gerrit_service_test.dart
@@ -28,7 +28,7 @@ void main() {
         await gerritService.branches(
           'myhost',
           'a/b/c',
-          subString: 'flutter-',
+          filterRegex: 'flutter-*',
         );
       } catch (e) {
         expect(e, isA<RetryException>());
@@ -42,7 +42,7 @@ void main() {
       final List<String> branches = await gerritService.branches(
         'myhost',
         'a/b/c',
-        subString: 'flutter-',
+        filterRegex: 'flutter-*',
       );
       expect(branches, equals(<String>['refs/heads/branch_a']));
     });
@@ -53,7 +53,7 @@ void main() {
       final List<String> branches = await gerritService.branches(
         'myhost',
         'a/b/c',
-        subString: 'flutter-',
+        filterRegex: 'flutter-',
       );
       expect(branches, equals(<String>[]));
     });

--- a/app_dart/test/service/gerrit_service_test.dart
+++ b/app_dart/test/service/gerrit_service_test.dart
@@ -12,7 +12,6 @@ import 'package:cocoon_service/src/service/gerrit_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/service/fake_auth_client.dart';

--- a/app_dart/test/src/service/fake_gerrit_service.dart
+++ b/app_dart/test/src/service/fake_gerrit_service.dart
@@ -30,7 +30,7 @@ class FakeGerritService extends GerritService {
   ];
 
   @override
-  Future<List<String>> branches(String repo, String project, {String? subString}) async => branchesValue;
+  Future<List<String>> branches(String repo, String project, {String? filterRegex}) async => branchesValue;
 
   @override
   Future<Iterable<GerritCommit>> commits(RepositorySlug slug, String branch) async => commitsValue ?? _defaultCommits;


### PR DESCRIPTION
There was an assumption that release branches all started with flutter-
which is only partially true as fuchsia* should be also considered
release branches.

Bug: https://github.com/flutter/flutter/issues/107761

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
