### PR TITLE
[codesign] add function to parse entitlement configs

### DIFF
--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
+import 'package:file/local.dart';
 import 'package:process/process.dart';
 
 import 'log.dart';
@@ -226,5 +228,23 @@ update these file paths accordingly.
       );
     }
     fileConsumed.add(entitlementCurrentPath);
+  }
+
+  /// Extract entitlements configurations from downloaded zip files.
+  ///
+  /// Parse and store codesign configurations detailed in configuration files.
+  /// File paths of entilement files and non entitlement files will be parsed and stored in [fileWithEntitlements].
+  Future<Set<String>> parseEntitlements(Directory parent, bool entitlements) async {
+    final String entitlementFilePath = entitlements
+        ? fileSystem.path.join(parent.path, 'entitlements.txt')
+        : fileSystem.path.join(parent.path, 'without_entitlements.txt');
+    if (!(await fileSystem.file(entitlementFilePath).exists())) {
+      throw CodesignException('entitilements configuration files are not detected \n'
+          'make sure you have provided them along with the engine artifacts \n');
+    }
+
+    final Set<String> fileWithEntitlements = <String>{};
+    fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
+    return fileWithEntitlements;
   }
 }

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
@@ -237,7 +238,7 @@ update these file paths accordingly.
         ? fileSystem.path.join(parent.path, 'entitlements.txt')
         : fileSystem.path.join(parent.path, 'without_entitlements.txt');
     if (!(await fileSystem.file(entitlementFilePath).exists())) {
-      throw CodesignException('entitilements configuration files are not detected \n'
+      throw CodesignException('$entitlementFilePath not found \n'
           'make sure you have provided them along with the engine artifacts \n');
     }
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -3,11 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
-import 'package:file/local.dart';
 import 'package:process/process.dart';
 
 import 'log.dart';

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -362,7 +362,7 @@ void main() {
     });
   });
 
-  group('pase entitlement configs: ', () {
+  group('parse entitlement configs: ', () {
     setUp(() {
       tempDir = fileSystem.systemTempDirectory.createTempSync('conductor_codesign');
       processManager = FakeProcessManager.list(<FakeCommand>[]);
@@ -383,11 +383,13 @@ void main() {
       log.onRecord.listen((LogRecord record) => records.add(record));
     });
 
-    test('parse and store file paths', () async {
+    test('correctly store file paths', () async {
       fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt')
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          'file_a\nfile_b\nfile_c\n',
+          '''file_a
+file_b
+file_c''',
           mode: FileMode.append,
           encoding: utf8,
         );
@@ -395,7 +397,8 @@ void main() {
       fileSystem.file('${tempDir.absolute.path}/test_entitlement/without_entitlements.txt')
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          'file_d\nfile_e\n',
+          '''file_d
+file_e''',
           mode: FileMode.append,
           encoding: utf8,
         );
@@ -428,7 +431,9 @@ void main() {
       fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt')
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          'file_a\nfile_b\nfile_c\n',
+          '''file_a
+file_b
+file_c''',
           mode: FileMode.append,
           encoding: utf8,
         );

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -384,12 +384,13 @@ void main() {
     });
 
     test('parse and store file paths', () async {
-      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt').createSync(recursive: true);
-      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt').writeAsStringSync(
-            'file_a\nfile_b\nfile_c\n',
-            mode: FileMode.append,
-            encoding: utf8,
-          );
+      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          'file_a\nfile_b\nfile_c\n',
+          mode: FileMode.append,
+          encoding: utf8,
+        );
 
       fileSystem.file('${tempDir.absolute.path}/test_entitlement/without_entitlements.txt')
         ..createSync(recursive: true)
@@ -424,12 +425,13 @@ void main() {
     });
 
     test('throw exception when configuration file is missing', () async {
-      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt').createSync(recursive: true);
-      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt').writeAsStringSync(
-            'file_a\nfile_b\nfile_c\n',
-            mode: FileMode.append,
-            encoding: utf8,
-          );
+      fileSystem.file('${tempDir.absolute.path}/test_entitlement/entitlements.txt')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          'file_a\nfile_b\nfile_c\n',
+          mode: FileMode.append,
+          encoding: utf8,
+        );
 
       final Set<String> fileWithEntitlements = await codesignVisitor.parseEntitlements(
         fileSystem.directory('${tempDir.absolute.path}/test_entitlement'),


### PR DESCRIPTION
This the fifth split (and a shorter split) of https://github.com/flutter/cocoon/pull/1861.

This PR adds function to parse and store entitlement files that were generated through GN.

prior splits: https://github.com/flutter/cocoon/pull/1972, https://github.com/flutter/cocoon/pull/1899, https://github.com/flutter/cocoon/pull/2003, https://github.com/flutter/cocoon/pull/2044.
