### PR TITLE
[dashboard] Create fake for FlutterAppIcon in tests

### DIFF
--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -194,7 +194,7 @@ packages:
       name: flutter_app_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3"
+    version: "0.0.8"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -610,5 +610,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.18.0-120.0.dev <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=2.8.0"

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   protobuf: ^2.0.1
   provider: ^6.0.2
   url_launcher: ^6.1.5
-  flutter_app_icons: ^0.0.3
+  flutter_app_icons: ^0.0.8
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/dashboard/test/build_dashboard_page_test.dart
+++ b/dashboard/test/build_dashboard_page_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 import 'package:flutter_dashboard/build_dashboard_page.dart';
 import 'package:flutter_dashboard/model/branch.pb.dart';
 import 'package:flutter_dashboard/model/build_status_response.pb.dart';
@@ -21,6 +22,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 import 'utils/fake_build.dart';
+import 'utils/fake_flutter_app_icons.dart';
 import 'utils/fake_google_account.dart';
 import 'utils/golden.dart';
 import 'utils/mocks.dart';
@@ -46,6 +48,8 @@ void main() {
     fakeAuthService = MockGoogleSignInService();
     when(fakeAuthService.isAuthenticated).thenAnswer((_) => Future<bool>.value(true));
     when(fakeAuthService.user).thenReturn(FakeGoogleSignInAccount());
+
+    FlutterAppIconsPlatform.instance = FakeFlutterAppIcons();
   });
 
   testWidgets('shows sign in button', (WidgetTester tester) async {

--- a/dashboard/test/state/build_test.dart
+++ b/dashboard/test/state/build_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 import 'package:flutter_dashboard/model/branch.pb.dart';
 import 'package:flutter_dashboard/model/build_status_response.pb.dart';
 import 'package:flutter_dashboard/model/commit.pb.dart';
@@ -16,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
 
+import '../utils/fake_flutter_app_icons.dart';
 import '../utils/mocks.dart';
 import '../utils/output.dart';
 
@@ -45,6 +47,8 @@ void main() {
             ..repository = 'flutter'
         ]),
       );
+
+      FlutterAppIconsPlatform.instance = FakeFlutterAppIcons();
     });
 
     tearDown(() {

--- a/dashboard/test/utils/fake_flutter_app_icons.dart
+++ b/dashboard/test/utils/fake_flutter_app_icons.dart
@@ -1,6 +1,7 @@
 // Copyright 2019 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 
 class FakeFlutterAppIcons extends FlutterAppIconsPlatform {

--- a/dashboard/test/utils/fake_flutter_app_icons.dart
+++ b/dashboard/test/utils/fake_flutter_app_icons.dart
@@ -1,0 +1,15 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
+
+class FakeFlutterAppIcons extends FlutterAppIconsPlatform {
+  @override
+  Future<String?> setIcon({
+    required String icon,
+    String oldIcon = '',
+    String appleTouchIcon = '',
+  }) async {
+    return icon;
+  }
+}

--- a/dashboard/test/widgets/commit_box_test.dart
+++ b/dashboard/test/widgets/commit_box_test.dart
@@ -4,11 +4,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 import 'package:flutter_dashboard/model/commit.pb.dart';
 import 'package:flutter_dashboard/widgets/commit_box.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import '../utils/fake_flutter_app_icons.dart';
 import '../utils/fake_url_launcher.dart';
 import '../utils/golden.dart';
 
@@ -33,6 +35,10 @@ void main() {
       ),
     ),
   );
+
+  setUp(() {
+    FlutterAppIconsPlatform.instance = FakeFlutterAppIcons();
+  });
 
   testWidgets('CommitBox shows information correctly', (WidgetTester tester) async {
     await tester.pumpWidget(basicApp);

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 import 'package:flutter_dashboard/logic/qualified_task.dart';
 import 'package:flutter_dashboard/logic/task_grid_filter.dart';
 import 'package:flutter_dashboard/model/commit.pb.dart';
@@ -23,11 +24,16 @@ import 'package:flutter_dashboard/widgets/task_icon.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../utils/fake_build.dart';
+import '../utils/fake_flutter_app_icons.dart';
 import '../utils/golden.dart';
 import '../utils/mocks.dart';
 import '../utils/task_icons.dart';
 
 void main() {
+  setUp(() {
+    FlutterAppIconsPlatform.instance = FakeFlutterAppIcons();
+  });
+
   testWidgets('TaskGridContainer shows loading indicator when statuses is empty', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
* Uprev flutter_app_icons to 0.0.8
* Fix tests failing as there was no fake plugin created for it as it was originally a no-op