### PR TITLE
Remove autosubmit on fail

### DIFF
--- a/auto_submit/lib/service/approver_service.dart
+++ b/auto_submit/lib/service/approver_service.dart
@@ -50,7 +50,7 @@ class ApproverService {
     if (labelNames.contains(Config.kRevertLabel) &&
         (config.rollerAccounts.contains(author) || approvedAuthorAssociations.contains(authorAssociation))) {
       log.info(
-          'Revert label and author has been validated. Attempting to approve the pull request. ${pullRequest.repo.toString()} by $author');
+          'Revert label and author has been validated. Attempting to approve the pull request. ${pullRequest.repo} by $author');
       await _approve(pullRequest, author);
     } else {
       log.info('Auto-review ignored for $author');
@@ -71,7 +71,7 @@ class ApproverService {
 
     final gh.CreatePullRequestReview review =
         gh.CreatePullRequestReview(slug.owner, slug.name, pullRequest.number!, 'APPROVE');
-    botClient.pullRequests.createReview(slug, review);
+    await botClient.pullRequests.createReview(slug, review);
     log.info('Review for $author complete');
   }
 }

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -48,7 +48,7 @@ class GithubService {
 
   /// Create a new issue in github.
   Future<Issue> createIssue({
-    required RepositorySlug repositorySlug,
+    required RepositorySlug slug,
     required String title,
     required String body,
     List<String>? labels,
@@ -64,7 +64,7 @@ class GithubService {
       assignees: assignees,
       state: state,
     );
-    return await github.issues.create(repositorySlug, issueRequest);
+    return await github.issues.create(slug, issueRequest);
   }
 
   /// Fetches the specified pull request.

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -47,14 +47,22 @@ class GithubService {
   }
 
   /// Create a new issue in github.
-  Future<Issue> createIssue(
-    RepositorySlug repositorySlug,
-    String title,
-    String body,
-  ) async {
+  Future<Issue> createIssue({
+    required RepositorySlug repositorySlug,
+    required String title,
+    required String body,
+    List<String>? labels,
+    String? assignee,
+    List<String>? assignees,
+    String? state,
+  }) async {
     IssueRequest issueRequest = IssueRequest(
       title: title,
       body: body,
+      labels: labels,
+      assignee: assignee,
+      assignees: assignees,
+      state: state,
     );
     return await github.issues.create(repositorySlug, issueRequest);
   }

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -27,7 +27,7 @@ Review request for Revert PR $repositorySlug#$revertPrNumber
   String _constructBody() {
     return '''
 Pull request $repositorySlug#$revertPrNumber was submitted and merged by
-$revertPrAuthor in order to revert changes made in this pull request $originalPrLink.
+@$revertPrAuthor in order to revert changes made in this pull request $originalPrLink.
 
 Please assign this issue to the person that will make the formal review on the
 revert request listed above.

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -4,10 +4,11 @@
 
 class RevertReviewTemplate {
   RevertReviewTemplate({
-      required this.repositorySlug,
-      required this.revertPrNumber, 
-      required this.revertPrAuthor,
-      required this.originalPrLink,}) {
+    required this.repositorySlug,
+    required this.revertPrNumber,
+    required this.revertPrAuthor,
+    required this.originalPrLink,
+  }) {
     constructTitle();
     constructBody();
   }
@@ -18,7 +19,7 @@ class RevertReviewTemplate {
   String originalPrLink;
 
   String? _title;
-  String? _body; 
+  String? _body;
 
   void constructTitle() {
     _title = '''
@@ -27,9 +28,9 @@ Review request for Revert PR $repositorySlug#$revertPrNumber
   }
 
   void constructBody() {
-_body = '''
-Pull request $repositorySlug#$revertPrNumber was submitted and merged by 
-$revertPrAuthor in order to revert changes made in this pull request $originalPrLink. 
+    _body = '''
+Pull request $repositorySlug#$revertPrNumber was submitted and merged by
+$revertPrAuthor in order to revert changes made in this pull request $originalPrLink.
 
 Please assign this issue to the person that will make the formal review on the
 revert request listed above.

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -1,0 +1,54 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class RevertReviewTemplate {
+  RevertReviewTemplate({
+      required this.repositorySlug,
+      required this.revertPrNumber, 
+      required this.revertPrAuthor,
+      required this.originalPrLink,}) {
+    constructTitle();
+    constructBody();
+  }
+
+  String repositorySlug;
+  int revertPrNumber;
+  String revertPrAuthor;
+  String originalPrLink;
+
+  String? _title;
+  String? _body; 
+
+  void constructTitle() {
+    _title = '''
+Review request for Revert PR $repositorySlug#$revertPrNumber
+''';
+  }
+
+  void constructBody() {
+_body = '''
+Pull request $repositorySlug#$revertPrNumber was submitted and merged by 
+$revertPrAuthor in order to revert changes made in this pull request $originalPrLink. 
+
+Please assign this issue to the person that will make the formal review on the
+revert request listed above.
+
+Please do the following so that we may track this issue to completion:
+1. Add the reviewer of revert pull request as the assignee of this issue.
+2. Add the label 'revert_review' to this issue.
+3. Close only when the review has been completed.
+
+
+PLEASE DO NOT MODIFY THE FOLLOWING
+{
+  'originalPrLink': '$originalPrLink',
+  'revertPrLink': '$repositorySlug#$revertPrNumber',
+  'revertPrAuthor': '$revertPrAuthor'
+}
+''';
+  }
+
+  String? get title => _title;
+  String? get body => _body;
+}

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -38,12 +38,14 @@ Please do the following so that we may track this issue to completion:
 3. Close only when the review has been completed.
 
 
-PLEASE DO NOT MODIFY THE FOLLOWING
+DO NOT EDIT, REVERT METADATA
+<!--
 {
   'originalPrLink': '$originalPrLink',
   'revertPrLink': '$repositorySlug#$revertPrNumber',
   'revertPrAuthor': '$revertPrAuthor'
 }
+-->
 ''';
   }
 

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -2,33 +2,30 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// A template for creating follow up review issues for created revert requests.
 class RevertReviewTemplate {
   RevertReviewTemplate({
     required this.repositorySlug,
     required this.revertPrNumber,
     required this.revertPrAuthor,
     required this.originalPrLink,
-  }) {
-    constructTitle();
-    constructBody();
-  }
+  });
 
-  String repositorySlug;
-  int revertPrNumber;
-  String revertPrAuthor;
-  String originalPrLink;
+  final String repositorySlug;
+  final int revertPrNumber;
+  final String revertPrAuthor;
+  final String originalPrLink;
 
-  String? _title;
-  String? _body;
-
-  void constructTitle() {
-    _title = '''
+  /// Constructs the issues title.
+  String _constructTitle() {
+    return '''
 Review request for Revert PR $repositorySlug#$revertPrNumber
 ''';
   }
 
-  void constructBody() {
-    _body = '''
+  /// Constructs the issues body.
+  String _constructBody() {
+    return '''
 Pull request $repositorySlug#$revertPrNumber was submitted and merged by
 $revertPrAuthor in order to revert changes made in this pull request $originalPrLink.
 
@@ -50,6 +47,6 @@ PLEASE DO NOT MODIFY THE FOLLOWING
 ''';
   }
 
-  String? get title => _title;
-  String? get body => _body;
+  String? get title => _constructTitle();
+  String? get body => _constructBody();
 }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -63,18 +63,18 @@ class ValidationService {
     switch (processMethod) {
       case ProcessMethod.processAutosubmit:
         await processPullRequest(
-            config: config, 
-            result: await getNewestPullRequestInfo(config, messagePullRequest), 
-            messagePullRequest: messagePullRequest, 
-            ackId: ackId, 
+            config: config,
+            result: await getNewestPullRequestInfo(config, messagePullRequest),
+            messagePullRequest: messagePullRequest,
+            ackId: ackId,
             pubsub: pubsub);
         break;
       case ProcessMethod.processRevert:
         await processRevertRequest(
-            config: config, 
-            result: await getNewestPullRequestInfo(config, messagePullRequest), 
-            messagePullRequest: messagePullRequest, 
-            ackId: ackId, 
+            config: config,
+            result: await getNewestPullRequestInfo(config, messagePullRequest),
+            messagePullRequest: messagePullRequest,
+            ackId: ackId,
             pubsub: pubsub);
         break;
       case ProcessMethod.doNotProcess:
@@ -119,10 +119,10 @@ class ValidationService {
   /// Processes a PullRequest running several validations to decide whether to
   /// land the commit or remove the autosubmit label.
   Future<void> processPullRequest({
-      required Config config, 
-      required QueryResult result, 
-      required github.PullRequest messagePullRequest, 
-      required String ackId, 
+      required Config config,
+      required QueryResult result,
+      required github.PullRequest messagePullRequest,
+      required String ackId,
       required PubSub pubsub,
       }) async {
 
@@ -173,8 +173,8 @@ class ValidationService {
 
     // If we got to this point it means we are ready to submit the PR.
     bool processed = await processMerge(
-        config: config, 
-        queryResult: result, 
+        config: config,
+        queryResult: result,
         messagePullRequest: messagePullRequest);
 
     if (!processed) {
@@ -214,8 +214,8 @@ class ValidationService {
       approverService.revertApproval(messagePullRequest);
 
       bool processed = await processMerge(
-        config: config, 
-        queryResult: result, 
+        config: config,
+        queryResult: result,
         messagePullRequest: messagePullRequest);
 
       if (processed) {
@@ -270,8 +270,8 @@ Exception: ${exception.message}
 
   /// Merges the commit if the PullRequest passes all the validations.
   Future<bool> processMerge({
-      required Config config, 
-      required QueryResult queryResult, 
+      required Config config,
+      required QueryResult queryResult,
       required github.PullRequest messagePullRequest,
       }) async {
 

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -130,13 +130,13 @@ class ValidationService {
         final String commmentMessage = result.message.isEmpty ? 'Validations Fail.' : result.message;
 
         String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, due to $commmentMessage';
-        
+
         log.info(message);
         await removeLabelAndComment(
-            githubService: gitHubService, 
-            repositorySlug: slug, 
-            prNumber: prNumber, 
-            prLabel: Config.kAutosubmitLabel, 
+            githubService: gitHubService,
+            repositorySlug: slug,
+            prNumber: prNumber,
+            prLabel: Config.kAutosubmitLabel,
             message: message);
 
         shouldReturn = true;
@@ -163,10 +163,10 @@ class ValidationService {
       String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
       log.info(message);
       await removeLabelAndComment(
-          githubService: gitHubService, 
-          repositorySlug: slug, 
-          prNumber: prNumber, 
-          prLabel: Config.kAutosubmitLabel, 
+          githubService: gitHubService,
+          repositorySlug: slug,
+          prNumber: prNumber,
+          prLabel: Config.kAutosubmitLabel,
           message: message);
     }
 
@@ -182,7 +182,7 @@ class ValidationService {
     Commit commit = pullRequest.commits!.nodes!.single.commit!;
     final String? sha = commit.oid;
     int number = messagePullRequest.number!;
-    
+
     try {
       // The createGitHubGraphQLClient can throw Exception.
       final graphql.GraphQLClient client = await config.createGitHubGraphQLClient(slug);
@@ -229,19 +229,19 @@ class ValidationService {
       bool processed = await processMerge(config, result, messagePullRequest);
       if (processed) {
         github.Issue issue = await gitHubService.createIssue(
-            slug,
-            'Follow up review for revert pull request $prNumber',
-            'Revert request by author ${result.repository!.pullRequest!.author}',
+          slug,
+          'Follow up review for revert pull request $prNumber',
+          'Revert request by author ${result.repository!.pullRequest!.author}',
         );
         log.info('Issue #${issue.id} was created to track the review for $prNumber in ${slug.fullName}');
       } else {
         String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
         log.info(message);
         await removeLabelAndComment(
-            githubService: gitHubService, 
-            repositorySlug: slug, 
-            prNumber: prNumber, 
-            prLabel: Config.kAutosubmitLabel, 
+            githubService: gitHubService,
+            repositorySlug: slug,
+            prNumber: prNumber,
+            prLabel: Config.kAutosubmitLabel,
             message: message);
       }
     } else {
@@ -250,12 +250,12 @@ class ValidationService {
       final String commentMessage =
           revertValidationResult.message.isEmpty ? 'Validations Fail.' : revertValidationResult.message;
       log.info('revert label is removed for ${slug.fullName}, pr: $prNumber, due to $commentMessage');
-      
+
       await removeLabelAndComment(
-          githubService: gitHubService, 
-          repositorySlug: slug, 
-          prNumber: prNumber, 
-          prLabel: Config.kAutosubmitLabel, 
+          githubService: gitHubService,
+          repositorySlug: slug,
+          prNumber: prNumber,
+          prLabel: Config.kAutosubmitLabel,
           message: commentMessage);
 
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');
@@ -265,8 +265,8 @@ class ValidationService {
     await pubsub.acknowledge('auto-submit-queue-sub', ackId);
   }
 
-  Future<void> removeLabelAndComment({
-      required GithubService githubService,
+  Future<void> removeLabelAndComment(
+      {required GithubService githubService,
       required github.RepositorySlug repositorySlug,
       required int prNumber,
       required String prLabel,

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -210,9 +210,10 @@ class ValidationService {
       await approverService!.revertApproval(result, messagePullRequest);
 
       bool processed = await processMerge(
-          config: config,
-          queryResult: result,
-          messagePullRequest: messagePullRequest,);
+        config: config,
+        queryResult: result,
+        messagePullRequest: messagePullRequest,
+      );
 
       if (processed) {
         try {
@@ -237,11 +238,12 @@ Exception: ${exception.message}
         String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
         log.info(message);
         await removeLabelAndComment(
-            githubService: gitHubService,
-            repositorySlug: slug,
-            prNumber: prNumber,
-            prLabel: Config.kRevertLabel,
-            message: message,);
+          githubService: gitHubService,
+          repositorySlug: slug,
+          prNumber: prNumber,
+          prLabel: Config.kRevertLabel,
+          message: message,
+        );
       }
     } else {
       // since we do not temporarily ignore anything with a revert request we
@@ -251,11 +253,12 @@ Exception: ${exception.message}
       log.info('revert label is removed for ${slug.fullName}, pr: $prNumber, due to $commentMessage');
 
       await removeLabelAndComment(
-          githubService: gitHubService,
-          repositorySlug: slug,
-          prNumber: prNumber,
-          prLabel: Config.kRevertLabel,
-          message: commentMessage,);
+        githubService: gitHubService,
+        repositorySlug: slug,
+        prNumber: prNumber,
+        prLabel: Config.kRevertLabel,
+        message: commentMessage,
+      );
 
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');
     }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -223,10 +223,10 @@ class ValidationService {
       if (processed.result) {
         try {
           RevertReviewTemplate revertReviewTemplate = RevertReviewTemplate(
-            repositorySlug: slug.fullName, 
-            revertPrNumber: prNumber, 
-            revertPrAuthor: result.repository!.pullRequest!.author!.login!, 
-            originalPrLink: revertValidation!.extractLinkFromText(messagePullRequest.body)!);
+              repositorySlug: slug.fullName,
+              revertPrNumber: prNumber,
+              revertPrAuthor: result.repository!.pullRequest!.author!.login!,
+              originalPrLink: revertValidation!.extractLinkFromText(messagePullRequest.body)!);
 
           github.Issue issue = await gitHubService.createIssue(
             repositorySlug: github.RepositorySlug('flutter', 'flutter'),
@@ -329,8 +329,6 @@ Exception: ${exception.message}
     await githubService.removeLabel(repositorySlug, prNumber, prLabel);
     await githubService.createComment(repositorySlug, prNumber, message);
   }
-
-
 }
 
 /// Small wrapper class to allow us to capture and create a comment in the PR with

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -236,7 +236,7 @@ Exception: ${exception.message}
             githubService: gitHubService,
             repositorySlug: slug,
             prNumber: prNumber,
-            prLabel: Config.kAutosubmitLabel,
+            prLabel: Config.kRevertLabel,
             message: message);
       }
     } else {
@@ -250,7 +250,7 @@ Exception: ${exception.message}
           githubService: gitHubService,
           repositorySlug: slug,
           prNumber: prNumber,
-          prLabel: Config.kAutosubmitLabel,
+          prLabel: Config.kRevertLabel,
           message: commentMessage);
 
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -210,9 +210,9 @@ class ValidationService {
       await approverService!.revertApproval(result, messagePullRequest);
 
       bool processed = await processMerge(
-          config: config, 
-          queryResult: result, 
-          messagePullRequest: messagePullRequest);
+          config: config,
+          queryResult: result,
+          messagePullRequest: messagePullRequest,);
 
       if (processed) {
         try {
@@ -241,7 +241,7 @@ Exception: ${exception.message}
             repositorySlug: slug,
             prNumber: prNumber,
             prLabel: Config.kRevertLabel,
-            message: message);
+            message: message,);
       }
     } else {
       // since we do not temporarily ignore anything with a revert request we
@@ -255,7 +255,7 @@ Exception: ${exception.message}
           repositorySlug: slug,
           prNumber: prNumber,
           prLabel: Config.kRevertLabel,
-          message: commentMessage);
+          message: commentMessage,);
 
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');
     }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -30,6 +30,7 @@ class ValidationService {
   ValidationService(this.config) {
     /// Validates a PR marked with the reverts label.
     revertValidation = Revert(config: config);
+    approverService = ApproverService(config);
 
     validations.addAll({
       /// Validates the PR has been approved following the codereview guidelines.
@@ -53,6 +54,7 @@ class ValidationService {
   }
 
   Revert? revertValidation;
+  ApproverService? approverService;
   final Config config;
   final Set<Validation> validations = <Validation>{};
 
@@ -205,8 +207,7 @@ class ValidationService {
 
     if (revertValidationResult.result) {
       // Approve the pull request automatically as it has been validated.
-      ApproverService approverService = ApproverService(config);
-      approverService.revertApproval(messagePullRequest);
+      approverService!.revertApproval(messagePullRequest);
 
       bool processed = await processMerge(config: config, queryResult: result, messagePullRequest: messagePullRequest);
 

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -207,9 +207,12 @@ class ValidationService {
 
     if (revertValidationResult.result) {
       // Approve the pull request automatically as it has been validated.
-      approverService!.revertApproval(messagePullRequest);
+      await approverService!.revertApproval(result, messagePullRequest);
 
-      bool processed = await processMerge(config: config, queryResult: result, messagePullRequest: messagePullRequest);
+      bool processed = await processMerge(
+          config: config, 
+          queryResult: result, 
+          messagePullRequest: messagePullRequest);
 
       if (processed) {
         try {

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -119,13 +119,12 @@ class ValidationService {
   /// Processes a PullRequest running several validations to decide whether to
   /// land the commit or remove the autosubmit label.
   Future<void> processPullRequest({
-      required Config config,
-      required QueryResult result,
-      required github.PullRequest messagePullRequest,
-      required String ackId,
-      required PubSub pubsub,
-      }) async {
-
+    required Config config,
+    required QueryResult result,
+    required github.PullRequest messagePullRequest,
+    required String ackId,
+    required PubSub pubsub,
+  }) async {
     List<ValidationResult> results = <ValidationResult>[];
 
     /// Runs all the validation defined in the service.
@@ -172,10 +171,7 @@ class ValidationService {
     }
 
     // If we got to this point it means we are ready to submit the PR.
-    bool processed = await processMerge(
-        config: config,
-        queryResult: result,
-        messagePullRequest: messagePullRequest);
+    bool processed = await processMerge(config: config, queryResult: result, messagePullRequest: messagePullRequest);
 
     if (!processed) {
       String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
@@ -200,8 +196,7 @@ class ValidationService {
     required github.PullRequest messagePullRequest,
     required String ackId,
     required PubSub pubsub,
-    }) async {
-
+  }) async {
     ValidationResult revertValidationResult = await revertValidation!.validate(result, messagePullRequest);
 
     github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
@@ -213,10 +208,7 @@ class ValidationService {
       ApproverService approverService = ApproverService(config);
       approverService.revertApproval(messagePullRequest);
 
-      bool processed = await processMerge(
-        config: config,
-        queryResult: result,
-        messagePullRequest: messagePullRequest);
+      bool processed = await processMerge(config: config, queryResult: result, messagePullRequest: messagePullRequest);
 
       if (processed) {
         try {
@@ -270,11 +262,10 @@ Exception: ${exception.message}
 
   /// Merges the commit if the PullRequest passes all the validations.
   Future<bool> processMerge({
-      required Config config,
-      required QueryResult queryResult,
-      required github.PullRequest messagePullRequest,
-      }) async {
-
+    required Config config,
+    required QueryResult queryResult,
+    required github.PullRequest messagePullRequest,
+  }) async {
     String id = queryResult.repository!.pullRequest!.id!;
     github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
     final PullRequest pullRequest = queryResult.repository!.pullRequest!;
@@ -307,8 +298,8 @@ Exception: ${exception.message}
   }
 
   /// Remove a pull request label and add a comment to the pull request.
-  Future<void> removeLabelAndComment({
-      required GithubService githubService,
+  Future<void> removeLabelAndComment(
+      {required GithubService githubService,
       required github.RepositorySlug repositorySlug,
       required int prNumber,
       required String prLabel,

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -70,7 +70,7 @@ class ValidationService {
             config, await getNewestPullRequestInfo(config, messagePullRequest), messagePullRequest, ackId, pubsub);
         break;
       case ProcessMethod.doNotProcess:
-        log.info('Shout not process ${messagePullRequest.toJson()}, and ack the message.');
+        log.info('Should not process ${messagePullRequest.toJson()}, and ack the message.');
         await pubsub.acknowledge('auto-submit-queue-sub', ackId);
         break;
     }
@@ -128,28 +128,50 @@ class ValidationService {
     for (ValidationResult result in results) {
       if (!result.result && result.action == Action.REMOVE_LABEL) {
         final String commmentMessage = result.message.isEmpty ? 'Validations Fail.' : result.message;
-        await gitHubService.createComment(slug, prNumber, commmentMessage);
-        await gitHubService.removeLabel(slug, prNumber, Config.kAutosubmitLabel);
-        log.info('auto label is removed for ${slug.fullName}, pr: $prNumber, due to $commmentMessage');
+
+        String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, due to $commmentMessage';
+        
+        log.info(message);
+        await removeLabelAndComment(
+            githubService: gitHubService, 
+            repositorySlug: slug, 
+            prNumber: prNumber, 
+            prLabel: Config.kAutosubmitLabel, 
+            message: message);
+
         shouldReturn = true;
       }
     }
+
     if (shouldReturn) {
       log.info('The pr ${slug.fullName}/$prNumber with message: $ackId should be acknowledged.');
       await pubsub.acknowledge('auto-submit-queue-sub', ackId);
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');
       return;
     }
+
     // If PR has some failures to ignore temporarily do nothing and continue.
     for (ValidationResult result in results) {
       if (!result.result && result.action == Action.IGNORE_TEMPORARILY) {
         return;
       }
     }
+
     // If we got to this point it means we are ready to submit the PR.
     bool processed = await processMerge(config, result, messagePullRequest);
-    if (processed) await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+    if (!processed) {
+      String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
+      log.info(message);
+      await removeLabelAndComment(
+          githubService: gitHubService, 
+          repositorySlug: slug, 
+          prNumber: prNumber, 
+          prLabel: Config.kAutosubmitLabel, 
+          message: message);
+    }
+
     log.info('Ack the processed message : $ackId.');
+    await pubsub.acknowledge('auto-submit-queue-sub', ackId);
   }
 
   /// Merges the commit if the PullRequest passes all the validations.
@@ -160,8 +182,11 @@ class ValidationService {
     Commit commit = pullRequest.commits!.nodes!.single.commit!;
     final String? sha = commit.oid;
     int number = messagePullRequest.number!;
-    final graphql.GraphQLClient client = await config.createGitHubGraphQLClient(slug);
+    
     try {
+      // The createGitHubGraphQLClient can throw Exception.
+      final graphql.GraphQLClient client = await config.createGitHubGraphQLClient(slug);
+
       final graphql.QueryResult result = await client.mutate(graphql.MutationOptions(
         document: mergePullRequestMutation,
         variables: <String, dynamic>{
@@ -194,7 +219,7 @@ class ValidationService {
 
     github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
     final int prNumber = messagePullRequest.number!;
-    final GithubService githubService = await config.createGithubService(slug);
+    final GithubService gitHubService = await config.createGithubService(slug);
 
     if (revertValidationResult.result) {
       // Approve the pull request automatically as it has been validated.
@@ -203,26 +228,50 @@ class ValidationService {
 
       bool processed = await processMerge(config, result, messagePullRequest);
       if (processed) {
-        await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+        github.Issue issue = await gitHubService.createIssue(
+            slug,
+            'Follow up review for revert pull request $prNumber',
+            'Revert request by author ${result.repository!.pullRequest!.author}',
+        );
+        log.info('Issue #${issue.id} was created to track the review for $prNumber in ${slug.fullName}');
+      } else {
+        String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
+        log.info(message);
+        await removeLabelAndComment(
+            githubService: gitHubService, 
+            repositorySlug: slug, 
+            prNumber: prNumber, 
+            prLabel: Config.kAutosubmitLabel, 
+            message: message);
       }
-      log.info('Ack the processed message : $ackId.');
-      github.Issue issue = await githubService.createIssue(
-        slug,
-        'Follow up review for revert pull request $prNumber',
-        'Revert request by author ${result.repository!.pullRequest!.author}',
-      );
-      log.info('Issue #${issue.id} was created to track the review for $prNumber in ${slug.fullName}');
     } else {
       // since we do not temporarily ignore anything with a revert request we
       // know we will report the error and remove the label.
-      final String commmentMessage =
+      final String commentMessage =
           revertValidationResult.message.isEmpty ? 'Validations Fail.' : revertValidationResult.message;
-      await githubService.createComment(slug, prNumber, commmentMessage);
-      await githubService.removeLabel(slug, prNumber, Config.kRevertLabel);
-      log.info('revert label is removed for ${slug.fullName}, pr: $prNumber, due to $commmentMessage');
-      log.info('The pr ${slug.fullName}/$prNumber with message: $ackId should be acknowledged.');
-      await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+      log.info('revert label is removed for ${slug.fullName}, pr: $prNumber, due to $commentMessage');
+      
+      await removeLabelAndComment(
+          githubService: gitHubService, 
+          repositorySlug: slug, 
+          prNumber: prNumber, 
+          prLabel: Config.kAutosubmitLabel, 
+          message: commentMessage);
+
       log.info('The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.');
     }
+
+    log.info('Ack the processed message : $ackId.');
+    await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+  }
+
+  Future<void> removeLabelAndComment({
+      required GithubService githubService,
+      required github.RepositorySlug repositorySlug,
+      required int prNumber,
+      required String prLabel,
+      required String message}) async {
+    await githubService.removeLabel(repositorySlug, prNumber, prLabel);
+    await githubService.createComment(repositorySlug, prNumber, message);
   }
 }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -235,7 +235,7 @@ Exception: ${exception.message}
           await gitHubService.createComment(slug, prNumber, errorMessage);
         }
       } else {
-        String message = 'auto label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
+        String message = 'revert label is removed for ${slug.fullName}, pr: $prNumber, merge did not succeed.';
         log.info(message);
         await removeLabelAndComment(
           githubService: gitHubService,

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -173,7 +173,7 @@ void main() {
       expect(pubsub.messagesQueue.length, 0);
       final List<LogRecord> errorLogs = records.where((LogRecord record) => record.level == Level.SEVERE).toList();
       expect(errorLogs.length, 1);
-      expect(errorLogs[0].message.contains('_processMerge'), true);
+      expect(errorLogs[0].message.contains('Failed to merge'), true);
       pubsub.messagesQueue.clear();
     });
 

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -167,8 +167,10 @@ void main() {
       };
       final List<LogRecord> records = <LogRecord>[];
       log.onRecord.listen((LogRecord record) => records.add(record));
+      // this is the test.
       await checkPullRequest.get();
-      expect(pubsub.messagesQueue.length, 1);
+      // every failure is now acknowledged from the queue.
+      expect(pubsub.messagesQueue.length, 0);
       final List<LogRecord> errorLogs = records.where((LogRecord record) => record.level == Level.SEVERE).toList();
       expect(errorLogs.length, 1);
       expect(errorLogs[0].message.contains('_processMerge'), true);

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -70,15 +70,17 @@ String generateWebhookEvent(
     }''';
 }
 
-PullRequest generatePullRequest(
-    {String? labelName,
-    String? autosubmitLabel = Config.kAutosubmitLabel,
-    String? repoName,
-    String? login,
-    String? authorAssociation,
-    String? author,
-    int? prNumber,
-    String? state}) {
+PullRequest generatePullRequest({
+  String? labelName,
+  String? autosubmitLabel = Config.kAutosubmitLabel,
+  String? repoName,
+  String? login,
+  String? authorAssociation,
+  String? author,
+  int? prNumber,
+  String? state,
+  String? body,
+}) {
   return PullRequest.fromJson(json.decode('''{
       "id": 1,
       "number": ${prNumber ?? 1347},
@@ -88,7 +90,7 @@ PullRequest generatePullRequest(
         "login": "${author ?? "octocat"}",
         "id": 1
       },
-      "body": "Please pull these awesome changes in!",
+      "body": "${body ?? "Please pull these awesome changes in!"}",
       "labels": [
         {
           "id": 487496476,

--- a/auto_submit/test/service/approver_service_test.dart
+++ b/auto_submit/test/service/approver_service_test.dart
@@ -29,14 +29,14 @@ void main() {
   });
 
   test('Verify approval ignored', () async {
-    gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
+    final gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
     await service.autoApproval(pr);
     verifyNever(pullRequests.createReview(any, captureAny));
   });
 
   test('Verify approve', () async {
     when(pullRequests.listReviews(any, any)).thenAnswer((_) => const Stream<gh.PullRequestReview>.empty());
-    gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
+    final gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
     await service.autoApproval(pr);
     final List<dynamic> reviews = verify(pullRequests.createReview(any, captureAny)).captured;
     expect(reviews.length, 1);
@@ -45,18 +45,18 @@ void main() {
   });
 
   test('Already approved', () async {
-    gh.PullRequestReview review =
+    final gh.PullRequestReview review =
         gh.PullRequestReview(id: 123, user: gh.User(login: 'fluttergithubbot'), state: 'APPROVED');
     when(pullRequests.listReviews(any, any)).thenAnswer((_) => Stream<gh.PullRequestReview>.value(review));
-    gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
+    final  gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
     await service.autoApproval(pr);
     verifyNever(pullRequests.createReview(any, captureAny));
   });
 
   test('AutoApproval does not approve revert pull request.', () async {
-    gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
-    List<gh.IssueLabel> issueLabels = pr.labels ?? [];
-    gh.IssueLabel issueLabel = gh.IssueLabel(name: 'revert');
+    final gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
+    final List<gh.IssueLabel> issueLabels = pr.labels ?? [];
+    final gh.IssueLabel issueLabel = gh.IssueLabel(name: 'revert');
     issueLabels.add(issueLabel);
     await service.autoApproval(pr);
     verifyNever(pullRequests.createReview(any, captureAny));
@@ -64,18 +64,18 @@ void main() {
 
   test('Revert request is auto approved.', () async {
     when(pullRequests.listReviews(any, any)).thenAnswer((_) => const Stream<gh.PullRequestReview>.empty());
-    gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
+    final gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
 
-    List<gh.IssueLabel> issueLabels = pr.labels ?? [];
-    gh.IssueLabel issueLabel = gh.IssueLabel(name: 'revert');
+    final List<gh.IssueLabel> issueLabels = pr.labels ?? [];
+    final gh.IssueLabel issueLabel = gh.IssueLabel(name: 'revert');
     issueLabels.add(issueLabel);
 
-    PullRequestHelper flutterRequest = PullRequestHelper(
+    final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
       reviews: <PullRequestReviewHelper>[],
     );
-    QueryResult queryResult = createQueryResult(flutterRequest);
+    final QueryResult queryResult = createQueryResult(flutterRequest);
 
     await service.revertApproval(queryResult, pr);
     final List<dynamic> reviews = verify(pullRequests.createReview(any, captureAny)).captured;
@@ -85,28 +85,28 @@ void main() {
   });
 
   test('Revert request is not auto approved when the revert label is not present.', () async {
-    gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
+    final gh.PullRequest pr = generatePullRequest(author: 'not_a_user');
 
-    PullRequestHelper flutterRequest = PullRequestHelper(
+    final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
       reviews: <PullRequestReviewHelper>[],
     );
-    QueryResult queryResult = createQueryResult(flutterRequest);
+    final QueryResult queryResult = createQueryResult(flutterRequest);
 
     await service.revertApproval(queryResult, pr);
     verifyNever(pullRequests.createReview(any, captureAny));
   });
 
   test('Revert request is not auto approved on bad author association.', () async {
-    gh.PullRequest pr = generatePullRequest(author: 'not_a_user', authorAssociation: 'CONTRIBUTOR');
+    final gh.PullRequest pr = generatePullRequest(author: 'not_a_user', authorAssociation: 'CONTRIBUTOR');
 
-    PullRequestHelper flutterRequest = PullRequestHelper(
+    final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
       reviews: <PullRequestReviewHelper>[],
     );
-    QueryResult queryResult = createQueryResult(flutterRequest);
+    final QueryResult queryResult = createQueryResult(flutterRequest);
 
     await service.revertApproval(queryResult, pr);
     verifyNever(pullRequests.createReview(any, captureAny));

--- a/auto_submit/test/service/approver_service_test.dart
+++ b/auto_submit/test/service/approver_service_test.dart
@@ -48,7 +48,7 @@ void main() {
     final gh.PullRequestReview review =
         gh.PullRequestReview(id: 123, user: gh.User(login: 'fluttergithubbot'), state: 'APPROVED');
     when(pullRequests.listReviews(any, any)).thenAnswer((_) => Stream<gh.PullRequestReview>.value(review));
-    final  gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
+    final gh.PullRequest pr = generatePullRequest(author: 'dependabot[bot]');
     await service.autoApproval(pr);
     verifyNever(pullRequests.createReview(any, captureAny));
   });

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -45,10 +45,10 @@ void main() {
     QueryResult queryResult = createQueryResult(flutterRequest);
 
     await validationService.processPullRequest(
-      config: config, 
-      result: queryResult, 
-      messagePullRequest: pullRequest, 
-      ackId: 'test', 
+      config: config,
+      result: queryResult,
+      messagePullRequest: pullRequest,
+      ackId: 'test',
       pubsub: pubsub);
 
     expect(githubService.issueComment, isNotNull);
@@ -112,6 +112,10 @@ void main() {
       final ProcessMethod processMethod = await validationService.processPullRequestMethod(pullRequest);
 
       expect(processMethod, ProcessMethod.doNotProcess);
+    });
+
+    group('Process merge tests.',() {
+
     });
   });
 }

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -45,11 +45,7 @@ void main() {
     QueryResult queryResult = createQueryResult(flutterRequest);
 
     await validationService.processPullRequest(
-      config: config,
-      result: queryResult,
-      messagePullRequest: pullRequest,
-      ackId: 'test',
-      pubsub: pubsub);
+        config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
 
     expect(githubService.issueComment, isNotNull);
     expect(githubService.labelRemoved, true);
@@ -114,8 +110,6 @@ void main() {
       expect(processMethod, ProcessMethod.doNotProcess);
     });
 
-    group('Process merge tests.',() {
-
-    });
+    group('Process merge tests.', () {});
   });
 }

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -216,7 +216,6 @@ void main() {
       // if the merge is successful we do not remove the label and we do not add a comment to the issue.
       expect(githubService.issueComment, isNotNull);
       IssueComment issueComment = githubService.issueComment!;
-      print(issueComment.body);
       assert(issueComment.body!.contains('create the follow up review issue'));
       expect(githubService.labelRemoved, false);
       // We acknowledge the issue.

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -44,7 +44,12 @@ void main() {
     pubsub.publish('auto-submit-queue-sub', pullRequest);
     QueryResult queryResult = createQueryResult(flutterRequest);
 
-    await validationService.processPullRequest(config, queryResult, pullRequest, 'test', pubsub);
+    await validationService.processPullRequest(
+      config: config, 
+      result: queryResult, 
+      messagePullRequest: pullRequest, 
+      ackId: 'test', 
+      pubsub: pubsub);
 
     expect(githubService.issueComment, isNotNull);
     expect(githubService.labelRemoved, true);

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -31,7 +31,7 @@ void main() {
     slug = RepositorySlug('flutter', 'cocoon');
   });
 
-  test('removes label and post comment when no approval', () async {
+  test('Removes label and post comment when no approval', () async {
     PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
@@ -52,8 +52,8 @@ void main() {
     assert(pubsub.messagesQueue.isEmpty);
   });
 
-  group('shouldProcess pull request', () {
-    test('should process message when autosubmit label exists and pr is open', () async {
+  group('ShouldProcess pull request', () {
+    test('Should process message when autosubmit label exists and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       githubService.pullRequestData = pullRequest;
       final ProcessMethod processMethod = await validationService.processPullRequestMethod(pullRequest);
@@ -61,7 +61,7 @@ void main() {
       expect(processMethod, ProcessMethod.processAutosubmit);
     });
 
-    test('skip processing message when autosubmit label does not exist anymore', () async {
+    test('Skip processing message when autosubmit label does not exist anymore', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.labels = <IssueLabel>[];
       githubService.pullRequestData = pullRequest;
@@ -70,7 +70,7 @@ void main() {
       expect(processMethod, ProcessMethod.doNotProcess);
     });
 
-    test('skip processing message when the pull request is closed', () async {
+    test('Skip processing message when the pull request is closed', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.state = 'closed';
       githubService.pullRequestData = pullRequest;
@@ -79,7 +79,7 @@ void main() {
       expect(processMethod, ProcessMethod.doNotProcess);
     });
 
-    test('should process message when revert label exists and pr is open', () async {
+    test('Should process message when revert label exists and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels = <IssueLabel>[issueLabel];
@@ -89,7 +89,7 @@ void main() {
       expect(processMethod, ProcessMethod.processRevert);
     });
 
-    test('should process message as revert when revert and autosubmit labels are present and pr is open', () async {
+    test('Should process message as revert when revert and autosubmit labels are present and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels!.add(issueLabel);
@@ -99,7 +99,7 @@ void main() {
       expect(processMethod, ProcessMethod.processRevert);
     });
 
-    test('skip processing message when revert label exists and pr is closed', () async {
+    test('Skip processing message when revert label exists and pr is closed', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.state = 'closed';
       IssueLabel issueLabel = IssueLabel(name: 'revert');

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -65,7 +65,10 @@ void main() {
     githubService.checkRunsData = checkRunsMock;
     githubService.createCommentData = createCommentMock;
     final FakePubSub pubsub = FakePubSub();
-    final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
+    final PullRequest pullRequest = generatePullRequest(
+      prNumber: 0,
+      repoName: slug.name,
+    );
     pubsub.publish('auto-submit-queue-sub', pullRequest);
     final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
@@ -89,10 +92,12 @@ void main() {
       githubService.checkRunsData = checkRunsMock;
       githubService.createCommentData = createCommentMock;
       final FakePubSub pubsub = FakePubSub();
-      final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      pullRequest.authorAssociation = 'OWNER';
-      pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
-      pullRequest.body = 'Reverts flutter/flutter#1234';
+      final PullRequest pullRequest = generatePullRequest(
+          prNumber: 0,
+          repoName: slug.name,
+          authorAssociation: 'OWNER',
+          labelName: 'revert',
+          body: 'Reverts flutter/flutter#1234');
 
       final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(true, Action.REMOVE_LABEL, '');
@@ -129,10 +134,13 @@ void main() {
       githubService.checkRunsData = checkRunsMock;
       githubService.createCommentData = createCommentMock;
       final FakePubSub pubsub = FakePubSub();
-      final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      pullRequest.authorAssociation = 'OWNER';
-      pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
-      pullRequest.body = 'Reverts flutter/flutter#1234';
+      final PullRequest pullRequest = generatePullRequest(
+        prNumber: 0,
+        repoName: slug.name,
+        authorAssociation: 'OWNER',
+        labelName: 'revert',
+        body: 'Reverts flutter/flutter#1234',
+      );
 
       final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(false, Action.REMOVE_LABEL, '');
@@ -162,9 +170,8 @@ void main() {
       githubService.checkRunsData = checkRunsMock;
       githubService.createCommentData = createCommentMock;
       final FakePubSub pubsub = FakePubSub();
-      final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      pullRequest.authorAssociation = 'OWNER';
-      pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
+      final PullRequest pullRequest =
+          generatePullRequest(prNumber: 0, repoName: slug.name, authorAssociation: 'OWNER', labelName: 'revert');
 
       final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(true, Action.REMOVE_LABEL, '');
@@ -196,10 +203,12 @@ void main() {
       githubService.throwOnCreateIssue = true;
       githubService.useRealComment = true;
       final FakePubSub pubsub = FakePubSub();
-      final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      pullRequest.authorAssociation = 'OWNER';
-      pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
-      pullRequest.body = 'Reverts flutter/flutter#1234';
+      final PullRequest pullRequest = generatePullRequest(
+          prNumber: 0,
+          repoName: slug.name,
+          authorAssociation: 'OWNER',
+          labelName: 'revert',
+          body: 'Reverts flutter/flutter#1234');
 
       final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(true, Action.REMOVE_LABEL, '');

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -36,7 +36,7 @@ void main() {
   });
 
   test('Removes label and post comment when no approval', () async {
-    PullRequestHelper flutterRequest = PullRequestHelper(
+    final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
       reviews: <PullRequestReviewHelper>[],
@@ -46,7 +46,7 @@ void main() {
     final FakePubSub pubsub = FakePubSub();
     final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
     pubsub.publish('auto-submit-queue-sub', pullRequest);
-    auto.QueryResult queryResult = createQueryResult(flutterRequest);
+    final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
     await validationService.processPullRequest(
         config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
@@ -57,7 +57,7 @@ void main() {
   });
 
   test('Remove label and post comment when no revert label.', () async {
-    PullRequestHelper flutterRequest = PullRequestHelper(
+    final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
       reviews: <PullRequestReviewHelper>[],
@@ -67,7 +67,7 @@ void main() {
     final FakePubSub pubsub = FakePubSub();
     final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
     pubsub.publish('auto-submit-queue-sub', pullRequest);
-    auto.QueryResult queryResult = createQueryResult(flutterRequest);
+    final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
     await validationService.processRevertRequest(
         config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
@@ -80,7 +80,7 @@ void main() {
   group('Processing revert reqeuests.', () {
     test('Merge valid revert request, issue created and message is acknowledged.', () async {
       githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => createFakeQueryResult();
-      PullRequestHelper flutterRequest = PullRequestHelper(
+      final PullRequestHelper flutterRequest = PullRequestHelper(
         prNumber: 0,
         lastCommitHash: oid,
         reviews: <PullRequestReviewHelper>[],
@@ -94,19 +94,19 @@ void main() {
       pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
       pullRequest.body = 'Reverts flutter/flutter#1234';
 
-      FakeRevert fakeRevert = FakeRevert(config: config);
+      final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(true, Action.REMOVE_LABEL, '');
       validationService.revertValidation = fakeRevert;
-      FakeApproverService fakeApproverService = FakeApproverService(config);
+      final FakeApproverService fakeApproverService = FakeApproverService(config);
       validationService.approverService = fakeApproverService;
 
-      Issue issue = Issue(
+      final Issue issue = Issue(
         id: 1234,
       );
       githubService.githubIssueMock = issue;
 
       pubsub.publish('auto-submit-queue-sub', pullRequest);
-      auto.QueryResult queryResult = createQueryResult(flutterRequest);
+      final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
       await validationService.processRevertRequest(
           config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
@@ -120,7 +120,7 @@ void main() {
 
     test('Fail to merge non valid revert, issue not created, comment is added and message is acknowledged.', () async {
       githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => createFakeQueryResult();
-      PullRequestHelper flutterRequest = PullRequestHelper(
+      final PullRequestHelper flutterRequest = PullRequestHelper(
         prNumber: 0,
         lastCommitHash: oid,
         reviews: <PullRequestReviewHelper>[],
@@ -134,14 +134,14 @@ void main() {
       pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
       pullRequest.body = 'Reverts flutter/flutter#1234';
 
-      FakeRevert fakeRevert = FakeRevert(config: config);
+      final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(false, Action.REMOVE_LABEL, '');
       validationService.revertValidation = fakeRevert;
-      FakeApproverService fakeApproverService = FakeApproverService(config);
+      final FakeApproverService fakeApproverService = FakeApproverService(config);
       validationService.approverService = fakeApproverService;
 
       pubsub.publish('auto-submit-queue-sub', pullRequest);
-      auto.QueryResult queryResult = createQueryResult(flutterRequest);
+      final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
       await validationService.processRevertRequest(
           config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
@@ -154,7 +154,7 @@ void main() {
     });
 
     test('Remove label and post comment when unable to process merge.', () async {
-      PullRequestHelper flutterRequest = PullRequestHelper(
+      final PullRequestHelper flutterRequest = PullRequestHelper(
         prNumber: 0,
         lastCommitHash: oid,
         reviews: <PullRequestReviewHelper>[],
@@ -166,14 +166,14 @@ void main() {
       pullRequest.authorAssociation = 'OWNER';
       pullRequest.labels = <IssueLabel>[IssueLabel(name: 'revert')];
 
-      FakeRevert fakeRevert = FakeRevert(config: config);
+      final FakeRevert fakeRevert = FakeRevert(config: config);
       fakeRevert.validationResult = ValidationResult(true, Action.REMOVE_LABEL, '');
       validationService.revertValidation = fakeRevert;
-      FakeApproverService fakeApproverService = FakeApproverService(config);
+      final FakeApproverService fakeApproverService = FakeApproverService(config);
       validationService.approverService = fakeApproverService;
 
       pubsub.publish('auto-submit-queue-sub', pullRequest);
-      auto.QueryResult queryResult = createQueryResult(flutterRequest);
+      final auto.QueryResult queryResult = createQueryResult(flutterRequest);
 
       await validationService.processRevertRequest(
           config: config, result: queryResult, messagePullRequest: pullRequest, ackId: 'test', pubsub: pubsub);
@@ -185,7 +185,7 @@ void main() {
 
     test('Fail to create follow up review issue, comment is added and message is acknowledged.', () async {
       githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => createFakeQueryResult();
-      PullRequestHelper flutterRequest = PullRequestHelper(
+      final PullRequestHelper flutterRequest = PullRequestHelper(
         prNumber: 0,
         lastCommitHash: oid,
         reviews: <PullRequestReviewHelper>[],
@@ -215,7 +215,7 @@ void main() {
 
       // if the merge is successful we do not remove the label and we do not add a comment to the issue.
       expect(githubService.issueComment, isNotNull);
-      IssueComment issueComment = githubService.issueComment!;
+      final IssueComment issueComment = githubService.issueComment!;
       assert(issueComment.body!.contains('create the follow up review issue'));
       expect(githubService.labelRemoved, false);
       // We acknowledge the issue.
@@ -252,7 +252,7 @@ void main() {
 
     test('Should process message when revert label exists and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      IssueLabel issueLabel = IssueLabel(name: 'revert');
+      final IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
       final ProcessMethod processMethod = await validationService.processPullRequestMethod(pullRequest);
@@ -262,7 +262,7 @@ void main() {
 
     test('Should process message as revert when revert and autosubmit labels are present and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
-      IssueLabel issueLabel = IssueLabel(name: 'revert');
+      final IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels!.add(issueLabel);
       githubService.pullRequestData = pullRequest;
       final ProcessMethod processMethod = await validationService.processPullRequestMethod(pullRequest);
@@ -273,7 +273,7 @@ void main() {
     test('Skip processing message when revert label exists and pr is closed', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.state = 'closed';
-      IssueLabel issueLabel = IssueLabel(name: 'revert');
+      final IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
       final ProcessMethod processMethod = await validationService.processPullRequestMethod(pullRequest);

--- a/auto_submit/test/src/service/fake_approver_service.dart
+++ b/auto_submit/test/src/service/fake_approver_service.dart
@@ -1,0 +1,20 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/service/approver_service.dart';
+import 'package:github/github.dart';
+
+class FakeApproverService extends ApproverService {
+  FakeApproverService(super.config);
+
+  @override
+  Future<void> autoApproval(PullRequest pullRequest) async {
+    // no op
+  }
+
+  @override
+  Future<void> revertApproval(PullRequest pullRequest) async {
+    // no op
+  }
+}

--- a/auto_submit/test/src/service/fake_approver_service.dart
+++ b/auto_submit/test/src/service/fake_approver_service.dart
@@ -2,19 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/service/approver_service.dart';
-import 'package:github/github.dart';
+import 'package:github/github.dart' as gh;
 
 class FakeApproverService extends ApproverService {
   FakeApproverService(super.config);
 
   @override
-  Future<void> autoApproval(PullRequest pullRequest) async {
+  Future<void> autoApproval(gh.PullRequest pullRequest) async {
     // no op
   }
 
   @override
-  Future<void> revertApproval(PullRequest pullRequest) async {
+  Future<void> revertApproval(QueryResult queryResult, gh.PullRequest pullRequest) async {
     // no op
   }
 }

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -36,6 +36,8 @@ class FakeGithubService implements GithubService {
   String? pullRequestFilesJsonMock;
   Issue? githubIssueMock;
 
+  bool throwOnCreateIssue = false;
+
   /// Setting either of these flags to true will pop the front element from the
   /// list. Setting either to false will just return the non list version from
   /// the appropriate method.
@@ -46,6 +48,7 @@ class FakeGithubService implements GithubService {
   List<PullRequest?> pullRequestMockList = [];
 
   IssueComment? issueComment;
+  bool useRealComment = false;
   bool labelRemoved = false;
 
   bool compareReturnValue = false;
@@ -134,7 +137,11 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<IssueComment> createComment(RepositorySlug slug, int number, String commentBody) async {
-    issueComment = IssueComment.fromJson(jsonDecode(createCommentMock!) as Map<String, dynamic>);
+    if (useRealComment) {
+      issueComment = IssueComment(id: number, body: commentBody);
+    } else {
+      issueComment = IssueComment.fromJson(jsonDecode(createCommentMock!) as Map<String, dynamic>);
+    }
     return issueComment!;
   }
 
@@ -183,6 +190,9 @@ class FakeGithubService implements GithubService {
     List<String>? assignees,
     String? state,
   }) async {
+    if (throwOnCreateIssue) {
+      throw GitHubError(github, 'Exception on github create issue.');
+    }
     return githubIssueMock!;
   }
 

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -175,7 +175,7 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<Issue> createIssue({
-    required RepositorySlug repositorySlug,
+    required RepositorySlug slug,
     required String title,
     required String body,
     List<String>? labels,

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -174,7 +174,15 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<Issue> createIssue(RepositorySlug repositorySlug, String title, String body) async {
+  Future<Issue> createIssue({
+    required RepositorySlug repositorySlug,
+    required String title,
+    required String body,
+    List<String>? labels,
+    String? assignee,
+    List<String>? assignees,
+    String? state,
+  }) async {
     return githubIssueMock!;
   }
 

--- a/auto_submit/test/src/validations/fake_revert.dart
+++ b/auto_submit/test/src/validations/fake_revert.dart
@@ -1,0 +1,20 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/model/auto_submit_query_result.dart' hide PullRequest;
+import 'package:auto_submit/validations/revert.dart';
+import 'package:auto_submit/validations/validation.dart';
+
+import 'package:github/github.dart';
+
+class FakeRevert extends Revert {
+  FakeRevert({required super.config});
+
+  ValidationResult? validationResult;
+
+  @override
+  Future<ValidationResult> validate(QueryResult result, PullRequest messagePullRequest) async {
+    return validationResult ?? ValidationResult(false, Action.IGNORE_TEMPORARILY, '');
+  }
+}

--- a/auto_submit/test/utilities/mocks.mocks.dart
+++ b/auto_submit/test/utilities/mocks.mocks.dart
@@ -25,167 +25,227 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeConfig_0 extends _i1.SmartFake implements _i2.Config {
-  _FakeConfig_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeConfig_0(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeClient_1(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeActivityService_2 extends _i1.SmartFake implements _i4.ActivityService {
-  _FakeActivityService_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeActivityService_2 extends _i1.SmartFake
+    implements _i4.ActivityService {
+  _FakeActivityService_2(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeAuthorizationsService_3 extends _i1.SmartFake implements _i4.AuthorizationsService {
-  _FakeAuthorizationsService_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeAuthorizationsService_3 extends _i1.SmartFake
+    implements _i4.AuthorizationsService {
+  _FakeAuthorizationsService_3(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeGistsService_4 extends _i1.SmartFake implements _i4.GistsService {
-  _FakeGistsService_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeGistsService_4(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeGitService_5 extends _i1.SmartFake implements _i4.GitService {
-  _FakeGitService_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeGitService_5(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeIssuesService_6 extends _i1.SmartFake implements _i4.IssuesService {
-  _FakeIssuesService_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeIssuesService_6(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeMiscService_7 extends _i1.SmartFake implements _i4.MiscService {
-  _FakeMiscService_7(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeMiscService_7(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeOrganizationsService_8 extends _i1.SmartFake implements _i4.OrganizationsService {
-  _FakeOrganizationsService_8(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeOrganizationsService_8 extends _i1.SmartFake
+    implements _i4.OrganizationsService {
+  _FakeOrganizationsService_8(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakePullRequestsService_9 extends _i1.SmartFake implements _i4.PullRequestsService {
-  _FakePullRequestsService_9(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePullRequestsService_9 extends _i1.SmartFake
+    implements _i4.PullRequestsService {
+  _FakePullRequestsService_9(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeRepositoriesService_10 extends _i1.SmartFake implements _i4.RepositoriesService {
-  _FakeRepositoriesService_10(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeRepositoriesService_10 extends _i1.SmartFake
+    implements _i4.RepositoriesService {
+  _FakeRepositoriesService_10(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeSearchService_11 extends _i1.SmartFake implements _i4.SearchService {
-  _FakeSearchService_11(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeSearchService_11(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeUrlShortenerService_12 extends _i1.SmartFake implements _i4.UrlShortenerService {
-  _FakeUrlShortenerService_12(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeUrlShortenerService_12 extends _i1.SmartFake
+    implements _i4.UrlShortenerService {
+  _FakeUrlShortenerService_12(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeUsersService_13 extends _i1.SmartFake implements _i4.UsersService {
-  _FakeUsersService_13(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeUsersService_13(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeChecksService_14 extends _i1.SmartFake implements _i4.ChecksService {
-  _FakeChecksService_14(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeChecksService_14(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeResponse_15 extends _i1.SmartFake implements _i3.Response {
-  _FakeResponse_15(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeResponse_15(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeGitHub_16 extends _i1.SmartFake implements _i4.GitHub {
-  _FakeGitHub_16(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeGitHub_16(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakePullRequest_17 extends _i1.SmartFake implements _i4.PullRequest {
-  _FakePullRequest_17(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakePullRequest_17(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakePullRequestMerge_18 extends _i1.SmartFake implements _i4.PullRequestMerge {
-  _FakePullRequestMerge_18(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePullRequestMerge_18 extends _i1.SmartFake
+    implements _i4.PullRequestMerge {
+  _FakePullRequestMerge_18(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakePullRequestComment_19 extends _i1.SmartFake implements _i4.PullRequestComment {
-  _FakePullRequestComment_19(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePullRequestComment_19 extends _i1.SmartFake
+    implements _i4.PullRequestComment {
+  _FakePullRequestComment_19(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakePullRequestReview_20 extends _i1.SmartFake implements _i4.PullRequestReview {
-  _FakePullRequestReview_20(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePullRequestReview_20 extends _i1.SmartFake
+    implements _i4.PullRequestReview {
+  _FakePullRequestReview_20(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeRepository_21 extends _i1.SmartFake implements _i4.Repository {
-  _FakeRepository_21(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeRepository_21(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeLicenseDetails_22 extends _i1.SmartFake implements _i4.LicenseDetails {
-  _FakeLicenseDetails_22(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeLicenseDetails_22 extends _i1.SmartFake
+    implements _i4.LicenseDetails {
+  _FakeLicenseDetails_22(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeLanguageBreakdown_23 extends _i1.SmartFake implements _i4.LanguageBreakdown {
-  _FakeLanguageBreakdown_23(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeLanguageBreakdown_23 extends _i1.SmartFake
+    implements _i4.LanguageBreakdown {
+  _FakeLanguageBreakdown_23(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeBranch_24 extends _i1.SmartFake implements _i4.Branch {
-  _FakeBranch_24(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeBranch_24(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeCommitComment_25 extends _i1.SmartFake implements _i4.CommitComment {
-  _FakeCommitComment_25(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeCommitComment_25(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryCommit_26 extends _i1.SmartFake implements _i4.RepositoryCommit {
-  _FakeRepositoryCommit_26(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeRepositoryCommit_26 extends _i1.SmartFake
+    implements _i4.RepositoryCommit {
+  _FakeRepositoryCommit_26(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeGitHubComparison_27 extends _i1.SmartFake implements _i4.GitHubComparison {
-  _FakeGitHubComparison_27(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeGitHubComparison_27 extends _i1.SmartFake
+    implements _i4.GitHubComparison {
+  _FakeGitHubComparison_27(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeGitHubFile_28 extends _i1.SmartFake implements _i4.GitHubFile {
-  _FakeGitHubFile_28(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeGitHubFile_28(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryContents_29 extends _i1.SmartFake implements _i4.RepositoryContents {
-  _FakeRepositoryContents_29(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeRepositoryContents_29 extends _i1.SmartFake
+    implements _i4.RepositoryContents {
+  _FakeRepositoryContents_29(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeContentCreation_30 extends _i1.SmartFake implements _i4.ContentCreation {
-  _FakeContentCreation_30(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeContentCreation_30 extends _i1.SmartFake
+    implements _i4.ContentCreation {
+  _FakeContentCreation_30(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeHook_31 extends _i1.SmartFake implements _i4.Hook {
-  _FakeHook_31(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeHook_31(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakePublicKey_32 extends _i1.SmartFake implements _i4.PublicKey {
-  _FakePublicKey_32(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakePublicKey_32(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryPages_33 extends _i1.SmartFake implements _i4.RepositoryPages {
-  _FakeRepositoryPages_33(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeRepositoryPages_33 extends _i1.SmartFake
+    implements _i4.RepositoryPages {
+  _FakeRepositoryPages_33(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakePageBuild_34 extends _i1.SmartFake implements _i4.PageBuild {
-  _FakePageBuild_34(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakePageBuild_34(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeRelease_35 extends _i1.SmartFake implements _i4.Release {
-  _FakeRelease_35(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeRelease_35(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeReleaseAsset_36 extends _i1.SmartFake implements _i4.ReleaseAsset {
-  _FakeReleaseAsset_36(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeReleaseAsset_36(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeContributorParticipation_37 extends _i1.SmartFake implements _i4.ContributorParticipation {
-  _FakeContributorParticipation_37(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeContributorParticipation_37 extends _i1.SmartFake
+    implements _i4.ContributorParticipation {
+  _FakeContributorParticipation_37(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryStatus_38 extends _i1.SmartFake implements _i4.RepositoryStatus {
-  _FakeRepositoryStatus_38(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeRepositoryStatus_38 extends _i1.SmartFake
+    implements _i4.RepositoryStatus {
+  _FakeRepositoryStatus_38(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
-class _FakeCombinedRepositoryStatus_39 extends _i1.SmartFake implements _i4.CombinedRepositoryStatus {
-  _FakeCombinedRepositoryStatus_39(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeCombinedRepositoryStatus_39 extends _i1.SmartFake
+    implements _i4.CombinedRepositoryStatus {
+  _FakeCombinedRepositoryStatus_39(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 class _FakeReleaseNotes_40 extends _i1.SmartFake implements _i4.ReleaseNotes {
-  _FakeReleaseNotes_40(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+  _FakeReleaseNotes_40(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
 }
 
 /// A class which mocks [ApproverService].
@@ -197,19 +257,23 @@ class MockApproverService extends _i1.Mock implements _i5.ApproverService {
   }
 
   @override
-  _i2.Config get config =>
-      (super.noSuchMethod(Invocation.getter(#config), returnValue: _FakeConfig_0(this, Invocation.getter(#config)))
-          as _i2.Config);
+  _i2.Config get config => (super.noSuchMethod(Invocation.getter(#config),
+          returnValue: _FakeConfig_0(this, Invocation.getter(#config)))
+      as _i2.Config);
   @override
   _i6.Future<void> autoApproval(_i4.PullRequest? pullRequest) =>
       (super.noSuchMethod(Invocation.method(#autoApproval, [pullRequest]),
-          returnValue: _i6.Future<void>.value(),
-          returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+              returnValue: _i6.Future<void>.value(),
+              returnValueForMissingStub: _i6.Future<void>.value())
+          as _i6.Future<void>);
   @override
-  _i6.Future<void> revertApproval(_i7.QueryResult? queryResult, _i4.PullRequest? pullRequest) =>
-      (super.noSuchMethod(Invocation.method(#revertApproval, [queryResult, pullRequest]),
-          returnValue: _i6.Future<void>.value(),
-          returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
+  _i6.Future<void> revertApproval(
+          _i7.QueryResult? queryResult, _i4.PullRequest? pullRequest) =>
+      (super.noSuchMethod(
+              Invocation.method(#revertApproval, [queryResult, pullRequest]),
+              returnValue: _i6.Future<void>.value(),
+              returnValueForMissingStub: _i6.Future<void>.value())
+          as _i6.Future<void>);
 }
 
 /// A class which mocks [GitHub].
@@ -222,57 +286,80 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
 
   @override
   set auth(_i4.Authentication? _auth) =>
-      super.noSuchMethod(Invocation.setter(#auth, _auth), returnValueForMissingStub: null);
+      super.noSuchMethod(Invocation.setter(#auth, _auth),
+          returnValueForMissingStub: null);
   @override
-  String get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint), returnValue: '') as String);
+  String get endpoint =>
+      (super.noSuchMethod(Invocation.getter(#endpoint), returnValue: '')
+          as String);
   @override
-  _i3.Client get client =>
-      (super.noSuchMethod(Invocation.getter(#client), returnValue: _FakeClient_1(this, Invocation.getter(#client)))
-          as _i3.Client);
+  _i3.Client get client => (super.noSuchMethod(Invocation.getter(#client),
+          returnValue: _FakeClient_1(this, Invocation.getter(#client)))
+      as _i3.Client);
   @override
-  _i4.ActivityService get activity => (super.noSuchMethod(Invocation.getter(#activity),
-      returnValue: _FakeActivityService_2(this, Invocation.getter(#activity))) as _i4.ActivityService);
+  _i4.ActivityService get activity =>
+      (super.noSuchMethod(Invocation.getter(#activity),
+              returnValue:
+                  _FakeActivityService_2(this, Invocation.getter(#activity)))
+          as _i4.ActivityService);
   @override
-  _i4.AuthorizationsService get authorizations => (super.noSuchMethod(Invocation.getter(#authorizations),
-          returnValue: _FakeAuthorizationsService_3(this, Invocation.getter(#authorizations)))
-      as _i4.AuthorizationsService);
+  _i4.AuthorizationsService get authorizations =>
+      (super.noSuchMethod(Invocation.getter(#authorizations),
+              returnValue: _FakeAuthorizationsService_3(
+                  this, Invocation.getter(#authorizations)))
+          as _i4.AuthorizationsService);
   @override
-  _i4.GistsService get gists =>
-      (super.noSuchMethod(Invocation.getter(#gists), returnValue: _FakeGistsService_4(this, Invocation.getter(#gists)))
-          as _i4.GistsService);
+  _i4.GistsService get gists => (super.noSuchMethod(Invocation.getter(#gists),
+          returnValue: _FakeGistsService_4(this, Invocation.getter(#gists)))
+      as _i4.GistsService);
   @override
-  _i4.GitService get git =>
-      (super.noSuchMethod(Invocation.getter(#git), returnValue: _FakeGitService_5(this, Invocation.getter(#git)))
-          as _i4.GitService);
+  _i4.GitService get git => (super.noSuchMethod(Invocation.getter(#git),
+          returnValue: _FakeGitService_5(this, Invocation.getter(#git)))
+      as _i4.GitService);
   @override
-  _i4.IssuesService get issues => (super.noSuchMethod(Invocation.getter(#issues),
-      returnValue: _FakeIssuesService_6(this, Invocation.getter(#issues))) as _i4.IssuesService);
+  _i4.IssuesService get issues => (super.noSuchMethod(
+          Invocation.getter(#issues),
+          returnValue: _FakeIssuesService_6(this, Invocation.getter(#issues)))
+      as _i4.IssuesService);
   @override
-  _i4.MiscService get misc =>
-      (super.noSuchMethod(Invocation.getter(#misc), returnValue: _FakeMiscService_7(this, Invocation.getter(#misc)))
-          as _i4.MiscService);
+  _i4.MiscService get misc => (super.noSuchMethod(Invocation.getter(#misc),
+          returnValue: _FakeMiscService_7(this, Invocation.getter(#misc)))
+      as _i4.MiscService);
   @override
-  _i4.OrganizationsService get organizations => (super.noSuchMethod(Invocation.getter(#organizations),
-      returnValue: _FakeOrganizationsService_8(this, Invocation.getter(#organizations))) as _i4.OrganizationsService);
+  _i4.OrganizationsService get organizations =>
+      (super.noSuchMethod(Invocation.getter(#organizations),
+              returnValue: _FakeOrganizationsService_8(
+                  this, Invocation.getter(#organizations)))
+          as _i4.OrganizationsService);
   @override
-  _i4.PullRequestsService get pullRequests => (super.noSuchMethod(Invocation.getter(#pullRequests),
-      returnValue: _FakePullRequestsService_9(this, Invocation.getter(#pullRequests))) as _i4.PullRequestsService);
+  _i4.PullRequestsService get pullRequests => (super.noSuchMethod(
+      Invocation.getter(#pullRequests),
+      returnValue: _FakePullRequestsService_9(
+          this, Invocation.getter(#pullRequests))) as _i4.PullRequestsService);
   @override
-  _i4.RepositoriesService get repositories => (super.noSuchMethod(Invocation.getter(#repositories),
-      returnValue: _FakeRepositoriesService_10(this, Invocation.getter(#repositories))) as _i4.RepositoriesService);
+  _i4.RepositoriesService get repositories => (super.noSuchMethod(
+      Invocation.getter(#repositories),
+      returnValue: _FakeRepositoriesService_10(
+          this, Invocation.getter(#repositories))) as _i4.RepositoriesService);
   @override
-  _i4.SearchService get search => (super.noSuchMethod(Invocation.getter(#search),
-      returnValue: _FakeSearchService_11(this, Invocation.getter(#search))) as _i4.SearchService);
+  _i4.SearchService get search => (super.noSuchMethod(
+          Invocation.getter(#search),
+          returnValue: _FakeSearchService_11(this, Invocation.getter(#search)))
+      as _i4.SearchService);
   @override
-  _i4.UrlShortenerService get urlShortener => (super.noSuchMethod(Invocation.getter(#urlShortener),
-      returnValue: _FakeUrlShortenerService_12(this, Invocation.getter(#urlShortener))) as _i4.UrlShortenerService);
+  _i4.UrlShortenerService get urlShortener => (super.noSuchMethod(
+      Invocation.getter(#urlShortener),
+      returnValue: _FakeUrlShortenerService_12(
+          this, Invocation.getter(#urlShortener))) as _i4.UrlShortenerService);
   @override
-  _i4.UsersService get users =>
-      (super.noSuchMethod(Invocation.getter(#users), returnValue: _FakeUsersService_13(this, Invocation.getter(#users)))
-          as _i4.UsersService);
+  _i4.UsersService get users => (super.noSuchMethod(Invocation.getter(#users),
+          returnValue: _FakeUsersService_13(this, Invocation.getter(#users)))
+      as _i4.UsersService);
   @override
-  _i4.ChecksService get checks => (super.noSuchMethod(Invocation.getter(#checks),
-      returnValue: _FakeChecksService_14(this, Invocation.getter(#checks))) as _i4.ChecksService);
+  _i4.ChecksService get checks => (super.noSuchMethod(
+          Invocation.getter(#checks),
+          returnValue: _FakeChecksService_14(this, Invocation.getter(#checks)))
+      as _i4.ChecksService);
   @override
   _i6.Future<T> getJSON<S, T>(String? path,
           {int? statusCode,
@@ -390,7 +477,18 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
           int? statusCode,
           void Function(_i3.Response)? fail,
           String? preview}) =>
-      (super.noSuchMethod(Invocation.method(#request, [method, path], {#headers: headers, #params: params, #body: body, #statusCode: statusCode, #fail: fail, #preview: preview}),
+      (super.noSuchMethod(
+          Invocation.method(#request, [
+            method,
+            path
+          ], {
+            #headers: headers,
+            #params: params,
+            #body: body,
+            #statusCode: statusCode,
+            #fail: fail,
+            #preview: preview
+          }),
           returnValue: _i6.Future<_i3.Response>.value(_FakeResponse_15(
               this,
               Invocation.method(#request, [
@@ -406,23 +504,26 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
               })))) as _i6.Future<_i3.Response>);
   @override
   void handleStatusCode(_i3.Response? response) =>
-      super.noSuchMethod(Invocation.method(#handleStatusCode, [response]), returnValueForMissingStub: null);
+      super.noSuchMethod(Invocation.method(#handleStatusCode, [response]),
+          returnValueForMissingStub: null);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
+      returnValueForMissingStub: null);
 }
 
 /// A class which mocks [PullRequestsService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock implements _i4.PullRequestsService {
+class MockPullRequestsService extends _i1.Mock
+    implements _i4.PullRequestsService {
   MockPullRequestsService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.GitHub get github =>
-      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
-          as _i4.GitHub);
+  _i4.GitHub get github => (super.noSuchMethod(Invocation.getter(#github),
+          returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
+      as _i4.GitHub);
   @override
   _i6.Stream<_i4.PullRequest> list(_i4.RepositorySlug? slug,
           {int? pages,
@@ -432,125 +533,188 @@ class MockPullRequestsService extends _i1.Mock implements _i4.PullRequestsServic
           String? sort = r'created',
           String? state = r'open'}) =>
       (super.noSuchMethod(
-          Invocation.method(#list, [slug],
-              {#pages: pages, #base: base, #direction: direction, #head: head, #sort: sort, #state: state}),
-          returnValue: _i6.Stream<_i4.PullRequest>.empty()) as _i6.Stream<_i4.PullRequest>);
+              Invocation.method(#list, [
+                slug
+              ], {
+                #pages: pages,
+                #base: base,
+                #direction: direction,
+                #head: head,
+                #sort: sort,
+                #state: state
+              }),
+              returnValue: _i6.Stream<_i4.PullRequest>.empty())
+          as _i6.Stream<_i4.PullRequest>);
   @override
   _i6.Future<_i4.PullRequest> get(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#get, [slug, number]),
-              returnValue:
-                  _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this, Invocation.method(#get, [slug, number]))))
-          as _i6.Future<_i4.PullRequest>);
+          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
+              this, Invocation.method(#get, [slug, number])))) as _i6
+          .Future<_i4.PullRequest>);
   @override
-  _i6.Future<_i4.PullRequest> create(_i4.RepositorySlug? slug, _i4.CreatePullRequest? request) => (super.noSuchMethod(
-          Invocation.method(#create, [slug, request]),
-          returnValue:
-              _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this, Invocation.method(#create, [slug, request]))))
-      as _i6.Future<_i4.PullRequest>);
+  _i6.Future<_i4.PullRequest> create(
+          _i4.RepositorySlug? slug, _i4.CreatePullRequest? request) =>
+      (super.noSuchMethod(Invocation.method(#create, [slug, request]),
+          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
+              this, Invocation.method(#create, [slug, request])))) as _i6
+          .Future<_i4.PullRequest>);
   @override
   _i6.Future<_i4.PullRequest> edit(_i4.RepositorySlug? slug, int? number,
           {String? title, String? body, String? state, String? base}) =>
-      (super.noSuchMethod(
-              Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
-              returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this,
-                  Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}))))
-          as _i6.Future<_i4.PullRequest>);
+      (super.noSuchMethod(Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
+          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
+              this,
+              Invocation.method(#edit, [
+                slug,
+                number
+              ], {
+                #title: title,
+                #body: body,
+                #state: state,
+                #base: base
+              })))) as _i6.Future<_i4.PullRequest>);
   @override
-  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.RepositoryCommit> listCommits(
+          _i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listCommits, [slug, number]),
-          returnValue: _i6.Stream<_i4.RepositoryCommit>.empty()) as _i6.Stream<_i4.RepositoryCommit>);
+              returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
+          as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i6.Stream<_i4.PullRequestFile> listFiles(_i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestFile> listFiles(
+          _i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listFiles, [slug, number]),
-          returnValue: _i6.Stream<_i4.PullRequestFile>.empty()) as _i6.Stream<_i4.PullRequestFile>);
+              returnValue: _i6.Stream<_i4.PullRequestFile>.empty())
+          as _i6.Stream<_i4.PullRequestFile>);
   @override
-  _i6.Stream<_i4.PullRequestReview> listReviews(_i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestReview> listReviews(
+          _i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listReviews, [slug, number]),
-          returnValue: _i6.Stream<_i4.PullRequestReview>.empty()) as _i6.Stream<_i4.PullRequestReview>);
+              returnValue: _i6.Stream<_i4.PullRequestReview>.empty())
+          as _i6.Stream<_i4.PullRequestReview>);
   @override
   _i6.Future<bool> isMerged(_i4.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Future<_i4.PullRequestMerge> merge(_i4.RepositorySlug? slug, int? number, {String? message}) =>
-      (super.noSuchMethod(Invocation.method(#merge, [slug, number], {#message: message}),
+  _i6.Future<_i4.PullRequestMerge> merge(_i4.RepositorySlug? slug, int? number,
+          {String? message}) =>
+      (super.noSuchMethod(
+              Invocation.method(#merge, [slug, number], {#message: message}),
               returnValue: _i6.Future<_i4.PullRequestMerge>.value(
-                  _FakePullRequestMerge_18(this, Invocation.method(#merge, [slug, number], {#message: message}))))
+                  _FakePullRequestMerge_18(
+                      this,
+                      Invocation.method(
+                          #merge, [slug, number], {#message: message}))))
           as _i6.Future<_i4.PullRequestMerge>);
   @override
-  _i6.Stream<_i4.PullRequestComment> listCommentsByPullRequest(_i4.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#listCommentsByPullRequest, [slug, number]),
-          returnValue: _i6.Stream<_i4.PullRequestComment>.empty()) as _i6.Stream<_i4.PullRequestComment>);
+  _i6.Stream<_i4.PullRequestComment> listCommentsByPullRequest(
+          _i4.RepositorySlug? slug, int? number) =>
+      (super.noSuchMethod(
+              Invocation.method(#listCommentsByPullRequest, [slug, number]),
+              returnValue: _i6.Stream<_i4.PullRequestComment>.empty())
+          as _i6.Stream<_i4.PullRequestComment>);
   @override
   _i6.Stream<_i4.PullRequestComment> listComments(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listComments, [slug]),
-          returnValue: _i6.Stream<_i4.PullRequestComment>.empty()) as _i6.Stream<_i4.PullRequestComment>);
+              returnValue: _i6.Stream<_i4.PullRequestComment>.empty())
+          as _i6.Stream<_i4.PullRequestComment>);
   @override
-  _i6.Future<_i4.PullRequestComment> createComment(
-          _i4.RepositorySlug? slug, int? number, _i4.CreatePullRequestComment? comment) =>
-      (super.noSuchMethod(Invocation.method(#createComment, [slug, number, comment]),
+  _i6.Future<_i4.PullRequestComment> createComment(_i4.RepositorySlug? slug,
+          int? number, _i4.CreatePullRequestComment? comment) =>
+      (super.noSuchMethod(
+              Invocation.method(#createComment, [slug, number, comment]),
               returnValue: _i6.Future<_i4.PullRequestComment>.value(
-                  _FakePullRequestComment_19(this, Invocation.method(#createComment, [slug, number, comment]))))
+                  _FakePullRequestComment_19(
+                      this,
+                      Invocation.method(
+                          #createComment, [slug, number, comment]))))
           as _i6.Future<_i4.PullRequestComment>);
   @override
-  _i6.Future<_i4.PullRequestReview> createReview(_i4.RepositorySlug? slug, _i4.CreatePullRequestReview? review) =>
+  _i6.Future<_i4.PullRequestReview> createReview(
+          _i4.RepositorySlug? slug, _i4.CreatePullRequestReview? review) =>
       (super.noSuchMethod(Invocation.method(#createReview, [slug, review]),
               returnValue: _i6.Future<_i4.PullRequestReview>.value(
-                  _FakePullRequestReview_20(this, Invocation.method(#createReview, [slug, review]))))
+                  _FakePullRequestReview_20(
+                      this, Invocation.method(#createReview, [slug, review]))))
           as _i6.Future<_i4.PullRequestReview>);
 }
 
 /// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesService {
+class MockRepositoriesService extends _i1.Mock
+    implements _i4.RepositoriesService {
   MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.GitHub get github =>
-      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
-          as _i4.GitHub);
+  _i4.GitHub get github => (super.noSuchMethod(Invocation.getter(#github),
+          returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
+      as _i4.GitHub);
   @override
   _i6.Stream<_i4.Repository> listRepositories(
-          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
-      (super.noSuchMethod(Invocation.method(#listRepositories, [], {#type: type, #sort: sort, #direction: direction}),
-          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
+          {String? type = r'owner',
+          String? sort = r'full_name',
+          String? direction = r'asc'}) =>
+      (super.noSuchMethod(
+              Invocation.method(#listRepositories, [],
+                  {#type: type, #sort: sort, #direction: direction}),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
   _i6.Stream<_i4.Repository> listUserRepositories(String? user,
-          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
+          {String? type = r'owner',
+          String? sort = r'full_name',
+          String? direction = r'asc'}) =>
       (super.noSuchMethod(
-          Invocation.method(#listUserRepositories, [user], {#type: type, #sort: sort, #direction: direction}),
-          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
+              Invocation.method(#listUserRepositories, [user],
+                  {#type: type, #sort: sort, #direction: direction}),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Stream<_i4.Repository> listOrganizationRepositories(String? org, {String? type = r'all'}) =>
-      (super.noSuchMethod(Invocation.method(#listOrganizationRepositories, [org], {#type: type}),
-          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
+  _i6.Stream<_i4.Repository> listOrganizationRepositories(String? org,
+          {String? type = r'all'}) =>
+      (super.noSuchMethod(
+              Invocation.method(
+                  #listOrganizationRepositories, [org], {#type: type}),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Stream<_i4.Repository> listPublicRepositories({int? limit = 50, DateTime? since}) =>
-      (super.noSuchMethod(Invocation.method(#listPublicRepositories, [], {#limit: limit, #since: since}),
-          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
+  _i6.Stream<_i4.Repository> listPublicRepositories(
+          {int? limit = 50, DateTime? since}) =>
+      (super.noSuchMethod(
+              Invocation.method(
+                  #listPublicRepositories, [], {#limit: limit, #since: since}),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
+          as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Future<_i4.Repository> createRepository(_i4.CreateRepository? repository, {String? org}) =>
-      (super.noSuchMethod(Invocation.method(#createRepository, [repository], {#org: org}),
-              returnValue: _i6.Future<_i4.Repository>.value(
-                  _FakeRepository_21(this, Invocation.method(#createRepository, [repository], {#org: org}))))
+  _i6.Future<_i4.Repository> createRepository(_i4.CreateRepository? repository,
+          {String? org}) =>
+      (super.noSuchMethod(
+              Invocation.method(#createRepository, [repository], {#org: org}),
+              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
+                  this,
+                  Invocation.method(
+                      #createRepository, [repository], {#org: org}))))
           as _i6.Future<_i4.Repository>);
   @override
   _i6.Future<_i4.LicenseDetails> getLicense(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLicense, [slug]),
-          returnValue: _i6.Future<_i4.LicenseDetails>.value(
-              _FakeLicenseDetails_22(this, Invocation.method(#getLicense, [slug])))) as _i6.Future<_i4.LicenseDetails>);
+              returnValue: _i6.Future<_i4.LicenseDetails>.value(
+                  _FakeLicenseDetails_22(
+                      this, Invocation.method(#getLicense, [slug]))))
+          as _i6.Future<_i4.LicenseDetails>);
   @override
   _i6.Future<_i4.Repository> getRepository(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getRepository, [slug]),
-              returnValue:
-                  _i6.Future<_i4.Repository>.value(_FakeRepository_21(this, Invocation.method(#getRepository, [slug]))))
+              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
+                  this, Invocation.method(#getRepository, [slug]))))
           as _i6.Future<_i4.Repository>);
   @override
   _i6.Stream<_i4.Repository> getRepositories(List<_i4.RepositorySlug>? slugs) =>
-      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]), returnValue: _i6.Stream<_i4.Repository>.empty())
+      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
           as _i6.Stream<_i4.Repository>);
   @override
   _i6.Future<_i4.Repository> editRepository(_i4.RepositorySlug? slug,
@@ -588,163 +752,215 @@ class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesServic
               })))) as _i6.Future<_i4.Repository>);
   @override
   _i6.Future<bool> deleteRepository(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.Contributor> listContributors(_i4.RepositorySlug? slug, {bool? anon = false}) =>
-      (super.noSuchMethod(Invocation.method(#listContributors, [slug], {#anon: anon}),
-          returnValue: _i6.Stream<_i4.Contributor>.empty()) as _i6.Stream<_i4.Contributor>);
+  _i6.Stream<_i4.Contributor> listContributors(_i4.RepositorySlug? slug,
+          {bool? anon = false}) =>
+      (super.noSuchMethod(
+              Invocation.method(#listContributors, [slug], {#anon: anon}),
+              returnValue: _i6.Stream<_i4.Contributor>.empty())
+          as _i6.Stream<_i4.Contributor>);
   @override
   _i6.Stream<_i4.Team> listTeams(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listTeams, [slug]), returnValue: _i6.Stream<_i4.Team>.empty())
-          as _i6.Stream<_i4.Team>);
+      (super.noSuchMethod(Invocation.method(#listTeams, [slug]),
+          returnValue: _i6.Stream<_i4.Team>.empty()) as _i6.Stream<_i4.Team>);
   @override
   _i6.Future<_i4.LanguageBreakdown> listLanguages(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listLanguages, [slug]),
               returnValue: _i6.Future<_i4.LanguageBreakdown>.value(
-                  _FakeLanguageBreakdown_23(this, Invocation.method(#listLanguages, [slug]))))
+                  _FakeLanguageBreakdown_23(
+                      this, Invocation.method(#listLanguages, [slug]))))
           as _i6.Future<_i4.LanguageBreakdown>);
   @override
-  _i6.Stream<_i4.Tag> listTags(_i4.RepositorySlug? slug, {int? page = 1, int? pages, int? perPage = 30}) =>
-      (super.noSuchMethod(Invocation.method(#listTags, [slug], {#page: page, #pages: pages, #perPage: perPage}),
+  _i6.Stream<_i4.Tag> listTags(_i4.RepositorySlug? slug,
+          {int? page = 1, int? pages, int? perPage = 30}) =>
+      (super.noSuchMethod(
+          Invocation.method(#listTags, [slug],
+              {#page: page, #pages: pages, #perPage: perPage}),
           returnValue: _i6.Stream<_i4.Tag>.empty()) as _i6.Stream<_i4.Tag>);
   @override
   _i6.Stream<_i4.Branch> listBranches(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listBranches, [slug]), returnValue: _i6.Stream<_i4.Branch>.empty())
+      (super.noSuchMethod(Invocation.method(#listBranches, [slug]),
+              returnValue: _i6.Stream<_i4.Branch>.empty())
           as _i6.Stream<_i4.Branch>);
   @override
   _i6.Future<_i4.Branch> getBranch(_i4.RepositorySlug? slug, String? branch) =>
       (super.noSuchMethod(Invocation.method(#getBranch, [slug, branch]),
-              returnValue:
-                  _i6.Future<_i4.Branch>.value(_FakeBranch_24(this, Invocation.method(#getBranch, [slug, branch]))))
+              returnValue: _i6.Future<_i4.Branch>.value(_FakeBranch_24(
+                  this, Invocation.method(#getBranch, [slug, branch]))))
           as _i6.Future<_i4.Branch>);
   @override
   _i6.Stream<_i4.Collaborator> listCollaborators(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCollaborators, [slug]),
-          returnValue: _i6.Stream<_i4.Collaborator>.empty()) as _i6.Stream<_i4.Collaborator>);
+              returnValue: _i6.Stream<_i4.Collaborator>.empty())
+          as _i6.Stream<_i4.Collaborator>);
   @override
   _i6.Future<bool> isCollaborator(_i4.RepositorySlug? slug, String? user) =>
-      (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
   _i6.Future<bool> addCollaborator(_i4.RepositorySlug? slug, String? user) =>
-      (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
   _i6.Future<bool> removeCollaborator(_i4.RepositorySlug? slug, String? user) =>
       (super.noSuchMethod(Invocation.method(#removeCollaborator, [slug, user]),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.CommitComment> listSingleCommitComments(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit) =>
-      (super.noSuchMethod(Invocation.method(#listSingleCommitComments, [slug, commit]),
-          returnValue: _i6.Stream<_i4.CommitComment>.empty()) as _i6.Stream<_i4.CommitComment>);
+  _i6.Stream<_i4.CommitComment> listSingleCommitComments(
+          _i4.RepositorySlug? slug, _i4.RepositoryCommit? commit) =>
+      (super.noSuchMethod(
+              Invocation.method(#listSingleCommitComments, [slug, commit]),
+              returnValue: _i6.Stream<_i4.CommitComment>.empty())
+          as _i6.Stream<_i4.CommitComment>);
   @override
   _i6.Stream<_i4.CommitComment> listCommitComments(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCommitComments, [slug]),
-          returnValue: _i6.Stream<_i4.CommitComment>.empty()) as _i6.Stream<_i4.CommitComment>);
+              returnValue: _i6.Stream<_i4.CommitComment>.empty())
+          as _i6.Stream<_i4.CommitComment>);
   @override
-  _i6.Future<_i4.CommitComment> createCommitComment(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit,
+  _i6.Future<_i4.CommitComment> createCommitComment(
+          _i4.RepositorySlug? slug, _i4.RepositoryCommit? commit,
           {String? body, String? path, int? position, int? line}) =>
-      (super
-          .noSuchMethod(Invocation.method(#createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}),
-              returnValue: _i6.Future<_i4.CommitComment>.value(_FakeCommitComment_25(
-                  this,
-                  Invocation.method(#createCommitComment, [slug, commit],
-                      {#body: body, #path: path, #position: position, #line: line})))) as _i6.Future<_i4.CommitComment>);
-  @override
-  _i6.Future<_i4.CommitComment> getCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
-      (super.noSuchMethod(Invocation.method(#getCommitComment, [slug], {#id: id}),
+      (super.noSuchMethod(
+              Invocation.method(#createCommitComment, [slug, commit],
+                  {#body: body, #path: path, #position: position, #line: line}),
               returnValue: _i6.Future<_i4.CommitComment>.value(
-                  _FakeCommitComment_25(this, Invocation.method(#getCommitComment, [slug], {#id: id}))))
+                  _FakeCommitComment_25(this, Invocation.method(#createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}))))
           as _i6.Future<_i4.CommitComment>);
   @override
-  _i6.Future<_i4.CommitComment> updateCommitComment(_i4.RepositorySlug? slug, {int? id, String? body}) =>
-      (super.noSuchMethod(Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}),
+  _i6.Future<_i4.CommitComment> getCommitComment(_i4.RepositorySlug? slug,
+          {int? id}) =>
+      (super.noSuchMethod(
+              Invocation.method(#getCommitComment, [slug], {#id: id}),
               returnValue: _i6.Future<_i4.CommitComment>.value(
-                  _FakeCommitComment_25(this, Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}))))
+                  _FakeCommitComment_25(this,
+                      Invocation.method(#getCommitComment, [slug], {#id: id}))))
+          as _i6.Future<_i4.CommitComment>);
+  @override
+  _i6.Future<_i4.CommitComment> updateCommitComment(_i4.RepositorySlug? slug,
+          {int? id, String? body}) =>
+      (super.noSuchMethod(
+              Invocation.method(
+                  #updateCommitComment, [slug], {#id: id, #body: body}),
+              returnValue: _i6.Future<_i4.CommitComment>.value(_FakeCommitComment_25(
+                  this,
+                  Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}))))
           as _i6.Future<_i4.CommitComment>);
   @override
   _i6.Future<bool> deleteCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
-      (super.noSuchMethod(Invocation.method(#deleteCommitComment, [slug], {#id: id}),
+      (super.noSuchMethod(
+          Invocation.method(#deleteCommitComment, [slug], {#id: id}),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug) => (super
-          .noSuchMethod(Invocation.method(#listCommits, [slug]), returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
-      as _i6.Stream<_i4.RepositoryCommit>);
+  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listCommits, [slug]),
+              returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
+          as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i6.Future<_i4.RepositoryCommit> getCommit(_i4.RepositorySlug? slug, String? sha) =>
+  _i6.Future<_i4.RepositoryCommit> getCommit(
+          _i4.RepositorySlug? slug, String? sha) =>
       (super.noSuchMethod(Invocation.method(#getCommit, [slug, sha]),
               returnValue: _i6.Future<_i4.RepositoryCommit>.value(
-                  _FakeRepositoryCommit_26(this, Invocation.method(#getCommit, [slug, sha]))))
+                  _FakeRepositoryCommit_26(
+                      this, Invocation.method(#getCommit, [slug, sha]))))
           as _i6.Future<_i4.RepositoryCommit>);
   @override
   _i6.Future<String> getCommitDiff(_i4.RepositorySlug? slug, String? sha) =>
-      (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]), returnValue: _i6.Future<String>.value(''))
-          as _i6.Future<String>);
+      (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]),
+          returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);
   @override
-  _i6.Future<_i4.GitHubComparison> compareCommits(_i4.RepositorySlug? slug, String? refBase, String? refHead) =>
-      (super.noSuchMethod(Invocation.method(#compareCommits, [slug, refBase, refHead]),
+  _i6.Future<_i4.GitHubComparison> compareCommits(
+          _i4.RepositorySlug? slug, String? refBase, String? refHead) =>
+      (super.noSuchMethod(
+              Invocation.method(#compareCommits, [slug, refBase, refHead]),
               returnValue: _i6.Future<_i4.GitHubComparison>.value(
-                  _FakeGitHubComparison_27(this, Invocation.method(#compareCommits, [slug, refBase, refHead]))))
+                  _FakeGitHubComparison_27(
+                      this,
+                      Invocation.method(
+                          #compareCommits, [slug, refBase, refHead]))))
           as _i6.Future<_i4.GitHubComparison>);
   @override
-  _i6.Future<_i4.GitHubFile> getReadme(_i4.RepositorySlug? slug, {String? ref}) => (super.noSuchMethod(
-      Invocation.method(#getReadme, [slug], {#ref: ref}),
-      returnValue: _i6.Future<_i4.GitHubFile>.value(
-          _FakeGitHubFile_28(this, Invocation.method(#getReadme, [slug], {#ref: ref})))) as _i6.Future<_i4.GitHubFile>);
+  _i6.Future<_i4.GitHubFile> getReadme(_i4.RepositorySlug? slug,
+          {String? ref}) =>
+      (super.noSuchMethod(Invocation.method(#getReadme, [slug], {#ref: ref}),
+              returnValue: _i6.Future<_i4.GitHubFile>.value(_FakeGitHubFile_28(
+                  this, Invocation.method(#getReadme, [slug], {#ref: ref}))))
+          as _i6.Future<_i4.GitHubFile>);
   @override
-  _i6.Future<_i4.RepositoryContents> getContents(_i4.RepositorySlug? slug, String? path, {String? ref}) =>
-      (super.noSuchMethod(Invocation.method(#getContents, [slug, path], {#ref: ref}),
+  _i6.Future<_i4.RepositoryContents> getContents(
+          _i4.RepositorySlug? slug, String? path, {String? ref}) =>
+      (super.noSuchMethod(
+              Invocation.method(#getContents, [slug, path], {#ref: ref}),
               returnValue: _i6.Future<_i4.RepositoryContents>.value(
-                  _FakeRepositoryContents_29(this, Invocation.method(#getContents, [slug, path], {#ref: ref}))))
+                  _FakeRepositoryContents_29(
+                      this,
+                      Invocation.method(
+                          #getContents, [slug, path], {#ref: ref}))))
           as _i6.Future<_i4.RepositoryContents>);
   @override
-  _i6.Future<_i4.ContentCreation> createFile(_i4.RepositorySlug? slug, _i4.CreateFile? file) =>
+  _i6.Future<_i4.ContentCreation> createFile(
+          _i4.RepositorySlug? slug, _i4.CreateFile? file) =>
       (super.noSuchMethod(Invocation.method(#createFile, [slug, file]),
               returnValue: _i6.Future<_i4.ContentCreation>.value(
-                  _FakeContentCreation_30(this, Invocation.method(#createFile, [slug, file]))))
+                  _FakeContentCreation_30(
+                      this, Invocation.method(#createFile, [slug, file]))))
           as _i6.Future<_i4.ContentCreation>);
   @override
-  _i6.Future<_i4.ContentCreation> updateFile(
-          _i4.RepositorySlug? slug, String? path, String? message, String? content, String? sha, {String? branch}) =>
+  _i6.Future<_i4.ContentCreation> updateFile(_i4.RepositorySlug? slug,
+          String? path, String? message, String? content, String? sha,
+          {String? branch}) =>
       (super.noSuchMethod(Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}),
-              returnValue: _i6.Future<_i4.ContentCreation>.value(_FakeContentCreation_30(
-                  this, Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}))))
-          as _i6.Future<_i4.ContentCreation>);
-  @override
-  _i6.Future<_i4.ContentCreation> deleteFile(
-          _i4.RepositorySlug? slug, String? path, String? message, String? sha, String? branch) =>
-      (super.noSuchMethod(Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
               returnValue: _i6.Future<_i4.ContentCreation>.value(
-                  _FakeContentCreation_30(this, Invocation.method(#deleteFile, [slug, path, message, sha, branch]))))
+                  _FakeContentCreation_30(this,
+                      Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}))))
           as _i6.Future<_i4.ContentCreation>);
   @override
-  _i6.Future<String?> getArchiveLink(_i4.RepositorySlug? slug, String? ref, {String? format = r'tarball'}) =>
-      (super.noSuchMethod(Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
+  _i6.Future<_i4.ContentCreation> deleteFile(_i4.RepositorySlug? slug,
+          String? path, String? message, String? sha, String? branch) =>
+      (super.noSuchMethod(
+              Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
+              returnValue: _i6.Future<_i4.ContentCreation>.value(
+                  _FakeContentCreation_30(
+                      this,
+                      Invocation.method(
+                          #deleteFile, [slug, path, message, sha, branch]))))
+          as _i6.Future<_i4.ContentCreation>);
+  @override
+  _i6.Future<String?> getArchiveLink(_i4.RepositorySlug? slug, String? ref,
+          {String? format = r'tarball'}) =>
+      (super.noSuchMethod(
+          Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
           returnValue: _i6.Future<String?>.value()) as _i6.Future<String?>);
   @override
   _i6.Stream<_i4.Repository> listForks(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listForks, [slug]), returnValue: _i6.Stream<_i4.Repository>.empty())
+      (super.noSuchMethod(Invocation.method(#listForks, [slug]),
+              returnValue: _i6.Stream<_i4.Repository>.empty())
           as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Future<_i4.Repository> createFork(_i4.RepositorySlug? slug, [_i4.CreateFork? fork]) => (super.noSuchMethod(
-          Invocation.method(#createFork, [slug, fork]),
-          returnValue:
-              _i6.Future<_i4.Repository>.value(_FakeRepository_21(this, Invocation.method(#createFork, [slug, fork]))))
-      as _i6.Future<_i4.Repository>);
+  _i6.Future<_i4.Repository> createFork(_i4.RepositorySlug? slug,
+          [_i4.CreateFork? fork]) =>
+      (super.noSuchMethod(Invocation.method(#createFork, [slug, fork]),
+              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
+                  this, Invocation.method(#createFork, [slug, fork]))))
+          as _i6.Future<_i4.Repository>);
   @override
   _i6.Stream<_i4.Hook> listHooks(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listHooks, [slug]), returnValue: _i6.Stream<_i4.Hook>.empty())
-          as _i6.Stream<_i4.Hook>);
+      (super.noSuchMethod(Invocation.method(#listHooks, [slug]),
+          returnValue: _i6.Stream<_i4.Hook>.empty()) as _i6.Stream<_i4.Hook>);
   @override
   _i6.Future<_i4.Hook> getHook(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#getHook, [slug, id]),
-              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(this, Invocation.method(#getHook, [slug, id]))))
+              returnValue: _i6.Future<_i4.Hook>.value(
+                  _FakeHook_31(this, Invocation.method(#getHook, [slug, id]))))
           as _i6.Future<_i4.Hook>);
   @override
-  _i6.Future<_i4.Hook> createHook(_i4.RepositorySlug? slug, _i4.CreateHook? hook) =>
+  _i6.Future<_i4.Hook> createHook(
+          _i4.RepositorySlug? slug, _i4.CreateHook? hook) =>
       (super.noSuchMethod(Invocation.method(#createHook, [slug, hook]),
-              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(this, Invocation.method(#createHook, [slug, hook]))))
+              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(
+                  this, Invocation.method(#createHook, [slug, hook]))))
           as _i6.Future<_i4.Hook>);
   @override
   _i6.Future<_i4.Hook> editHook(_i4.RepositorySlug? slug, _i4.Hook? hookToEdit,
@@ -787,87 +1003,121 @@ class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesServic
               })))) as _i6.Future<_i4.Hook>);
   @override
   _i6.Future<bool> testPushHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
-  @override
-  _i6.Future<bool> pingHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
-  @override
-  _i6.Future<bool> deleteHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
-          as _i6.Future<bool>);
-  @override
-  _i6.Stream<_i4.PublicKey> listDeployKeys(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]), returnValue: _i6.Stream<_i4.PublicKey>.empty())
-          as _i6.Stream<_i4.PublicKey>);
-  @override
-  _i6.Future<_i4.PublicKey> getDeployKey(_i4.RepositorySlug? slug, {int? id}) => (super.noSuchMethod(
-      Invocation.method(#getDeployKey, [slug], {#id: id}),
-      returnValue: _i6.Future<_i4.PublicKey>.value(
-          _FakePublicKey_32(this, Invocation.method(#getDeployKey, [slug], {#id: id})))) as _i6.Future<_i4.PublicKey>);
-  @override
-  _i6.Future<_i4.PublicKey> createDeployKey(_i4.RepositorySlug? slug, _i4.CreatePublicKey? key) =>
-      (super.noSuchMethod(Invocation.method(#createDeployKey, [slug, key]),
-          returnValue: _i6.Future<_i4.PublicKey>.value(
-              _FakePublicKey_32(this, Invocation.method(#createDeployKey, [slug, key])))) as _i6.Future<_i4.PublicKey>);
-  @override
-  _i6.Future<bool> deleteDeployKey({_i4.RepositorySlug? slug, _i4.PublicKey? key}) =>
-      (super.noSuchMethod(Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
+      (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Future<_i4.RepositoryCommit> merge(_i4.RepositorySlug? slug, _i4.CreateMerge? merge) =>
+  _i6.Future<bool> pingHook(_i4.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  @override
+  _i6.Future<bool> deleteHook(_i4.RepositorySlug? slug, int? id) =>
+      (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  @override
+  _i6.Stream<_i4.PublicKey> listDeployKeys(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]),
+              returnValue: _i6.Stream<_i4.PublicKey>.empty())
+          as _i6.Stream<_i4.PublicKey>);
+  @override
+  _i6.Future<_i4.PublicKey> getDeployKey(_i4.RepositorySlug? slug, {int? id}) =>
+      (super.noSuchMethod(Invocation.method(#getDeployKey, [slug], {#id: id}),
+              returnValue: _i6.Future<_i4.PublicKey>.value(_FakePublicKey_32(
+                  this, Invocation.method(#getDeployKey, [slug], {#id: id}))))
+          as _i6.Future<_i4.PublicKey>);
+  @override
+  _i6.Future<_i4.PublicKey> createDeployKey(
+          _i4.RepositorySlug? slug, _i4.CreatePublicKey? key) =>
+      (super.noSuchMethod(Invocation.method(#createDeployKey, [slug, key]),
+              returnValue: _i6.Future<_i4.PublicKey>.value(_FakePublicKey_32(
+                  this, Invocation.method(#createDeployKey, [slug, key]))))
+          as _i6.Future<_i4.PublicKey>);
+  @override
+  _i6.Future<bool> deleteDeployKey(
+          {_i4.RepositorySlug? slug, _i4.PublicKey? key}) =>
+      (super.noSuchMethod(
+          Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  @override
+  _i6.Future<_i4.RepositoryCommit> merge(
+          _i4.RepositorySlug? slug, _i4.CreateMerge? merge) =>
       (super.noSuchMethod(Invocation.method(#merge, [slug, merge]),
               returnValue: _i6.Future<_i4.RepositoryCommit>.value(
-                  _FakeRepositoryCommit_26(this, Invocation.method(#merge, [slug, merge]))))
+                  _FakeRepositoryCommit_26(
+                      this, Invocation.method(#merge, [slug, merge]))))
           as _i6.Future<_i4.RepositoryCommit>);
   @override
-  _i6.Future<_i4.RepositoryPages> getPagesInfo(_i4.RepositorySlug? slug) => (super.noSuchMethod(
-      Invocation.method(#getPagesInfo, [slug]),
-      returnValue: _i6.Future<_i4.RepositoryPages>.value(
-          _FakeRepositoryPages_33(this, Invocation.method(#getPagesInfo, [slug])))) as _i6.Future<_i4.RepositoryPages>);
+  _i6.Future<_i4.RepositoryPages> getPagesInfo(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getPagesInfo, [slug]),
+              returnValue: _i6.Future<_i4.RepositoryPages>.value(
+                  _FakeRepositoryPages_33(
+                      this, Invocation.method(#getPagesInfo, [slug]))))
+          as _i6.Future<_i4.RepositoryPages>);
   @override
   _i6.Stream<_i4.PageBuild> listPagesBuilds(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]), returnValue: _i6.Stream<_i4.PageBuild>.empty())
+      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]),
+              returnValue: _i6.Stream<_i4.PageBuild>.empty())
           as _i6.Stream<_i4.PageBuild>);
   @override
-  _i6.Future<_i4.PageBuild> getLatestPagesBuild(_i4.RepositorySlug? slug) => (super.noSuchMethod(
-          Invocation.method(#getLatestPagesBuild, [slug]),
-          returnValue:
-              _i6.Future<_i4.PageBuild>.value(_FakePageBuild_34(this, Invocation.method(#getLatestPagesBuild, [slug]))))
-      as _i6.Future<_i4.PageBuild>);
+  _i6.Future<_i4.PageBuild> getLatestPagesBuild(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#getLatestPagesBuild, [slug]),
+              returnValue: _i6.Future<_i4.PageBuild>.value(_FakePageBuild_34(
+                  this, Invocation.method(#getLatestPagesBuild, [slug]))))
+          as _i6.Future<_i4.PageBuild>);
   @override
   _i6.Stream<_i4.Release> listReleases(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listReleases, [slug]), returnValue: _i6.Stream<_i4.Release>.empty())
+      (super.noSuchMethod(Invocation.method(#listReleases, [slug]),
+              returnValue: _i6.Stream<_i4.Release>.empty())
           as _i6.Stream<_i4.Release>);
   @override
   _i6.Future<_i4.Release> getLatestRelease(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLatestRelease, [slug]),
-              returnValue:
-                  _i6.Future<_i4.Release>.value(_FakeRelease_35(this, Invocation.method(#getLatestRelease, [slug]))))
+              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
+                  this, Invocation.method(#getLatestRelease, [slug]))))
           as _i6.Future<_i4.Release>);
   @override
   _i6.Future<_i4.Release> getReleaseById(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#getReleaseById, [slug, id]),
-              returnValue:
-                  _i6.Future<_i4.Release>.value(_FakeRelease_35(this, Invocation.method(#getReleaseById, [slug, id]))))
+              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
+                  this, Invocation.method(#getReleaseById, [slug, id]))))
           as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> getReleaseByTagName(_i4.RepositorySlug? slug, String? tagName) => (super.noSuchMethod(
-      Invocation.method(#getReleaseByTagName, [slug, tagName]),
-      returnValue: _i6.Future<_i4.Release>.value(
-          _FakeRelease_35(this, Invocation.method(#getReleaseByTagName, [slug, tagName])))) as _i6.Future<_i4.Release>);
+  _i6.Future<_i4.Release> getReleaseByTagName(
+          _i4.RepositorySlug? slug, String? tagName) =>
+      (super.noSuchMethod(
+              Invocation.method(#getReleaseByTagName, [slug, tagName]),
+              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(this,
+                  Invocation.method(#getReleaseByTagName, [slug, tagName]))))
+          as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> createRelease(_i4.RepositorySlug? slug, _i4.CreateRelease? createRelease,
+  _i6.Future<_i4.Release> createRelease(
+          _i4.RepositorySlug? slug, _i4.CreateRelease? createRelease,
           {bool? getIfExists = true}) =>
       (super.noSuchMethod(Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}),
-              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
-                  this, Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}))))
-          as _i6.Future<_i4.Release>);
+          returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
+              this,
+              Invocation.method(#createRelease, [slug, createRelease],
+                  {#getIfExists: getIfExists})))) as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> editRelease(_i4.RepositorySlug? slug, _i4.Release? releaseToEdit,
-          {String? tagName, String? targetCommitish, String? name, String? body, bool? draft, bool? preRelease}) =>
-      (super.noSuchMethod(Invocation.method(#editRelease, [slug, releaseToEdit], {#tagName: tagName, #targetCommitish: targetCommitish, #name: name, #body: body, #draft: draft, #preRelease: preRelease}),
+  _i6.Future<_i4.Release> editRelease(
+          _i4.RepositorySlug? slug, _i4.Release? releaseToEdit,
+          {String? tagName,
+          String? targetCommitish,
+          String? name,
+          String? body,
+          bool? draft,
+          bool? preRelease}) =>
+      (super.noSuchMethod(
+          Invocation.method(#editRelease, [
+            slug,
+            releaseToEdit
+          ], {
+            #tagName: tagName,
+            #targetCommitish: targetCommitish,
+            #name: name,
+            #body: body,
+            #draft: draft,
+            #preRelease: preRelease
+          }),
           returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
               this,
               Invocation.method(#editRelease, [
@@ -882,81 +1132,109 @@ class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesServic
                 #preRelease: preRelease
               })))) as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<bool> deleteRelease(_i4.RepositorySlug? slug, _i4.Release? release) => (super
-          .noSuchMethod(Invocation.method(#deleteRelease, [slug, release]), returnValue: _i6.Future<bool>.value(false))
-      as _i6.Future<bool>);
+  _i6.Future<bool> deleteRelease(
+          _i4.RepositorySlug? slug, _i4.Release? release) =>
+      (super.noSuchMethod(Invocation.method(#deleteRelease, [slug, release]),
+          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.ReleaseAsset> listReleaseAssets(_i4.RepositorySlug? slug, _i4.Release? release) =>
-      (super.noSuchMethod(Invocation.method(#listReleaseAssets, [slug, release]),
-          returnValue: _i6.Stream<_i4.ReleaseAsset>.empty()) as _i6.Stream<_i4.ReleaseAsset>);
+  _i6.Stream<_i4.ReleaseAsset> listReleaseAssets(
+          _i4.RepositorySlug? slug, _i4.Release? release) =>
+      (super.noSuchMethod(
+              Invocation.method(#listReleaseAssets, [slug, release]),
+              returnValue: _i6.Stream<_i4.ReleaseAsset>.empty())
+          as _i6.Stream<_i4.ReleaseAsset>);
   @override
-  _i6.Future<_i4.ReleaseAsset> getReleaseAsset(_i4.RepositorySlug? slug, _i4.Release? release, {int? assetId}) =>
+  _i6.Future<_i4.ReleaseAsset> getReleaseAsset(
+          _i4.RepositorySlug? slug, _i4.Release? release, {int? assetId}) =>
       (super.noSuchMethod(Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}),
-              returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
-                  this, Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}))))
-          as _i6.Future<_i4.ReleaseAsset>);
+          returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
+              this,
+              Invocation.method(#getReleaseAsset, [slug, release],
+                  {#assetId: assetId})))) as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i6.Future<_i4.ReleaseAsset> editReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? assetToEdit,
+  _i6.Future<_i4.ReleaseAsset> editReleaseAsset(
+          _i4.RepositorySlug? slug, _i4.ReleaseAsset? assetToEdit,
           {String? name, String? label}) =>
       (super.noSuchMethod(Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}),
-              returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
-                  this, Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}))))
-          as _i6.Future<_i4.ReleaseAsset>);
+          returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
+              this,
+              Invocation.method(#editReleaseAsset, [slug, assetToEdit],
+                  {#name: name, #label: label})))) as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i6.Future<bool> deleteReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? asset) =>
+  _i6.Future<bool> deleteReleaseAsset(
+          _i4.RepositorySlug? slug, _i4.ReleaseAsset? asset) =>
       (super.noSuchMethod(Invocation.method(#deleteReleaseAsset, [slug, asset]),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Future<List<_i4.ReleaseAsset>> uploadReleaseAssets(
-          _i4.Release? release, Iterable<_i4.CreateReleaseAsset>? createReleaseAssets) =>
-      (super.noSuchMethod(Invocation.method(#uploadReleaseAssets, [release, createReleaseAssets]),
-              returnValue: _i6.Future<List<_i4.ReleaseAsset>>.value(<_i4.ReleaseAsset>[]))
-          as _i6.Future<List<_i4.ReleaseAsset>>);
+  _i6.Future<List<_i4.ReleaseAsset>> uploadReleaseAssets(_i4.Release? release,
+          Iterable<_i4.CreateReleaseAsset>? createReleaseAssets) =>
+      (super.noSuchMethod(
+          Invocation.method(
+              #uploadReleaseAssets, [release, createReleaseAssets]),
+          returnValue: _i6.Future<List<_i4.ReleaseAsset>>.value(
+              <_i4.ReleaseAsset>[])) as _i6.Future<List<_i4.ReleaseAsset>>);
   @override
-  _i6.Future<List<_i4.ContributorStatistics>> listContributorStats(_i4.RepositorySlug? slug) =>
+  _i6.Future<List<_i4.ContributorStatistics>> listContributorStats(
+          _i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listContributorStats, [slug]),
-              returnValue: _i6.Future<List<_i4.ContributorStatistics>>.value(<_i4.ContributorStatistics>[]))
+              returnValue: _i6.Future<List<_i4.ContributorStatistics>>.value(
+                  <_i4.ContributorStatistics>[]))
           as _i6.Future<List<_i4.ContributorStatistics>>);
   @override
-  _i6.Stream<_i4.YearCommitCountWeek> listCommitActivity(_i4.RepositorySlug? slug) =>
+  _i6.Stream<_i4.YearCommitCountWeek> listCommitActivity(
+          _i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCommitActivity, [slug]),
-          returnValue: _i6.Stream<_i4.YearCommitCountWeek>.empty()) as _i6.Stream<_i4.YearCommitCountWeek>);
+              returnValue: _i6.Stream<_i4.YearCommitCountWeek>.empty())
+          as _i6.Stream<_i4.YearCommitCountWeek>);
   @override
-  _i6.Stream<_i4.WeeklyChangesCount> listCodeFrequency(_i4.RepositorySlug? slug) =>
+  _i6.Stream<_i4.WeeklyChangesCount> listCodeFrequency(
+          _i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCodeFrequency, [slug]),
-          returnValue: _i6.Stream<_i4.WeeklyChangesCount>.empty()) as _i6.Stream<_i4.WeeklyChangesCount>);
+              returnValue: _i6.Stream<_i4.WeeklyChangesCount>.empty())
+          as _i6.Stream<_i4.WeeklyChangesCount>);
   @override
-  _i6.Future<_i4.ContributorParticipation> getParticipation(_i4.RepositorySlug? slug) =>
+  _i6.Future<_i4.ContributorParticipation> getParticipation(
+          _i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getParticipation, [slug]),
               returnValue: _i6.Future<_i4.ContributorParticipation>.value(
-                  _FakeContributorParticipation_37(this, Invocation.method(#getParticipation, [slug]))))
+                  _FakeContributorParticipation_37(
+                      this, Invocation.method(#getParticipation, [slug]))))
           as _i6.Future<_i4.ContributorParticipation>);
   @override
-  _i6.Stream<_i4.PunchcardEntry> listPunchcard(_i4.RepositorySlug? slug) => (super
-          .noSuchMethod(Invocation.method(#listPunchcard, [slug]), returnValue: _i6.Stream<_i4.PunchcardEntry>.empty())
-      as _i6.Stream<_i4.PunchcardEntry>);
+  _i6.Stream<_i4.PunchcardEntry> listPunchcard(_i4.RepositorySlug? slug) =>
+      (super.noSuchMethod(Invocation.method(#listPunchcard, [slug]),
+              returnValue: _i6.Stream<_i4.PunchcardEntry>.empty())
+          as _i6.Stream<_i4.PunchcardEntry>);
   @override
-  _i6.Stream<_i4.RepositoryStatus> listStatuses(_i4.RepositorySlug? slug, String? ref) =>
+  _i6.Stream<_i4.RepositoryStatus> listStatuses(
+          _i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#listStatuses, [slug, ref]),
-          returnValue: _i6.Stream<_i4.RepositoryStatus>.empty()) as _i6.Stream<_i4.RepositoryStatus>);
+              returnValue: _i6.Stream<_i4.RepositoryStatus>.empty())
+          as _i6.Stream<_i4.RepositoryStatus>);
   @override
-  _i6.Future<_i4.RepositoryStatus> createStatus(_i4.RepositorySlug? slug, String? ref, _i4.CreateStatus? request) =>
-      (super.noSuchMethod(Invocation.method(#createStatus, [slug, ref, request]),
+  _i6.Future<_i4.RepositoryStatus> createStatus(
+          _i4.RepositorySlug? slug, String? ref, _i4.CreateStatus? request) =>
+      (super.noSuchMethod(
+              Invocation.method(#createStatus, [slug, ref, request]),
               returnValue: _i6.Future<_i4.RepositoryStatus>.value(
-                  _FakeRepositoryStatus_38(this, Invocation.method(#createStatus, [slug, ref, request]))))
+                  _FakeRepositoryStatus_38(this,
+                      Invocation.method(#createStatus, [slug, ref, request]))))
           as _i6.Future<_i4.RepositoryStatus>);
   @override
-  _i6.Future<_i4.CombinedRepositoryStatus> getCombinedStatus(_i4.RepositorySlug? slug, String? ref) =>
+  _i6.Future<_i4.CombinedRepositoryStatus> getCombinedStatus(
+          _i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#getCombinedStatus, [slug, ref]),
               returnValue: _i6.Future<_i4.CombinedRepositoryStatus>.value(
-                  _FakeCombinedRepositoryStatus_39(this, Invocation.method(#getCombinedStatus, [slug, ref]))))
+                  _FakeCombinedRepositoryStatus_39(this,
+                      Invocation.method(#getCombinedStatus, [slug, ref]))))
           as _i6.Future<_i4.CombinedRepositoryStatus>);
   @override
-  _i6.Future<_i4.ReleaseNotes> generateReleaseNotes(_i4.CreateReleaseNotes? crn) =>
+  _i6.Future<_i4.ReleaseNotes> generateReleaseNotes(
+          _i4.CreateReleaseNotes? crn) =>
       (super.noSuchMethod(Invocation.method(#generateReleaseNotes, [crn]),
-              returnValue: _i6.Future<_i4.ReleaseNotes>.value(
-                  _FakeReleaseNotes_40(this, Invocation.method(#generateReleaseNotes, [crn]))))
-          as _i6.Future<_i4.ReleaseNotes>);
+          returnValue: _i6.Future<_i4.ReleaseNotes>.value(_FakeReleaseNotes_40(
+              this, Invocation.method(#generateReleaseNotes, [crn])))) as _i6
+          .Future<_i4.ReleaseNotes>);
 }
 
 /// A class which mocks [GitHubComparison].
@@ -969,7 +1247,8 @@ class MockGitHubComparison extends _i1.Mock implements _i4.GitHubComparison {
 
   @override
   Map<String, dynamic> toJson() =>
-      (super.noSuchMethod(Invocation.method(#toJson, []), returnValue: <String, dynamic>{}) as Map<String, dynamic>);
+      (super.noSuchMethod(Invocation.method(#toJson, []),
+          returnValue: <String, dynamic>{}) as Map<String, dynamic>);
 }
 
 /// A class which mocks [Response].
@@ -982,17 +1261,25 @@ class MockResponse extends _i1.Mock implements _i3.Response {
 
   @override
   _i8.Uint8List get bodyBytes =>
-      (super.noSuchMethod(Invocation.getter(#bodyBytes), returnValue: _i8.Uint8List(0)) as _i8.Uint8List);
+      (super.noSuchMethod(Invocation.getter(#bodyBytes),
+          returnValue: _i8.Uint8List(0)) as _i8.Uint8List);
   @override
-  String get body => (super.noSuchMethod(Invocation.getter(#body), returnValue: '') as String);
+  String get body =>
+      (super.noSuchMethod(Invocation.getter(#body), returnValue: '') as String);
   @override
-  int get statusCode => (super.noSuchMethod(Invocation.getter(#statusCode), returnValue: 0) as int);
+  int get statusCode =>
+      (super.noSuchMethod(Invocation.getter(#statusCode), returnValue: 0)
+          as int);
   @override
   Map<String, String> get headers =>
-      (super.noSuchMethod(Invocation.getter(#headers), returnValue: <String, String>{}) as Map<String, String>);
+      (super.noSuchMethod(Invocation.getter(#headers),
+          returnValue: <String, String>{}) as Map<String, String>);
   @override
-  bool get isRedirect => (super.noSuchMethod(Invocation.getter(#isRedirect), returnValue: false) as bool);
+  bool get isRedirect =>
+      (super.noSuchMethod(Invocation.getter(#isRedirect), returnValue: false)
+          as bool);
   @override
   bool get persistentConnection =>
-      (super.noSuchMethod(Invocation.getter(#persistentConnection), returnValue: false) as bool);
+      (super.noSuchMethod(Invocation.getter(#persistentConnection),
+          returnValue: false) as bool);
 }

--- a/auto_submit/test/utilities/mocks.mocks.dart
+++ b/auto_submit/test/utilities/mocks.mocks.dart
@@ -25,227 +25,167 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: subtype_of_sealed_class
 
 class _FakeConfig_0 extends _i1.SmartFake implements _i2.Config {
-  _FakeConfig_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeConfig_0(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeClient_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeActivityService_2 extends _i1.SmartFake
-    implements _i4.ActivityService {
-  _FakeActivityService_2(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeActivityService_2 extends _i1.SmartFake implements _i4.ActivityService {
+  _FakeActivityService_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeAuthorizationsService_3 extends _i1.SmartFake
-    implements _i4.AuthorizationsService {
-  _FakeAuthorizationsService_3(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeAuthorizationsService_3 extends _i1.SmartFake implements _i4.AuthorizationsService {
+  _FakeAuthorizationsService_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeGistsService_4 extends _i1.SmartFake implements _i4.GistsService {
-  _FakeGistsService_4(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGistsService_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeGitService_5 extends _i1.SmartFake implements _i4.GitService {
-  _FakeGitService_5(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGitService_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeIssuesService_6 extends _i1.SmartFake implements _i4.IssuesService {
-  _FakeIssuesService_6(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeIssuesService_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeMiscService_7 extends _i1.SmartFake implements _i4.MiscService {
-  _FakeMiscService_7(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeMiscService_7(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeOrganizationsService_8 extends _i1.SmartFake
-    implements _i4.OrganizationsService {
-  _FakeOrganizationsService_8(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeOrganizationsService_8 extends _i1.SmartFake implements _i4.OrganizationsService {
+  _FakeOrganizationsService_8(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePullRequestsService_9 extends _i1.SmartFake
-    implements _i4.PullRequestsService {
-  _FakePullRequestsService_9(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakePullRequestsService_9 extends _i1.SmartFake implements _i4.PullRequestsService {
+  _FakePullRequestsService_9(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeRepositoriesService_10 extends _i1.SmartFake
-    implements _i4.RepositoriesService {
-  _FakeRepositoriesService_10(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeRepositoriesService_10 extends _i1.SmartFake implements _i4.RepositoriesService {
+  _FakeRepositoriesService_10(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeSearchService_11 extends _i1.SmartFake implements _i4.SearchService {
-  _FakeSearchService_11(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSearchService_11(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeUrlShortenerService_12 extends _i1.SmartFake
-    implements _i4.UrlShortenerService {
-  _FakeUrlShortenerService_12(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeUrlShortenerService_12 extends _i1.SmartFake implements _i4.UrlShortenerService {
+  _FakeUrlShortenerService_12(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeUsersService_13 extends _i1.SmartFake implements _i4.UsersService {
-  _FakeUsersService_13(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeUsersService_13(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeChecksService_14 extends _i1.SmartFake implements _i4.ChecksService {
-  _FakeChecksService_14(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeChecksService_14(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeResponse_15 extends _i1.SmartFake implements _i3.Response {
-  _FakeResponse_15(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeResponse_15(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeGitHub_16 extends _i1.SmartFake implements _i4.GitHub {
-  _FakeGitHub_16(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGitHub_16(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakePullRequest_17 extends _i1.SmartFake implements _i4.PullRequest {
-  _FakePullRequest_17(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakePullRequest_17(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePullRequestMerge_18 extends _i1.SmartFake
-    implements _i4.PullRequestMerge {
-  _FakePullRequestMerge_18(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakePullRequestMerge_18 extends _i1.SmartFake implements _i4.PullRequestMerge {
+  _FakePullRequestMerge_18(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePullRequestComment_19 extends _i1.SmartFake
-    implements _i4.PullRequestComment {
-  _FakePullRequestComment_19(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakePullRequestComment_19 extends _i1.SmartFake implements _i4.PullRequestComment {
+  _FakePullRequestComment_19(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePullRequestReview_20 extends _i1.SmartFake
-    implements _i4.PullRequestReview {
-  _FakePullRequestReview_20(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakePullRequestReview_20 extends _i1.SmartFake implements _i4.PullRequestReview {
+  _FakePullRequestReview_20(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeRepository_21 extends _i1.SmartFake implements _i4.Repository {
-  _FakeRepository_21(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeRepository_21(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeLicenseDetails_22 extends _i1.SmartFake
-    implements _i4.LicenseDetails {
-  _FakeLicenseDetails_22(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeLicenseDetails_22 extends _i1.SmartFake implements _i4.LicenseDetails {
+  _FakeLicenseDetails_22(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeLanguageBreakdown_23 extends _i1.SmartFake
-    implements _i4.LanguageBreakdown {
-  _FakeLanguageBreakdown_23(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeLanguageBreakdown_23 extends _i1.SmartFake implements _i4.LanguageBreakdown {
+  _FakeLanguageBreakdown_23(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeBranch_24 extends _i1.SmartFake implements _i4.Branch {
-  _FakeBranch_24(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeBranch_24(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeCommitComment_25 extends _i1.SmartFake implements _i4.CommitComment {
-  _FakeCommitComment_25(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeCommitComment_25(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryCommit_26 extends _i1.SmartFake
-    implements _i4.RepositoryCommit {
-  _FakeRepositoryCommit_26(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeRepositoryCommit_26 extends _i1.SmartFake implements _i4.RepositoryCommit {
+  _FakeRepositoryCommit_26(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeGitHubComparison_27 extends _i1.SmartFake
-    implements _i4.GitHubComparison {
-  _FakeGitHubComparison_27(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeGitHubComparison_27 extends _i1.SmartFake implements _i4.GitHubComparison {
+  _FakeGitHubComparison_27(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeGitHubFile_28 extends _i1.SmartFake implements _i4.GitHubFile {
-  _FakeGitHubFile_28(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeGitHubFile_28(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryContents_29 extends _i1.SmartFake
-    implements _i4.RepositoryContents {
-  _FakeRepositoryContents_29(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeRepositoryContents_29 extends _i1.SmartFake implements _i4.RepositoryContents {
+  _FakeRepositoryContents_29(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeContentCreation_30 extends _i1.SmartFake
-    implements _i4.ContentCreation {
-  _FakeContentCreation_30(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeContentCreation_30 extends _i1.SmartFake implements _i4.ContentCreation {
+  _FakeContentCreation_30(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeHook_31 extends _i1.SmartFake implements _i4.Hook {
-  _FakeHook_31(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeHook_31(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakePublicKey_32 extends _i1.SmartFake implements _i4.PublicKey {
-  _FakePublicKey_32(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakePublicKey_32(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryPages_33 extends _i1.SmartFake
-    implements _i4.RepositoryPages {
-  _FakeRepositoryPages_33(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeRepositoryPages_33 extends _i1.SmartFake implements _i4.RepositoryPages {
+  _FakeRepositoryPages_33(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakePageBuild_34 extends _i1.SmartFake implements _i4.PageBuild {
-  _FakePageBuild_34(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakePageBuild_34(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeRelease_35 extends _i1.SmartFake implements _i4.Release {
-  _FakeRelease_35(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeRelease_35(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeReleaseAsset_36 extends _i1.SmartFake implements _i4.ReleaseAsset {
-  _FakeReleaseAsset_36(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeReleaseAsset_36(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeContributorParticipation_37 extends _i1.SmartFake
-    implements _i4.ContributorParticipation {
-  _FakeContributorParticipation_37(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeContributorParticipation_37 extends _i1.SmartFake implements _i4.ContributorParticipation {
+  _FakeContributorParticipation_37(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeRepositoryStatus_38 extends _i1.SmartFake
-    implements _i4.RepositoryStatus {
-  _FakeRepositoryStatus_38(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeRepositoryStatus_38 extends _i1.SmartFake implements _i4.RepositoryStatus {
+  _FakeRepositoryStatus_38(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeCombinedRepositoryStatus_39 extends _i1.SmartFake
-    implements _i4.CombinedRepositoryStatus {
-  _FakeCombinedRepositoryStatus_39(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+class _FakeCombinedRepositoryStatus_39 extends _i1.SmartFake implements _i4.CombinedRepositoryStatus {
+  _FakeCombinedRepositoryStatus_39(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 class _FakeReleaseNotes_40 extends _i1.SmartFake implements _i4.ReleaseNotes {
-  _FakeReleaseNotes_40(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeReleaseNotes_40(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 /// A class which mocks [ApproverService].
@@ -257,23 +197,19 @@ class MockApproverService extends _i1.Mock implements _i5.ApproverService {
   }
 
   @override
-  _i2.Config get config => (super.noSuchMethod(Invocation.getter(#config),
-          returnValue: _FakeConfig_0(this, Invocation.getter(#config)))
-      as _i2.Config);
+  _i2.Config get config =>
+      (super.noSuchMethod(Invocation.getter(#config), returnValue: _FakeConfig_0(this, Invocation.getter(#config)))
+          as _i2.Config);
   @override
   _i6.Future<void> autoApproval(_i4.PullRequest? pullRequest) =>
       (super.noSuchMethod(Invocation.method(#autoApproval, [pullRequest]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+          returnValue: _i6.Future<void>.value(),
+          returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
   @override
-  _i6.Future<void> revertApproval(
-          _i7.QueryResult? queryResult, _i4.PullRequest? pullRequest) =>
-      (super.noSuchMethod(
-              Invocation.method(#revertApproval, [queryResult, pullRequest]),
-              returnValue: _i6.Future<void>.value(),
-              returnValueForMissingStub: _i6.Future<void>.value())
-          as _i6.Future<void>);
+  _i6.Future<void> revertApproval(_i7.QueryResult? queryResult, _i4.PullRequest? pullRequest) =>
+      (super.noSuchMethod(Invocation.method(#revertApproval, [queryResult, pullRequest]),
+          returnValue: _i6.Future<void>.value(),
+          returnValueForMissingStub: _i6.Future<void>.value()) as _i6.Future<void>);
 }
 
 /// A class which mocks [GitHub].
@@ -286,80 +222,57 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
 
   @override
   set auth(_i4.Authentication? _auth) =>
-      super.noSuchMethod(Invocation.setter(#auth, _auth),
-          returnValueForMissingStub: null);
+      super.noSuchMethod(Invocation.setter(#auth, _auth), returnValueForMissingStub: null);
   @override
-  String get endpoint =>
-      (super.noSuchMethod(Invocation.getter(#endpoint), returnValue: '')
-          as String);
+  String get endpoint => (super.noSuchMethod(Invocation.getter(#endpoint), returnValue: '') as String);
   @override
-  _i3.Client get client => (super.noSuchMethod(Invocation.getter(#client),
-          returnValue: _FakeClient_1(this, Invocation.getter(#client)))
-      as _i3.Client);
+  _i3.Client get client =>
+      (super.noSuchMethod(Invocation.getter(#client), returnValue: _FakeClient_1(this, Invocation.getter(#client)))
+          as _i3.Client);
   @override
-  _i4.ActivityService get activity =>
-      (super.noSuchMethod(Invocation.getter(#activity),
-              returnValue:
-                  _FakeActivityService_2(this, Invocation.getter(#activity)))
-          as _i4.ActivityService);
+  _i4.ActivityService get activity => (super.noSuchMethod(Invocation.getter(#activity),
+      returnValue: _FakeActivityService_2(this, Invocation.getter(#activity))) as _i4.ActivityService);
   @override
-  _i4.AuthorizationsService get authorizations =>
-      (super.noSuchMethod(Invocation.getter(#authorizations),
-              returnValue: _FakeAuthorizationsService_3(
-                  this, Invocation.getter(#authorizations)))
-          as _i4.AuthorizationsService);
+  _i4.AuthorizationsService get authorizations => (super.noSuchMethod(Invocation.getter(#authorizations),
+          returnValue: _FakeAuthorizationsService_3(this, Invocation.getter(#authorizations)))
+      as _i4.AuthorizationsService);
   @override
-  _i4.GistsService get gists => (super.noSuchMethod(Invocation.getter(#gists),
-          returnValue: _FakeGistsService_4(this, Invocation.getter(#gists)))
-      as _i4.GistsService);
+  _i4.GistsService get gists =>
+      (super.noSuchMethod(Invocation.getter(#gists), returnValue: _FakeGistsService_4(this, Invocation.getter(#gists)))
+          as _i4.GistsService);
   @override
-  _i4.GitService get git => (super.noSuchMethod(Invocation.getter(#git),
-          returnValue: _FakeGitService_5(this, Invocation.getter(#git)))
-      as _i4.GitService);
+  _i4.GitService get git =>
+      (super.noSuchMethod(Invocation.getter(#git), returnValue: _FakeGitService_5(this, Invocation.getter(#git)))
+          as _i4.GitService);
   @override
-  _i4.IssuesService get issues => (super.noSuchMethod(
-          Invocation.getter(#issues),
-          returnValue: _FakeIssuesService_6(this, Invocation.getter(#issues)))
-      as _i4.IssuesService);
+  _i4.IssuesService get issues => (super.noSuchMethod(Invocation.getter(#issues),
+      returnValue: _FakeIssuesService_6(this, Invocation.getter(#issues))) as _i4.IssuesService);
   @override
-  _i4.MiscService get misc => (super.noSuchMethod(Invocation.getter(#misc),
-          returnValue: _FakeMiscService_7(this, Invocation.getter(#misc)))
-      as _i4.MiscService);
+  _i4.MiscService get misc =>
+      (super.noSuchMethod(Invocation.getter(#misc), returnValue: _FakeMiscService_7(this, Invocation.getter(#misc)))
+          as _i4.MiscService);
   @override
-  _i4.OrganizationsService get organizations =>
-      (super.noSuchMethod(Invocation.getter(#organizations),
-              returnValue: _FakeOrganizationsService_8(
-                  this, Invocation.getter(#organizations)))
-          as _i4.OrganizationsService);
+  _i4.OrganizationsService get organizations => (super.noSuchMethod(Invocation.getter(#organizations),
+      returnValue: _FakeOrganizationsService_8(this, Invocation.getter(#organizations))) as _i4.OrganizationsService);
   @override
-  _i4.PullRequestsService get pullRequests => (super.noSuchMethod(
-      Invocation.getter(#pullRequests),
-      returnValue: _FakePullRequestsService_9(
-          this, Invocation.getter(#pullRequests))) as _i4.PullRequestsService);
+  _i4.PullRequestsService get pullRequests => (super.noSuchMethod(Invocation.getter(#pullRequests),
+      returnValue: _FakePullRequestsService_9(this, Invocation.getter(#pullRequests))) as _i4.PullRequestsService);
   @override
-  _i4.RepositoriesService get repositories => (super.noSuchMethod(
-      Invocation.getter(#repositories),
-      returnValue: _FakeRepositoriesService_10(
-          this, Invocation.getter(#repositories))) as _i4.RepositoriesService);
+  _i4.RepositoriesService get repositories => (super.noSuchMethod(Invocation.getter(#repositories),
+      returnValue: _FakeRepositoriesService_10(this, Invocation.getter(#repositories))) as _i4.RepositoriesService);
   @override
-  _i4.SearchService get search => (super.noSuchMethod(
-          Invocation.getter(#search),
-          returnValue: _FakeSearchService_11(this, Invocation.getter(#search)))
-      as _i4.SearchService);
+  _i4.SearchService get search => (super.noSuchMethod(Invocation.getter(#search),
+      returnValue: _FakeSearchService_11(this, Invocation.getter(#search))) as _i4.SearchService);
   @override
-  _i4.UrlShortenerService get urlShortener => (super.noSuchMethod(
-      Invocation.getter(#urlShortener),
-      returnValue: _FakeUrlShortenerService_12(
-          this, Invocation.getter(#urlShortener))) as _i4.UrlShortenerService);
+  _i4.UrlShortenerService get urlShortener => (super.noSuchMethod(Invocation.getter(#urlShortener),
+      returnValue: _FakeUrlShortenerService_12(this, Invocation.getter(#urlShortener))) as _i4.UrlShortenerService);
   @override
-  _i4.UsersService get users => (super.noSuchMethod(Invocation.getter(#users),
-          returnValue: _FakeUsersService_13(this, Invocation.getter(#users)))
-      as _i4.UsersService);
+  _i4.UsersService get users =>
+      (super.noSuchMethod(Invocation.getter(#users), returnValue: _FakeUsersService_13(this, Invocation.getter(#users)))
+          as _i4.UsersService);
   @override
-  _i4.ChecksService get checks => (super.noSuchMethod(
-          Invocation.getter(#checks),
-          returnValue: _FakeChecksService_14(this, Invocation.getter(#checks)))
-      as _i4.ChecksService);
+  _i4.ChecksService get checks => (super.noSuchMethod(Invocation.getter(#checks),
+      returnValue: _FakeChecksService_14(this, Invocation.getter(#checks))) as _i4.ChecksService);
   @override
   _i6.Future<T> getJSON<S, T>(String? path,
           {int? statusCode,
@@ -477,18 +390,7 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
           int? statusCode,
           void Function(_i3.Response)? fail,
           String? preview}) =>
-      (super.noSuchMethod(
-          Invocation.method(#request, [
-            method,
-            path
-          ], {
-            #headers: headers,
-            #params: params,
-            #body: body,
-            #statusCode: statusCode,
-            #fail: fail,
-            #preview: preview
-          }),
+      (super.noSuchMethod(Invocation.method(#request, [method, path], {#headers: headers, #params: params, #body: body, #statusCode: statusCode, #fail: fail, #preview: preview}),
           returnValue: _i6.Future<_i3.Response>.value(_FakeResponse_15(
               this,
               Invocation.method(#request, [
@@ -504,26 +406,23 @@ class MockGitHub extends _i1.Mock implements _i4.GitHub {
               })))) as _i6.Future<_i3.Response>);
   @override
   void handleStatusCode(_i3.Response? response) =>
-      super.noSuchMethod(Invocation.method(#handleStatusCode, [response]),
-          returnValueForMissingStub: null);
+      super.noSuchMethod(Invocation.method(#handleStatusCode, [response]), returnValueForMissingStub: null);
   @override
-  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []),
-      returnValueForMissingStub: null);
+  void dispose() => super.noSuchMethod(Invocation.method(#dispose, []), returnValueForMissingStub: null);
 }
 
 /// A class which mocks [PullRequestsService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock
-    implements _i4.PullRequestsService {
+class MockPullRequestsService extends _i1.Mock implements _i4.PullRequestsService {
   MockPullRequestsService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.GitHub get github => (super.noSuchMethod(Invocation.getter(#github),
-          returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
-      as _i4.GitHub);
+  _i4.GitHub get github =>
+      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
+          as _i4.GitHub);
   @override
   _i6.Stream<_i4.PullRequest> list(_i4.RepositorySlug? slug,
           {int? pages,
@@ -533,188 +432,125 @@ class MockPullRequestsService extends _i1.Mock
           String? sort = r'created',
           String? state = r'open'}) =>
       (super.noSuchMethod(
-              Invocation.method(#list, [
-                slug
-              ], {
-                #pages: pages,
-                #base: base,
-                #direction: direction,
-                #head: head,
-                #sort: sort,
-                #state: state
-              }),
-              returnValue: _i6.Stream<_i4.PullRequest>.empty())
-          as _i6.Stream<_i4.PullRequest>);
+          Invocation.method(#list, [slug],
+              {#pages: pages, #base: base, #direction: direction, #head: head, #sort: sort, #state: state}),
+          returnValue: _i6.Stream<_i4.PullRequest>.empty()) as _i6.Stream<_i4.PullRequest>);
   @override
   _i6.Future<_i4.PullRequest> get(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#get, [slug, number]),
-          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
-              this, Invocation.method(#get, [slug, number])))) as _i6
-          .Future<_i4.PullRequest>);
+              returnValue:
+                  _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this, Invocation.method(#get, [slug, number]))))
+          as _i6.Future<_i4.PullRequest>);
   @override
-  _i6.Future<_i4.PullRequest> create(
-          _i4.RepositorySlug? slug, _i4.CreatePullRequest? request) =>
-      (super.noSuchMethod(Invocation.method(#create, [slug, request]),
-          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
-              this, Invocation.method(#create, [slug, request])))) as _i6
-          .Future<_i4.PullRequest>);
+  _i6.Future<_i4.PullRequest> create(_i4.RepositorySlug? slug, _i4.CreatePullRequest? request) => (super.noSuchMethod(
+          Invocation.method(#create, [slug, request]),
+          returnValue:
+              _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this, Invocation.method(#create, [slug, request]))))
+      as _i6.Future<_i4.PullRequest>);
   @override
   _i6.Future<_i4.PullRequest> edit(_i4.RepositorySlug? slug, int? number,
           {String? title, String? body, String? state, String? base}) =>
-      (super.noSuchMethod(Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
-          returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(
-              this,
-              Invocation.method(#edit, [
-                slug,
-                number
-              ], {
-                #title: title,
-                #body: body,
-                #state: state,
-                #base: base
-              })))) as _i6.Future<_i4.PullRequest>);
+      (super.noSuchMethod(
+              Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}),
+              returnValue: _i6.Future<_i4.PullRequest>.value(_FakePullRequest_17(this,
+                  Invocation.method(#edit, [slug, number], {#title: title, #body: body, #state: state, #base: base}))))
+          as _i6.Future<_i4.PullRequest>);
   @override
-  _i6.Stream<_i4.RepositoryCommit> listCommits(
-          _i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listCommits, [slug, number]),
-              returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
-          as _i6.Stream<_i4.RepositoryCommit>);
+          returnValue: _i6.Stream<_i4.RepositoryCommit>.empty()) as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i6.Stream<_i4.PullRequestFile> listFiles(
-          _i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestFile> listFiles(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listFiles, [slug, number]),
-              returnValue: _i6.Stream<_i4.PullRequestFile>.empty())
-          as _i6.Stream<_i4.PullRequestFile>);
+          returnValue: _i6.Stream<_i4.PullRequestFile>.empty()) as _i6.Stream<_i4.PullRequestFile>);
   @override
-  _i6.Stream<_i4.PullRequestReview> listReviews(
-          _i4.RepositorySlug? slug, int? number) =>
+  _i6.Stream<_i4.PullRequestReview> listReviews(_i4.RepositorySlug? slug, int? number) =>
       (super.noSuchMethod(Invocation.method(#listReviews, [slug, number]),
-              returnValue: _i6.Stream<_i4.PullRequestReview>.empty())
-          as _i6.Stream<_i4.PullRequestReview>);
+          returnValue: _i6.Stream<_i4.PullRequestReview>.empty()) as _i6.Stream<_i4.PullRequestReview>);
   @override
   _i6.Future<bool> isMerged(_i4.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#isMerged, [slug, number]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
-  _i6.Future<_i4.PullRequestMerge> merge(_i4.RepositorySlug? slug, int? number,
-          {String? message}) =>
-      (super.noSuchMethod(
-              Invocation.method(#merge, [slug, number], {#message: message}),
+  _i6.Future<_i4.PullRequestMerge> merge(_i4.RepositorySlug? slug, int? number, {String? message}) =>
+      (super.noSuchMethod(Invocation.method(#merge, [slug, number], {#message: message}),
               returnValue: _i6.Future<_i4.PullRequestMerge>.value(
-                  _FakePullRequestMerge_18(
-                      this,
-                      Invocation.method(
-                          #merge, [slug, number], {#message: message}))))
+                  _FakePullRequestMerge_18(this, Invocation.method(#merge, [slug, number], {#message: message}))))
           as _i6.Future<_i4.PullRequestMerge>);
   @override
-  _i6.Stream<_i4.PullRequestComment> listCommentsByPullRequest(
-          _i4.RepositorySlug? slug, int? number) =>
-      (super.noSuchMethod(
-              Invocation.method(#listCommentsByPullRequest, [slug, number]),
-              returnValue: _i6.Stream<_i4.PullRequestComment>.empty())
-          as _i6.Stream<_i4.PullRequestComment>);
+  _i6.Stream<_i4.PullRequestComment> listCommentsByPullRequest(_i4.RepositorySlug? slug, int? number) =>
+      (super.noSuchMethod(Invocation.method(#listCommentsByPullRequest, [slug, number]),
+          returnValue: _i6.Stream<_i4.PullRequestComment>.empty()) as _i6.Stream<_i4.PullRequestComment>);
   @override
   _i6.Stream<_i4.PullRequestComment> listComments(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listComments, [slug]),
-              returnValue: _i6.Stream<_i4.PullRequestComment>.empty())
-          as _i6.Stream<_i4.PullRequestComment>);
+          returnValue: _i6.Stream<_i4.PullRequestComment>.empty()) as _i6.Stream<_i4.PullRequestComment>);
   @override
-  _i6.Future<_i4.PullRequestComment> createComment(_i4.RepositorySlug? slug,
-          int? number, _i4.CreatePullRequestComment? comment) =>
-      (super.noSuchMethod(
-              Invocation.method(#createComment, [slug, number, comment]),
+  _i6.Future<_i4.PullRequestComment> createComment(
+          _i4.RepositorySlug? slug, int? number, _i4.CreatePullRequestComment? comment) =>
+      (super.noSuchMethod(Invocation.method(#createComment, [slug, number, comment]),
               returnValue: _i6.Future<_i4.PullRequestComment>.value(
-                  _FakePullRequestComment_19(
-                      this,
-                      Invocation.method(
-                          #createComment, [slug, number, comment]))))
+                  _FakePullRequestComment_19(this, Invocation.method(#createComment, [slug, number, comment]))))
           as _i6.Future<_i4.PullRequestComment>);
   @override
-  _i6.Future<_i4.PullRequestReview> createReview(
-          _i4.RepositorySlug? slug, _i4.CreatePullRequestReview? review) =>
+  _i6.Future<_i4.PullRequestReview> createReview(_i4.RepositorySlug? slug, _i4.CreatePullRequestReview? review) =>
       (super.noSuchMethod(Invocation.method(#createReview, [slug, review]),
               returnValue: _i6.Future<_i4.PullRequestReview>.value(
-                  _FakePullRequestReview_20(
-                      this, Invocation.method(#createReview, [slug, review]))))
+                  _FakePullRequestReview_20(this, Invocation.method(#createReview, [slug, review]))))
           as _i6.Future<_i4.PullRequestReview>);
 }
 
 /// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRepositoriesService extends _i1.Mock
-    implements _i4.RepositoriesService {
+class MockRepositoriesService extends _i1.Mock implements _i4.RepositoriesService {
   MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.GitHub get github => (super.noSuchMethod(Invocation.getter(#github),
-          returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
-      as _i4.GitHub);
+  _i4.GitHub get github =>
+      (super.noSuchMethod(Invocation.getter(#github), returnValue: _FakeGitHub_16(this, Invocation.getter(#github)))
+          as _i4.GitHub);
   @override
   _i6.Stream<_i4.Repository> listRepositories(
-          {String? type = r'owner',
-          String? sort = r'full_name',
-          String? direction = r'asc'}) =>
-      (super.noSuchMethod(
-              Invocation.method(#listRepositories, [],
-                  {#type: type, #sort: sort, #direction: direction}),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
-          as _i6.Stream<_i4.Repository>);
+          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
+      (super.noSuchMethod(Invocation.method(#listRepositories, [], {#type: type, #sort: sort, #direction: direction}),
+          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
   _i6.Stream<_i4.Repository> listUserRepositories(String? user,
-          {String? type = r'owner',
-          String? sort = r'full_name',
-          String? direction = r'asc'}) =>
+          {String? type = r'owner', String? sort = r'full_name', String? direction = r'asc'}) =>
       (super.noSuchMethod(
-              Invocation.method(#listUserRepositories, [user],
-                  {#type: type, #sort: sort, #direction: direction}),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
-          as _i6.Stream<_i4.Repository>);
+          Invocation.method(#listUserRepositories, [user], {#type: type, #sort: sort, #direction: direction}),
+          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Stream<_i4.Repository> listOrganizationRepositories(String? org,
-          {String? type = r'all'}) =>
-      (super.noSuchMethod(
-              Invocation.method(
-                  #listOrganizationRepositories, [org], {#type: type}),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
-          as _i6.Stream<_i4.Repository>);
+  _i6.Stream<_i4.Repository> listOrganizationRepositories(String? org, {String? type = r'all'}) =>
+      (super.noSuchMethod(Invocation.method(#listOrganizationRepositories, [org], {#type: type}),
+          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Stream<_i4.Repository> listPublicRepositories(
-          {int? limit = 50, DateTime? since}) =>
-      (super.noSuchMethod(
-              Invocation.method(
-                  #listPublicRepositories, [], {#limit: limit, #since: since}),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
-          as _i6.Stream<_i4.Repository>);
+  _i6.Stream<_i4.Repository> listPublicRepositories({int? limit = 50, DateTime? since}) =>
+      (super.noSuchMethod(Invocation.method(#listPublicRepositories, [], {#limit: limit, #since: since}),
+          returnValue: _i6.Stream<_i4.Repository>.empty()) as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Future<_i4.Repository> createRepository(_i4.CreateRepository? repository,
-          {String? org}) =>
-      (super.noSuchMethod(
-              Invocation.method(#createRepository, [repository], {#org: org}),
-              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
-                  this,
-                  Invocation.method(
-                      #createRepository, [repository], {#org: org}))))
+  _i6.Future<_i4.Repository> createRepository(_i4.CreateRepository? repository, {String? org}) =>
+      (super.noSuchMethod(Invocation.method(#createRepository, [repository], {#org: org}),
+              returnValue: _i6.Future<_i4.Repository>.value(
+                  _FakeRepository_21(this, Invocation.method(#createRepository, [repository], {#org: org}))))
           as _i6.Future<_i4.Repository>);
   @override
   _i6.Future<_i4.LicenseDetails> getLicense(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLicense, [slug]),
-              returnValue: _i6.Future<_i4.LicenseDetails>.value(
-                  _FakeLicenseDetails_22(
-                      this, Invocation.method(#getLicense, [slug]))))
-          as _i6.Future<_i4.LicenseDetails>);
+          returnValue: _i6.Future<_i4.LicenseDetails>.value(
+              _FakeLicenseDetails_22(this, Invocation.method(#getLicense, [slug])))) as _i6.Future<_i4.LicenseDetails>);
   @override
   _i6.Future<_i4.Repository> getRepository(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getRepository, [slug]),
-              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
-                  this, Invocation.method(#getRepository, [slug]))))
+              returnValue:
+                  _i6.Future<_i4.Repository>.value(_FakeRepository_21(this, Invocation.method(#getRepository, [slug]))))
           as _i6.Future<_i4.Repository>);
   @override
   _i6.Stream<_i4.Repository> getRepositories(List<_i4.RepositorySlug>? slugs) =>
-      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
+      (super.noSuchMethod(Invocation.method(#getRepositories, [slugs]), returnValue: _i6.Stream<_i4.Repository>.empty())
           as _i6.Stream<_i4.Repository>);
   @override
   _i6.Future<_i4.Repository> editRepository(_i4.RepositorySlug? slug,
@@ -752,215 +588,163 @@ class MockRepositoriesService extends _i1.Mock
               })))) as _i6.Future<_i4.Repository>);
   @override
   _i6.Future<bool> deleteRepository(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#deleteRepository, [slug]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.Contributor> listContributors(_i4.RepositorySlug? slug,
-          {bool? anon = false}) =>
-      (super.noSuchMethod(
-              Invocation.method(#listContributors, [slug], {#anon: anon}),
-              returnValue: _i6.Stream<_i4.Contributor>.empty())
-          as _i6.Stream<_i4.Contributor>);
+  _i6.Stream<_i4.Contributor> listContributors(_i4.RepositorySlug? slug, {bool? anon = false}) =>
+      (super.noSuchMethod(Invocation.method(#listContributors, [slug], {#anon: anon}),
+          returnValue: _i6.Stream<_i4.Contributor>.empty()) as _i6.Stream<_i4.Contributor>);
   @override
   _i6.Stream<_i4.Team> listTeams(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listTeams, [slug]),
-          returnValue: _i6.Stream<_i4.Team>.empty()) as _i6.Stream<_i4.Team>);
+      (super.noSuchMethod(Invocation.method(#listTeams, [slug]), returnValue: _i6.Stream<_i4.Team>.empty())
+          as _i6.Stream<_i4.Team>);
   @override
   _i6.Future<_i4.LanguageBreakdown> listLanguages(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listLanguages, [slug]),
               returnValue: _i6.Future<_i4.LanguageBreakdown>.value(
-                  _FakeLanguageBreakdown_23(
-                      this, Invocation.method(#listLanguages, [slug]))))
+                  _FakeLanguageBreakdown_23(this, Invocation.method(#listLanguages, [slug]))))
           as _i6.Future<_i4.LanguageBreakdown>);
   @override
-  _i6.Stream<_i4.Tag> listTags(_i4.RepositorySlug? slug,
-          {int? page = 1, int? pages, int? perPage = 30}) =>
-      (super.noSuchMethod(
-          Invocation.method(#listTags, [slug],
-              {#page: page, #pages: pages, #perPage: perPage}),
+  _i6.Stream<_i4.Tag> listTags(_i4.RepositorySlug? slug, {int? page = 1, int? pages, int? perPage = 30}) =>
+      (super.noSuchMethod(Invocation.method(#listTags, [slug], {#page: page, #pages: pages, #perPage: perPage}),
           returnValue: _i6.Stream<_i4.Tag>.empty()) as _i6.Stream<_i4.Tag>);
   @override
   _i6.Stream<_i4.Branch> listBranches(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listBranches, [slug]),
-              returnValue: _i6.Stream<_i4.Branch>.empty())
+      (super.noSuchMethod(Invocation.method(#listBranches, [slug]), returnValue: _i6.Stream<_i4.Branch>.empty())
           as _i6.Stream<_i4.Branch>);
   @override
   _i6.Future<_i4.Branch> getBranch(_i4.RepositorySlug? slug, String? branch) =>
       (super.noSuchMethod(Invocation.method(#getBranch, [slug, branch]),
-              returnValue: _i6.Future<_i4.Branch>.value(_FakeBranch_24(
-                  this, Invocation.method(#getBranch, [slug, branch]))))
+              returnValue:
+                  _i6.Future<_i4.Branch>.value(_FakeBranch_24(this, Invocation.method(#getBranch, [slug, branch]))))
           as _i6.Future<_i4.Branch>);
   @override
   _i6.Stream<_i4.Collaborator> listCollaborators(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCollaborators, [slug]),
-              returnValue: _i6.Stream<_i4.Collaborator>.empty())
-          as _i6.Stream<_i4.Collaborator>);
+          returnValue: _i6.Stream<_i4.Collaborator>.empty()) as _i6.Stream<_i4.Collaborator>);
   @override
   _i6.Future<bool> isCollaborator(_i4.RepositorySlug? slug, String? user) =>
-      (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#isCollaborator, [slug, user]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
   _i6.Future<bool> addCollaborator(_i4.RepositorySlug? slug, String? user) =>
-      (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#addCollaborator, [slug, user]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
   _i6.Future<bool> removeCollaborator(_i4.RepositorySlug? slug, String? user) =>
       (super.noSuchMethod(Invocation.method(#removeCollaborator, [slug, user]),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.CommitComment> listSingleCommitComments(
-          _i4.RepositorySlug? slug, _i4.RepositoryCommit? commit) =>
-      (super.noSuchMethod(
-              Invocation.method(#listSingleCommitComments, [slug, commit]),
-              returnValue: _i6.Stream<_i4.CommitComment>.empty())
-          as _i6.Stream<_i4.CommitComment>);
+  _i6.Stream<_i4.CommitComment> listSingleCommitComments(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit) =>
+      (super.noSuchMethod(Invocation.method(#listSingleCommitComments, [slug, commit]),
+          returnValue: _i6.Stream<_i4.CommitComment>.empty()) as _i6.Stream<_i4.CommitComment>);
   @override
   _i6.Stream<_i4.CommitComment> listCommitComments(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCommitComments, [slug]),
-              returnValue: _i6.Stream<_i4.CommitComment>.empty())
-          as _i6.Stream<_i4.CommitComment>);
+          returnValue: _i6.Stream<_i4.CommitComment>.empty()) as _i6.Stream<_i4.CommitComment>);
   @override
-  _i6.Future<_i4.CommitComment> createCommitComment(
-          _i4.RepositorySlug? slug, _i4.RepositoryCommit? commit,
+  _i6.Future<_i4.CommitComment> createCommitComment(_i4.RepositorySlug? slug, _i4.RepositoryCommit? commit,
           {String? body, String? path, int? position, int? line}) =>
-      (super.noSuchMethod(
-              Invocation.method(#createCommitComment, [slug, commit],
-                  {#body: body, #path: path, #position: position, #line: line}),
-              returnValue: _i6.Future<_i4.CommitComment>.value(
-                  _FakeCommitComment_25(this, Invocation.method(#createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}))))
-          as _i6.Future<_i4.CommitComment>);
-  @override
-  _i6.Future<_i4.CommitComment> getCommitComment(_i4.RepositorySlug? slug,
-          {int? id}) =>
-      (super.noSuchMethod(
-              Invocation.method(#getCommitComment, [slug], {#id: id}),
-              returnValue: _i6.Future<_i4.CommitComment>.value(
-                  _FakeCommitComment_25(this,
-                      Invocation.method(#getCommitComment, [slug], {#id: id}))))
-          as _i6.Future<_i4.CommitComment>);
-  @override
-  _i6.Future<_i4.CommitComment> updateCommitComment(_i4.RepositorySlug? slug,
-          {int? id, String? body}) =>
-      (super.noSuchMethod(
-              Invocation.method(
-                  #updateCommitComment, [slug], {#id: id, #body: body}),
+      (super
+          .noSuchMethod(Invocation.method(#createCommitComment, [slug, commit], {#body: body, #path: path, #position: position, #line: line}),
               returnValue: _i6.Future<_i4.CommitComment>.value(_FakeCommitComment_25(
                   this,
-                  Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}))))
+                  Invocation.method(#createCommitComment, [slug, commit],
+                      {#body: body, #path: path, #position: position, #line: line})))) as _i6.Future<_i4.CommitComment>);
+  @override
+  _i6.Future<_i4.CommitComment> getCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
+      (super.noSuchMethod(Invocation.method(#getCommitComment, [slug], {#id: id}),
+              returnValue: _i6.Future<_i4.CommitComment>.value(
+                  _FakeCommitComment_25(this, Invocation.method(#getCommitComment, [slug], {#id: id}))))
+          as _i6.Future<_i4.CommitComment>);
+  @override
+  _i6.Future<_i4.CommitComment> updateCommitComment(_i4.RepositorySlug? slug, {int? id, String? body}) =>
+      (super.noSuchMethod(Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}),
+              returnValue: _i6.Future<_i4.CommitComment>.value(
+                  _FakeCommitComment_25(this, Invocation.method(#updateCommitComment, [slug], {#id: id, #body: body}))))
           as _i6.Future<_i4.CommitComment>);
   @override
   _i6.Future<bool> deleteCommitComment(_i4.RepositorySlug? slug, {int? id}) =>
-      (super.noSuchMethod(
-          Invocation.method(#deleteCommitComment, [slug], {#id: id}),
+      (super.noSuchMethod(Invocation.method(#deleteCommitComment, [slug], {#id: id}),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listCommits, [slug]),
-              returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
-          as _i6.Stream<_i4.RepositoryCommit>);
+  _i6.Stream<_i4.RepositoryCommit> listCommits(_i4.RepositorySlug? slug) => (super
+          .noSuchMethod(Invocation.method(#listCommits, [slug]), returnValue: _i6.Stream<_i4.RepositoryCommit>.empty())
+      as _i6.Stream<_i4.RepositoryCommit>);
   @override
-  _i6.Future<_i4.RepositoryCommit> getCommit(
-          _i4.RepositorySlug? slug, String? sha) =>
+  _i6.Future<_i4.RepositoryCommit> getCommit(_i4.RepositorySlug? slug, String? sha) =>
       (super.noSuchMethod(Invocation.method(#getCommit, [slug, sha]),
               returnValue: _i6.Future<_i4.RepositoryCommit>.value(
-                  _FakeRepositoryCommit_26(
-                      this, Invocation.method(#getCommit, [slug, sha]))))
+                  _FakeRepositoryCommit_26(this, Invocation.method(#getCommit, [slug, sha]))))
           as _i6.Future<_i4.RepositoryCommit>);
   @override
   _i6.Future<String> getCommitDiff(_i4.RepositorySlug? slug, String? sha) =>
-      (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]),
-          returnValue: _i6.Future<String>.value('')) as _i6.Future<String>);
+      (super.noSuchMethod(Invocation.method(#getCommitDiff, [slug, sha]), returnValue: _i6.Future<String>.value(''))
+          as _i6.Future<String>);
   @override
-  _i6.Future<_i4.GitHubComparison> compareCommits(
-          _i4.RepositorySlug? slug, String? refBase, String? refHead) =>
-      (super.noSuchMethod(
-              Invocation.method(#compareCommits, [slug, refBase, refHead]),
+  _i6.Future<_i4.GitHubComparison> compareCommits(_i4.RepositorySlug? slug, String? refBase, String? refHead) =>
+      (super.noSuchMethod(Invocation.method(#compareCommits, [slug, refBase, refHead]),
               returnValue: _i6.Future<_i4.GitHubComparison>.value(
-                  _FakeGitHubComparison_27(
-                      this,
-                      Invocation.method(
-                          #compareCommits, [slug, refBase, refHead]))))
+                  _FakeGitHubComparison_27(this, Invocation.method(#compareCommits, [slug, refBase, refHead]))))
           as _i6.Future<_i4.GitHubComparison>);
   @override
-  _i6.Future<_i4.GitHubFile> getReadme(_i4.RepositorySlug? slug,
-          {String? ref}) =>
-      (super.noSuchMethod(Invocation.method(#getReadme, [slug], {#ref: ref}),
-              returnValue: _i6.Future<_i4.GitHubFile>.value(_FakeGitHubFile_28(
-                  this, Invocation.method(#getReadme, [slug], {#ref: ref}))))
-          as _i6.Future<_i4.GitHubFile>);
+  _i6.Future<_i4.GitHubFile> getReadme(_i4.RepositorySlug? slug, {String? ref}) => (super.noSuchMethod(
+      Invocation.method(#getReadme, [slug], {#ref: ref}),
+      returnValue: _i6.Future<_i4.GitHubFile>.value(
+          _FakeGitHubFile_28(this, Invocation.method(#getReadme, [slug], {#ref: ref})))) as _i6.Future<_i4.GitHubFile>);
   @override
-  _i6.Future<_i4.RepositoryContents> getContents(
-          _i4.RepositorySlug? slug, String? path, {String? ref}) =>
-      (super.noSuchMethod(
-              Invocation.method(#getContents, [slug, path], {#ref: ref}),
+  _i6.Future<_i4.RepositoryContents> getContents(_i4.RepositorySlug? slug, String? path, {String? ref}) =>
+      (super.noSuchMethod(Invocation.method(#getContents, [slug, path], {#ref: ref}),
               returnValue: _i6.Future<_i4.RepositoryContents>.value(
-                  _FakeRepositoryContents_29(
-                      this,
-                      Invocation.method(
-                          #getContents, [slug, path], {#ref: ref}))))
+                  _FakeRepositoryContents_29(this, Invocation.method(#getContents, [slug, path], {#ref: ref}))))
           as _i6.Future<_i4.RepositoryContents>);
   @override
-  _i6.Future<_i4.ContentCreation> createFile(
-          _i4.RepositorySlug? slug, _i4.CreateFile? file) =>
+  _i6.Future<_i4.ContentCreation> createFile(_i4.RepositorySlug? slug, _i4.CreateFile? file) =>
       (super.noSuchMethod(Invocation.method(#createFile, [slug, file]),
               returnValue: _i6.Future<_i4.ContentCreation>.value(
-                  _FakeContentCreation_30(
-                      this, Invocation.method(#createFile, [slug, file]))))
+                  _FakeContentCreation_30(this, Invocation.method(#createFile, [slug, file]))))
           as _i6.Future<_i4.ContentCreation>);
   @override
-  _i6.Future<_i4.ContentCreation> updateFile(_i4.RepositorySlug? slug,
-          String? path, String? message, String? content, String? sha,
-          {String? branch}) =>
+  _i6.Future<_i4.ContentCreation> updateFile(
+          _i4.RepositorySlug? slug, String? path, String? message, String? content, String? sha, {String? branch}) =>
       (super.noSuchMethod(Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}),
-              returnValue: _i6.Future<_i4.ContentCreation>.value(
-                  _FakeContentCreation_30(this,
-                      Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}))))
+              returnValue: _i6.Future<_i4.ContentCreation>.value(_FakeContentCreation_30(
+                  this, Invocation.method(#updateFile, [slug, path, message, content, sha], {#branch: branch}))))
           as _i6.Future<_i4.ContentCreation>);
   @override
-  _i6.Future<_i4.ContentCreation> deleteFile(_i4.RepositorySlug? slug,
-          String? path, String? message, String? sha, String? branch) =>
-      (super.noSuchMethod(
-              Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
+  _i6.Future<_i4.ContentCreation> deleteFile(
+          _i4.RepositorySlug? slug, String? path, String? message, String? sha, String? branch) =>
+      (super.noSuchMethod(Invocation.method(#deleteFile, [slug, path, message, sha, branch]),
               returnValue: _i6.Future<_i4.ContentCreation>.value(
-                  _FakeContentCreation_30(
-                      this,
-                      Invocation.method(
-                          #deleteFile, [slug, path, message, sha, branch]))))
+                  _FakeContentCreation_30(this, Invocation.method(#deleteFile, [slug, path, message, sha, branch]))))
           as _i6.Future<_i4.ContentCreation>);
   @override
-  _i6.Future<String?> getArchiveLink(_i4.RepositorySlug? slug, String? ref,
-          {String? format = r'tarball'}) =>
-      (super.noSuchMethod(
-          Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
+  _i6.Future<String?> getArchiveLink(_i4.RepositorySlug? slug, String? ref, {String? format = r'tarball'}) =>
+      (super.noSuchMethod(Invocation.method(#getArchiveLink, [slug, ref], {#format: format}),
           returnValue: _i6.Future<String?>.value()) as _i6.Future<String?>);
   @override
   _i6.Stream<_i4.Repository> listForks(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listForks, [slug]),
-              returnValue: _i6.Stream<_i4.Repository>.empty())
+      (super.noSuchMethod(Invocation.method(#listForks, [slug]), returnValue: _i6.Stream<_i4.Repository>.empty())
           as _i6.Stream<_i4.Repository>);
   @override
-  _i6.Future<_i4.Repository> createFork(_i4.RepositorySlug? slug,
-          [_i4.CreateFork? fork]) =>
-      (super.noSuchMethod(Invocation.method(#createFork, [slug, fork]),
-              returnValue: _i6.Future<_i4.Repository>.value(_FakeRepository_21(
-                  this, Invocation.method(#createFork, [slug, fork]))))
-          as _i6.Future<_i4.Repository>);
+  _i6.Future<_i4.Repository> createFork(_i4.RepositorySlug? slug, [_i4.CreateFork? fork]) => (super.noSuchMethod(
+          Invocation.method(#createFork, [slug, fork]),
+          returnValue:
+              _i6.Future<_i4.Repository>.value(_FakeRepository_21(this, Invocation.method(#createFork, [slug, fork]))))
+      as _i6.Future<_i4.Repository>);
   @override
   _i6.Stream<_i4.Hook> listHooks(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listHooks, [slug]),
-          returnValue: _i6.Stream<_i4.Hook>.empty()) as _i6.Stream<_i4.Hook>);
+      (super.noSuchMethod(Invocation.method(#listHooks, [slug]), returnValue: _i6.Stream<_i4.Hook>.empty())
+          as _i6.Stream<_i4.Hook>);
   @override
   _i6.Future<_i4.Hook> getHook(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#getHook, [slug, id]),
-              returnValue: _i6.Future<_i4.Hook>.value(
-                  _FakeHook_31(this, Invocation.method(#getHook, [slug, id]))))
+              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(this, Invocation.method(#getHook, [slug, id]))))
           as _i6.Future<_i4.Hook>);
   @override
-  _i6.Future<_i4.Hook> createHook(
-          _i4.RepositorySlug? slug, _i4.CreateHook? hook) =>
+  _i6.Future<_i4.Hook> createHook(_i4.RepositorySlug? slug, _i4.CreateHook? hook) =>
       (super.noSuchMethod(Invocation.method(#createHook, [slug, hook]),
-              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(
-                  this, Invocation.method(#createHook, [slug, hook]))))
+              returnValue: _i6.Future<_i4.Hook>.value(_FakeHook_31(this, Invocation.method(#createHook, [slug, hook]))))
           as _i6.Future<_i4.Hook>);
   @override
   _i6.Future<_i4.Hook> editHook(_i4.RepositorySlug? slug, _i4.Hook? hookToEdit,
@@ -1003,121 +787,87 @@ class MockRepositoriesService extends _i1.Mock
               })))) as _i6.Future<_i4.Hook>);
   @override
   _i6.Future<bool> testPushHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#testPushHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
   _i6.Future<bool> pingHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#pingHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
   _i6.Future<bool> deleteHook(_i4.RepositorySlug? slug, int? id) =>
-      (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+      (super.noSuchMethod(Invocation.method(#deleteHook, [slug, id]), returnValue: _i6.Future<bool>.value(false))
+          as _i6.Future<bool>);
   @override
   _i6.Stream<_i4.PublicKey> listDeployKeys(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]),
-              returnValue: _i6.Stream<_i4.PublicKey>.empty())
+      (super.noSuchMethod(Invocation.method(#listDeployKeys, [slug]), returnValue: _i6.Stream<_i4.PublicKey>.empty())
           as _i6.Stream<_i4.PublicKey>);
   @override
-  _i6.Future<_i4.PublicKey> getDeployKey(_i4.RepositorySlug? slug, {int? id}) =>
-      (super.noSuchMethod(Invocation.method(#getDeployKey, [slug], {#id: id}),
-              returnValue: _i6.Future<_i4.PublicKey>.value(_FakePublicKey_32(
-                  this, Invocation.method(#getDeployKey, [slug], {#id: id}))))
-          as _i6.Future<_i4.PublicKey>);
+  _i6.Future<_i4.PublicKey> getDeployKey(_i4.RepositorySlug? slug, {int? id}) => (super.noSuchMethod(
+      Invocation.method(#getDeployKey, [slug], {#id: id}),
+      returnValue: _i6.Future<_i4.PublicKey>.value(
+          _FakePublicKey_32(this, Invocation.method(#getDeployKey, [slug], {#id: id})))) as _i6.Future<_i4.PublicKey>);
   @override
-  _i6.Future<_i4.PublicKey> createDeployKey(
-          _i4.RepositorySlug? slug, _i4.CreatePublicKey? key) =>
+  _i6.Future<_i4.PublicKey> createDeployKey(_i4.RepositorySlug? slug, _i4.CreatePublicKey? key) =>
       (super.noSuchMethod(Invocation.method(#createDeployKey, [slug, key]),
-              returnValue: _i6.Future<_i4.PublicKey>.value(_FakePublicKey_32(
-                  this, Invocation.method(#createDeployKey, [slug, key]))))
-          as _i6.Future<_i4.PublicKey>);
+          returnValue: _i6.Future<_i4.PublicKey>.value(
+              _FakePublicKey_32(this, Invocation.method(#createDeployKey, [slug, key])))) as _i6.Future<_i4.PublicKey>);
   @override
-  _i6.Future<bool> deleteDeployKey(
-          {_i4.RepositorySlug? slug, _i4.PublicKey? key}) =>
-      (super.noSuchMethod(
-          Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
+  _i6.Future<bool> deleteDeployKey({_i4.RepositorySlug? slug, _i4.PublicKey? key}) =>
+      (super.noSuchMethod(Invocation.method(#deleteDeployKey, [], {#slug: slug, #key: key}),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Future<_i4.RepositoryCommit> merge(
-          _i4.RepositorySlug? slug, _i4.CreateMerge? merge) =>
+  _i6.Future<_i4.RepositoryCommit> merge(_i4.RepositorySlug? slug, _i4.CreateMerge? merge) =>
       (super.noSuchMethod(Invocation.method(#merge, [slug, merge]),
               returnValue: _i6.Future<_i4.RepositoryCommit>.value(
-                  _FakeRepositoryCommit_26(
-                      this, Invocation.method(#merge, [slug, merge]))))
+                  _FakeRepositoryCommit_26(this, Invocation.method(#merge, [slug, merge]))))
           as _i6.Future<_i4.RepositoryCommit>);
   @override
-  _i6.Future<_i4.RepositoryPages> getPagesInfo(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#getPagesInfo, [slug]),
-              returnValue: _i6.Future<_i4.RepositoryPages>.value(
-                  _FakeRepositoryPages_33(
-                      this, Invocation.method(#getPagesInfo, [slug]))))
-          as _i6.Future<_i4.RepositoryPages>);
+  _i6.Future<_i4.RepositoryPages> getPagesInfo(_i4.RepositorySlug? slug) => (super.noSuchMethod(
+      Invocation.method(#getPagesInfo, [slug]),
+      returnValue: _i6.Future<_i4.RepositoryPages>.value(
+          _FakeRepositoryPages_33(this, Invocation.method(#getPagesInfo, [slug])))) as _i6.Future<_i4.RepositoryPages>);
   @override
   _i6.Stream<_i4.PageBuild> listPagesBuilds(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]),
-              returnValue: _i6.Stream<_i4.PageBuild>.empty())
+      (super.noSuchMethod(Invocation.method(#listPagesBuilds, [slug]), returnValue: _i6.Stream<_i4.PageBuild>.empty())
           as _i6.Stream<_i4.PageBuild>);
   @override
-  _i6.Future<_i4.PageBuild> getLatestPagesBuild(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#getLatestPagesBuild, [slug]),
-              returnValue: _i6.Future<_i4.PageBuild>.value(_FakePageBuild_34(
-                  this, Invocation.method(#getLatestPagesBuild, [slug]))))
-          as _i6.Future<_i4.PageBuild>);
+  _i6.Future<_i4.PageBuild> getLatestPagesBuild(_i4.RepositorySlug? slug) => (super.noSuchMethod(
+          Invocation.method(#getLatestPagesBuild, [slug]),
+          returnValue:
+              _i6.Future<_i4.PageBuild>.value(_FakePageBuild_34(this, Invocation.method(#getLatestPagesBuild, [slug]))))
+      as _i6.Future<_i4.PageBuild>);
   @override
   _i6.Stream<_i4.Release> listReleases(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listReleases, [slug]),
-              returnValue: _i6.Stream<_i4.Release>.empty())
+      (super.noSuchMethod(Invocation.method(#listReleases, [slug]), returnValue: _i6.Stream<_i4.Release>.empty())
           as _i6.Stream<_i4.Release>);
   @override
   _i6.Future<_i4.Release> getLatestRelease(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getLatestRelease, [slug]),
-              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
-                  this, Invocation.method(#getLatestRelease, [slug]))))
+              returnValue:
+                  _i6.Future<_i4.Release>.value(_FakeRelease_35(this, Invocation.method(#getLatestRelease, [slug]))))
           as _i6.Future<_i4.Release>);
   @override
   _i6.Future<_i4.Release> getReleaseById(_i4.RepositorySlug? slug, int? id) =>
       (super.noSuchMethod(Invocation.method(#getReleaseById, [slug, id]),
-              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
-                  this, Invocation.method(#getReleaseById, [slug, id]))))
+              returnValue:
+                  _i6.Future<_i4.Release>.value(_FakeRelease_35(this, Invocation.method(#getReleaseById, [slug, id]))))
           as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> getReleaseByTagName(
-          _i4.RepositorySlug? slug, String? tagName) =>
-      (super.noSuchMethod(
-              Invocation.method(#getReleaseByTagName, [slug, tagName]),
-              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(this,
-                  Invocation.method(#getReleaseByTagName, [slug, tagName]))))
-          as _i6.Future<_i4.Release>);
+  _i6.Future<_i4.Release> getReleaseByTagName(_i4.RepositorySlug? slug, String? tagName) => (super.noSuchMethod(
+      Invocation.method(#getReleaseByTagName, [slug, tagName]),
+      returnValue: _i6.Future<_i4.Release>.value(
+          _FakeRelease_35(this, Invocation.method(#getReleaseByTagName, [slug, tagName])))) as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> createRelease(
-          _i4.RepositorySlug? slug, _i4.CreateRelease? createRelease,
+  _i6.Future<_i4.Release> createRelease(_i4.RepositorySlug? slug, _i4.CreateRelease? createRelease,
           {bool? getIfExists = true}) =>
       (super.noSuchMethod(Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}),
-          returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
-              this,
-              Invocation.method(#createRelease, [slug, createRelease],
-                  {#getIfExists: getIfExists})))) as _i6.Future<_i4.Release>);
+              returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
+                  this, Invocation.method(#createRelease, [slug, createRelease], {#getIfExists: getIfExists}))))
+          as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<_i4.Release> editRelease(
-          _i4.RepositorySlug? slug, _i4.Release? releaseToEdit,
-          {String? tagName,
-          String? targetCommitish,
-          String? name,
-          String? body,
-          bool? draft,
-          bool? preRelease}) =>
-      (super.noSuchMethod(
-          Invocation.method(#editRelease, [
-            slug,
-            releaseToEdit
-          ], {
-            #tagName: tagName,
-            #targetCommitish: targetCommitish,
-            #name: name,
-            #body: body,
-            #draft: draft,
-            #preRelease: preRelease
-          }),
+  _i6.Future<_i4.Release> editRelease(_i4.RepositorySlug? slug, _i4.Release? releaseToEdit,
+          {String? tagName, String? targetCommitish, String? name, String? body, bool? draft, bool? preRelease}) =>
+      (super.noSuchMethod(Invocation.method(#editRelease, [slug, releaseToEdit], {#tagName: tagName, #targetCommitish: targetCommitish, #name: name, #body: body, #draft: draft, #preRelease: preRelease}),
           returnValue: _i6.Future<_i4.Release>.value(_FakeRelease_35(
               this,
               Invocation.method(#editRelease, [
@@ -1132,109 +882,81 @@ class MockRepositoriesService extends _i1.Mock
                 #preRelease: preRelease
               })))) as _i6.Future<_i4.Release>);
   @override
-  _i6.Future<bool> deleteRelease(
-          _i4.RepositorySlug? slug, _i4.Release? release) =>
-      (super.noSuchMethod(Invocation.method(#deleteRelease, [slug, release]),
-          returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
+  _i6.Future<bool> deleteRelease(_i4.RepositorySlug? slug, _i4.Release? release) => (super
+          .noSuchMethod(Invocation.method(#deleteRelease, [slug, release]), returnValue: _i6.Future<bool>.value(false))
+      as _i6.Future<bool>);
   @override
-  _i6.Stream<_i4.ReleaseAsset> listReleaseAssets(
-          _i4.RepositorySlug? slug, _i4.Release? release) =>
-      (super.noSuchMethod(
-              Invocation.method(#listReleaseAssets, [slug, release]),
-              returnValue: _i6.Stream<_i4.ReleaseAsset>.empty())
-          as _i6.Stream<_i4.ReleaseAsset>);
+  _i6.Stream<_i4.ReleaseAsset> listReleaseAssets(_i4.RepositorySlug? slug, _i4.Release? release) =>
+      (super.noSuchMethod(Invocation.method(#listReleaseAssets, [slug, release]),
+          returnValue: _i6.Stream<_i4.ReleaseAsset>.empty()) as _i6.Stream<_i4.ReleaseAsset>);
   @override
-  _i6.Future<_i4.ReleaseAsset> getReleaseAsset(
-          _i4.RepositorySlug? slug, _i4.Release? release, {int? assetId}) =>
+  _i6.Future<_i4.ReleaseAsset> getReleaseAsset(_i4.RepositorySlug? slug, _i4.Release? release, {int? assetId}) =>
       (super.noSuchMethod(Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}),
-          returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
-              this,
-              Invocation.method(#getReleaseAsset, [slug, release],
-                  {#assetId: assetId})))) as _i6.Future<_i4.ReleaseAsset>);
+              returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
+                  this, Invocation.method(#getReleaseAsset, [slug, release], {#assetId: assetId}))))
+          as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i6.Future<_i4.ReleaseAsset> editReleaseAsset(
-          _i4.RepositorySlug? slug, _i4.ReleaseAsset? assetToEdit,
+  _i6.Future<_i4.ReleaseAsset> editReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? assetToEdit,
           {String? name, String? label}) =>
       (super.noSuchMethod(Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}),
-          returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
-              this,
-              Invocation.method(#editReleaseAsset, [slug, assetToEdit],
-                  {#name: name, #label: label})))) as _i6.Future<_i4.ReleaseAsset>);
+              returnValue: _i6.Future<_i4.ReleaseAsset>.value(_FakeReleaseAsset_36(
+                  this, Invocation.method(#editReleaseAsset, [slug, assetToEdit], {#name: name, #label: label}))))
+          as _i6.Future<_i4.ReleaseAsset>);
   @override
-  _i6.Future<bool> deleteReleaseAsset(
-          _i4.RepositorySlug? slug, _i4.ReleaseAsset? asset) =>
+  _i6.Future<bool> deleteReleaseAsset(_i4.RepositorySlug? slug, _i4.ReleaseAsset? asset) =>
       (super.noSuchMethod(Invocation.method(#deleteReleaseAsset, [slug, asset]),
           returnValue: _i6.Future<bool>.value(false)) as _i6.Future<bool>);
   @override
-  _i6.Future<List<_i4.ReleaseAsset>> uploadReleaseAssets(_i4.Release? release,
-          Iterable<_i4.CreateReleaseAsset>? createReleaseAssets) =>
-      (super.noSuchMethod(
-          Invocation.method(
-              #uploadReleaseAssets, [release, createReleaseAssets]),
-          returnValue: _i6.Future<List<_i4.ReleaseAsset>>.value(
-              <_i4.ReleaseAsset>[])) as _i6.Future<List<_i4.ReleaseAsset>>);
+  _i6.Future<List<_i4.ReleaseAsset>> uploadReleaseAssets(
+          _i4.Release? release, Iterable<_i4.CreateReleaseAsset>? createReleaseAssets) =>
+      (super.noSuchMethod(Invocation.method(#uploadReleaseAssets, [release, createReleaseAssets]),
+              returnValue: _i6.Future<List<_i4.ReleaseAsset>>.value(<_i4.ReleaseAsset>[]))
+          as _i6.Future<List<_i4.ReleaseAsset>>);
   @override
-  _i6.Future<List<_i4.ContributorStatistics>> listContributorStats(
-          _i4.RepositorySlug? slug) =>
+  _i6.Future<List<_i4.ContributorStatistics>> listContributorStats(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listContributorStats, [slug]),
-              returnValue: _i6.Future<List<_i4.ContributorStatistics>>.value(
-                  <_i4.ContributorStatistics>[]))
+              returnValue: _i6.Future<List<_i4.ContributorStatistics>>.value(<_i4.ContributorStatistics>[]))
           as _i6.Future<List<_i4.ContributorStatistics>>);
   @override
-  _i6.Stream<_i4.YearCommitCountWeek> listCommitActivity(
-          _i4.RepositorySlug? slug) =>
+  _i6.Stream<_i4.YearCommitCountWeek> listCommitActivity(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCommitActivity, [slug]),
-              returnValue: _i6.Stream<_i4.YearCommitCountWeek>.empty())
-          as _i6.Stream<_i4.YearCommitCountWeek>);
+          returnValue: _i6.Stream<_i4.YearCommitCountWeek>.empty()) as _i6.Stream<_i4.YearCommitCountWeek>);
   @override
-  _i6.Stream<_i4.WeeklyChangesCount> listCodeFrequency(
-          _i4.RepositorySlug? slug) =>
+  _i6.Stream<_i4.WeeklyChangesCount> listCodeFrequency(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#listCodeFrequency, [slug]),
-              returnValue: _i6.Stream<_i4.WeeklyChangesCount>.empty())
-          as _i6.Stream<_i4.WeeklyChangesCount>);
+          returnValue: _i6.Stream<_i4.WeeklyChangesCount>.empty()) as _i6.Stream<_i4.WeeklyChangesCount>);
   @override
-  _i6.Future<_i4.ContributorParticipation> getParticipation(
-          _i4.RepositorySlug? slug) =>
+  _i6.Future<_i4.ContributorParticipation> getParticipation(_i4.RepositorySlug? slug) =>
       (super.noSuchMethod(Invocation.method(#getParticipation, [slug]),
               returnValue: _i6.Future<_i4.ContributorParticipation>.value(
-                  _FakeContributorParticipation_37(
-                      this, Invocation.method(#getParticipation, [slug]))))
+                  _FakeContributorParticipation_37(this, Invocation.method(#getParticipation, [slug]))))
           as _i6.Future<_i4.ContributorParticipation>);
   @override
-  _i6.Stream<_i4.PunchcardEntry> listPunchcard(_i4.RepositorySlug? slug) =>
-      (super.noSuchMethod(Invocation.method(#listPunchcard, [slug]),
-              returnValue: _i6.Stream<_i4.PunchcardEntry>.empty())
-          as _i6.Stream<_i4.PunchcardEntry>);
+  _i6.Stream<_i4.PunchcardEntry> listPunchcard(_i4.RepositorySlug? slug) => (super
+          .noSuchMethod(Invocation.method(#listPunchcard, [slug]), returnValue: _i6.Stream<_i4.PunchcardEntry>.empty())
+      as _i6.Stream<_i4.PunchcardEntry>);
   @override
-  _i6.Stream<_i4.RepositoryStatus> listStatuses(
-          _i4.RepositorySlug? slug, String? ref) =>
+  _i6.Stream<_i4.RepositoryStatus> listStatuses(_i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#listStatuses, [slug, ref]),
-              returnValue: _i6.Stream<_i4.RepositoryStatus>.empty())
-          as _i6.Stream<_i4.RepositoryStatus>);
+          returnValue: _i6.Stream<_i4.RepositoryStatus>.empty()) as _i6.Stream<_i4.RepositoryStatus>);
   @override
-  _i6.Future<_i4.RepositoryStatus> createStatus(
-          _i4.RepositorySlug? slug, String? ref, _i4.CreateStatus? request) =>
-      (super.noSuchMethod(
-              Invocation.method(#createStatus, [slug, ref, request]),
+  _i6.Future<_i4.RepositoryStatus> createStatus(_i4.RepositorySlug? slug, String? ref, _i4.CreateStatus? request) =>
+      (super.noSuchMethod(Invocation.method(#createStatus, [slug, ref, request]),
               returnValue: _i6.Future<_i4.RepositoryStatus>.value(
-                  _FakeRepositoryStatus_38(this,
-                      Invocation.method(#createStatus, [slug, ref, request]))))
+                  _FakeRepositoryStatus_38(this, Invocation.method(#createStatus, [slug, ref, request]))))
           as _i6.Future<_i4.RepositoryStatus>);
   @override
-  _i6.Future<_i4.CombinedRepositoryStatus> getCombinedStatus(
-          _i4.RepositorySlug? slug, String? ref) =>
+  _i6.Future<_i4.CombinedRepositoryStatus> getCombinedStatus(_i4.RepositorySlug? slug, String? ref) =>
       (super.noSuchMethod(Invocation.method(#getCombinedStatus, [slug, ref]),
               returnValue: _i6.Future<_i4.CombinedRepositoryStatus>.value(
-                  _FakeCombinedRepositoryStatus_39(this,
-                      Invocation.method(#getCombinedStatus, [slug, ref]))))
+                  _FakeCombinedRepositoryStatus_39(this, Invocation.method(#getCombinedStatus, [slug, ref]))))
           as _i6.Future<_i4.CombinedRepositoryStatus>);
   @override
-  _i6.Future<_i4.ReleaseNotes> generateReleaseNotes(
-          _i4.CreateReleaseNotes? crn) =>
+  _i6.Future<_i4.ReleaseNotes> generateReleaseNotes(_i4.CreateReleaseNotes? crn) =>
       (super.noSuchMethod(Invocation.method(#generateReleaseNotes, [crn]),
-          returnValue: _i6.Future<_i4.ReleaseNotes>.value(_FakeReleaseNotes_40(
-              this, Invocation.method(#generateReleaseNotes, [crn])))) as _i6
-          .Future<_i4.ReleaseNotes>);
+              returnValue: _i6.Future<_i4.ReleaseNotes>.value(
+                  _FakeReleaseNotes_40(this, Invocation.method(#generateReleaseNotes, [crn]))))
+          as _i6.Future<_i4.ReleaseNotes>);
 }
 
 /// A class which mocks [GitHubComparison].
@@ -1247,8 +969,7 @@ class MockGitHubComparison extends _i1.Mock implements _i4.GitHubComparison {
 
   @override
   Map<String, dynamic> toJson() =>
-      (super.noSuchMethod(Invocation.method(#toJson, []),
-          returnValue: <String, dynamic>{}) as Map<String, dynamic>);
+      (super.noSuchMethod(Invocation.method(#toJson, []), returnValue: <String, dynamic>{}) as Map<String, dynamic>);
 }
 
 /// A class which mocks [Response].
@@ -1261,25 +982,17 @@ class MockResponse extends _i1.Mock implements _i3.Response {
 
   @override
   _i8.Uint8List get bodyBytes =>
-      (super.noSuchMethod(Invocation.getter(#bodyBytes),
-          returnValue: _i8.Uint8List(0)) as _i8.Uint8List);
+      (super.noSuchMethod(Invocation.getter(#bodyBytes), returnValue: _i8.Uint8List(0)) as _i8.Uint8List);
   @override
-  String get body =>
-      (super.noSuchMethod(Invocation.getter(#body), returnValue: '') as String);
+  String get body => (super.noSuchMethod(Invocation.getter(#body), returnValue: '') as String);
   @override
-  int get statusCode =>
-      (super.noSuchMethod(Invocation.getter(#statusCode), returnValue: 0)
-          as int);
+  int get statusCode => (super.noSuchMethod(Invocation.getter(#statusCode), returnValue: 0) as int);
   @override
   Map<String, String> get headers =>
-      (super.noSuchMethod(Invocation.getter(#headers),
-          returnValue: <String, String>{}) as Map<String, String>);
+      (super.noSuchMethod(Invocation.getter(#headers), returnValue: <String, String>{}) as Map<String, String>);
   @override
-  bool get isRedirect =>
-      (super.noSuchMethod(Invocation.getter(#isRedirect), returnValue: false)
-          as bool);
+  bool get isRedirect => (super.noSuchMethod(Invocation.getter(#isRedirect), returnValue: false) as bool);
   @override
   bool get persistentConnection =>
-      (super.noSuchMethod(Invocation.getter(#persistentConnection),
-          returnValue: false) as bool);
+      (super.noSuchMethod(Invocation.getter(#persistentConnection), returnValue: false) as bool);
 }


### PR DESCRIPTION
## Description 

If merging has failed the autosubmit cannot remove the label in an exceptional case.
See https://github.com/flutter/flutter/issues/109754.

When an exception occurs we return from the call to the API caller with an error code and are unable to remove the label allowing this failure loop to continue.

## Related issues

fixes https://github.com/flutter/flutter/issues/109754

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
