### PR TITLE
Fixed two minor issues for revert functionality not merging issue

### DIFF
--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -199,7 +199,7 @@ class ValidationService {
     if (revertValidationResult.result) {
       // Approve the pull request automatically as it has been validated.
       ApproverService approverService = ApproverService(config);
-      approverService.revertApproval(messagePullRequest);
+      await approverService.revertApproval(messagePullRequest);
 
       bool processed = await processMerge(config, result, messagePullRequest);
       if (processed) {
@@ -207,7 +207,7 @@ class ValidationService {
       }
       log.info('Ack the processed message : $ackId.');
       github.Issue issue = await githubService.createIssue(
-        slug,
+        github.RepositorySlug('flutter', 'flutter'),
         'Follow up review for revert pull request $prNumber',
         'Revert request by author ${result.repository!.pullRequest!.author}',
       );


### PR DESCRIPTION
## Description

Fixed two issues preventing merge of approved revert request.
1. added async to wait for approval before proceeding.
2. Fixed Repository Slug to create issue in flutter/flutter and not target slug.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
