### PR TITLE
Temporarily remove the step about the revert_review label when creating follow up review on revert pull requests

### DIFF
--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -23,6 +23,8 @@ Review request for Revert PR $repositorySlug#$revertPrNumber
 ''';
   }
 
+  // TODO (ricardoamador) add the step about adding the revert_review label 
+  // back in once bot can respond to it.
   /// Constructs the issues body.
   String _constructBody() {
     return '''
@@ -34,8 +36,7 @@ revert request listed above.
 
 Please do the following so that we may track this issue to completion:
 1. Add the reviewer of revert pull request as the assignee of this issue.
-2. Add the label 'revert_review' to this issue.
-3. Close only when the review has been completed.
+2. Close only when the review has been completed.
 
 
 DO NOT EDIT, REVERT METADATA

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -23,7 +23,7 @@ Review request for Revert PR $repositorySlug#$revertPrNumber
 ''';
   }
 
-  // TODO (ricardoamador) add the step about adding the revert_review label 
+  // TODO (ricardoamador) add the step about adding the revert_review label
   // back in once bot can respond to it.
   /// Constructs the issues body.
   String _constructBody() {

--- a/auto_submit/lib/service/revert_review_template.dart
+++ b/auto_submit/lib/service/revert_review_template.dart
@@ -23,8 +23,8 @@ Review request for Revert PR $repositorySlug#$revertPrNumber
 ''';
   }
 
-  // TODO (ricardoamador) add the step about adding the revert_review label
-  // back in once bot can respond to it.
+  // TODO(ricardoamador): add the step about adding the revert_review label
+  // back in once bot can respond to it, https://github.com/flutter/flutter/issues/110868
   /// Constructs the issues body.
   String _constructBody() {
     return '''


### PR DESCRIPTION
## Description

Remove the step for adding the 'revert_review' label as it is causing confusion. The autosubmit bot does not currently respond to it so we will add it back at that time.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
