### PR TITLE
Fix use of deprecated members in cocoon dashboard

### DIFF
--- a/dashboard/lib/widgets/commit_author_avatar.dart
+++ b/dashboard/lib/widgets/commit_author_avatar.dart
@@ -29,7 +29,7 @@ class CommitAuthorAvatar extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     final double hue = (360.0 * authorHash / (1 << 15)) % 360.0;
-    final double themeValue = HSVColor.fromColor(theme.backgroundColor).value;
+    final double themeValue = HSVColor.fromColor(theme.colorScheme.background).value;
     Color authorColor = HSVColor.fromAHSV(1.0, hue, 0.4, themeValue).toColor();
     if (theme.brightness == Brightness.dark) {
       authorColor = HSLColor.fromColor(authorColor).withLightness(.65).toColor();

--- a/dashboard/lib/widgets/commit_box.dart
+++ b/dashboard/lib/widgets/commit_box.dart
@@ -56,7 +56,7 @@ class CommitBoxState extends State<CommitBox> {
       ),
     );
 
-    Overlay.of(context)!.insert(_commitOverlay!);
+    Overlay.of(context).insert(_commitOverlay!);
   }
 
   void _closeOverlay() => _commitOverlay?.remove();

--- a/dashboard/lib/widgets/error_brook_watcher.dart
+++ b/dashboard/lib/widgets/error_brook_watcher.dart
@@ -63,7 +63,7 @@ class _ErrorBrookWatcherState extends State<ErrorBrookWatcher> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: snackbarContent,
-        backgroundColor: Theme.of(context).errorColor,
+        backgroundColor: Theme.of(context).colorScheme.error,
         duration: ErrorBrookWatcher.errorSnackbarDuration,
       ),
     );

--- a/dashboard/lib/widgets/task_grid.dart
+++ b/dashboard/lib/widgets/task_grid.dart
@@ -360,7 +360,7 @@ class _TaskGridState extends State<TaskGrid> {
       _taskOverlay = OverlayEntry(
         builder: (BuildContext context) => TaskOverlayEntry(
           position: (this.context.findRenderObject() as RenderBox)
-              .localToGlobal(localPosition!, ancestor: Overlay.of(context)!.context.findRenderObject()),
+              .localToGlobal(localPosition!, ancestor: Overlay.of(context).context.findRenderObject()),
           task: task,
           showSnackBarCallback: ScaffoldMessenger.of(context).showSnackBar,
           closeCallback: _closeOverlay,
@@ -368,7 +368,7 @@ class _TaskGridState extends State<TaskGrid> {
           commit: commit,
         ),
       );
-      Overlay.of(context)!.insert(_taskOverlay!);
+      Overlay.of(context).insert(_taskOverlay!);
     };
   }
 


### PR DESCRIPTION
## Description

Dependencies have been updated in the dashboard and we were using deprecated members of certain classes. This pr updates to the correct usage.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
