### PR TITLE
Exempt package test runners from test bot

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -470,7 +470,13 @@ class GithubWebhookSubscription extends SubscriptionHandler {
           !filename.endsWith('.cirrus.yml') &&
           !filename.contains('.ci/') &&
           !filename.contains('.github/') &&
-          !filename.endsWith('.md')) {
+          !filename.endsWith('.md') &&
+          // Custom package-specific test runners. These do not count as tests
+          // for the purposes of testing a change that otherwise needs tests,
+          // but since they are the driver for tests they don't need test
+          // coverage.
+          !filename.endsWith('tool/run_tests.dart') &&
+          !filename.endsWith('run_tests.sh')) {
         needsTests = !_allChangesAreCodeComments(file);
       }
       // See https://github.com/flutter/flutter/wiki/Plugin-Tests for discussion

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2112,6 +2112,31 @@ void foo() {
       ));
     });
 
+    test('Packages does not comment for custom test driver', () async {
+      const int issueNumber = 123;
+
+      tester.message = generateGithubWebhookMessage(
+        action: 'opened',
+        number: issueNumber,
+        slug: Config.packagesSlug,
+      );
+
+      when(pullRequestsService.listFiles(Config.packagesSlug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+          PullRequestFile()..filename = 'packages/foo/tool/run_tests.dart',
+          PullRequestFile()..filename = 'packages/foo/run_tests.sh',
+        ]),
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(issuesService.createComment(
+        Config.packagesSlug,
+        issueNumber,
+        argThat(contains(config.missingTestsPullRequestMessageValue)),
+      ));
+    });
+
     test('Schedule tasks when pull request is closed and merged', () async {
       const int issueNumber = 123;
 


### PR DESCRIPTION
Adds flutter/package custom package test driver scripts to the list of files that don't need tests.

Fixes https://github.com/flutter/flutter/issues/103452

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
