### PR TITLE
[scheduler] Ignore bringup on release branches

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -60,7 +60,13 @@ class CiYaml {
   /// This shouldn't be confused for targets that have the property named dependency, which is used by the
   /// flutter_deps recipe module on LUCI.
   List<Target> getInitialTargets(List<Target> targets) {
-    return targets.where((Target target) => target.value.dependencies.isEmpty).toList();
+    Iterable<Target> initialTargets = targets.where((Target target) => target.value.dependencies.isEmpty).toList();
+    if (branch != Config.defaultBranch(slug)) {
+      // Filter out bringup targets for release branches
+      initialTargets = initialTargets.where((Target target) => !target.value.bringup);
+    }
+
+    return initialTargets.toList();
   }
 
   Iterable<Target> get _targets => config.targets.map((pb.Target target) => Target(

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -32,7 +32,6 @@ import 'config.dart';
 import 'datastore.dart';
 import 'github_checks_service.dart';
 import 'github_service.dart';
-import 'luci.dart';
 import 'luci_build_service.dart';
 
 /// Scheduler service to validate all commits to supported Flutter repositories.
@@ -234,15 +233,6 @@ class Scheduler {
       branch: commit.branch!,
       totConfig: totCiYaml,
     );
-  }
-
-  /// Get all [LuciBuilder] run for [ciYaml].
-  Future<List<LuciBuilder>> getPostSubmitBuilders(CiYaml ciYaml) async {
-    final Iterable<Target> postsubmitLuciTargets =
-        ciYaml.postsubmitTargets.where((Target target) => target.value.scheduler == pb.SchedulerSystem.luci);
-    final List<LuciBuilder> builders =
-        postsubmitLuciTargets.map((Target target) => LuciBuilder.fromTarget(target)).toList();
-    return builders;
   }
 
   /// Get `.ci.yaml` from GitHub, and store the bytes in redis for future retrieval.

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -8,6 +8,7 @@ import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:cocoon_service/src/service/buildbucket.dart';
 import 'package:cocoon_service/src/service/cache_service.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
@@ -55,10 +56,12 @@ class FakeScheduler extends Scheduler {
 }
 
 final CiYaml emptyConfig = CiYaml(
-  branch: 'master',
-  slug: RepositorySlug('flutter', 'flutter'),
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(
-    enabledBranches: <String>['master'],
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.flutterSlug),
+    ],
     targets: <pb.Target>[
       pb.Target(
         name: 'Linux A',
@@ -69,10 +72,10 @@ final CiYaml emptyConfig = CiYaml(
 );
 
 CiYaml exampleConfig = CiYaml(
-  slug: RepositorySlug('flutter', 'flutter'),
-  branch: 'master',
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(enabledBranches: <String>[
-    'master'
+    Config.defaultBranch(Config.flutterSlug),
   ], targets: <pb.Target>[
     pb.Target(
       name: 'Linux A',
@@ -97,10 +100,10 @@ CiYaml exampleConfig = CiYaml(
 );
 
 CiYaml batchPolicyConfig = CiYaml(
-  slug: RepositorySlug('flutter', 'flutter'),
-  branch: 'master',
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(enabledBranches: <String>[
-    'master'
+    Config.defaultBranch(Config.flutterSlug),
   ], targets: <pb.Target>[
     pb.Target(
       name: 'Linux_android A',


### PR DESCRIPTION
Remove bringup targets from being scheduled on release branches. The release team doesn't look at these, they create noise, and use extra capacity.