### PR TITLE
Exempt analysis_options.yaml from test requirement

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -312,15 +312,15 @@ class GithubWebhookSubscription extends SubscriptionHandler {
   /// Returns true if changes to [filename] are exempt from the testing
   /// requirement, across repositories.
   bool _isTestExempt(String filename) {
-    return filename.contains('.ci.yaml')
-        || filename.contains('.cirrus.yml')
-        || filename.contains('analysis_options.yaml')
-        || filename.contains('AUTHORS')
-        || filename.contains('CODEOWNERS')
-        || filename.contains('pubspec.yaml')
+    return filename.contains('.ci.yaml') ||
+        filename.contains('.cirrus.yml') ||
+        filename.contains('analysis_options.yaml') ||
+        filename.contains('AUTHORS') ||
+        filename.contains('CODEOWNERS') ||
+        filename.contains('pubspec.yaml') ||
         // Exempt categories.
-        || filename.contains('.github/')
-        || filename.endsWith('.md');
+        filename.contains('.github/') ||
+        filename.endsWith('.md');
   }
 
   /// Returns the set of labels applicable to a file in the framework repo.

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -256,13 +256,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
 
       if (addedCode &&
-          !filename.contains('AUTHORS') &&
-          !filename.contains('pubspec.yaml') &&
-          !filename.contains('.ci.yaml') &&
-          !filename.contains('.cirrus.yml') &&
-          !filename.contains('.github') &&
-          !filename.endsWith('.md') &&
-          !filename.contains('CODEOWNERS') &&
+          !_isTestExempt(filename) &&
           !filename.startsWith('dev/bots/') &&
           !filename.endsWith('.gitignore')) {
         needsTests = !_allChangesAreCodeComments(file);
@@ -313,6 +307,20 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('dev/devicelab/lib/tasks') ||
         filename.startsWith('dev/devicelab/lib/tasks') ||
         objectiveCTestRegex.hasMatch(filename);
+  }
+
+  /// Returns true if changes to [filename] are exempt from the testing
+  /// requirement, across repositories.
+  bool _isTestExempt(String filename) {
+    return filename.contains('.ci.yaml')
+        || filename.contains('.cirrus.yml')
+        || filename.contains('analysis_options.yaml')
+        || filename.contains('AUTHORS')
+        || filename.contains('CODEOWNERS')
+        || filename.contains('pubspec.yaml')
+        // Exempt categories.
+        || filename.contains('.github/')
+        || filename.endsWith('.md');
   }
 
   /// Returns the set of labels applicable to a file in the framework repo.
@@ -463,14 +471,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
 
       if (addedCode &&
-          !filename.endsWith('AUTHORS') &&
-          !filename.endsWith('CODEOWNERS') &&
-          !filename.endsWith('pubspec.yaml') &&
-          !filename.endsWith('.ci.yaml') &&
-          !filename.endsWith('.cirrus.yml') &&
+          !_isTestExempt(filename) &&
           !filename.contains('.ci/') &&
-          !filename.contains('.github/') &&
-          !filename.endsWith('.md') &&
           // Custom package-specific test runners. These do not count as tests
           // for the purposes of testing a change that otherwise needs tests,
           // but since they are the driver for tests they don't need test

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1142,6 +1142,26 @@ void main() {
       ));
     });
 
+    test('Framework no comment if only analysis options changed', () async {
+      const int issueNumber = 123;
+      tester.message = generateGithubWebhookMessage(action: 'opened', number: issueNumber);
+      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
+
+      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+          PullRequestFile()..filename = 'analysis_options.yaml',
+        ]),
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(issuesService.createComment(
+        slug,
+        issueNumber,
+        argThat(contains(config.missingTestsPullRequestMessageValue)),
+      ));
+    });
+
     test('Framework no comment if only CODEOWNERS changed', () async {
       const int issueNumber = 123;
       tester.message = generateGithubWebhookMessage(action: 'opened', number: issueNumber);


### PR DESCRIPTION
Analysis options are inherently tested by steps that run analysis, so don't need tests.

Extracts the common set of test-exempt files from the flutter/flutter and flutter/plugins+packages checks to minimize duplicate code. (Switching flutter/engine to sharing the same set of exemptions is out of scope for this refactor, as it would change behavior.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
