### PR TITLE
Add dev/benchmarks example apps to test patterns

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -311,7 +311,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('dev/bots/test.dart') ||
         filename.startsWith('dev/devicelab/bin/tasks') ||
         filename.startsWith('dev/devicelab/lib/tasks') ||
-        filename.startsWith('dev/devicelab/lib/tasks') ||
+        filename.startsWith('dev/benchmarks') ||
         objectiveCTestRegex.hasMatch(filename);
   }
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1040,6 +1040,7 @@ void main() {
           PullRequestFile()..filename = 'dev/bots/test.dart',
           PullRequestFile()..filename = 'dev/devicelab/bin/tasks/analyzer_benchmark.dart',
           PullRequestFile()..filename = 'dev/devicelab/lib/tasks/plugin_tests.dart',
+          PullRequestFile()..filename = 'dev/benchmarks/microbenchmarks/lib/foundation/all_elements_bench.dart',
         ]),
       );
 


### PR DESCRIPTION
`dev/benchmarks` only contains integration test apps used for benchmarks:
```
complex_layout
macrobenchmarks
microbenchmarks
multiple_flutters
platform_channels_benchmarks
platform_views_layout
platform_views_layout_hybrid_composition
test_apps
```

Count these files as tests in the framework.

Seen in https://github.com/flutter/flutter/pull/112502

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
