### PR TITLE
[dashboard] Truncate branch names

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -53,6 +53,11 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
   /// master on one repo, to main for a different repo.
   String? branch;
 
+  /// Example branch for [truncate].
+  ///
+  /// Include the ellipsis to get the correct length that should be truncated at.
+  final String _exampleBranch = 'flutter-3.12-candidate.23...';
+
   @override
   void initState() {
     super.initState();
@@ -249,7 +254,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
               padding: const EdgeInsets.only(top: 9.0),
               child: Center(
                 child: Text(
-                  truncate(buildState.currentBranch, 28),
+                  truncate(buildState.currentBranch, _exampleBranch.length),
                   style: theme.primaryTextTheme.bodyLarge,
                 ),
               ),
@@ -264,7 +269,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
                 padding: const EdgeInsets.only(top: 9.0),
                 child: Center(
                   child: Text(
-                    truncate(b.branch, 28),
+                    truncate(b.branch, _exampleBranch.length),
                     style: theme.primaryTextTheme.bodyLarge,
                   ),
                 ),

--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dashboard/model/branch.pb.dart';
 import 'package:provider/provider.dart';
+import 'package:truncate/truncate.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'logic/task_grid_filter.dart';
@@ -248,7 +249,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
               padding: const EdgeInsets.only(top: 9.0),
               child: Center(
                 child: Text(
-                  buildState.currentBranch,
+                  truncate(buildState.currentBranch, 28),
                   style: theme.primaryTextTheme.bodyLarge,
                 ),
               ),
@@ -263,7 +264,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
                 padding: const EdgeInsets.only(top: 9.0),
                 child: Center(
                   child: Text(
-                    b.branch,
+                    truncate(b.branch, 28),
                     style: theme.primaryTextTheme.bodyLarge,
                   ),
                 ),

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -323,7 +323,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -447,7 +447,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   timing:
     dependency: transitive
     description:
@@ -497,6 +497,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  truncate:
+    dependency: "direct main"
+    description:
+      name: truncate
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -566,7 +573,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
@@ -589,5 +596,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.10.0"

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   provider: ^6.0.2
   url_launcher: ^6.1.5
   flutter_app_icons: ^0.0.8
+  truncate: ^3.0.1
 
 dev_dependencies:
   build_runner: ^2.2.1

--- a/dashboard/test/build_dashboard_page_test.dart
+++ b/dashboard/test/build_dashboard_page_test.dart
@@ -197,6 +197,7 @@ void main() {
     // Open settings overlay
     await tester.tap(find.byIcon(Icons.settings));
     await tester.pump();
+    await tester.pump(const Duration(seconds: 1)); // Finish the menu animation.
 
     expect(find.text('Vacuum GitHub Commits'), findsOneWidget);
   });

--- a/dashboard/test/utils/fake_build.dart
+++ b/dashboard/test/utils/fake_build.dart
@@ -76,10 +76,15 @@ class FakeBuildState extends ChangeNotifier implements BuildState {
           ..repository = repo
           ..branch = defaultBranches[repo]!,
       );
-      fakeBranches.add(
-        Branch()
-          ..repository = repo
-          ..branch = '$repo-release',
+      fakeBranches.addAll(
+        <Branch>[
+          Branch()
+            ..repository = repo
+            ..branch = '$repo-release',
+          Branch()
+            ..repository = repo
+            ..branch = '$repo-release-very-long-name-that-should-be-truncated',
+        ],
       );
     }
     return fakeBranches;


### PR DESCRIPTION
This trims branches to not be as long in the build dashboard. It makes the max length able to show full release candidate branches, but any longer is trimmed.

Adds `package:truncate` to `dashboard`. This is already used in `app_dart`