### PR TITLE
Revert will wait for required checks to complete.

### DIFF
--- a/auto_submit/lib/exception/retryable_checkrun_exception.dart
+++ b/auto_submit/lib/exception/retryable_checkrun_exception.dart
@@ -1,0 +1,12 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class RetryableCheckRunException implements Exception {
+  RetryableCheckRunException(this.cause);
+
+  final String cause;
+
+  @override
+  String toString() => cause;
+}

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -37,8 +37,12 @@ class Config {
   static const String kRevertLabel = 'revert';
 
   static const int backOfMultiplier = 200;
-  static const int backoffAttempts = 3;
+  static const int backoffAttempts = 5;
   static const int maxDelaySeconds = 1;
+
+  static const int backOfMultiplierCheckWait = 500;
+  static const int backoffAttemptsCheckWait = 5;
+  static const int maxDelaySecondsCheckWait = 5;
 
   static const String flutter = 'flutter';
   static const String flutterGcpProjectId = 'flutter-dashboard';

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -24,6 +24,24 @@ class GithubService {
     return await github.checks.checkRuns.listCheckRunsForRef(slug, ref: ref).toList();
   }
 
+  Future<List<CheckRun>> getCheckRunsFiltered({
+    required RepositorySlug slug,
+    required String ref,
+    String? checkName,
+    CheckRunStatus? status,
+    CheckRunFilter? filter,
+  }) async {
+    return await github.checks.checkRuns
+        .listCheckRunsForRef(
+          slug,
+          ref: ref,
+          checkName: checkName,
+          status: status,
+          filter: filter,
+        )
+        .toList();
+  }
+
   /// Fetches the specified commit.
   Future<RepositoryCommit> getCommit(RepositorySlug slug, String sha) async {
     return await github.repositories.getCommit(slug, sha);

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -303,6 +303,10 @@ Exception: ${exception.message}
 
         log.info(message);
       }
+    } else if (!revertValidationResult.result && revertValidationResult.action == Action.IGNORE_TEMPORARILY) {
+      // if required check runs have not completed process again.
+      log.info('Some of the required checks have not completed. Requeueing.');
+      return;
     } else {
       // since we do not temporarily ignore anything with a revert request we
       // know we will report the error and remove the label.
@@ -338,7 +342,6 @@ Exception: ${exception.message}
       // The createGitHubGraphQLClient can throw Exception on github permissions
       // errors.
       final graphql.GraphQLClient client = await config.createGitHubGraphQLClient(slug);
-
       graphql.QueryResult? result;
 
       await _runProcessMergeWithRetries(

--- a/auto_submit/lib/validations/required_check_runs.dart
+++ b/auto_submit/lib/validations/required_check_runs.dart
@@ -1,0 +1,5 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const List<String> requiredCheckRuns = ['ci.yaml validation'];

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -291,12 +291,58 @@ void main() {
       assert(pubsub.messagesQueue.isEmpty);
     });
 
+    test('Revert returns on in process required checkRuns.', () async {
+      githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => createFakeQueryResult();
+      final PullRequestHelper flutterRequest = PullRequestHelper(
+        prNumber: 0,
+        lastCommitHash: oid,
+        reviews: <PullRequestReviewHelper>[],
+      );
+
+      githubService.checkRunsData = inProgressCheckRunsMock;
+      githubService.createCommentData = createCommentMock;
+      githubService.throwOnCreateIssue = true;
+      githubService.useRealComment = true;
+      final FakePubSub pubsub = FakePubSub();
+      final PullRequest pullRequest = generatePullRequest(
+        prNumber: 0,
+        repoName: slug.name,
+        authorAssociation: 'OWNER',
+        labelName: 'revert',
+        body: 'Reverts flutter/flutter#1234',
+      );
+
+      final FakeRevert fakeRevert = FakeRevert(config: config);
+      fakeRevert.validationResult =
+          ValidationResult(false, Action.IGNORE_TEMPORARILY, 'Some of the required checks did not complete in time.');
+      validationService.revertValidation = fakeRevert;
+      final FakeApproverService fakeApproverService = FakeApproverService(config);
+      validationService.approverService = fakeApproverService;
+
+      unawaited(pubsub.publish('auto-submit-queue-sub', pullRequest));
+      final auto.QueryResult queryResult = createQueryResult(flutterRequest);
+
+      await validationService.processRevertRequest(
+        config: config,
+        result: queryResult,
+        messagePullRequest: pullRequest,
+        ackId: 'test',
+        pubsub: pubsub,
+      );
+
+      // if the merge is successful we do not remove the label and we do not add a comment to the issue.
+      expect(githubService.issueComment, isNull);
+      expect(githubService.labelRemoved, false);
+      // We acknowledge the issue.
+      assert(pubsub.messagesQueue.isNotEmpty);
+    });
+
     test('Exhaust retries on merge on retryable error.', () async {
       validationService = ValidationService(
         config,
         retryOptions: const RetryOptions(
-          delayFactor: Duration(milliseconds: 1),
-          maxDelay: Duration(milliseconds: 1),
+          delayFactor: Duration.zero,
+          maxDelay: Duration.zero,
           maxAttempts: 1,
         ),
       );
@@ -481,8 +527,7 @@ void main() {
     test('Merge fails the first time but then succeeds after retry.', () async {
       validationService = ValidationService(
         config,
-        retryOptions:
-            const RetryOptions(delayFactor: Duration(milliseconds: 50), maxDelay: Duration(seconds: 1), maxAttempts: 3),
+        retryOptions: const RetryOptions(delayFactor: Duration.zero, maxDelay: Duration.zero, maxAttempts: 3),
       );
 
       // Create a result that will trigger a retry.

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -107,6 +107,27 @@ class FakeGithubService implements GithubService {
   }
 
   @override
+  Future<List<CheckRun>> getCheckRunsFiltered({
+    required RepositorySlug slug,
+    required String ref,
+    String? checkName,
+    CheckRunStatus? status,
+    CheckRunFilter? filter,
+  }) async {
+    List<CheckRun> checkRuns = await getCheckRuns(slug, ref);
+    if (checkName != null) {
+      List<CheckRun> checkRunsFilteredByName = [];
+      for (CheckRun checkRun in checkRuns) {
+        if (checkRun.name == checkName) {
+          checkRunsFilteredByName.add(checkRun);
+        }
+      }
+      return checkRunsFilteredByName;
+    }
+    return checkRuns;
+  }
+
+  @override
   Future<RepositoryCommit> getCommit(RepositorySlug slug, String sha) async {
     final RepositoryCommit commit = RepositoryCommit.fromJson(jsonDecode(commitMock!) as Map<String, dynamic>);
     return commit;

--- a/auto_submit/test/validations/revert_test_data.dart
+++ b/auto_submit/test/validations/revert_test_data.dart
@@ -510,3 +510,42 @@ const String originalPullRequestFilesSubsetJson = """
     }
   ]
 """;
+
+const String ciyamlCheckRun = '''
+{
+  "total_count": 1,
+  "check_runs": [
+    {
+      "id": 8752872923,
+      "name": "ci.yaml validation",
+      "head_sha": "60612a38d705d00a234e0aabba08247fc0dda1ac",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2022-10-06T20:50:57Z",
+      "completed_at": "2022-10-06T20:51:40Z",
+      "check_suite": {
+        "id": 8654966141
+      }
+    }
+  ]
+}
+''';
+
+const String ciyamlCheckRunNotComplete = '''
+{
+  "total_count": 1,
+  "check_runs": [
+    {
+      "id": 8752872923,
+      "name": "ci.yaml validation",
+      "head_sha": "60612a38d705d00a234e0aabba08247fc0dda1ac",
+      "status": "in_progress",
+      "started_at": "2022-10-06T20:50:57Z",
+      "completed_at": "2022-10-06T20:51:40Z",
+      "check_suite": {
+        "id": 8654966141
+      }
+    }
+  ]
+}
+''';


### PR DESCRIPTION
## Description

When creating a revert request, a user can add a label to the request while opening the revert. This means the checks will be made immediately and when this occurs we can sometimes get in the situation that he ci.yaml a required check has not yet completed. This means the label will be removed and the user will be notified we cannot merge the request. 

This fix is to wait only for the ci.yaml check to complete before merging as it is the only required check. 

![image](https://user-images.githubusercontent.com/32242716/194609154-85cec683-3718-4b4f-bf2e-c9fa27e4f74c.png)

## Issues Addressed

Fixes https://github.com/flutter/flutter/issues/113070

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
