### PR TITLE
Add delay between deflake github requests

### DIFF
--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -81,6 +81,9 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
           await bigquery.listRecentBuildRecordsForBuilder(kBigQueryProjectId, builder: info.name, limit: kRecordNumber);
       if (_shouldDeflake(builderRecords)) {
         await _deflakyPullRequest(gitHub, slug, info: info, ciContent: ciContent, testOwnership: testOwnership);
+        // Manually add a 1s delay between consecutive GitHub requests to deal with secondary rate limit error.
+        // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+        await Future.delayed(const Duration(seconds: 1));
       } else if (_shouldFileIssue(builderRecords, info)) {
         final BuilderDetail builderDetail = BuilderDetail(
           statistic: stagingBuilderStatisticList

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -83,7 +83,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
         await _deflakyPullRequest(gitHub, slug, info: info, ciContent: ciContent, testOwnership: testOwnership);
         // Manually add a 1s delay between consecutive GitHub requests to deal with secondary rate limit error.
         // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
-        await Future.delayed(const Duration(seconds: 1));
+        await Future.delayed(config.githubRequestDelay);
       } else if (_shouldFileIssue(builderRecords, info)) {
         final BuilderDetail builderDetail = BuilderDetail(
           statistic: stagingBuilderStatisticList

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -271,6 +271,9 @@ class Config {
   // Default number of commits to return for benchmark dashboard.
   int /*!*/ get maxRecords => 50;
 
+  // Delay between consecutive GitHub deflake request calls.
+  Duration get githubRequestDelay => const Duration(seconds: 1);
+
   // Repository status context for github status.
   String get flutterBuild => 'flutter-build';
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -55,6 +55,7 @@ class FakeConfig implements Config {
     this.supportedBranchesValue,
     this.supportedReposValue,
     this.batchSizeValue,
+    this.githubRequestDelayValue,
     FakeDatastoreDB? dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
 
@@ -95,6 +96,7 @@ class FakeConfig implements Config {
   List<String>? supportedBranchesValue;
   String? overrideTreeStatusLabelValue;
   Set<gh.RepositorySlug>? supportedReposValue;
+  Duration? githubRequestDelayValue;
 
   @override
   Future<gh.GitHub> createGitHubClient({gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async => githubClient!;
@@ -122,6 +124,9 @@ class FakeConfig implements Config {
 
   @override
   FakeDatastoreDB get db => dbValue;
+
+  @override
+  Duration get githubRequestDelay => githubRequestDelayValue ?? Duration.zero;
 
   @override
   int get maxTaskRetries => maxTaskRetriesValue!;


### PR DESCRIPTION
When multiple github requests are called in a short period, it hits 
```
You have exceeded a secondary rate limit 
```
This PR adds a 1s delay between calls following: https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits

More context: https://github.com/flutter/flutter/issues/102402