### PR TITLE
Using protobuf instead of ciyaml directly.

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -165,14 +165,21 @@ List<String> validateOwnership(String ciYamlContent, String testOwnersContent) {
   final List<String> noOwnerBuilders = <String>[];
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
-  final pb.SchedulerConfig schedulerConfig = CiYaml(
+  final CiYaml ciYamlFromProto = CiYaml(
     slug: Config.flutterSlug,
     branch: Config.defaultBranch(Config.flutterSlug),
     config: unCheckedSchedulerConfig,
-  ).config;
+  );
+
+  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.config;
+
   for (pb.Target target in schedulerConfig.targets) {
     final String builder = target.name;
-    final String? owner = getTestOwnership(builder, getTypeForBuilder(builder, ciYaml!), testOwnersContent).owner;
+    final String? owner = getTestOwnership(
+      builder,
+      getTypeForBuilder(builder, ciYamlFromProto),
+      testOwnersContent,
+    ).owner;
     print('$builder: $owner');
     if (owner == null) {
       noOwnerBuilders.add(builder);

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -89,6 +89,14 @@ class Target {
     return BatchPolicy();
   }
 
+  /// Get the tags from the defined properties in the ci.
+  ///
+  /// Return an empty list if no tags are found.
+  List<String>? get getTags {
+    Map<String, Object> properties = getProperties();
+    return (properties.containsKey('tags')) ? (properties['tags'] as List).map((e) => e as String).toList() : [];
+  }
+
   /// Gets the assembled properties for this [pb.Target].
   ///
   /// Target properties are prioritized in:

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -92,7 +92,7 @@ class Target {
   /// Get the tags from the defined properties in the ci.
   ///
   /// Return an empty list if no tags are found.
-  List<String>? get getTags {
+  List<String> get getTags {
     Map<String, Object> properties = getProperties();
     return (properties.containsKey('tags')) ? (properties['tags'] as List).map((e) => e as String).toList() : [];
   }

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -75,7 +75,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       kTestOwnerPath,
     );
     for (final _BuilderInfo info in eligibleBuilders) {
-      final BuilderType type = getTypeForBuilder(info.name, ciYaml); //loadYaml(ciContent) as YamlMap);
+      final BuilderType type = getTypeForBuilder(info.name, ciYaml);
       final TestOwnership testOwnership = getTestOwnership(info.name!, type, testOwnerContent);
       final List<BuilderRecord> builderRecords =
           await bigquery.listRecentBuildRecordsForBuilder(kBigQueryProjectId, builder: info.name, limit: kRecordNumber);
@@ -151,6 +151,8 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       if (nameToExistingPRs.containsKey(builder)) {
         continue;
       }
+
+      //TODO: https://github.com/flutter/flutter/issues/113232
       int builderLineNumber = lines.indexWhere((String line) => line.contains('name: $builder')) + 1;
       while (builderLineNumber < lines.length && !lines[builderLineNumber].contains('name:')) {
         if (lines[builderLineNumber].contains('$kCiYamlTargetIsFlakyKey:')) {

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -74,6 +74,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       slug,
       kTestOwnerPath,
     );
+
     for (final _BuilderInfo info in eligibleBuilders) {
       final BuilderType type = getTypeForBuilder(info.name, ciYaml);
       final TestOwnership testOwnership = getTestOwnership(info.name!, type, testOwnerContent);
@@ -152,7 +153,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
         continue;
       }
 
-      //TODO: https://github.com/flutter/flutter/issues/113232
+      //TODO (ricardoamador): Refactor this so we don't need to parse the entire yaml looking for commented issues, https://github.com/flutter/flutter/issues/113232
       int builderLineNumber = lines.indexWhere((String line) => line.contains('name: $builder')) + 1;
       while (builderLineNumber < lines.length && !lines[builderLineNumber].contains('name:')) {
         if (lines[builderLineNumber].contains('$kCiYamlTargetIsFlakyKey:')) {

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -75,7 +75,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       kTestOwnerPath,
     );
     for (final _BuilderInfo info in eligibleBuilders) {
-      final BuilderType type = getTypeForBuilder(info.name, loadYaml(ciContent) as YamlMap);
+      final BuilderType type = getTypeForBuilder(info.name, ciYaml); //loadYaml(ciContent) as YamlMap);
       final TestOwnership testOwnership = getTestOwnership(info.name!, type, testOwnerContent);
       final List<BuilderRecord> builderRecords =
           await bigquery.listRecentBuildRecordsForBuilder(kBigQueryProjectId, builder: info.name, limit: kRecordNumber);

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -57,7 +57,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
       if (statistic.flakyRate < _threshold) {
         continue;
       }
-      final BuilderType type = getTypeForBuilder(statistic.name, ci!);
+      final BuilderType type = getTypeForBuilder(statistic.name, ciYaml);
       await _fileIssueAndPR(
         gitHub,
         slug,
@@ -65,7 +65,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
             statistic: statistic,
             existingIssue: nameToExistingIssue[statistic.name],
             existingPullRequest: nameToExistingPR[statistic.name],
-            isMarkedFlaky: _getIsMarkedFlaky(statistic.name, ci),
+            isMarkedFlaky: _getIsMarkedFlaky(statistic.name, ci!),
             type: type,
             ownership: getTestOwnership(statistic.name, type, testOwnerContent)),
       );

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:core';
 
 import 'package:cocoon_service/ci_yaml.dart';
+import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 
 import '../service/bigquery.dart';
@@ -450,7 +451,10 @@ BuilderType getTypeForBuilder(String? builderName, CiYaml ciYaml) {
 List<dynamic>? _getTags(String? builderName, CiYaml ciYaml) {
   List<Target> allTargets = ciYaml.presubmitTargets;
   allTargets.addAll(ciYaml.postsubmitTargets);
-  Target target = allTargets.firstWhere((element) => element.value.name == builderName);
+  Target? target = allTargets.firstWhereOrNull((element) => element.value.name == builderName);
+  if (target == null) {
+    return null;
+  }
   return jsonDecode(target.value.properties[kCiYamlTargetTagsKey] as String) as List<dynamic>?;
 }
 

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -43,7 +43,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     final BigqueryService bigquery = await config.createBigQueryService();
 
     CiYaml? localCiYaml = ciYaml;
-    if (localCiYaml == null) { 
+    if (localCiYaml == null) {
       final YamlMap? ci = loadYaml(await gitHub.getFileContent(
         slug,
         kCiYamlPath,

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -105,6 +105,34 @@ void main() {
         });
       });
 
+      test('tags are parsed from within properties', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Linux_build_test',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'android_sdk': 'abc',
+          },
+          properties: <String, String>{'xcode': '12abc', 'tags': '["devicelab", "android", "linux"]'},
+        );
+        expect(target.getTags, ['devicelab', 'android', 'linux']);
+      });
+
+      test('we do not blow up if tags are not present', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Linux_build_test',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'android_sdk': 'abc',
+          },
+          properties: <String, String>{
+            'xcode': '12abc',
+          },
+        );
+        expect(target.getTags, []);
+      });
+
       test('platform properties with xcode', () {
         final Target target = generateTarget(
           1,

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -5,8 +5,6 @@
 import 'dart:convert';
 
 import 'package:cocoon_service/cocoon_service.dart';
-import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
-import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:cocoon_service/src/request_handlers/flaky_handler_utils.dart';
 import 'package:cocoon_service/src/service/bigquery.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
@@ -57,88 +55,6 @@ void main() {
           .thenAnswer((Invocation invocation) {
         return const Stream<Issue>.empty();
       });
-
-      // when gets the content of .ci.yaml
-      // when(mockRepositoriesService.getContents(
-      //   captureAny,
-      //   kCiYamlPath,
-      // )).thenAnswer((Invocation invocation) {
-      //   return Future<RepositoryContents>.value(
-      //       RepositoryContents(file: GitHubFile(content: gitHubEncode(ciYamlContent))));
-      // });
-
-      final CiYaml testCiYaml = CiYaml(
-        slug: Config.flutterSlug,
-        branch: Config.defaultBranch(Config.flutterSlug),
-        config: pb.SchedulerConfig(
-          enabledBranches: <String>[
-            Config.defaultBranch(Config.flutterSlug),
-          ],
-          targets: <pb.Target>[
-            pb.Target(
-              name: 'Mac_android android_semantics_integration_test',
-              scheduler: pb.SchedulerSystem.luci,
-              presubmit: false,
-              properties: <String, String>{
-                'tags': jsonEncode(['devicelab'])
-              },
-            ),
-            pb.Target(
-              name: 'Mac_android ignore_myflakiness',
-              scheduler: pb.SchedulerSystem.luci,
-              presubmit: false,
-              properties: <String, String>{
-                'ignore_flakiness': 'true',
-                'tags': jsonEncode(['devicelab']),
-              }
-            ),
-            pb.Target(
-              name: 'Linux ci_yaml flutter roller',
-              scheduler: pb.SchedulerSystem.luci,
-              bringup: true,
-              timeout: 30,
-              runIf: ['.ci.yaml'],
-              recipe: 'infra/ci_yaml',
-              properties: <String, String> {
-                'tags': jsonEncode(["framework", "hostonly", "shard"]),
-              },
-
-            ),
-            pb.Target(
-              name: 'Mac build_tests_1_4',
-              scheduler: pb.SchedulerSystem.luci,
-              recipe: 'flutter/flutter_drone',
-              timeout: 60,
-              properties: <String, String> {
-                'add_recipes_cq': 'true',
-                'shard': 'build_tests',
-                'subshard': '1_4',
-                'tags': jsonEncode(["framework", "hostonly", "shard"]),
-                'dependencies': jsonEncode([
-                  {
-                    'dependency': 'android_sdk', 'version': 'version:29.0',
-                  },
-                  {
-                    'dependency': 'chrome_and_driver', 'version': 'version:84',
-                  },
-                  {
-                    'dependency': 'xcode', 'version': '13a233',
-                  },
-                  {
-                    'dependency': 'open_jdk', 'version': '11',
-                  },
-                  {
-                    'dependency': 'gems', 'version': 'v3.3.14',
-                  },
-                  {
-                    'dependency': 'goldctl', 'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
-                  },
-                ]),
-              },
-            ),
-          ],
-        ),
-      );
 
       // when gets the content of TESTOWNERS
       when(mockRepositoriesService.getContents(

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -10,7 +10,6 @@ import 'package:cocoon_service/src/service/config.dart';
 
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 
-
 const String expectedSemanticsIntegrationTestIssueComment = '''
 [prod pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
 One recent flaky example for a same commit: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/103
@@ -225,14 +224,13 @@ final CiYaml testCiYaml = CiYaml(
         },
       ),
       pb.Target(
-        name: 'Mac_android ignore_myflakiness',
-        scheduler: pb.SchedulerSystem.luci,
-        presubmit: false,
-        properties: <String, String>{
-          'ignore_flakiness': 'true',
-          'tags': jsonEncode(['devicelab']),
-        }
-      ),
+          name: 'Mac_android ignore_myflakiness',
+          scheduler: pb.SchedulerSystem.luci,
+          presubmit: false,
+          properties: <String, String>{
+            'ignore_flakiness': 'true',
+            'tags': jsonEncode(['devicelab']),
+          }),
       pb.Target(
         name: 'Linux ci_yaml flutter roller',
         scheduler: pb.SchedulerSystem.luci,
@@ -240,39 +238,44 @@ final CiYaml testCiYaml = CiYaml(
         timeout: 30,
         runIf: ['.ci.yaml'],
         recipe: 'infra/ci_yaml',
-        properties: <String, String> {
+        properties: <String, String>{
           'tags': jsonEncode(["framework", "hostonly", "shard"]),
         },
-
       ),
       pb.Target(
         name: 'Mac build_tests_1_4',
         scheduler: pb.SchedulerSystem.luci,
         recipe: 'flutter/flutter_drone',
         timeout: 60,
-        properties: <String, String> {
+        properties: <String, String>{
           'add_recipes_cq': 'true',
           'shard': 'build_tests',
           'subshard': '1_4',
           'tags': jsonEncode(["framework", "hostonly", "shard"]),
           'dependencies': jsonEncode([
             {
-              'dependency': 'android_sdk', 'version': 'version:29.0',
+              'dependency': 'android_sdk',
+              'version': 'version:29.0',
             },
             {
-              'dependency': 'chrome_and_driver', 'version': 'version:84',
+              'dependency': 'chrome_and_driver',
+              'version': 'version:84',
             },
             {
-              'dependency': 'xcode', 'version': '13a233',
+              'dependency': 'xcode',
+              'version': '13a233',
             },
             {
-              'dependency': 'open_jdk', 'version': '11',
+              'dependency': 'open_jdk',
+              'version': '11',
             },
             {
-              'dependency': 'gems', 'version': 'v3.3.14',
+              'dependency': 'gems',
+              'version': 'v3.3.14',
             },
             {
-              'dependency': 'goldctl', 'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
+              'dependency': 'goldctl',
+              'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
             },
           ]),
         },

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -4,7 +4,12 @@
 
 import 'dart:convert';
 
+import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/service/bigquery.dart';
+import 'package:cocoon_service/src/service/config.dart';
+
+import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
+
 
 const String expectedSemanticsIntegrationTestIssueComment = '''
 [prod pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
@@ -203,66 +208,78 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
-const String ciYamlContent = '''
-# Describes the targets run in continuous integration environment.
-#
-# Flutter infra uses this file to generate a checklist of tasks to be performed
-# for every commit.
-#
-# More information at:
-#  * https://github.com/flutter/cocoon/blob/master/scheduler/README.md
-enabled_branches:
-  - master
+final CiYaml testCiYaml = CiYaml(
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
+  config: pb.SchedulerConfig(
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.flutterSlug),
+    ],
+    targets: <pb.Target>[
+      pb.Target(
+        name: 'Mac_android android_semantics_integration_test',
+        scheduler: pb.SchedulerSystem.luci,
+        presubmit: false,
+        properties: <String, String>{
+          'tags': jsonEncode(['devicelab'])
+        },
+      ),
+      pb.Target(
+        name: 'Mac_android ignore_myflakiness',
+        scheduler: pb.SchedulerSystem.luci,
+        presubmit: false,
+        properties: <String, String>{
+          'ignore_flakiness': 'true',
+          'tags': jsonEncode(['devicelab']),
+        }
+      ),
+      pb.Target(
+        name: 'Linux ci_yaml flutter roller',
+        scheduler: pb.SchedulerSystem.luci,
+        bringup: true,
+        timeout: 30,
+        runIf: ['.ci.yaml'],
+        recipe: 'infra/ci_yaml',
+        properties: <String, String> {
+          'tags': jsonEncode(["framework", "hostonly", "shard"]),
+        },
 
-targets:
-  - name: Mac_android android_semantics_integration_test
-    builder: Mac_android android_semantics_integration_test
-    presubmit: false
-    scheduler: luci
-    properties:
-      tags: >
-        ["devicelab"]
-
-  - name: Mac_android ignore_myflakiness
-    builder: Mac_android android_semantics_integration_test
-    presubmit: false
-    scheduler: luci
-    properties:
-      ignore_flakiness: "true"
-      tags: >
-        ["devicelab"]
-
-  - name: Linux ci_yaml flutter roller
-    recipe: infra/ci_yaml
-    bringup: true # TODO(chillers): https://github.com/flutter/flutter/issues/93225
-    timeout: 30
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - .ci.yaml
-
-  - name: Mac build_tests_1_4
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode", "version": "13a233"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
-        ]
-      shard: build_tests
-      subshard: "1_4"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-''';
+      ),
+      pb.Target(
+        name: 'Mac build_tests_1_4',
+        scheduler: pb.SchedulerSystem.luci,
+        recipe: 'flutter/flutter_drone',
+        timeout: 60,
+        properties: <String, String> {
+          'add_recipes_cq': 'true',
+          'shard': 'build_tests',
+          'subshard': '1_4',
+          'tags': jsonEncode(["framework", "hostonly", "shard"]),
+          'dependencies': jsonEncode([
+            {
+              'dependency': 'android_sdk', 'version': 'version:29.0',
+            },
+            {
+              'dependency': 'chrome_and_driver', 'version': 'version:84',
+            },
+            {
+              'dependency': 'xcode', 'version': '13a233',
+            },
+            {
+              'dependency': 'open_jdk', 'version': '11',
+            },
+            {
+              'dependency': 'gems', 'version': 'v3.3.14',
+            },
+            {
+              'dependency': 'goldctl', 'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
+            },
+          ]),
+        },
+      ),
+    ],
+  ),
+);
 
 const String testOwnersContent = '''
 

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/ci_yaml.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -323,7 +323,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -447,7 +447,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   timing:
     dependency: transitive
     description:
@@ -573,7 +573,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
@@ -596,5 +596,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.10.0"


### PR DESCRIPTION
## Description

Update to flaky issues handler code so that we use the protobuf and wrappers instead of using the ciYaml directly. This will avoid issues with deprecated features as we will only receive changes via the protobuf definitions.

## Issue(s)

https://github.com/flutter/flutter/issues/87529

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
