### PR TITLE
Updated with a fix for the validate test owners fix. As the current c…

### DIFF
--- a/app_dart/bin/validate_task_ownership.dart
+++ b/app_dart/bin/validate_task_ownership.dart
@@ -28,7 +28,7 @@ Future<List<String>> remoteCheck(String repo, String ref) async {
     ref: ref,
   );
 
-  final List<String> noOwnerBuilders = validateOwnership(ciYamlContent, testOwnersContent);
+  final List<String> noOwnerBuilders = validateOwnership(ciYamlContent, testOwnersContent, unfilteredTargets: true);
   return noOwnerBuilders;
 }
 
@@ -42,7 +42,7 @@ List<String> localCheck(String ciYamlPath, String testOwnersPath) {
     io.exit(1);
   }
   final List<String> noOwnerBuilders =
-      validateOwnership(ciYamlFile.readAsStringSync(), testOwnersFile.readAsStringSync());
+      validateOwnership(ciYamlFile.readAsStringSync(), testOwnersFile.readAsStringSync(), unfilteredTargets: true);
   return noOwnerBuilders;
 }
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -161,18 +161,26 @@ Future<void> insertBigquery(String tableName, Map<String, dynamic> data, Tableda
 }
 
 /// Validate test ownership defined in [testOwnersContent] for tests configured in `ciYamlContent`.
-List<String> validateOwnership(String ciYamlContent, String testOwnersContent) {
+List<String> validateOwnership(String ciYamlContent, String testOwnersContent, {bool unfilteredTargets = false}) {
   final List<String> noOwnerBuilders = <String>[];
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
-  final pb.SchedulerConfig schedulerConfig = CiYaml(
+  
+  final CiYaml ciYamlFromProto = CiYaml(
     slug: Config.flutterSlug,
     branch: Config.defaultBranch(Config.flutterSlug),
     config: unCheckedSchedulerConfig,
-  ).config;
+  );
+
+  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.config;
+
   for (pb.Target target in schedulerConfig.targets) {
     final String builder = target.name;
-    final String? owner = getTestOwnership(builder, getTypeForBuilder(builder, ciYaml!), testOwnersContent).owner;
+    final String? owner = getTestOwnership(
+      builder,
+      getTypeForBuilder(builder, ciYamlFromProto, unfilteredTargets: unfilteredTargets),
+      testOwnersContent,
+    ).owner;
     print('$builder: $owner');
     if (owner == null) {
       noOwnerBuilders.add(builder);

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -75,6 +75,12 @@ class CiYaml {
         slug: slug,
       ));
 
+  List<Target> get targets => config.targets.map((pb.Target target) => Target(
+        schedulerConfig: config,
+        value: target,
+        slug: slug,
+      )).toList();
+
   /// Filter [targets] to only those that are expected to run for [branch].
   ///
   /// A [Target] is expected to run if:

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -89,6 +89,14 @@ class Target {
     return BatchPolicy();
   }
 
+  /// Get the tags from the defined properties in the ci.
+  ///
+  /// Return an empty list if no tags are found.
+  List<String> get getTags {
+    Map<String, Object> properties = getProperties();
+    return (properties.containsKey('tags')) ? (properties['tags'] as List).map((e) => e as String).toList() : [];
+  }
+
   /// Gets the assembled properties for this [pb.Target].
   ///
   /// Target properties are prioritized in:

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -74,8 +74,9 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       slug,
       kTestOwnerPath,
     );
+
     for (final _BuilderInfo info in eligibleBuilders) {
-      final BuilderType type = getTypeForBuilder(info.name, loadYaml(ciContent) as YamlMap);
+      final BuilderType type = getTypeForBuilder(info.name, ciYaml);
       final TestOwnership testOwnership = getTestOwnership(info.name!, type, testOwnerContent);
       final List<BuilderRecord> builderRecords =
           await bigquery.listRecentBuildRecordsForBuilder(kBigQueryProjectId, builder: info.name, limit: kRecordNumber);
@@ -154,6 +155,8 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
       if (nameToExistingPRs.containsKey(builder)) {
         continue;
       }
+
+      //TODO (ricardoamador): Refactor this so we don't need to parse the entire yaml looking for commented issues, https://github.com/flutter/flutter/issues/113232
       int builderLineNumber = lines.indexWhere((String line) => line.contains('name: $builder')) + 1;
       while (builderLineNumber < lines.length && !lines[builderLineNumber].contains('name:')) {
         if (lines[builderLineNumber].contains('$kCiYamlTargetIsFlakyKey:')) {

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -57,7 +57,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
       if (statistic.flakyRate < _threshold) {
         continue;
       }
-      final BuilderType type = getTypeForBuilder(statistic.name, ci!);
+      final BuilderType type = getTypeForBuilder(statistic.name, ciYaml);
       await _fileIssueAndPR(
         gitHub,
         slug,
@@ -65,7 +65,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
             statistic: statistic,
             existingIssue: nameToExistingIssue[statistic.name],
             existingPullRequest: nameToExistingPR[statistic.name],
-            isMarkedFlaky: _getIsMarkedFlaky(statistic.name, ci),
+            isMarkedFlaky: _getIsMarkedFlaky(statistic.name, ci!),
             type: type,
             ownership: getTestOwnership(statistic.name, type, testOwnerContent)),
       );

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -105,6 +105,34 @@ void main() {
         });
       });
 
+      test('tags are parsed from within properties', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Linux_build_test',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'android_sdk': 'abc',
+          },
+          properties: <String, String>{'xcode': '12abc', 'tags': '["devicelab", "android", "linux"]'},
+        );
+        expect(target.getTags, ['devicelab', 'android', 'linux']);
+      });
+
+      test('we do not blow up if tags are not present', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Linux_build_test',
+          platformProperties: <String, String>{
+            // This should be overrided by the target specific property
+            'android_sdk': 'abc',
+          },
+          properties: <String, String>{
+            'xcode': '12abc',
+          },
+        );
+        expect(target.getTags, []);
+      });
+
       test('platform properties with xcode', () {
         final Target target = generateTarget(
           1,

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -56,14 +56,6 @@ void main() {
         return const Stream<Issue>.empty();
       });
 
-      // when gets the content of .ci.yaml
-      when(mockRepositoriesService.getContents(
-        captureAny,
-        kCiYamlPath,
-      )).thenAnswer((Invocation invocation) {
-        return Future<RepositoryContents>.value(
-            RepositoryContents(file: GitHubFile(content: gitHubEncode(ciYamlContent))));
-      });
       // when gets the content of TESTOWNERS
       when(mockRepositoriesService.getContents(
         captureAny,
@@ -87,6 +79,7 @@ void main() {
       handler = UpdateExistingFlakyIssue(
         config: config,
         authenticationProvider: auth,
+        ciYaml: testCiYaml,
       );
     });
 
@@ -326,6 +319,7 @@ void main() {
       )).thenAnswer((Invocation invocation) {
         return Future<Response>.value(Response('[]', 200));
       });
+
       final Map<String, dynamic> result = await utf8.decoder
           .bind((await tester.get<Body>(handler)).serialize() as Stream<List<int>>)
           .transform(json.decoder)

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -4,7 +4,11 @@
 
 import 'dart:convert';
 
+import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/service/bigquery.dart';
+import 'package:cocoon_service/src/service/config.dart';
+
+import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 
 const String expectedSemanticsIntegrationTestIssueComment = '''
 [prod pool] current flaky ratio for the past (up to) 100 commits is 50.00%. Flaky number: 3; total number: 10.
@@ -203,66 +207,82 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter
 Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
-const String ciYamlContent = '''
-# Describes the targets run in continuous integration environment.
-#
-# Flutter infra uses this file to generate a checklist of tasks to be performed
-# for every commit.
-#
-# More information at:
-#  * https://github.com/flutter/cocoon/blob/master/scheduler/README.md
-enabled_branches:
-  - master
-
-targets:
-  - name: Mac_android android_semantics_integration_test
-    builder: Mac_android android_semantics_integration_test
-    presubmit: false
-    scheduler: luci
-    properties:
-      tags: >
-        ["devicelab"]
-
-  - name: Mac_android ignore_myflakiness
-    builder: Mac_android android_semantics_integration_test
-    presubmit: false
-    scheduler: luci
-    properties:
-      ignore_flakiness: "true"
-      tags: >
-        ["devicelab"]
-
-  - name: Linux ci_yaml flutter roller
-    recipe: infra/ci_yaml
-    bringup: true # TODO(chillers): https://github.com/flutter/flutter/issues/93225
-    timeout: 30
-    properties:
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-    runIf:
-      - .ci.yaml
-
-  - name: Mac build_tests_1_4
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:29.0"},
-          {"dependency": "chrome_and_driver", "version": "version:84"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode", "version": "13a233"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
-        ]
-      shard: build_tests
-      subshard: "1_4"
-      tags: >
-        ["framework","hostonly","shard"]
-    scheduler: luci
-''';
+final CiYaml testCiYaml = CiYaml(
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
+  config: pb.SchedulerConfig(
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.flutterSlug),
+    ],
+    targets: <pb.Target>[
+      pb.Target(
+        name: 'Mac_android android_semantics_integration_test',
+        scheduler: pb.SchedulerSystem.luci,
+        presubmit: false,
+        properties: <String, String>{
+          'tags': jsonEncode(['devicelab'])
+        },
+      ),
+      pb.Target(
+          name: 'Mac_android ignore_myflakiness',
+          scheduler: pb.SchedulerSystem.luci,
+          presubmit: false,
+          properties: <String, String>{
+            'ignore_flakiness': 'true',
+            'tags': jsonEncode(['devicelab']),
+          }),
+      pb.Target(
+        name: 'Linux ci_yaml flutter roller',
+        scheduler: pb.SchedulerSystem.luci,
+        bringup: true,
+        timeout: 30,
+        runIf: ['.ci.yaml'],
+        recipe: 'infra/ci_yaml',
+        properties: <String, String>{
+          'tags': jsonEncode(["framework", "hostonly", "shard"]),
+        },
+      ),
+      pb.Target(
+        name: 'Mac build_tests_1_4',
+        scheduler: pb.SchedulerSystem.luci,
+        recipe: 'flutter/flutter_drone',
+        timeout: 60,
+        properties: <String, String>{
+          'add_recipes_cq': 'true',
+          'shard': 'build_tests',
+          'subshard': '1_4',
+          'tags': jsonEncode(["framework", "hostonly", "shard"]),
+          'dependencies': jsonEncode([
+            {
+              'dependency': 'android_sdk',
+              'version': 'version:29.0',
+            },
+            {
+              'dependency': 'chrome_and_driver',
+              'version': 'version:84',
+            },
+            {
+              'dependency': 'xcode',
+              'version': '13a233',
+            },
+            {
+              'dependency': 'open_jdk',
+              'version': '11',
+            },
+            {
+              'dependency': 'gems',
+              'version': 'v3.3.14',
+            },
+            {
+              'dependency': 'goldctl',
+              'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
+            },
+          ]),
+        },
+      ),
+    ],
+  ),
+);
 
 const String testOwnersContent = '''
 

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/ci_yaml.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -323,7 +323,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -447,7 +447,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   timing:
     dependency: transitive
     description:
@@ -573,7 +573,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
@@ -596,5 +596,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.10.0"


### PR DESCRIPTION
## Description

This pull request adds a fix for revert (https://github.com/flutter/cocoon/pull/2220) that was failing the validate_task_ownership. The fix was to allow the test access to all targets since the current implementation will filter the targets based on the default branch for the merge. The validate_task_ownership test uses a candidate branch which does not work with filtered targets.

## Issues Fixed by this Pull Request

Fixes https://github.com/flutter/flutter/issues/113473

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
