### PR TITLE
Allow cache cleanup in osx_properties.

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -129,6 +129,10 @@ class Target {
         'sdk_version': mergedProperties['xcode']!,
       };
 
+      if (mergedProperties.containsKey('cleanup_xcode_cache')) {
+        (xcodeVersion as Map)['cleanup_xcode_cache'] = mergedProperties['cleanup_xcode_cache']!;
+      }
+
       if (iosPlatforms.contains(getPlatform())) {
         mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;
       } else {

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -127,11 +127,9 @@ class Target {
     if (mergedProperties.containsKey('xcode')) {
       final Object xcodeVersion = <String, Object>{
         'sdk_version': mergedProperties['xcode']!,
+        if (mergedProperties.containsKey('cleanup_xcode_cache'))
+          'cleanup_cache': mergedProperties['cleanup_xcode_cache']!
       };
-
-      if (mergedProperties.containsKey('cleanup_xcode_cache')) {
-        (xcodeVersion as Map)['cleanup_cache'] = mergedProperties['cleanup_xcode_cache']!;
-      }
 
       if (iosPlatforms.contains(getPlatform())) {
         mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -130,7 +130,7 @@ class Target {
       };
 
       if (mergedProperties.containsKey('cleanup_xcode_cache')) {
-        (xcodeVersion as Map)['cleanup_xcode_cache'] = mergedProperties['cleanup_xcode_cache']!;
+        (xcodeVersion as Map)['cleanup_cache'] = mergedProperties['cleanup_xcode_cache']!;
       }
 
       if (iosPlatforms.contains(getPlatform())) {

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -123,7 +123,7 @@ void main() {
         });
       });
 
-      test('platform properties with xcode', () {
+      test('platform properties with xcode and clean_cache', () {
         final Target target = generateTarget(
           1,
           platform: 'Mac_ios',

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -123,6 +123,21 @@ void main() {
         });
       });
 
+      test('platform properties with xcode', () {
+        final Target target = generateTarget(
+          1,
+          platform: 'Mac_ios',
+          platformProperties: <String, String>{'xcode': '12abc', 'cleanup_xcode_cache': 'true'},
+        );
+        expect(target.getProperties(), <String, Object>{
+          'xcode': '12abc',
+          'cleanup_xcode_cache': true,
+          'dependencies': <String>[],
+          '\$flutter/devicelab_osx_sdk': <String, Object>{'sdk_version': '12abc', 'cleanup_cache': true},
+          'bringup': false,
+        });
+      });
+
       test('platform properties with runtime_versions', () {
         final Target target = generateTarget(
           1,


### PR DESCRIPTION
The scheduler is overriding the osx_properties passed from infra configs. This PR adds support for cleanup_xcode_cache.

Bug: https://github.com/flutter/flutter/issues/113539


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
