### PR TITLE
Remove obsolete branch doc

### DIFF
--- a/app_dart/README.md
+++ b/app_dart/README.md
@@ -164,9 +164,3 @@ For more options run:
 ```sh
 $ dart dev/deploy.dart --help
 ```
-
-### Branching support for flutter repo
-
-Add targeted branches in `dev/branches.txt`, based on which cocoon API filters targeted branches and then runs tests on those branches. With tests running against different branches, the frontend then supports listing commits on a specific branch (defaulting to master).
-
-Once the PR has merged, go to https://flutter-dashboard.appspot.com/api/flush-cache?key=flutterBranches to flush the cache and have the latest change take effect. Otherwise, it can take 12 hours for it to propagate. Ensure you are signed into [cocoon dashboard](https://flutter-dashboard.appspot.com) otherwise it will throw a 403.


### PR DESCRIPTION
The `dev/branches.txt` has been removed and this PR removes obsolete doc.