### PR TITLE
Support postsubmit checkruns for plugins/packages

### DIFF
--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -103,6 +103,7 @@ Future<void> main() async {
         config: config,
         luciBuildService: luciBuildService,
         scheduler: scheduler,
+        githubChecksService: githubChecksService,
       ),
       '/api/push-build-status-to-github': PushBuildStatusToGithub(
         config: config,

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:cocoon_service/ci_yaml.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:gcloud/db.dart';
+import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
@@ -17,6 +18,7 @@ import '../request_handling/exceptions.dart';
 import '../request_handling/subscription_handler.dart';
 import '../service/datastore.dart';
 import '../service/logging.dart';
+import '../service/github_checks_service.dart';
 import '../service/scheduler.dart';
 
 /// An endpoint for listening to build updates for postsubmit builds.
@@ -35,11 +37,13 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     @visibleForTesting this.datastoreProvider = DatastoreService.defaultProvider,
     required this.luciBuildService,
     required this.scheduler,
+    required this.githubChecksService,
   }) : super(subscriptionName: 'luci-postsubmit');
 
   final DatastoreServiceProvider datastoreProvider;
   final LuciBuildService luciBuildService;
   final Scheduler scheduler;
+  final GithubChecksService githubChecksService;
 
   @override
   Future<Body> post() async {
@@ -69,6 +73,22 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       userData = jsonDecode(buildPushMessage.userData!) as Map<String, dynamic>;
     } on FormatException {
       userData = jsonDecode(String.fromCharCodes(base64.decode(buildPushMessage.userData!))) as Map<String, dynamic>;
+    }
+
+    if (userData.containsKey('repo_owner') && userData.containsKey('repo_name')) {
+      // Message is coming from a github checks api (postsubmit) enabled repo. We need to
+      // create the slug from the data in the message and send the check status
+      // update.
+
+      RepositorySlug slug = RepositorySlug(
+        userData['repo_owner'] as String,
+        userData['repo_name'] as String,
+      );
+      await githubChecksService.updateCheckStatus(
+        buildPushMessage,
+        luciBuildService,
+        slug,
+      );
     }
 
     final String? rawTaskKey = userData['task_key'] as String?;

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -49,6 +49,14 @@ class Config {
         pluginsSlug,
       };
 
+  /// List of Github postsubmit supported repos.
+  ///
+  /// This adds support for check runs to the repo.
+  Set<gh.RepositorySlug> get postsubmitSupportedRepos => <gh.RepositorySlug>{
+        packagesSlug,
+        pluginsSlug,
+      };
+
   /// List of Cirrus supported repos.
   static Set<String> cirrusSupportedRepos = <String>{'plugins', 'packages', 'flutter'};
 
@@ -416,5 +424,9 @@ class Config {
 
   bool githubPresubmitSupportedRepo(gh.RepositorySlug slug) {
     return supportedRepos.contains(slug);
+  }
+
+  bool githubPostsubmitSupportedRepo(gh.RepositorySlug slug) {
+    return postsubmitSupportedRepos.contains(slug);
   }
 }

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -101,7 +101,7 @@ class GithubChecksService {
     // If status has completed with failure then provide more details.
     if (status == github.CheckRunStatus.completed && failedStatesSet.contains(conclusion)) {
       final Build build =
-          await luciBuildService.getTryBuildById(buildPushMessage.build!.id, fields: 'id,builder,summaryMarkdown');
+          await luciBuildService.getBuildById(buildPushMessage.build!.id, fields: 'id,builder,summaryMarkdown');
       output = github.CheckRunOutput(title: checkRun.name!, summary: getGithubSummary(build.summaryMarkdown));
     }
     log.fine('Updating check run with output: [$output]');

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -164,6 +164,7 @@ void main() {
       'COMPLETED',
       result: 'SUCCESS',
       builderName: 'Linux Packages',
+      // Use escaped string to mock json decoded ones.
       userData:
           '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"repo_owner\\": \\"flutter\\", \\"repo_name\\": \\"packages\\"}',
     );

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -52,6 +52,7 @@ class FakeConfig implements Config {
     this.flutterGoldFollowUpAlertValue,
     this.flutterGoldDraftChangeValue,
     this.flutterGoldStalePRValue,
+    this.postsubmitSupportedReposValue,
     this.supportedBranchesValue,
     this.supportedReposValue,
     this.batchSizeValue,
@@ -96,6 +97,7 @@ class FakeConfig implements Config {
   List<String>? supportedBranchesValue;
   String? overrideTreeStatusLabelValue;
   Set<gh.RepositorySlug>? supportedReposValue;
+  Set<gh.RepositorySlug>? postsubmitSupportedReposValue;
   Duration? githubRequestDelayValue;
 
   @override
@@ -231,6 +233,14 @@ class FakeConfig implements Config {
   }
 
   @override
+  bool githubPostsubmitSupportedRepo(gh.RepositorySlug slug) {
+    return <gh.RepositorySlug>[
+      Config.packagesSlug,
+      Config.pluginsSlug,
+    ].contains(slug);
+  }
+
+  @override
   Future<String> generateGithubToken(gh.RepositorySlug slug) {
     throw UnimplementedError();
   }
@@ -266,6 +276,10 @@ class FakeConfig implements Config {
 
   @override
   Set<gh.RepositorySlug> get supportedRepos => supportedReposValue ?? <gh.RepositorySlug>{Config.flutterSlug};
+
+  @override
+  Set<gh.RepositorySlug> get postsubmitSupportedRepos =>
+      postsubmitSupportedReposValue ?? <gh.RepositorySlug>{Config.packagesSlug};
 
   @override
   Future<Iterable<Branch>> getBranches(gh.RepositorySlug slug) async {


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/106902

This PR enables checkrun support for plugins and packages:
1) create checkrun when commit lands
2) update checkrun when builds finish

This PR has been validated with cocoon repo:
<img width="976" alt="Screen Shot 2022-10-21 at 2 44 20 PM" src="https://user-images.githubusercontent.com/54558023/197293345-44c5afd0-ad7b-4d86-abe7-ce1df63abb34.png">

/cc @stuartmorgan 