### PR TITLE
[app_dart] Reduce create branch delays

### DIFF
--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -27,7 +27,7 @@ class BranchService {
   BranchService({
     required this.config,
     required this.gerritService,
-    this.retryOptions = const RetryOptions(),
+    this.retryOptions = const RetryOptions(maxAttempts: 3),
   });
 
   final Config config;

--- a/app_dart/lib/src/service/gerrit_service.dart
+++ b/app_dart/lib/src/service/gerrit_service.dart
@@ -108,7 +108,7 @@ class GerritService {
     final http.Client client = RetryClient(
       authClient,
       when: (http.BaseResponse response) => _responseIsAcceptable(response) == false,
-      delay: (int attempt) => retryDelay ?? const Duration(seconds: 3) * attempt,
+      delay: (int attempt) => retryDelay ?? const Duration(seconds: 1) * attempt,
     );
     final http.Response response = await client.put(
       url,


### PR DESCRIPTION
An attempted fix at getting the pubsub retries to kick in by reducing max runtime to less than 60 seconds.

https://github.com/flutter/flutter/issues/112036