### PR TITLE
[codesign + recipe ] read passwords from a file

### DIFF
--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -16,9 +16,9 @@ const String kHelpFlag = 'help';
 const String kDryrunFlag = 'dryrun';
 const String kCodesignCertNameOption = 'CODESIGN-CERT-NAME';
 const String kCodesignUserNameOption = 'CODESIGN-USERNAME';
-const String kGcsDownloadPathOption = 'GCS-DOWNLOAD-PATH';
-const String kGcsUploadPathOption = 'GCS-UPLOAD-PATH';
-const String kCredentialsPathOption = 'PASSWORD-FILE-PATH';
+const String kGcsDownloadPathOption = 'gcs-download-path';
+const String kGcsUploadPathOption = 'gcs-upload-path';
+const String kCredentialsPathOption = 'password-file-path';
 
 /// Perform Mac code signing based on file paths.
 ///
@@ -32,21 +32,28 @@ const String kCredentialsPathOption = 'PASSWORD-FILE-PATH';
 /// For [kGcsDownloadPathOption] and [kGcsUploadPathOption], they are required parameter to specify the google cloud bucket paths.
 /// [kGcsDownloadPathOption] is the google cloud bucket prefix to download the remote artifacts,
 /// [kGcsUploadPathOption] is the cloud bucket prefix to upload codesigned artifact to.
-/// For example, supply '--GCS-DOWNLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip',
-/// and code sign app will download the artifact at 'flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip' on google cloud storage
+/// For example, supply
+/// '--gcs-download-path=gs://flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip',
+/// and code sign app will download the artifact at
+/// 'flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip'
+/// on google cloud storage
 ///
-/// For [kCredentialsPathOption], this is the file path of the password file in file system. The password file stores sensitive passwords.
+/// For [kCredentialsPathOption], this is the file path of the password file in file system.
+/// The password file stores sensitive passwords.
 /// sensitive passwords include <CODESIGN-APPSTORE-ID>, <CODESIGN-TEAM-ID>, and <APP-SPECIFIC-PASSWORD>.
-/// For example, if a user supplies --PASSWORD-FILE-PATH=/tmp/passwords.txt, then we would be expecting a password file located at /tmp/passwords.txt.
-/// The password file should provide the password value for each of the password name, deliminated by a single colon. The content of a password file would look similar to:
+/// For example, if a user supplies --password-file-path=/tmp/passwords.txt,
+/// then we would be expecting a password file located at /tmp/passwords.txt.
+/// The password file should provide the password value for each of the password name, deliminated by a single colon.
+/// The content of a password file would look similar to:
 /// CODESIGN-APPSTORE-ID:123
 /// CODESIGN-TEAM-ID:456
 /// APP-SPECIFIC-PASSWORD:789
 ///
 /// Usage:
 /// ```shell
-/// dart run bin/codesign.dart --[no-]dryrun --GCS-DOWNLOAD-PATH=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
-/// --GCS-UPLOAD-PATH=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
+/// dart run bin/codesign.dart --[no-]dryrun
+/// --gcs-download-path=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
+/// --gcs-upload-path=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
 /// ```
 Future<void> main(List<String> args) async {
   final ArgParser parser = ArgParser();
@@ -65,13 +72,13 @@ Future<void> main(List<String> args) async {
     ..addOption(
       kGcsDownloadPathOption,
       help: 'The google cloud bucket path to download the artifact from\n'
-          'e.g. supply `--GCS-DOWNLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip`'
+          'e.g. supply `--gcs-download-path=gs://flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip`'
           ' if you would like to codesign ios-deploy.zip, which has a google cloud bucket path of flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip to be downloaded from \n',
     )
     ..addOption(
       kGcsUploadPathOption,
       help: 'The google cloud bucket path to upload the artifact to. \n'
-          'e.g. supply `--GCS-UPLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip`'
+          'e.g. supply `--gcs-upload-path=gs://flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip`'
           ' if you would like to codesign ios-deploy.zip, which has a google cloud bucket path of flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip to be uploaded to',
     )
     ..addOption(

--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -14,8 +14,8 @@ import 'package:process/process.dart';
 /// Definitions of variables are included in help texts below.
 const String kHelpFlag = 'help';
 const String kDryrunFlag = 'dryrun';
-const String kCodesignCertNameOption = 'CODESIGN-CERT-NAME';
-const String kCodesignUserNameOption = 'CODESIGN-USERNAME';
+const String kCodesignCertNameOption = 'codesign-cert-name';
+const String kCodesignUserNameOption = 'codesign-username';
 const String kGcsDownloadPathOption = 'gcs-download-path';
 const String kGcsUploadPathOption = 'gcs-upload-path';
 const String kAppSpecificPasswordOption = 'app-specific-password-file-path';
@@ -56,8 +56,8 @@ const String kCodesignTeamIDOption = 'codesign-team-id-file-path';
 /// Usage:
 /// ```shell
 /// dart run bin/codesign.dart --[no-]dryrun
-/// --CODESIGN-CERT-NAME="FLUTTER.IO LLC"
-/// --CODESIGN_USERNAME=stores@flutter.io
+/// --codesign-cert-name="FLUTTER.IO LLC"
+/// --codesign-username=stores@flutter.io
 /// --codesign-team-id-file-path=/a/b/c.txt
 /// --codesign-appstore-id-file-path=/a/b/b.txt
 /// --app-specific-password-file-path=/a/b/a.txt
@@ -115,15 +115,13 @@ Future<void> main(List<String> args) async {
 
   const Platform platform = LocalPlatform();
 
-  final String codesignCertName = getValueFromEnvOrArgs(kCodesignCertNameOption, argResults, platform.environment)!;
-  final String codesignUserName = getValueFromEnvOrArgs(kCodesignUserNameOption, argResults, platform.environment)!;
-  final String gCloudDownloadPath = getValueFromEnvOrArgs(kGcsDownloadPathOption, argResults, platform.environment)!;
-  final String gCloudUploadPath = getValueFromEnvOrArgs(kGcsUploadPathOption, argResults, platform.environment)!;
-  final String appSpecificPasswordFilePath =
-      getValueFromEnvOrArgs(kAppSpecificPasswordOption, argResults, platform.environment)!;
-  final String codesignAppstoreIDFilePath =
-      getValueFromEnvOrArgs(kCodesignAppstoreIDOption, argResults, platform.environment)!;
-  final String codesignTeamIDFilePath = getValueFromEnvOrArgs(kCodesignTeamIDOption, argResults, platform.environment)!;
+  final String codesignCertName = getValueFromArgs(kCodesignCertNameOption, argResults)!;
+  final String codesignUserName = getValueFromArgs(kCodesignUserNameOption, argResults)!;
+  final String gCloudDownloadPath = getValueFromArgs(kGcsDownloadPathOption, argResults)!;
+  final String gCloudUploadPath = getValueFromArgs(kGcsUploadPathOption, argResults)!;
+  final String appSpecificPasswordFilePath = getValueFromArgs(kAppSpecificPasswordOption, argResults)!;
+  final String codesignAppstoreIDFilePath = getValueFromArgs(kCodesignAppstoreIDOption, argResults)!;
+  final String codesignTeamIDFilePath = getValueFromArgs(kCodesignTeamIDOption, argResults)!;
 
   final bool dryrun = argResults[kDryrunFlag] as bool;
 

--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -42,7 +42,7 @@ const String kCodesignTeamIDOption = 'codesign-team-id-file-path';
 /// For [kAppSpecificPasswordOption], [kCodesignAppstoreIDOption] and [kCodesignTeamIDOption],
 /// they are file paths of the password files in the file system.
 /// Each of the file paths stores a single line of sensitive password.
-/// sensitive passwords include <CODESIGN-APPSTORE-ID>, <CODESIGN-TEAM-ID>, and <APP-SPECIFIC-PASSWORD>.
+/// sensitive passwords include <CODESIGN_APPSTORE_ID>, <CODESIGN_TEAM_ID>, and <APP_SPECIFIC_PASSWORD>.
 /// For example, if a user supplies --app-specific-password-file-path=/tmp/passwords.txt,
 /// then we would be expecting a password file located at /tmp/passwords.txt.
 /// The password file should contain the password name APP-SPECIFIC-PASSWORD and its value, deliminated by a single colon.
@@ -96,12 +96,12 @@ Future<void> main(List<String> args) async {
     ..addOption(
       kCodesignAppstoreIDOption,
       help:
-          'The file path of a password file in file system. The password file stores the sensitive password <CODESIGN-APPSTORE-ID> \n',
+          'The file path of a password file in file system. The password file stores the sensitive password <CODESIGN_APPSTORE_ID> \n',
     )
     ..addOption(
       kCodesignTeamIDOption,
       help:
-          'The file path of a password file in file system. The password file stores the sensitive password <CODESIGN-TEAM-ID> \n',
+          'The file path of a password file in file system. The password file stores the sensitive password <CODESIGN_TEAM_ID> \n',
     )
     ..addFlag(
       kDryrunFlag,

--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -14,13 +14,10 @@ import 'package:process/process.dart';
 /// Definitions of variables are included in help texts below.
 const String kHelpFlag = 'help';
 const String kDryrunFlag = 'dryrun';
-const String kCodesignCertNameOption = 'codesign-cert-name';
-const String kCodesignUserNameOption = 'codesign-username';
-const String kAppSpecificPasswordOption = 'app-specific-password';
-const String kCodesignAppStoreIdOption = 'codesign-appstore-id';
-const String kCodesignTeamIdOption = 'codesign-team-id';
-const String kGcsDownloadPathOption = 'gcs-download-path';
-const String kGcsUploadPathOption = 'gcs-upload-path';
+const String kCodesignCertNameOption = 'CODESIGN-CERT-NAME';
+const String kCodesignUserNameOption = 'CODESIGN-USERNAME';
+const String kGcsDownloadPathOption = 'GCS-DOWNLOAD-PATH';
+const String kGcsUploadPathOption = 'GCS-UPLOAD-PATH';
 
 /// Perform Mac code signing based on file paths.
 ///
@@ -34,13 +31,13 @@ const String kGcsUploadPathOption = 'gcs-upload-path';
 /// For [kGcsDownloadPathOption] and [kGcsUploadPathOption], they are required parameter to specify the google cloud bucket paths.
 /// [kGcsDownloadPathOption] is the google cloud bucket prefix to download the remote artifacts,
 /// [kGcsUploadPathOption] is the cloud bucket prefix to upload codesigned artifact to.
-/// For example, supply '--gcs-download-path=gs://flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip',
+/// For example, supply '--GCS-DOWNLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip',
 /// and code sign app will download the artifact at 'flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip' on google cloud storage
 ///
 /// Usage:
 /// ```shell
-/// dart run bin/codesign.dart --[no-]dryrun --gcs-download-path=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
-/// --gcs-upload-path=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
+/// dart run bin/codesign.dart --[no-]dryrun --GCS-DOWNLOAD-PATH=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
+/// --GCS-UPLOAD-PATH=gs://flutter_infra_release/flutter/<commit>/android-arm-profile/artifacts.zip
 /// ```
 Future<void> main(List<String> args) async {
   final ArgParser parser = ArgParser();
@@ -57,27 +54,15 @@ Future<void> main(List<String> args) async {
           'the name of the certificate for flutter, for example, is: FLUTTER.IO LLC',
     )
     ..addOption(
-      kAppSpecificPasswordOption,
-      help: 'Unique password specifically for codesigning the given application.',
-    )
-    ..addOption(
-      kCodesignAppStoreIdOption,
-      help: 'Apple developer account email used for authentication with notary service.',
-    )
-    ..addOption(
-      kCodesignTeamIdOption,
-      help: 'Team-id is used by notary service for xcode version 13+.',
-    )
-    ..addOption(
       kGcsDownloadPathOption,
       help: 'The google cloud bucket path to download the artifact from\n'
-          'e.g. supply `--gcs-download-path=gs://flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip`'
+          'e.g. supply `--GCS-DOWNLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip`'
           ' if you would like to codesign ios-deploy.zip, which has a google cloud bucket path of flutter_infra_release/ios-usb-dependencies/unsigned/ios-deploy/<commit>/ios-deploy.zip to be downloaded from \n',
     )
     ..addOption(
       kGcsUploadPathOption,
       help: 'The google cloud bucket path to upload the artifact to. \n'
-          'e.g. supply `--gcs-upload-path=gs://flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip`'
+          'e.g. supply `--GCS-UPLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip`'
           ' if you would like to codesign ios-deploy.zip, which has a google cloud bucket path of flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip to be uploaded to',
     )
     ..addFlag(
@@ -92,10 +77,6 @@ Future<void> main(List<String> args) async {
 
   final String codesignCertName = getValueFromEnvOrArgs(kCodesignCertNameOption, argResults, platform.environment)!;
   final String codesignUserName = getValueFromEnvOrArgs(kCodesignUserNameOption, argResults, platform.environment)!;
-  final String appSpecificPassword =
-      getValueFromEnvOrArgs(kAppSpecificPasswordOption, argResults, platform.environment)!;
-  final String codesignAppstoreId = getValueFromEnvOrArgs(kCodesignAppStoreIdOption, argResults, platform.environment)!;
-  final String codesignTeamId = getValueFromEnvOrArgs(kCodesignTeamIdOption, argResults, platform.environment)!;
   final String gCloudDownloadPath = getValueFromEnvOrArgs(kGcsDownloadPathOption, argResults, platform.environment)!;
   final String gCloudUploadPath = getValueFromEnvOrArgs(kGcsUploadPathOption, argResults, platform.environment)!;
 
@@ -119,9 +100,6 @@ Future<void> main(List<String> args) async {
   return FileCodesignVisitor(
     codesignCertName: codesignCertName,
     codesignUserName: codesignUserName,
-    appSpecificPassword: appSpecificPassword,
-    codesignAppstoreId: codesignAppstoreId,
-    codesignTeamId: codesignTeamId,
     fileSystem: fileSystem,
     rootDirectory: rootDirectory,
     processManager: processManager,

--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -15,7 +15,6 @@ import 'package:process/process.dart';
 const String kHelpFlag = 'help';
 const String kDryrunFlag = 'dryrun';
 const String kCodesignCertNameOption = 'codesign-cert-name';
-const String kCodesignUserNameOption = 'codesign-username';
 const String kGcsDownloadPathOption = 'gcs-download-path';
 const String kGcsUploadPathOption = 'gcs-upload-path';
 const String kAppSpecificPasswordOption = 'app-specific-password-file-path';
@@ -50,14 +49,13 @@ const String kCodesignTeamIDOption = 'codesign-team-id-file-path';
 /// The content of a password file would look similar to:
 /// APP-SPECIFIC-PASSWORD:789
 ///
-/// [kCodesignCertNameOption] and [kCodesignUserNameOption] are public information. For codesigning flutter artifacts,
-/// a user can provide values for these two variables as shown in the example below.
+/// [kCodesignCertNameOption] is public information. For codesigning flutter artifacts,
+/// a user can provide values for this variable as shown in the example below.
 ///
 /// Usage:
 /// ```shell
 /// dart run bin/codesign.dart --[no-]dryrun
 /// --codesign-cert-name="FLUTTER.IO LLC"
-/// --codesign-username=stores@flutter.io
 /// --codesign-team-id-file-path=/a/b/c.txt
 /// --codesign-appstore-id-file-path=/a/b/b.txt
 /// --app-specific-password-file-path=/a/b/a.txt
@@ -116,7 +114,6 @@ Future<void> main(List<String> args) async {
   const Platform platform = LocalPlatform();
 
   final String codesignCertName = getValueFromArgs(kCodesignCertNameOption, argResults)!;
-  final String codesignUserName = getValueFromArgs(kCodesignUserNameOption, argResults)!;
   final String gCloudDownloadPath = getValueFromArgs(kGcsDownloadPathOption, argResults)!;
   final String gCloudUploadPath = getValueFromArgs(kGcsUploadPathOption, argResults)!;
   final String appSpecificPasswordFilePath = getValueFromArgs(kAppSpecificPasswordOption, argResults)!;
@@ -142,7 +139,6 @@ Future<void> main(List<String> args) async {
 
   return FileCodesignVisitor(
     codesignCertName: codesignCertName,
-    codesignUserName: codesignUserName,
     fileSystem: fileSystem,
     rootDirectory: rootDirectory,
     appSpecificPasswordFilePath: appSpecificPasswordFilePath,

--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -18,6 +18,7 @@ const String kCodesignCertNameOption = 'CODESIGN-CERT-NAME';
 const String kCodesignUserNameOption = 'CODESIGN-USERNAME';
 const String kGcsDownloadPathOption = 'GCS-DOWNLOAD-PATH';
 const String kGcsUploadPathOption = 'GCS-UPLOAD-PATH';
+const String kCredentialsPathOption = 'PASSWORD-FILE-PATH';
 
 /// Perform Mac code signing based on file paths.
 ///
@@ -33,6 +34,14 @@ const String kGcsUploadPathOption = 'GCS-UPLOAD-PATH';
 /// [kGcsUploadPathOption] is the cloud bucket prefix to upload codesigned artifact to.
 /// For example, supply '--GCS-DOWNLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip',
 /// and code sign app will download the artifact at 'flutter_infra_release/ios-usb-dependencies/unsigned/libimobiledevice/<commit>/libimobiledevice.zip' on google cloud storage
+///
+/// For [kCredentialsPathOption], this is the file path of the password file in file system. The password file stores sensitive passwords.
+/// sensitive passwords include <CODESIGN-APPSTORE-ID>, <CODESIGN-TEAM-ID>, and <APP-SPECIFIC-PASSWORD>.
+/// For example, if a user supplies --PASSWORD-FILE-PATH=/tmp/passwords.txt, then we would be expecting a password file located at /tmp/passwords.txt.
+/// The password file should provide the password value for each of the password name, deliminated by a single colon. The content of a password file would look similar to:
+/// CODESIGN-APPSTORE-ID:123
+/// CODESIGN-TEAM-ID:456
+/// APP-SPECIFIC-PASSWORD:789
 ///
 /// Usage:
 /// ```shell
@@ -65,6 +74,11 @@ Future<void> main(List<String> args) async {
           'e.g. supply `--GCS-UPLOAD-PATH=gs://flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip`'
           ' if you would like to codesign ios-deploy.zip, which has a google cloud bucket path of flutter_infra_release/ios-usb-dependencies/ios-deploy/<commit>/ios-deploy.zip to be uploaded to',
     )
+    ..addOption(
+      kCredentialsPathOption,
+      help: 'The file path of the password file in file system. The password file stores sensitive passwords.\n'
+          'sensitive passwords include <CODESIGN-APPSTORE-ID>, <CODESIGN-TEAM-ID>, and <APP-SPECIFIC-PASSWORD> \n',
+    )
     ..addFlag(
       kDryrunFlag,
       defaultsTo: true,
@@ -79,6 +93,7 @@ Future<void> main(List<String> args) async {
   final String codesignUserName = getValueFromEnvOrArgs(kCodesignUserNameOption, argResults, platform.environment)!;
   final String gCloudDownloadPath = getValueFromEnvOrArgs(kGcsDownloadPathOption, argResults, platform.environment)!;
   final String gCloudUploadPath = getValueFromEnvOrArgs(kGcsUploadPathOption, argResults, platform.environment)!;
+  final String passwordsFilePath = getValueFromEnvOrArgs(kCredentialsPathOption, argResults, platform.environment)!;
 
   final bool dryrun = argResults[kDryrunFlag] as bool;
 
@@ -102,6 +117,7 @@ Future<void> main(List<String> args) async {
     codesignUserName: codesignUserName,
     fileSystem: fileSystem,
     rootDirectory: rootDirectory,
+    passwordsFilePath: passwordsFilePath,
     processManager: processManager,
     dryrun: dryrun,
     gcsDownloadPath: gCloudDownloadPath,

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -72,9 +72,9 @@ class FileCodesignVisitor {
   Set<String> fileConsumed = <String>{};
   Set<String> directoriesVisited = <String>{};
   Map<String, String> availablePasswords = {
-    'CODESIGN-APPSTORE-ID': '',
-    'CODESIGN-TEAM-ID': '',
-    'APP-SPECIFIC-PASSWORD': ''
+    'CODESIGN_APPSTORE_ID': '',
+    'CODESIGN_TEAM_ID': '',
+    'APP_SPECIFIC_PASSWORD': ''
   };
 
   late final File entitlementsFile;
@@ -133,7 +133,7 @@ update these file paths accordingly.
   ///
   /// The password file should provide the password name and value, deliminated by a single colon.
   /// The content of a password file would look similar to:
-  /// CODESIGN-APPSTORE-ID:123
+  /// CODESIGN_APPSTORE_ID:123
   Future<void> readPassword(String passwordFilePath) async {
     if (!(await fileSystem.file(passwordFilePath).exists())) {
       throw CodesignException('$passwordFilePath not found \n'
@@ -167,11 +167,11 @@ update these file paths accordingly.
     }
     if (availablePasswords.containsValue('')) {
       throw CodesignException('certian passwords are missing. \n'
-          'make sure you have provided <CODESIGN-APPSTORE-ID>, <CODESIGN-TEAM-ID>, and <APP-SPECIFIC-PASSWORD>');
+          'make sure you have provided <CODESIGN_APPSTORE_ID>, <CODESIGN_TEAM_ID>, and <APP_SPECIFIC_PASSWORD>');
     }
-    codesignAppstoreId = availablePasswords['CODESIGN-APPSTORE-ID']!;
-    codesignTeamId = availablePasswords['CODESIGN-TEAM-ID']!;
-    appSpecificPassword = availablePasswords['APP-SPECIFIC-PASSWORD']!;
+    codesignAppstoreId = availablePasswords['CODESIGN_APPSTORE_ID']!;
+    codesignTeamId = availablePasswords['CODESIGN_TEAM_ID']!;
+    appSpecificPassword = availablePasswords['APP_SPECIFIC_PASSWORD']!;
 
     await processRemoteZip();
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -26,7 +26,6 @@ enum NotaryStatus {
 class FileCodesignVisitor {
   FileCodesignVisitor({
     required this.codesignCertName,
-    required this.codesignUserName,
     required this.fileSystem,
     required this.rootDirectory,
     required this.processManager,
@@ -53,7 +52,6 @@ class FileCodesignVisitor {
   final GoogleCloudStorage googleCloudStorage;
 
   final String codesignCertName;
-  final String codesignUserName;
   final String gcsDownloadPath;
   final String gcsUploadPath;
   final String appSpecificPasswordFilePath;

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -33,6 +33,7 @@ class FileCodesignVisitor {
     required this.gcsDownloadPath,
     required this.gcsUploadPath,
     required this.googleCloudStorage,
+    required this.passwordsFilePath,
     this.dryrun = true,
     this.notarizationTimerDuration = const Duration(seconds: 5),
   }) {
@@ -53,6 +54,7 @@ class FileCodesignVisitor {
   final String codesignUserName;
   final String gcsDownloadPath;
   final String gcsUploadPath;
+  final String passwordsFilePath;
   final bool dryrun;
   final Duration notarizationTimerDuration;
 
@@ -127,9 +129,13 @@ update these file paths accordingly.
 
   /// Extract credentials needed for code sign app.
   ///
-  /// Assume the passwords exist with the file path /tmp/passwords.txt.
+  /// Credentials are stored in a file located at [passwordsFilePath].
+  /// The password file should provide the password value for each of the password name, deliminated by a single colon.
+  /// The content of a password file would look similar to:
+  /// CODESIGN-APPSTORE-ID:123
+  /// CODESIGN-TEAM-ID:456
+  /// APP-SPECIFIC-PASSWORD:789
   Future<void> readPasswords(FileSystem fileSystem) async {
-    String passwordsFilePath = '/tmp/passwords.txt';
     if (!(await fileSystem.file(passwordsFilePath).exists())) {
       throw CodesignException('$passwordsFilePath not found \n'
           'make sure you have provided codesign credentials in a file \n');

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -89,39 +89,22 @@ class CodesignException implements Exception {
   String toString() => 'Exception: $message';
 }
 
-/// Translate CLI arg names to env variable names.
+/// Return the command line argument by parsing [argResults].
 ///
-/// For example, 'state-file' -> 'STATE_FILE'.
-String fromArgToEnvName(String argName) {
-  return argName.toUpperCase().replaceAll('-', '_');
-}
-
-/// Either return the value from [env] or fall back to [argResults].
-///
-/// If the key does not exist in either the environment or CLI args, throws a
-/// [ConductorException].
-///
-/// The environment is favored over CLI args since the latter can have a default
-/// value, which the environment should be able to override.
-String? getValueFromEnvOrArgs(
+/// If the key does not exist in CLI args, throws a [CodesignException].
+String? getValueFromArgs(
   String name,
-  ArgResults argResults,
-  Map<String, String> env, {
+  ArgResults argResults, {
   bool allowNull = false,
 }) {
-  final String envName = fromArgToEnvName(name);
-  if (env[envName] != null) {
-    return env[envName];
-  }
   final String? argValue = argResults[name] as String?;
   if (argValue != null) {
     return argValue;
   }
-
   if (allowNull) {
     return null;
   }
-  throw CodesignException('Expected either the CLI arg --$name or the environment variable $envName '
+  throw CodesignException('Expected either the CLI arg --$name '
       'to be provided!');
 }
 

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -38,7 +38,6 @@ void main() {
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
         appSpecificPasswordFilePath: appSpecificPasswordFilePath,
@@ -156,7 +155,6 @@ void main() {
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
         appSpecificPasswordFilePath: appSpecificPasswordFilePath,
@@ -425,7 +423,6 @@ void main() {
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
         appSpecificPasswordFilePath: appSpecificPasswordFilePath,
@@ -699,7 +696,6 @@ void main() {
     test('visitBinary codesigns binary with / without entitlement', () async {
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
         appSpecificPasswordFilePath: appSpecificPasswordFilePath,
@@ -792,7 +788,6 @@ void main() {
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         gcsDownloadPath: 'flutter/$randomString/FILEPATH',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
@@ -898,7 +893,6 @@ file_c''',
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         gcsDownloadPath: 'flutter/$randomString/FILEPATH',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
@@ -1221,7 +1215,6 @@ status: Invalid''',
       );
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         gcsDownloadPath: 'gs://ios-usb-dependencies/unsigned/libimobiledevice/$randomString/libimobiledevice.zip',
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,
@@ -1399,7 +1392,6 @@ status: Invalid''',
       ]);
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
-        codesignUserName: randomString,
         gcsDownloadPath: 'gs://ios-usb-dependencies/unsigned/libimobiledevice/$randomString/libimobiledevice.zip',
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -97,6 +97,11 @@ void main() {
     });
 
     test('lacking required passwords throws exception', () async {
+      codesignVisitor.availablePasswords = {
+        'CODESIGN-APPSTORE-ID': '',
+        'CODESIGN-TEAM-ID': '',
+        'APP-SPECIFIC-PASSWORD': ''
+      };
       fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -17,6 +17,7 @@ import './src/fake_process_manager.dart';
 
 void main() {
   const String randomString = 'abcd1234';
+  const String passwordsFilePath = '/tmp/passwords.txt';
   final MemoryFileSystem fileSystem = MemoryFileSystem.test();
   final List<LogRecord> records = <LogRecord>[];
 
@@ -38,6 +39,7 @@ void main() {
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/$randomString',
@@ -51,7 +53,7 @@ void main() {
     });
 
     test('incorrectly formatted password file throws exception', () async {
-      fileSystem.file('/tmp/passwords.txt')
+      fileSystem.file(passwordsFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(
           '''file_a
@@ -64,7 +66,7 @@ file_c''',
       expect(
         () async {
           await codesignVisitor.readPasswords(fileSystem);
-          fileSystem.file('/tmp/passwords.txt').deleteSync();
+          fileSystem.file(passwordsFilePath).deleteSync();
         },
         throwsA(
           isA<CodesignException>(),
@@ -73,7 +75,7 @@ file_c''',
     });
 
     test('unknown password name throws an exception', () async {
-      fileSystem.file('/tmp/passwords.txt')
+      fileSystem.file(passwordsFilePath)
         ..createSync(recursive: true, exclusive: true)
         ..writeAsStringSync(
           '''dart:dart''',
@@ -84,7 +86,7 @@ file_c''',
       expect(
         () async {
           await codesignVisitor.readPasswords(fileSystem);
-          await fileSystem.file('/tmp/passwords.txt').delete();
+          await fileSystem.file(passwordsFilePath).delete();
         },
         throwsA(
           isA<CodesignException>(),
@@ -93,7 +95,7 @@ file_c''',
     });
 
     test('lacking any of the required passwords throws exception', () async {
-      fileSystem.file('/tmp/passwords.txt')
+      fileSystem.file(passwordsFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(
           '''CODESIGN-TEAM-ID:123
@@ -105,7 +107,7 @@ CODESIGN-APPSTORE-ID:123''',
       expect(
         () async {
           await codesignVisitor.readPasswords(fileSystem);
-          await fileSystem.file('/tmp/passwords.txt').delete();
+          await fileSystem.file(passwordsFilePath).delete();
         },
         throwsA(
           isA<CodesignException>(),
@@ -114,7 +116,7 @@ CODESIGN-APPSTORE-ID:123''',
     });
 
     test('providing all required passwords returns normally', () async {
-      fileSystem.file('/tmp/passwords.txt')
+      fileSystem.file(passwordsFilePath)
         ..createSync(recursive: true, exclusive: true)
         ..writeAsStringSync(
           '''CODESIGN-APPSTORE-ID:123
@@ -126,7 +128,7 @@ APP-SPECIFIC-PASSWORD:123''',
 
       expect(() async {
         await codesignVisitor.readPasswords(fileSystem);
-        await fileSystem.file('/tmp/passwords.txt').delete();
+        await fileSystem.file(passwordsFilePath).delete();
       }, returnsNormally);
     });
   });
@@ -153,6 +155,7 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/$randomString',
@@ -419,6 +422,7 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/FILEPATH',
@@ -690,6 +694,7 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'flutter/$randomString/FILEPATH',
@@ -782,6 +787,7 @@ APP-SPECIFIC-PASSWORD:123''',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
       );
@@ -885,6 +891,7 @@ file_c''',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
       );
@@ -1205,6 +1212,7 @@ status: Invalid''',
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         notarizationTimerDuration: const Duration(seconds: 0),
@@ -1215,7 +1223,7 @@ status: Invalid''',
       codesignVisitor.directoriesVisited.clear();
       records.clear();
       log.onRecord.listen((LogRecord record) => records.add(record));
-      fileSystem.file('/tmp/passwords.txt')
+      fileSystem.file(passwordsFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''CODESIGN-APPSTORE-ID:$randomString
 CODESIGN-TEAM-ID:$randomString
@@ -1376,6 +1384,7 @@ APP-SPECIFIC-PASSWORD:$randomString''');
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
+        passwordsFilePath: passwordsFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         notarizationTimerDuration: const Duration(seconds: 0),

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -97,14 +97,14 @@ void main() {
 
     test('lacking required passwords throws exception', () async {
       codesignVisitor.availablePasswords = {
-        'CODESIGN-APPSTORE-ID': '',
-        'CODESIGN-TEAM-ID': '',
+        'CODESIGN_APPSTORE_ID': '',
+        'CODESIGN_TEAM_ID': '',
         'APP-SPECIFIC-PASSWORD': ''
       };
       fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          'CODESIGN-APPSTORE-ID:123',
+          'CODESIGN_APPSTORE_ID:123',
           mode: FileMode.write,
           encoding: utf8,
         );
@@ -124,7 +124,7 @@ void main() {
       fileSystem.file(appSpecificPasswordFilePath)
         ..createSync(recursive: true, exclusive: true)
         ..writeAsStringSync(
-          'APP-SPECIFIC-PASSWORD:123',
+          'APP_SPECIFIC_PASSWORD:123',
           mode: FileMode.write,
           encoding: utf8,
         );
@@ -1234,13 +1234,13 @@ status: Invalid''',
       log.onRecord.listen((LogRecord record) => records.add(record));
       fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync('CODESIGN-APPSTORE-ID:$randomString');
+        ..writeAsStringSync('CODESIGN_APPSTORE_ID:$randomString');
       fileSystem.file(codesignTeamIDFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync('CODESIGN-TEAM-ID:$randomString');
+        ..writeAsStringSync('CODESIGN_TEAM_ID:$randomString');
       fileSystem.file(appSpecificPasswordFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync('APP-SPECIFIC-PASSWORD:$randomString');
+        ..writeAsStringSync('APP_SPECIFIC_PASSWORD:$randomString');
     });
 
     test('codesign optional switches artifacts when dryrun is false', () async {

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -17,7 +17,9 @@ import './src/fake_process_manager.dart';
 
 void main() {
   const String randomString = 'abcd1234';
-  const String passwordsFilePath = '/tmp/passwords.txt';
+  const String appSpecificPasswordFilePath = '/tmp/passwords.txt';
+  const String codesignAppstoreIDFilePath = '/tmp/appID.txt';
+  const String codesignTeamIDFilePath = '/tmp/teamID.txt';
   final MemoryFileSystem fileSystem = MemoryFileSystem.test();
   final List<LogRecord> records = <LogRecord>[];
 
@@ -39,7 +41,9 @@ void main() {
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/$randomString',
@@ -53,20 +57,18 @@ void main() {
     });
 
     test('incorrectly formatted password file throws exception', () async {
-      fileSystem.file(passwordsFilePath)
+      fileSystem.file(appSpecificPasswordFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          '''file_a
-file_b
-file_c''',
+          'file_a',
           mode: FileMode.write,
           encoding: utf8,
         );
 
       expect(
         () async {
-          await codesignVisitor.readPasswords(fileSystem);
-          fileSystem.file(passwordsFilePath).deleteSync();
+          await codesignVisitor.readPassword(appSpecificPasswordFilePath);
+          fileSystem.file(appSpecificPasswordFilePath).deleteSync();
         },
         throwsA(
           isA<CodesignException>(),
@@ -75,18 +77,18 @@ file_c''',
     });
 
     test('unknown password name throws an exception', () async {
-      fileSystem.file(passwordsFilePath)
+      fileSystem.file(codesignTeamIDFilePath)
         ..createSync(recursive: true, exclusive: true)
         ..writeAsStringSync(
-          '''dart:dart''',
+          'dart:dart',
           mode: FileMode.write,
           encoding: utf8,
         );
 
       expect(
         () async {
-          await codesignVisitor.readPasswords(fileSystem);
-          await fileSystem.file(passwordsFilePath).delete();
+          await codesignVisitor.readPassword(codesignTeamIDFilePath);
+          await fileSystem.file(codesignTeamIDFilePath).delete();
         },
         throwsA(
           isA<CodesignException>(),
@@ -94,20 +96,19 @@ file_c''',
       );
     });
 
-    test('lacking any of the required passwords throws exception', () async {
-      fileSystem.file(passwordsFilePath)
+    test('lacking required passwords throws exception', () async {
+      fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
         ..writeAsStringSync(
-          '''CODESIGN-TEAM-ID:123
-CODESIGN-APPSTORE-ID:123''',
+          'CODESIGN-APPSTORE-ID:123',
           mode: FileMode.write,
           encoding: utf8,
         );
 
       expect(
         () async {
-          await codesignVisitor.readPasswords(fileSystem);
-          await fileSystem.file(passwordsFilePath).delete();
+          await codesignVisitor.validateAll();
+          await fileSystem.file(codesignAppstoreIDFilePath).delete();
         },
         throwsA(
           isA<CodesignException>(),
@@ -115,20 +116,18 @@ CODESIGN-APPSTORE-ID:123''',
       );
     });
 
-    test('providing all required passwords returns normally', () async {
-      fileSystem.file(passwordsFilePath)
+    test('providing correctly formatted password returns normally', () async {
+      fileSystem.file(appSpecificPasswordFilePath)
         ..createSync(recursive: true, exclusive: true)
         ..writeAsStringSync(
-          '''CODESIGN-APPSTORE-ID:123
-CODESIGN-TEAM-ID:123
-APP-SPECIFIC-PASSWORD:123''',
+          'APP-SPECIFIC-PASSWORD:123',
           mode: FileMode.write,
           encoding: utf8,
         );
 
       expect(() async {
-        await codesignVisitor.readPasswords(fileSystem);
-        await fileSystem.file(passwordsFilePath).delete();
+        await codesignVisitor.readPassword(appSpecificPasswordFilePath);
+        await fileSystem.file(appSpecificPasswordFilePath).delete();
       }, returnsNormally);
     });
   });
@@ -155,7 +154,9 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/$randomString',
@@ -422,7 +423,9 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'gs://flutter/$randomString/FILEPATH',
@@ -694,7 +697,9 @@ APP-SPECIFIC-PASSWORD:123''',
         codesignUserName: randomString,
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         gcsDownloadPath: 'flutter/$randomString/FILEPATH',
@@ -787,7 +792,9 @@ APP-SPECIFIC-PASSWORD:123''',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
       );
@@ -891,7 +898,9 @@ file_c''',
         gcsUploadPath: 'flutter/$randomString/FILEPATH',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
       );
@@ -1212,7 +1221,9 @@ status: Invalid''',
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         notarizationTimerDuration: const Duration(seconds: 0),
@@ -1223,11 +1234,15 @@ status: Invalid''',
       codesignVisitor.directoriesVisited.clear();
       records.clear();
       log.onRecord.listen((LogRecord record) => records.add(record));
-      fileSystem.file(passwordsFilePath)
+      fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync('''CODESIGN-APPSTORE-ID:$randomString
-CODESIGN-TEAM-ID:$randomString
-APP-SPECIFIC-PASSWORD:$randomString''');
+        ..writeAsStringSync('CODESIGN-APPSTORE-ID:$randomString');
+      fileSystem.file(codesignTeamIDFilePath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('CODESIGN-TEAM-ID:$randomString');
+      fileSystem.file(appSpecificPasswordFilePath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('APP-SPECIFIC-PASSWORD:$randomString');
     });
 
     test('codesign optional switches artifacts when dryrun is false', () async {
@@ -1384,7 +1399,9 @@ APP-SPECIFIC-PASSWORD:$randomString''');
         gcsUploadPath: 'gs://ios-usb-dependencies/libimobiledevice/$randomString/libimobiledevice.zip',
         googleCloudStorage: googleCloudStorage,
         fileSystem: fileSystem,
-        passwordsFilePath: passwordsFilePath,
+        appSpecificPasswordFilePath: appSpecificPasswordFilePath,
+        codesignAppstoreIDFilePath: codesignAppstoreIDFilePath,
+        codesignTeamIDFilePath: codesignTeamIDFilePath,
         processManager: processManager,
         rootDirectory: rootDirectory,
         notarizationTimerDuration: const Duration(seconds: 0),


### PR DESCRIPTION
Currently we assume the codesign credentials are stored in a file located at '/tmp/passwords.txt' (we can change this file path location). And code sign standalone app will read the credentials from this file, as opposed from reading from user input or environment variables. Also capped the naming of credentials and parameters per request. 