### PR TITLE
Bump appengine version to latest version

### DIFF
--- a/app_dart/pubspec.lock
+++ b/app_dart/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: appengine
-      sha256: "8c442e5ae3c9b4b8ad6bf40736258c889b2505b0eb9d9c5e79bccf158b025546"
+      sha256: "5ffa6ea675ffbf13808d0b023a6e7eb9322d4392495be1c5a8fc01f2399d4717"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.4"
   archive:
     dependency: transitive
     description:
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: grpc
-      sha256: "3e8e04c6277059b66d67951143842097e52bbf3f2c6fca2e67d3607b48d5c3ab"
+      sha256: a73c16e4f6a4a819be892bb2c73cc1d0b00e36095f69b0738cc91a733e3d27ba
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   hive:
     dependency: transitive
     description:

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.19.0-0 <3.0.0'
 
 dependencies:
-  appengine: ^0.13.3
+  appengine: ^0.13.4
   args: ^2.3.1
   collection: ^1.17.0
   corsac_jwt: ^1.0.0-nullsafety.1
@@ -25,8 +25,7 @@ dependencies:
   googleapis_auth: ^1.3.1
   gql: ^0.14.0
   graphql: ^5.1.1
-  # dart-lang/appengine#154
-  grpc: ">=3.0.2 <3.1.0"
+  grpc: ^3.1.0
   http: ^0.13.5
   json_annotation: ^4.7.0
   logging: ^1.1.0

--- a/auto_submit/pubspec.lock
+++ b/auto_submit/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: appengine
-      sha256: "8c442e5ae3c9b4b8ad6bf40736258c889b2505b0eb9d9c5e79bccf158b025546"
+      sha256: "5ffa6ea675ffbf13808d0b023a6e7eb9322d4392495be1c5a8fc01f2399d4717"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.2"
+    version: "0.13.4"
   archive:
     dependency: transitive
     description:
@@ -346,13 +346,13 @@ packages:
     source: hosted
     version: "2.2.0"
   grpc:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: grpc
-      sha256: "3e8e04c6277059b66d67951143842097e52bbf3f2c6fca2e67d3607b48d5c3ab"
+      sha256: a73c16e4f6a4a819be892bb2c73cc1d0b00e36095f69b0738cc91a733e3d27ba
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   hive:
     dependency: transitive
     description:

--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -11,14 +11,12 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  appengine: ^0.13.2
+  appengine: ^0.13.4
   corsac_jwt: ^1.0.0-nullsafety.1
   github: ^9.5.0
   googleapis: ^9.2.0
   googleapis_auth: ^1.3.1
   graphql: ^5.1.1
-  # dart-lang/appengine#154
-  grpc: ">=3.0.2 <3.1.0"
   gql: ^0.14.0
   http: ^0.13.5
   json_annotation: ^4.7.0


### PR DESCRIPTION
With upstream fix (https://github.com/dart-lang/appengine/pull/155) from appengine, a new version has been pushed to pub.dev.

This PR bumps appengine version to latest 0.13.4.

Fixes: https://github.com/flutter/flutter/issues/114270
Related early workaround PR: https://github.com/flutter/cocoon/pull/2275