### PR TITLE
Make gallery dependency file test-exempt

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -310,7 +310,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.contains('pubspec.yaml') ||
         // Exempt categories.
         filename.contains('.github/') ||
-        filename.endsWith('.md');
+        filename.endsWith('.md') ||
+        // Exempt paths.
+        filename.startsWith('dev/devicelab/lib/versions/gallery.dart');
   }
 
   /// Returns the set of labels applicable to a file in the framework repo.


### PR DESCRIPTION
dev/devicelab/lib/versions/gallery.dart contains the flutter/gallery repo SHA to be synced during the gallery transitions test. Semantically, it's similar to the engine's DEPS file or a pubspec.yaml in that updates to it are version bumps.

This marks this file test exempt in our GitHub web hook.

Uncovered during fixing: https://github.com/flutter/flutter/issues/114025


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
