### PR TITLE
[dashboard] Use flutter.js and local canvaskit.

### DIFF
--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -29,18 +29,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "271b8899fc99f9df4f4ed419fa14e2fff392c7b2c162fbb87b222e2e963ddc73"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -356,10 +356,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "80c2989398773fa06e2457e9ff08580f24e9858b28462a722241cb53e5613478"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -484,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "6db16374bc3497d21aa0eebe674d3db9fdf82082aac0f04dc7b44e4af5b08afc"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -529,10 +529,10 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: f1d172e22a5432c042b5adfa9aff621372e4292231d9d73ad00f486ad01c2395
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ceeddf59d613e862e77f4b506cfc2945ac9637ce0b4c00f4f4c1ac639f3e9731
+      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   timing:
     dependency: transitive
     description:

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -13,7 +13,6 @@ found in the LICENSE file. -->
   -->
   <meta http-equiv="refresh" content="86400">
 
-
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -22,13 +21,25 @@ found in the LICENSE file. -->
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
+
+  <script src="flutter.js" defer></script>
 </head>
 <body>
-<script src="main.dart.js" type="application/javascript"></script>
 <script>
-  window.flutterConfiguration = {
-    canvasKitBaseUrl: "/canvaskit/"
-  };
+  window.addEventListener('load', function() {
+    // Contact dit@ when this starts throwing warnings in development :)
+    window.flutterConfiguration = {
+      canvasKitBaseUrl: "/canvaskit/"
+    };
+    _flutter.loader.loadEntrypoint({
+      onEntrypointLoaded: async function(engineInitializer) {
+        engineInitializer.initializeEngine(
+        ).then(function (appRunner) {
+          appRunner.runApp();
+        });
+      }
+    })
+  });
   (function(w,d,s,g,js,fjs){
     g=w.gapi||(w.gapi={});g.analytics={q:[],ready:function(cb){this.q.push(cb)}};
     js=d.createElement(s);fjs=d.getElementsByTagName(s)[0];

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -27,8 +27,8 @@ found in the LICENSE file. -->
 <body>
 <script>
   window.addEventListener('load', function() {
-    // Contact dit@ when this starts throwing warnings in development :)
     window.flutterConfiguration = {
+      // Use the local build of CanvasKit rather than the CDN.
       canvasKitBaseUrl: "/canvaskit/"
     };
     _flutter.loader.loadEntrypoint({


### PR DESCRIPTION
### Change

This PR updates the dashboard's `web/index.html` to:

* Use `flutter.js` to embed flutter ([as described here](https://docs.flutter.dev/development/platform-integration/web/initialization)).
* Use the `canvasKitBaseUrl` config option to load the locally distributed canvaskit, rather than the version from the external CDN.

### Note

Once [this `flutter/engine` PR](https://github.com/flutter/engine/pull/37187) lands, the dashboard will start to warn (in development) about `flutterConfiguration` being deprecated. The fix is to pass the configuration object to the `initializeEngine` call, like so (feel free to reach out to me for any assistance!):

```javascript
  engineInitializer.initializeEngine({
    canvasKitBaseUrl: "/canvaskit/",
  }).then(function (appRunner) {
    appRunner.runApp();
  });
```

(This also updates the pubspec.lock with whatever was generated last in my machine)

### Fixes

* (Internal security audit)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
