### PR TITLE
Update revert url to start with /

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -49,6 +49,6 @@ cron:
   schedule: every 1 minutes
 
 - description: check revert review issues for closed issues to update in our database
-  url: 'api/update-revert-issues'
+  url: '/api/update-revert-issues'
   target: auto-submit
   schedule: every 24 hours


### PR DESCRIPTION
It seems as though the cocoon-cron-job has been failing due to a missing /

https://pantheon.corp.google.com/cloud-build/builds;region=global?query=trigger_id%3D%228e6790d7-1a7b-46e7-998b-f481964be9ff%22&project=flutter-dashboard

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
