### PR TITLE
Temporarily add logging of results messages.

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -52,9 +52,9 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final String data = message.data!;
     BuildPushMessage buildPushMessage;
     try {
-      buildPushMessage =
-          BuildPushMessage.fromJson(json.decode(String.fromCharCodes(base64.decode(data))) as Map<String, dynamic>);
-      log.info('Result message from base64: ${String.fromCharCodes(base64.decode(data))}');
+      final String decodedData = String.fromCharCodes(base64.decode(data));
+      buildPushMessage = BuildPushMessage.fromJson(json.decode(decodedData) as Map<String, dynamic>);
+      log.info('Result message from base64: $decodedData');
     } on FormatException {
       buildPushMessage = BuildPushMessage.fromJson(json.decode(data) as Map<String, dynamic>);
       log.info('Result message: $data');

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -54,8 +54,10 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     try {
       buildPushMessage =
           BuildPushMessage.fromJson(json.decode(String.fromCharCodes(base64.decode(data))) as Map<String, dynamic>);
+      log.info('Result message from base64: ${String.fromCharCodes(base64.decode(data))}');
     } on FormatException {
       buildPushMessage = BuildPushMessage.fromJson(json.decode(data) as Map<String, dynamic>);
+      log.info('Result message: $data');
     }
     log.fine(buildPushMessage.userData);
     log.fine('Updating buildId=${buildPushMessage.build?.id} for result=${buildPushMessage.build?.result}');


### PR DESCRIPTION
This will give us visibility of the message format required to report results from builders from dart-internal.

Bug: https://github.com/flutter/flutter/issues/115730
## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
