### PR TITLE
[codesign + open to suggestions] log warning instead of exception when metadata isn't present

### DIFF
--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -317,8 +317,10 @@ update these file paths accordingly.
         ? fileSystem.path.join(parent.path, 'entitlements.txt')
         : fileSystem.path.join(parent.path, 'without_entitlements.txt');
     if (!(await fileSystem.file(entitlementFilePath).exists())) {
-      throw CodesignException('$entitlementFilePath not found \n'
-          'make sure you have provided them along with the engine artifacts \n');
+      log.warning('$entitlementFilePath not found. '
+          'by default, system will assume there is no ${entitlements ? '' : 'without_'}entitlements file.'
+          'if this is not intended, please provide them along with the engine artifacts.');
+      return <String>{};
     }
 
     final Set<String> fileWithEntitlements = <String>{};

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -318,7 +318,8 @@ update these file paths accordingly.
         : fileSystem.path.join(parent.path, 'without_entitlements.txt');
     if (!(await fileSystem.file(entitlementFilePath).exists())) {
       log.warning('$entitlementFilePath not found. '
-          'by default, system will assume there is no ${entitlements ? '' : 'without_'}entitlements file.'
+          'by default, system will assume there is no ${entitlements ? '' : 'without_'}entitlements file. '
+          'As a result, no binary will be codesigned.'
           'if this is not intended, please provide them along with the engine artifacts.');
       return <String>{};
     }

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -651,7 +651,7 @@ file_e''',
       );
     });
 
-    test('throw exception when configuration file is missing', () async {
+    test('log warnings when configuration file is missing', () async {
       fileSystem.file('${rootDirectory.absolute.path}/test_entitlement_2/entitlements.txt')
         ..createSync(recursive: true)
         ..writeAsStringSync(
@@ -675,14 +675,19 @@ file_c''',
           'file_c',
         ]),
       );
+      await codesignVisitor.parseEntitlements(
+        fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement_2'),
+        false,
+      );
+      final List<String> messages = records
+          .where((LogRecord record) => record.level == Level.WARNING)
+          .map((LogRecord record) => record.message)
+          .toList();
       expect(
-        () => codesignVisitor.parseEntitlements(
-          fileSystem.directory('/Users/xilaizhang/Desktop/test_entitlement_2'),
-          false,
-        ),
-        throwsA(
-          isA<CodesignException>(),
-        ),
+        messages,
+        contains('${rootDirectory.absolute.path}/test_entitlement_2/without_entitlements.txt not found. '
+            'by default, system will assume there is no without_entitlements file.'
+            'if this is not intended, please provide them along with the engine artifacts.'),
       );
     });
   });

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -686,7 +686,8 @@ file_c''',
       expect(
         messages,
         contains('${rootDirectory.absolute.path}/test_entitlement_2/without_entitlements.txt not found. '
-            'by default, system will assume there is no without_entitlements file.'
+            'by default, system will assume there is no without_entitlements file. '
+            'As a result, no binary will be codesigned.'
             'if this is not intended, please provide them along with the engine artifacts.'),
       );
     });


### PR DESCRIPTION
open to suggestions, we have two options here:
1. enforce every artifact to have both `entitlements.txt` and `without_entitlements.txt` as metadata, and throw exception when any of the metadata is missing.
2. allow artifact to have a single or no metadata file, to imply that the artifact does not have any binary files to be codesigned (with/without entitlements). In this case we will convert exception to warning. 