### PR TITLE
Change some LuciBuildService methods to return Build objects

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -326,7 +326,7 @@ class LuciBuildService {
   /// Sends [ScheduleBuildRequest] the buildset, user_agent, and
   /// github_link tags are applied to match the original build. The build
   /// properties from the original build are also preserved.
-  Future<bool> rescheduleBuild({
+  Future<Build> rescheduleBuild({
     required String commitSha,
     required String builderName,
     required push_message.BuildPushMessage buildPushMessage,
@@ -336,7 +336,7 @@ class LuciBuildService {
     // is expecting just the last part after "."(prod).
     final String bucketName = buildPushMessage.build!.bucket!.split('.').last;
     final Map<String, dynamic>? userData = jsonDecode(buildPushMessage.userData!) as Map<String, dynamic>?;
-    await buildBucketClient.scheduleBuild(
+    return await buildBucketClient.scheduleBuild(
       ScheduleBuildRequest(
         builderId: BuilderId(
           project: buildPushMessage.build!.project,
@@ -356,13 +356,12 @@ class LuciBuildService {
         ),
       ),
     );
-    return true;
   }
 
   /// Sends [ScheduleBuildRequest] for [pullRequest] using [checkRunEvent].
   ///
   /// Returns true if it is able to send the scheduleBuildRequest. Otherwise, false.
-  Future<bool> rescheduleUsingCheckRunEvent(cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<Build> rescheduleUsingCheckRunEvent(cocoon_checks.CheckRunEvent checkRunEvent) async {
     final github.RepositorySlug slug = checkRunEvent.repository!.slug();
 
     final String sha = checkRunEvent.checkRun!.headSha!;
@@ -401,7 +400,7 @@ class LuciBuildService {
 
     final String buildUrl = 'https://ci.chromium.org/ui/b/${scheduleBuild.id}';
     await githubChecksUtil.updateCheckRun(config, slug, githubCheckRun, detailsUrl: buildUrl);
-    return true;
+    return scheduleBuild;
   }
 
   /// Gets [Build] using its [id] and passing the additional

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -323,9 +323,12 @@ class LuciBuildService {
     return expectedFailedBuilds.toList();
   }
 
-  /// Sends [ScheduleBuildRequest] the buildset, user_agent, and
-  /// github_link tags are applied to match the original build. The build
-  /// properties from the original build are also preserved.
+  /// Sends [ScheduleBuildRequest] using information from a given build's
+  /// [BuildPushMessage].
+  ///
+  /// The buildset, user_agent, and github_link tags are applied to match the
+  /// original build. The build properties and user data from the original build
+  /// are also preserved.
   Future<Build> rescheduleBuild({
     required String commitSha,
     required String builderName,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -363,7 +363,7 @@ class LuciBuildService {
 
   /// Sends [ScheduleBuildRequest] for [pullRequest] using [checkRunEvent].
   ///
-  /// Returns true if it is able to send the scheduleBuildRequest. Otherwise, false.
+  /// Returns the [Build] returned by scheduleBuildRequest.
   Future<Build> rescheduleUsingCheckRunEvent(cocoon_checks.CheckRunEvent checkRunEvent) async {
     final github.RepositorySlug slug = checkRunEvent.repository!.slug();
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -450,7 +450,8 @@ class Scheduler {
             success = true;
           }
         } else {
-          success = await luciBuildService.rescheduleUsingCheckRunEvent(checkRunEvent);
+          await luciBuildService.rescheduleUsingCheckRunEvent(checkRunEvent);
+          success = true;
         }
 
         log.fine('CheckName: $name State: $success');

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -740,11 +740,13 @@ void main() {
 
     test('Reschedule an existing build', () async {
       when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((_) async => generateBuild(1));
-      await service.rescheduleBuild(
+      final build = await service.rescheduleBuild(
         commitSha: 'abc',
         builderName: 'mybuild',
         buildPushMessage: buildPushMessage,
       );
+      expect(build.id, '1');
+      expect(build.status, Status.success);
       verify(mockBuildBucketClient.scheduleBuild(any)).called(1);
     });
   });

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -740,12 +740,11 @@ void main() {
 
     test('Reschedule an existing build', () async {
       when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((_) async => generateBuild(1));
-      final bool rescheduled = await service.rescheduleBuild(
+      await service.rescheduleBuild(
         commitSha: 'abc',
         builderName: 'mybuild',
         buildPushMessage: buildPushMessage,
       );
-      expect(rescheduled, isTrue);
       verify(mockBuildBucketClient.scheduleBuild(any)).called(1);
     });
   });

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4763,7 +4763,7 @@ class MockLuciBuildService extends _i1.Mock implements _i31.LuciBuildService {
         returnValue: _i17.Future<List<_i9.Build?>>.value(<_i9.Build?>[]),
       ) as _i17.Future<List<_i9.Build?>>);
   @override
-  _i17.Future<bool> rescheduleBuild({
+  _i17.Future<_i9.Build> rescheduleBuild({
     required String? commitSha,
     required String? builderName,
     required _i30.BuildPushMessage? buildPushMessage,
@@ -4778,16 +4778,33 @@ class MockLuciBuildService extends _i1.Mock implements _i31.LuciBuildService {
             #buildPushMessage: buildPushMessage,
           },
         ),
-        returnValue: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i17.Future<_i9.Build>.value(_FakeBuild_8(
+          this,
+          Invocation.method(
+            #rescheduleBuild,
+            [],
+            {
+              #commitSha: commitSha,
+              #builderName: builderName,
+              #buildPushMessage: buildPushMessage,
+            },
+          ),
+        )),
+      ) as _i17.Future<_i9.Build>);
   @override
-  _i17.Future<bool> rescheduleUsingCheckRunEvent(_i33.CheckRunEvent? checkRunEvent) => (super.noSuchMethod(
+  _i17.Future<_i9.Build> rescheduleUsingCheckRunEvent(_i33.CheckRunEvent? checkRunEvent) => (super.noSuchMethod(
         Invocation.method(
           #rescheduleUsingCheckRunEvent,
           [checkRunEvent],
         ),
-        returnValue: _i17.Future<bool>.value(false),
-      ) as _i17.Future<bool>);
+        returnValue: _i17.Future<_i9.Build>.value(_FakeBuild_8(
+          this,
+          Invocation.method(
+            #rescheduleUsingCheckRunEvent,
+            [checkRunEvent],
+          ),
+        )),
+      ) as _i17.Future<_i9.Build>);
   @override
   _i17.Future<_i9.Build> getBuildById(
     String? id, {


### PR DESCRIPTION
`rescheduleBuild` and `rescheduleUsingCheckRunEvent` now return `Build` objects instead of `true`.

Addresses https://github.com/flutter/flutter/issues/83945

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.