### PR TITLE
Add test exemption for embedder tests and fixtures

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -313,7 +313,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.contains('.github/') ||
         filename.endsWith('.md') ||
         // Exempt paths.
-        filename.startsWith('dev/devicelab/lib/versions/gallery.dart');
+        filename.startsWith('dev/devicelab/lib/versions/gallery.dart') ||
+        filename.startsWith('shell/platform/embedder/tests') ||
+        filename.startsWith('shell/platform/embedder/fixtures');
   }
 
   /// Returns the set of labels applicable to a file in the framework repo.

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -889,9 +889,11 @@ void main() {
       final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
 
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.value(
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()..filename = 'dev/devicelab/lib/versions/gallery.dart',
-        ),
+          PullRequestFile()..filename = 'shell/platform/embedder/tests/embedder_test_context.cc',
+          PullRequestFile()..filename = 'shell/platform/embedder/fixtures/main.dart',
+        ]),
       );
 
       when(issuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer(


### PR DESCRIPTION
Embedder API tests in the engine are implemented as C++ unit tests and test infrastructure such as embedder_test_context_metal.{h,cc} (located under the shell/platform/embedder/tests directory), which execute and test Dart functions (and associated test assets) stored in the shell/platform/embedder/fixtures directory.

Uncovered while sending https://github.com/flutter/engine/pull/38133.

Issue: https://github.com/flutter/flutter/issues/116381


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
