### PR TITLE
Try to find existing check run instead of creating new one when re-running a postsubmit build from the dashboard

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -84,11 +84,13 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task.name);
 
     // Try to find the existing GitHub PR check run associated with this specific commit and task.
+    log.fine('Looking up existing check run...');
     final checkRunResults = await luciBuildService.githubChecksUtil
         .listCheckRunsForRef(config, commit.slug, ref: commit.sha!, checkName: target.value.name);
     final CheckRun? existingCheckRun = await checkRunResults
         .cast<CheckRun?>()
         .firstWhere((element) => element!.name == target.value.name, orElse: () => null);
+    log.fine('Found $existingCheckRun');
 
     final Map<String, List<String>> tags = <String, List<String>>{
       'triggered_by': <String>[token.email!],


### PR DESCRIPTION
When you currently hit RERUN on a postsubmit build from the dashboard, it creates a new check run on the GitHub PR. This PR tries to find and use the existing check run from the previous attempt.

Addresses https://github.com/flutter/flutter/issues/116739, which is tracking https://github.com/flutter/flutter/issues/116226

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.