### PR TITLE
Add a retry when obtaining the github token

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -333,7 +333,7 @@ class Config {
       // If generating the github token fails, wait 3 seconds and retry up to 3 times.
       createFn: () => retryOptions.retry(
         () async => await _generateGithubToken(slug),
-        retryIf: (Exception e) => true,
+        retryIf: (Exception e) => e is GitHubError,
       ),
       // Tokens are minted for 10 minutes
       ttl: const Duration(minutes: 8),

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -326,8 +326,7 @@ class Config {
 
   Future<String> generateGithubToken(gh.RepositorySlug slug) async {
     // GitHub's secondary rate limits are run into very frequently when making auth tokens.
-    const RetryOptions retryOptions =
-        RetryOptions(maxAttempts: 3, delayFactor: Duration(seconds: 3));
+    const RetryOptions retryOptions = RetryOptions(maxAttempts: 3, delayFactor: Duration(seconds: 3));
     final Uint8List? cacheValue = await _cache.getOrCreate(
       configCacheName,
       'githubToken-${slug.fullName}',


### PR DESCRIPTION
This is meant to potentially address the secondary rate limit errors, since it seems that occurs most often from generating the GitHub tokens.

* If creating the GitHub token fails for any reason, wait 3 seconds and then retry.
* If after 3 attempts it is still failing, throw an exception like normal

Related issue: https://github.com/flutter/flutter/issues/102402

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]
* Note: I was unsure how to test this, as it doesn't seem like I can really mock anything, and this relies on generating a legitimate github token.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
