### PR TITLE
[cron] Increase vacuum frequency to 10 minutes

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -5,7 +5,7 @@
 cron:
 - description: retrieve missing commits
   url: /api/vacuum-github-commits
-  schedule: every 1 hours
+  schedule: every 10 minutes
 
 - description: backfills builds
   url: /api/scheduler/batch-backfiller


### PR DESCRIPTION
Reduce outage latency.

With the removal of the release branch logic from this handler, there should be spare quota to running this more often.