### PR TITLE
Revert "Bump graphql from 5.1.2-beta.6 to 5.1.2 in /auto_submit"

### DIFF
--- a/auto_submit/pubspec.lock
+++ b/auto_submit/pubspec.lock
@@ -294,7 +294,7 @@ packages:
       name: graphql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.2"
+    version: "5.1.2-beta.6"
   graphs:
     dependency: transitive
     description:

--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   github: ^9.7.0
   googleapis: ^9.2.0
   googleapis_auth: ^1.3.1
-  graphql: ^5.1.2
+  graphql: ^5.1.2-beta.6
   gql: ^0.14.0
   http: ^0.13.5
   json_annotation: ^4.7.0


### PR DESCRIPTION
Reverts flutter/cocoon#2374