### PR TITLE
Add verification of build provenance

### DIFF
--- a/app_dart/cloudbuild_app_dart_docker.yaml
+++ b/app_dart/cloudbuild_app_dart_docker.yaml
@@ -10,7 +10,6 @@ steps:
     entrypoint: '/bin/bash'
     args: ['cloud_build/dashboard_build.sh']
 
-
   # Build docker image
   - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
     args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', 'app_dart']
@@ -18,3 +17,7 @@ steps:
 timeout: 1200s
 
 images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA']
+
+# If build provenance is not generated, the docker deployment will fail.
+options:
+  requestedVerifyOption: VERIFIED

--- a/auto_submit/cloudbuild_auto_submit_docker.yaml
+++ b/auto_submit/cloudbuild_auto_submit_docker.yaml
@@ -9,3 +9,7 @@ steps:
 timeout: 1200s
 
 images: ['us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA']
+
+# If build provenance is not generated, the docker deployment will fail.
+options:
+  requestedVerifyOption: VERIFIED


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter/issues/117928

Adding this will require the autosubmit bot and cocoon to have provenance in order to be deployed. If there is no provenance for any reason, it will not deploy the image.

Additional info on this change can be found here: https://cloud.google.com/build/docs/securing-builds/view-build-provenance#req-metadata

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
