### PR TITLE
Eliminate unnecessary errors in the logs and fail gracefully if we cannot find build to reschedule.

### DIFF
--- a/app_dart/lib/src/service/NoBuildFoundException.dart
+++ b/app_dart/lib/src/service/NoBuildFoundException.dart
@@ -1,0 +1,13 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class NoBuildFoundException implements Exception {
+  /// Create a custom exception for no build found Errors.
+  NoBuildFoundException(this.cause);
+
+  final String cause;
+
+  @override
+  String toString() => cause;
+}

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:cocoon_service/src/service/NoBuildFoundException.dart';
 import 'package:github/github.dart' as github;
 import 'package:github/hooks.dart';
 
@@ -406,7 +407,7 @@ class LuciBuildService {
       await githubChecksUtil.updateCheckRun(config, slug, githubCheckRun, detailsUrl: buildUrl);
       return scheduleBuild;
     } else {
-      throw const NotFoundException('Unable to find try build.');
+      throw NoBuildFoundException('Unable to find try build.');
     }
   }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -5,6 +5,7 @@
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:cocoon_service/src/service/NoBuildFoundException.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/scheduler/policy.dart';
 import 'package:gcloud/db.dart';
@@ -453,8 +454,8 @@ class Scheduler {
           try {
             await luciBuildService.rescheduleUsingCheckRunEvent(checkRunEvent);
             success = true;
-          } catch (e) {
-            log.warning('No build found for reschedule.');   
+          } on NoBuildFoundException {
+            log.warning('No build found to reschedule.');
           }
         }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -450,8 +450,12 @@ class Scheduler {
             success = true;
           }
         } else {
-          await luciBuildService.rescheduleUsingCheckRunEvent(checkRunEvent);
-          success = true;
+          try {
+            await luciBuildService.rescheduleUsingCheckRunEvent(checkRunEvent);
+            success = true;
+          } catch (e) {
+            log.warning('No build found for reschedule.');   
+          }
         }
 
         log.fine('CheckName: $name State: $success');

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -539,7 +539,7 @@ void main() {
     test('reschedule using checkrun event fails gracefully', () async {
       when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
           .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 1'));
-
+      
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[
@@ -553,21 +553,11 @@ void main() {
       });
 
       final pushMessage = generateCheckRunEvent(action: 'created', numberOfPullRequests: 1);
-      // print(pushMessage.data);
-      // print(json.decode(pushMessage.data!));
       final Map<String, dynamic> jsonMap = json.decode(pushMessage.data!);
       final Map<String, dynamic> jsonSubMap = json.decode(jsonMap['2']);
       final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(jsonSubMap);
 
-      // Repository repository = Repository.fromJson(jsonMap['2']['repository']);
-      // print(repository);
-      // final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(json.decode(pushMessage.data!));
-      // print(checkRunEvent.checkRun);
-      // final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(pushMessage);
-      // print(checkRunEvent.action);
-      // print(checkRunEvent.repository);
-      expect(() async => await service.rescheduleUsingCheckRunEvent(checkRunEvent),
-          throwsA(const TypeMatcher<NoBuildFoundException>()));
+      expect(() async => await service.rescheduleUsingCheckRunEvent(checkRunEvent), throwsA(const TypeMatcher<NoBuildFoundException>()));
     });
 
     test('do not create postsubmit checkrun for bringup: true target', () async {

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -557,7 +557,8 @@ void main() {
       final Map<String, dynamic> jsonSubMap = json.decode(jsonMap['2']);
       final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(jsonSubMap);
 
-      expect(() async => await service.rescheduleUsingCheckRunEvent(checkRunEvent), throwsA(const TypeMatcher<NoBuildFoundException>()));
+      expect(() async => await service.rescheduleUsingCheckRunEvent(checkRunEvent),
+          throwsA(const TypeMatcher<NoBuildFoundException>()));
     });
 
     test('do not create postsubmit checkrun for bringup: true target', () async {

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -12,11 +12,13 @@ import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/NoBuildFoundException.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/logging.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:github/github.dart';
+import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_checks;
 import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -28,6 +30,7 @@ import '../src/service/fake_github_service.dart';
 import '../src/utilities/entity_generators.dart';
 import '../src/utilities/mocks.dart';
 import '../src/utilities/push_message.dart';
+import '../src/utilities/webhook_generators.dart';
 
 void main() {
   late FakeConfig config;
@@ -531,6 +534,40 @@ void main() {
         'repo_owner': 'flutter',
         'repo_name': 'packages'
       });
+    });
+
+    test('reschedule using checkrun event fails gracefully', () async {
+      when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
+          .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 1'));
+
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return const BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[],
+              ),
+            )
+          ],
+        );
+      });
+
+      final pushMessage = generateCheckRunEvent(action: 'created', numberOfPullRequests: 1);
+      // print(pushMessage.data);
+      // print(json.decode(pushMessage.data!));
+      final Map<String, dynamic> jsonMap = json.decode(pushMessage.data!);
+      final Map<String, dynamic> jsonSubMap = json.decode(jsonMap['2']);
+      final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(jsonSubMap);
+
+      // Repository repository = Repository.fromJson(jsonMap['2']['repository']);
+      // print(repository);
+      // final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(json.decode(pushMessage.data!));
+      // print(checkRunEvent.checkRun);
+      // final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(pushMessage);
+      // print(checkRunEvent.action);
+      // print(checkRunEvent.repository);
+      expect(() async => await service.rescheduleUsingCheckRunEvent(checkRunEvent),
+          throwsA(const TypeMatcher<NoBuildFoundException>()));
     });
 
     test('do not create postsubmit checkrun for bringup: true target', () async {

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -539,7 +539,7 @@ void main() {
     test('reschedule using checkrun event fails gracefully', () async {
       when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
           .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 1'));
-      
+
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return const BatchResponse(
           responses: <Response>[


### PR DESCRIPTION
Cleanup the logs so we can better isolate and debug errors from the infra services. This fix addresses the issue when we attempt to reschedule builds then access the empty build list. Instead we will now catch an exception and log a warning. 

![image](https://user-images.githubusercontent.com/32242716/212996428-045e53c9-1a4e-4d36-aed8-91fa4343a9d8.png)

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/118631

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
