### PR TITLE
[app_dart] Fix stale tasks timestamp encoding

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -77,9 +77,8 @@ class VacuumStaleTasks extends RequestHandler<Body> {
       }
     }
 
-    final Iterable<Task> inserts = tasksToBeReset
-        .map((Task task) => task..status = Task.statusNew)
-        .map((Task task) => task..createTimestamp = 0);
+    final Iterable<Task> inserts =
+        tasksToBeReset.map((Task task) => task..status = Task.statusNew).map((Task task) => task..createTimestamp = 0);
     await datastore.insert(inserts.toList());
   }
 }

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -79,7 +79,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
 
     final Iterable<Task> inserts = tasksToBeReset
         .map((Task task) => task..status = Task.statusNew)
-        .map((Task task) => task..createTimestamp = null);
+        .map((Task task) => task..createTimestamp = 0);
     await datastore.insert(inserts.toList());
   }
 }

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -100,7 +100,7 @@ void main() {
       expect(tasks[0], originalTasks[0]);
       expect(tasks[1], originalTasks[1]);
       expect(tasks[2].status, Task.statusNew);
-      expect(tasks[2].createTimestamp, isNull);
+      expect(tasks[2].createTimestamp, 0);
     });
   });
 }


### PR DESCRIPTION
Follow up to https://github.com/flutter/cocoon/pull/2471

This column can't be set to null.

```
Error while encoding entity (Bad state: Property validation failed for property createTimestamp while trying to serialize entity of kind Task. , #0 
```