### PR TITLE
Do not request tests for engine deletion-only PRs

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -415,8 +415,13 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     bool needsTests = false;
 
     await for (PullRequestFile file in files) {
+      final int linesAdded = file.additionsCount ?? 1;
+      final int linesDeleted = file.deletionsCount ?? 0;
+      final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
+      final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
+
       final String filename = file.filename!.toLowerCase();
-      if (filename.endsWith('.dart') ||
+      if (addedCode && filename.endsWith('.dart') ||
           filename.endsWith('.mm') ||
           filename.endsWith('.m') ||
           filename.endsWith('.java') ||

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -239,14 +239,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     bool needsTests = false;
 
     await for (PullRequestFile file in files) {
-      // When null, do not assume 0 lines have been added.
       final String filename = file.filename!;
-      final int linesAdded = file.additionsCount ?? 1;
-      final int linesDeleted = file.deletionsCount ?? 0;
-      final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
-      final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
 
-      if (addedCode &&
+      if (_fileContainsAddedCode(file) &&
           !_isTestExempt(filename) &&
           !filename.startsWith('dev/bots/') &&
           !filename.endsWith('.gitignore')) {
@@ -415,13 +410,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     bool needsTests = false;
 
     await for (PullRequestFile file in files) {
-      final int linesAdded = file.additionsCount ?? 1;
-      final int linesDeleted = file.deletionsCount ?? 0;
-      final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
-      final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
-
       final String filename = file.filename!.toLowerCase();
-      if (addedCode && filename.endsWith('.dart') ||
+      if (_fileContainsAddedCode(file) && filename.endsWith('.dart') ||
           filename.endsWith('.mm') ||
           filename.endsWith('.m') ||
           filename.endsWith('.java') ||
@@ -454,6 +444,14 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     }
   }
 
+  bool _fileContainsAddedCode(PullRequestFile file) {
+    // When null, do not assume 0 lines have been added.
+    final int linesAdded = file.additionsCount ?? 1;
+    final int linesDeleted = file.deletionsCount ?? 0;
+    final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
+    return linesAdded > 0 || linesDeleted != linesTotal;
+  }
+
   // Runs automated test checks for both flutter/packages and flutter/plugins.
   Future<void> _applyPackageTestChecks(GitHub gitHubClient, String? eventAction, PullRequest pr) async {
     final RepositorySlug slug = pr.base!.repo!.slug();
@@ -464,13 +462,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     await for (PullRequestFile file in files) {
       final String filename = file.filename!;
 
-      // When null, do not assume 0 lines have been added.
-      final int linesAdded = file.additionsCount ?? 1;
-      final int linesDeleted = file.deletionsCount ?? 0;
-      final int linesTotal = file.changesCount ?? linesDeleted + linesAdded;
-      final bool addedCode = linesAdded > 0 || linesDeleted != linesTotal;
-
-      if (addedCode &&
+      if (_fileContainsAddedCode(file) &&
           !_isTestExempt(filename) &&
           !filename.contains('.ci/') &&
           // Custom package-specific test runners. These do not count as tests

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1951,7 +1951,7 @@ void foo() {
       );
 
       when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-            (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()
             ..filename = 'flutter/lib/ui/foo.dart'
             ..deletionsCount = 20


### PR DESCRIPTION
Matches framework repo:
https://github.com/flutter/cocoon/blob/68e36df5bf668d67ae52c036bd427518e0a38929/app_dart/lib/src/request_handlers/github/webhook_subscription.dart#L241-L249

and packages repos:
https://github.com/flutter/cocoon/blob/68e36df5bf668d67ae52c036bd427518e0a38929/app_dart/lib/src/request_handlers/github/webhook_subscription.dart#L463-L468

Would have avoided requesting tests for https://github.com/flutter/engine/pull/39682

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
