### PR TITLE
Add framework label to integration_test PRs

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -343,7 +343,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       'packages/flutter_goldens_client/': <String>['framework', 'a: tests', 'team'],
       'packages/flutter_test/': <String>['framework', 'a: tests'],
       'packages/fuchsia_remote_debug_protocol/': <String>['tool'],
-      'packages/integration_test/': <String>['integration_test'],
+      'packages/integration_test/': <String>['integration_test', 'framework'],
     };
     const Map<String, List<String>> pathContainsLabels = <String, List<String>>{
       'accessibility': <String>['a: accessibility'],

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -620,7 +620,7 @@ void main() {
         // Label applies to integration_test package
         expect(
           GithubWebhookSubscription.getLabelsForFrameworkPath('packages/integration_test/lib/common.dart'),
-          contains('integration_test'),
+          <String>{'integration_test', 'framework'},
         );
       });
     });


### PR DESCRIPTION
`integration_test` PRs are not currently triaged on their own as one of the ["classification labels"](https://github.com/flutter/flutter/wiki/Triage#triaging-prs) that indicate a particular team will look at it.  Add the `framework` label so they are included in the framework team's triage.

https://github.com/flutter/flutter/pull/117977 would have been triaged sooner.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
