### PR TITLE
Call proper semantics API

### DIFF
--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -54,7 +54,7 @@ void main([List<String> args = const <String>[]]) {
     ),
   );
   // Enable extensions like Vimium to traverse the dashboard
-  RendererBinding.instance.setSemanticsEnabled(true);
+  RendererBinding.instance.pipelineOwner.ensureSemantics();
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
Calling `setSemanticsEnabled` is error-prone as the platform can override this and turn semantics on/off willy-nilly and we are in the process of removing this API. Calling `ensureSemantics` ensures that semantics stay turned on no matter what the platform says.