### PR TITLE
[app_dart] Skip postsubmit checks on framework

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -574,6 +574,10 @@ class LuciBuildService {
     Target target,
     Map<String, dynamic> rawUserData,
   ) async {
+    if (commit.slug == Config.flutterSlug) {
+      // Framework has too many targets, and will get throttled.
+      return;
+    }
     final github.CheckRun checkRun = await githubChecksUtil.createCheckRun(
       config,
       target.slug,

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -367,12 +367,6 @@ void main() {
       expect(userData, <String, dynamic>{
         'commit_key': 'flutter/flutter/master/1',
         'task_key': '1',
-        'check_run_id': 1,
-        'commit_sha': '0',
-        'commit_branch': 'master',
-        'builder_name': 'Linux 1',
-        'repo_owner': 'flutter',
-        'repo_name': 'flutter',
       });
       final Map<String, dynamic> properties = scheduleBuild.properties!;
       expect(properties, <String, dynamic>{


### PR DESCRIPTION
Mitigation for https://github.com/flutter/flutter/issues/120395

Long term, we should migrate this to graphql to handle the framework load.