### PR TITLE
Retry provenance

### DIFF
--- a/analyze/analyze.dart
+++ b/analyze/analyze.dart
@@ -206,7 +206,8 @@ const Set<String> kExecutableAllowlist = <String>{
   'test_utilities/bin/flutter_test_runner.sh',
   'test_utilities/bin/global_test_runner.dart',
   'test_utilities/bin/prepare_environment.sh',
-  'cloud_build/verify-provenance.sh'
+  'cloud_build/verify_provenance.sh',
+  'cloud_build/get_docker_image_provenance.sh'
 };
 
 Future<void> _checkForNewExecutables() async {

--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -12,11 +12,9 @@ steps:
     args:
       - '-c'
       - |-
-        gcloud artifacts docker images describe \
+        cloud_build/get_docker_image_provenance.sh \
           us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA:latest \
-          --format json \
-          --show-provenance \
-          > unverified-provenance.json
+          unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
   - name: 'golang:stretch'
@@ -24,7 +22,7 @@ steps:
     args:
       - '-c'
       - |-
-        cloud_build/verify-provenance.sh
+        cloud_build/verify_provenance.sh unverified_provenance.json
 
   # Deploy a new version to google cloud.
   - name: gcr.io/cloud-builders/gcloud

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -523,7 +523,7 @@ void main() {
     test('Skip non-existing builder', () async {
       final Commit commit = generateCommit(0);
       when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-        .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 2'));
+          .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 2'));
       when(mockBuildBucketClient.listBuilders(any)).thenAnswer((_) async {
         return const ListBuildersResponse(
           builders: [

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -522,6 +522,8 @@ void main() {
 
     test('Skip non-existing builder', () async {
       final Commit commit = generateCommit(0);
+      when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
+        .thenAnswer((_) async => generateCheckRun(1, name: 'Linux 2'));
       when(mockBuildBucketClient.listBuilders(any)).thenAnswer((_) async {
         return const ListBuildersResponse(
           builders: [

--- a/auto_submit/cloudbuild_auto_submit_deploy.yaml
+++ b/auto_submit/cloudbuild_auto_submit_deploy.yaml
@@ -12,10 +12,9 @@ steps:
     args:
       - '-c'
       - |-
-        gcloud artifacts docker images describe \
+        cloud_build/get_docker_image_provenance.sh \
           us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA:latest \
-          --show-provenance --format json \
-          > unverified-provenance.json
+          unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
   - name: 'golang:stretch'
@@ -23,7 +22,7 @@ steps:
     args:
       - '-c'
       - |-
-        cloud_build/verify-provenance.sh
+        cloud_build/verify_provenance.sh unverified_provenance.json
 
   # Deploy a new version to google cloud.
   - name: gcr.io/cloud-builders/gcloud

--- a/cloud_build/get_docker_image_provenance.sh
+++ b/cloud_build/get_docker_image_provenance.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2023 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This script is used to pull a docker image's provenance and save it to a file.
+DOCKER_IMAGE_URL=$1
+OUTPUT_DIRECTORY=$2
+# Getting the docker image provenance can be flaky, so retry up to 3 times.
+MAX_ATTEMPTS=3
+
+for attempt in $(seq 1 $MAX_ATTEMPTS)
+do
+    echo "(Attempt $attempt) Obtaining provenance for $1"
+    gcloud artifacts docker images describe \
+        $DOCKER_IMAGE_URL --show-provenance --format json > $OUTPUT_DIRECTORY
+    COMMAND_RESULT=$?
+    if [[ $COMMAND_RESULT -eq 0 ]]
+    then
+        break
+    else
+        echo "Failed to obtain provenance. Retrying in 30 seconds"
+        sleep 30
+    fi
+done
+
+if [[ $COMMAND_RESULT -ne 0 ]]
+then
+  echo "Failed to download provenance." && exit $COMMAND_RESULT
+fi

--- a/cloud_build/get_docker_image_provenance.sh
+++ b/cloud_build/get_docker_image_provenance.sh
@@ -17,9 +17,10 @@ do
     COMMAND_RESULT=$?
     if [[ $COMMAND_RESULT -eq 0 ]]
     then
+        echo "Successfully obtained provenance and saved to $2"
         break
     else
-        echo "Failed to obtain provenance. Retrying in 30 seconds"
+        echo "Failed to obtain provenance."
         sleep 30
     fi
 done

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -26,9 +26,9 @@ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@a4388826
 # Note: jq is used in order to obtain the full artifact registry url from
 # the provenance metadata.
 echo "Verifying the provenance is valid and correct..."
-FULLY_QUALIFIED_DIGEST=$(cat unverified-provenance.json | \
+FULLY_QUALIFIED_DIGEST=$(cat $1 | \
   jq -r .image_summary.fully_qualified_digest)
 slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
   --source-uri https://github.com/flutter/cocoon \
   --builder-id=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3 \
-  --provenance-path unverified-provenance.json
+  --provenance-path $1


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/121559

* Move obtaining provenance to a separate shell script
* Add retry logic to the script in case the provenance isn't obtained on the first try.
* Added parameters to the provenance verification, in order to make it more reusable
* Fixed a unit test that was failing based on the order of the unit test

Occasionally the provenance fails to be obtained, so adding a retry in order to obtain more information

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
