### PR TITLE
Add a method to device_doctor to allow it to wait for an android device to become available

### DIFF
--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:

--- a/device_doctor/bin/main.dart
+++ b/device_doctor/bin/main.dart
@@ -12,7 +12,7 @@ const String actionFlag = 'action';
 const String deviceOSFlag = 'device-os';
 const String helpFlag = 'help';
 const String outputFlag = 'output';
-const List<String> supportedOptions = <String>['healthcheck', 'prepare', 'recovery', 'properties'];
+const List<String> supportedOptions = <String>['healthcheck', 'prepare', 'recovery', 'properties', 'deviceready'];
 const List<String> supportedDeviceOS = <String>['ios', 'android'];
 const String defaultOutputPath = '.output';
 
@@ -56,7 +56,8 @@ Future<void> main(List<String> args) async {
       allowedHelp: {
         'healthcheck': 'Check device health status.',
         'recovery': 'Clean up and reboot device.',
-        'properties': 'Return device properties/dimensions.'
+        'properties': 'Return device properties/dimensions.',
+        'deviceready': 'Wait for a device to become ready.'
       },
     )
     ..addOption('$outputFlag', help: 'Path to the output file')
@@ -86,5 +87,8 @@ Future<void> main(List<String> args) async {
       break;
     case 'properties':
       await deviceDiscovery.deviceProperties();
+      break;
+    case 'deviceready':
+      await deviceDiscovery.devicesReady();
   }
 }

--- a/device_doctor/lib/src/android_device.dart
+++ b/device_doctor/lib/src/android_device.dart
@@ -389,7 +389,7 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     processManager ??= LocalProcessManager();
 
     final RetryOptions r = RetryOptions(
-      maxAttempts: 4,
+      maxAttempts: 5,
       // set to the same as the timeout so each interval is 15 seconds
       delayFactor: deviceOutputTimeout,
       maxDelay: timeout,

--- a/device_doctor/lib/src/device.dart
+++ b/device_doctor/lib/src/device.dart
@@ -40,6 +40,8 @@ abstract class DeviceDiscovery {
 
   /// Prepares the device.
   Future<void> prepareDevices();
+
+  Future<bool> devicesReady();
 }
 
 /// A proxy for one specific phone device.

--- a/device_doctor/lib/src/ios_device.dart
+++ b/device_doctor/lib/src/ios_device.dart
@@ -207,6 +207,12 @@ class IosDeviceDiscovery implements DeviceDiscovery {
       await device.prepare();
     }
   }
+
+  @override
+  Future<bool> devicesReady({Duration timeout = const Duration(seconds: 60)}) async {
+    // support ios later.
+    return true;
+  }
 }
 
 /// iOS device.

--- a/device_doctor/lib/src/no_device_found_exception.dart
+++ b/device_doctor/lib/src/no_device_found_exception.dart
@@ -1,0 +1,12 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class NoDeviceFoundException implements Exception {
+  NoDeviceFoundException(this.cause);
+
+  final String cause;
+
+  @override
+  String toString() => cause;
+}


### PR DESCRIPTION
Make a change to device doctor that is callable from devicelab_drone.py recipe so that we can allow the framework to wait for android devices to become available through adb. 

This change will make 5 attempts to read the device list from adb with a 15 second wait between each retry giving us 5 attempts over a total of 60 seconds. This may need to be adjusted when I test via recipes but 1 minute should be a good start.

*List which issues are fixed by this PR. You must list at least one issue.*
Addresses: https://github.com/flutter/flutter/issues/121420 - thought I will close after testing with the recipes framework.
This should also fix the following flaky tests:
https://github.com/flutter/flutter/issues/120802
https://github.com/flutter/flutter/issues/120806

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
