### PR TITLE
Limit postsubmit checkrun update logic to `postsubmitSupportedRepos` only

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -99,7 +99,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
 
     // Only update GitHub checks if target is not bringup
-    if (target.value.bringup == false) {
+    if (target.value.bringup == false && config.postsubmitSupportedRepos.contains(target.slug)) {
       log.info('Updating check status for ${target.getTestName}');
       await githubChecksService.updateCheckStatus(
         buildPushMessage,

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -138,7 +138,7 @@ CiYaml exampleConfig = CiYaml(
   ),
 );
 
-CiYaml batchPolicyConfig = CiYaml(
+final CiYaml batchPolicyConfig = CiYaml(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(
@@ -156,12 +156,42 @@ CiYaml batchPolicyConfig = CiYaml(
   ),
 );
 
-final CiYaml bringupConfig = CiYaml(
+final CiYaml unsupportedPostsubmitCheckrunConfig = CiYaml(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(
     enabledBranches: <String>[
       Config.defaultBranch(Config.flutterSlug),
+    ],
+    targets: <pb.Target>[
+      pb.Target(
+        name: 'Linux flutter',
+      ),
+    ],
+  ),
+);
+
+final CiYaml nonBringupPackagesConfig = CiYaml(
+  slug: Config.packagesSlug,
+  branch: Config.defaultBranch(Config.packagesSlug),
+  config: pb.SchedulerConfig(
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.packagesSlug),
+    ],
+    targets: <pb.Target>[
+      pb.Target(
+        name: 'Linux nonbringup',
+      ),
+    ],
+  ),
+);
+
+final CiYaml bringupPackagesConfig = CiYaml(
+  slug: Config.packagesSlug,
+  branch: Config.defaultBranch(Config.packagesSlug),
+  config: pb.SchedulerConfig(
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.packagesSlug),
     ],
     targets: <pb.Target>[
       pb.Target(


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/2516, which disabled postsubmit `checkrun` creation on other repos. This PR disables postsumbmit `checkrun` update on other repos.

Fixes: https://github.com/flutter/flutter/issues/122314