### PR TITLE
Wait all futures complete before return when there are errors in `batch backfiller`

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -92,7 +92,7 @@ class BatchBackfiller extends RequestHandler {
       });
       // Schedule all builds asynchronously.
       // Schedule after db updates to avoid duplicate scheduling when db update fails.
-      await Future.wait<void>(backfillRequestList(backfill), eagerError: true);
+      await Future.wait<void>(backfillRequestList(backfill));
     } catch (error) {
       log.severe('Failed to update tasks when backfilling: $error');
     }


### PR DESCRIPTION
Batch backfiller API now bundles all suitable back filling targets in a Future list, and exits with error whenever an error happens in any Future (with `eagerError: true`). This has caused hanging yellow boxes without builds scheduled (https://github.com/flutter/flutter/issues/122117).

This PR disables `eagerError`, this way all other Futures will continue even there is any error occurring. 