### PR TITLE
Enforce `backfillerTargetLimit` when backfilling

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -62,7 +62,7 @@ class BatchBackfiller extends RequestHandler {
     }
 
     // Check if should be scheduled (there is no yellow runs). Run the most recent gray.
-    final List<Tuple<Target, FullTask, int>> backfill = <Tuple<Target, FullTask, int>>[];
+    List<Tuple<Target, FullTask, int>> backfill = <Tuple<Target, FullTask, int>>[];
     for (List<FullTask> taskColumn in taskMap.values) {
       final FullTask task = taskColumn.first;
       final CiYaml ciYaml = await scheduler.getCiYaml(task.commit);
@@ -75,6 +75,11 @@ class BatchBackfiller extends RequestHandler {
       if (backfillTask != null) {
         backfill.add(Tuple<Target, FullTask, int>(target, backfillTask, priority));
       }
+    }
+
+    // Limits the number of targets to be backfilled in each cycle.
+    if (backfill.length > config.backfillerTargetLimit) {
+      backfill = backfill.sublist(0, config.backfillerTargetLimit);
     }
 
     log.fine('Backfilling ${backfill.length} builds');

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -151,6 +151,9 @@ class Config {
   /// Batch size of builds to schedule in each swarming request.
   int get batchSize => 5;
 
+  /// Upper limit of targets to be backfilled in API call.
+  int get backfillerTargetLimit => 50;
+
   /// Max retries when scheduling builds.
   static const RetryOptions schedulerRetry = RetryOptions(maxAttempts: 3);
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -57,6 +57,7 @@ class FakeConfig implements Config {
     this.supportedBranchesValue,
     this.supportedReposValue,
     this.batchSizeValue,
+    this.backfillerTargetLimitValue,
     this.githubRequestDelayValue,
     FakeDatastoreDB? dbValue,
   }) : dbValue = dbValue ?? FakeDatastoreDB();
@@ -87,6 +88,7 @@ class FakeConfig implements Config {
   String? waitingForTreeToGoGreenLabelNameValue;
   Set<String>? rollerAccountsValue;
   int? maxRecordsValue;
+  int? backfillerTargetLimitValue;
   String? flutterGoldPendingValue;
   String? flutterGoldSuccessValue;
   String? flutterGoldChangesValue;
@@ -137,6 +139,9 @@ class FakeConfig implements Config {
   /// Size of the shards to send to buildBucket when scheduling builds.
   @override
   int get schedulingShardSize => 5;
+
+  @override
+  int get backfillerTargetLimit => backfillerTargetLimitValue ?? 50;
 
   @override
   int get batchSize => batchSizeValue ?? 5;

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -152,6 +152,9 @@ final CiYaml batchPolicyConfig = CiYaml(
       pb.Target(
         name: 'Linux_android B',
       ),
+      pb.Target(
+        name: 'Linux_android C',
+      ),
     ],
   ),
 );


### PR DESCRIPTION
This is an attempt to fix issue https://github.com/flutter/flutter/issues/122117 by limiting the number of back filler targets, which limits the number of pub/sub requests in each API.