### PR TITLE
Skip tests check for `dependabot[bot]`

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -317,6 +317,7 @@ class Config {
         'skia-flutter-autoroll',
         'engine-flutter-autoroll',
         'dependabot',
+        'dependabot[bot]',
       };
 
   Future<String> generateJsonWebToken() async {

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -64,6 +64,7 @@ void main() {
         'skia-flutter-autoroll',
         'engine-flutter-autoroll',
         'dependabot',
+        'dependabot[bot]',
       },
       tabledataResource: tabledataResource,
       wrongHeadBranchPullRequestMessageValue: 'wrongHeadBranchPullRequestMessage',
@@ -1644,6 +1645,7 @@ void foo() {
       final Set<String> inputs = {
         'engine-flutter-autoroll',
         'dependabot',
+        'dependabot[bot]',
       };
 
       for (String element in inputs) {


### PR DESCRIPTION
Some PRs from roller `dependabot` are with `user.login` as `dependabot[bot]` in webhook payload. This PR covers it to skip tests check for repos (packages, engine, framework).

Fixes: https://github.com/flutter/flutter/issues/108129