### PR TITLE
add new error message pattern to ios_debug_symbol_doctor

### DIFF
--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -183,6 +183,9 @@ class XCDevice {
   });
 
   static const String _debugSymbolDescriptionPattern = r' is busy: Fetching debug symbols for ';
+  static final RegExp _preparingPhoneForDevelopmentPattern = RegExp(
+    r'Preparing .* for development\. Xcode will continue when .* is finished\.',
+  );
 
   /// Parse subset of JSON from `parseJson` associated with a particular XCDevice.
   factory XCDevice.fromMap(Map<String, Object?> map) {
@@ -192,8 +195,11 @@ class XCDevice {
     bool validError = false;
     if (error != null) {
       final String description = error['description'] as String;
-      if (description.contains(_debugSymbolDescriptionPattern)) {
+      if (description.contains(_debugSymbolDescriptionPattern) ||
+          _preparingPhoneForDevelopmentPattern.hasMatch(description)) {
         validError = true;
+      } else {
+        print('not matching pattern: $description');
       }
     }
     return XCDevice._(

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -18,7 +18,7 @@ import 'utils.dart';
 
 Future<void> main() async {
   for (final String deviceName in const <String>['iPhone', 'iPhone 11', "Flutter's iOS Phone"]) {
-    test('XCDevice surfaces "Fetching debug symbols" error messages for "$deviceName"', () {
+    test('ios_debug_symbol_doctor surfaces "Fetching debug symbols" error messages for "$deviceName"', () {
       final Iterable<XCDevice> devices = XCDevice.parseJson(_jsonWithErrors(deviceName));
       final Iterable<XCDevice> erroredDevices = devices.where((XCDevice device) {
         return device.hasError;
@@ -28,7 +28,21 @@ Future<void> main() async {
       expect(erroredDevice.error!['code'], -10);
       expect(erroredDevice.error!['failureReason'], isEmpty);
       expect(erroredDevice.error!['description'], '$deviceName is busy: Fetching debug symbols for $deviceName');
-      expect(erroredDevice.error!['recoverySuggestion'], 'Xcode will continue when iPhone is finished.');
+      expect(erroredDevice.error!['recoverySuggestion'], 'Xcode will continue when $deviceName is finished.');
+      expect(erroredDevice.error!['domain'], 'com.apple.platform.iphoneos');
+    });
+
+    test('ios_debug_symbol_doctor surfaces "Preparing $deviceName for development" error message', () {
+      final Iterable<XCDevice> devices = XCDevice.parseJson(_jsonWithPreparingErrors(deviceName));
+      final Iterable<XCDevice> erroredDevices = devices.where((XCDevice device) {
+        return device.hasError;
+      });
+      expect(erroredDevices, hasLength(1), reason: devices.toString());
+      final XCDevice erroredDevice = erroredDevices.single;
+      expect(erroredDevice.error!['code'], -10);
+      expect(erroredDevice.error!['failureReason'], isEmpty);
+      expect(erroredDevice.error!['description'], contains('$deviceName is busy: Preparing $deviceName for development'));
+      expect(erroredDevice.error!['recoverySuggestion'], 'Xcode will continue when $deviceName is finished.');
       expect(erroredDevice.error!['domain'], 'com.apple.platform.iphoneos');
     });
   }
@@ -172,7 +186,7 @@ String _jsonWithErrors(String name) => '''
       "code" : -10,
       "failureReason" : "",
       "description" : "$name is busy: Fetching debug symbols for $name",
-      "recoverySuggestion" : "Xcode will continue when iPhone is finished.",
+      "recoverySuggestion" : "Xcode will continue when $name is finished.",
       "domain" : "com.apple.platform.iphoneos"
     },
     "operatingSystemVersion" : "15.1 (19B74)",
@@ -181,7 +195,32 @@ String _jsonWithErrors(String name) => '''
     "architecture" : "arm64",
     "interface" : "usb",
     "available" : false,
-    "name" : "iPhone",
+    "name" : "$name",
+    "modelUTI" : "com.apple.iphone-6s-e1ccb7"
+  }
+]
+''';
+
+String _jsonWithPreparingErrors(String name) => '''
+[
+  {
+    "modelCode" : "iPhone8,1",
+    "simulator" : false,
+    "modelName" : "iPhone 6s",
+    "error" : {
+      "code" : -10,
+      "failureReason" : "",
+      "description" : "$name is busy: Preparing $name for development. Xcode will continue when $name is finished. (code -10)",
+      "recoverySuggestion" : "Xcode will continue when $name is finished.",
+      "domain" : "com.apple.platform.iphoneos"
+    },
+    "operatingSystemVersion" : "15.1 (19B74)",
+    "identifier" : "e3f3a0cf8005b8b34f14d16fa224b19017648353",
+    "platform" : "com.apple.platform.iphoneos",
+    "architecture" : "arm64",
+    "interface" : "usb",
+    "available" : false,
+    "name" : "$name",
     "modelUTI" : "com.apple.iphone-6s-e1ccb7"
   }
 ]

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -41,7 +41,8 @@ Future<void> main() async {
       final XCDevice erroredDevice = erroredDevices.single;
       expect(erroredDevice.error!['code'], -10);
       expect(erroredDevice.error!['failureReason'], isEmpty);
-      expect(erroredDevice.error!['description'], contains('$deviceName is busy: Preparing $deviceName for development'));
+      expect(
+          erroredDevice.error!['description'], contains('$deviceName is busy: Preparing $deviceName for development'));
       expect(erroredDevice.error!['recoverySuggestion'], 'Xcode will continue when $deviceName is finished.');
       expect(erroredDevice.error!['domain'], 'com.apple.platform.iphoneos');
     });


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/123257

Treat messages that look like:

`! Error: iPhone 11 is busy: Preparing iPhone 11 for development. Xcode will continue when iPhone 11 is finished. (code -10)`

As debug symbol errors that should be recovered by opening Xcode.