### PR TITLE
Update verify_provenance.sh to check two different source uris

### DIFF
--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -6,7 +6,9 @@
 # This script is used to verify provenance of our artifacts using slsa-verifier.
 # If slsa-verifier is unable to ensure the provenance of the artifact is
 # legitimate, then the script will exit with a non-zero exit code.
-set -e
+PROVENANCE_PATH=$1
+BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3
+SOURCE_URI=https://github.com/flutter/cocoon
 
 # Download the jq binary in order to obtain the artifact registry url from the
 # docker image provenance.
@@ -20,6 +22,9 @@ pushd tooling
 go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
 popd
 
+FULLY_QUALIFIED_DIGEST=$(cat $PROVENANCE_PATH |
+  jq -r .image_summary.fully_qualified_digest)
+
 # This command uses slsa-verifier to ensure the provenance has the correct
 # source location and builder.
 # "source-uri" is the original location of the source code
@@ -29,9 +34,30 @@ popd
 # Note: jq is used in order to obtain the full artifact registry url from
 # the provenance metadata.
 echo "Verifying the provenance is valid and correct..."
-FULLY_QUALIFIED_DIGEST=$(cat $1 | \
-  jq -r .image_summary.fully_qualified_digest)
+echo "Checking for source-uri of $SOURCE_URI"
 slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
-  --source-uri git+https://github.com/flutter/cocoon \
-  --builder-id=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3 \
-  --provenance-path $1
+  --source-uri $SOURCE_URI \
+  --builder-id=$BUILDER_ID \
+  --provenance-path $PROVENANCE_PATH
+
+# If the provenance failed, try again, but check for 'git+' in the source-uri
+# Context: Cloud Build is sometimes generating provenance with 'git+', but it
+# will eventually be generated for all builds.
+COMMAND_RESULT=$?
+if [[ $COMMAND_RESULT -eq 0 ]]; then
+  echo "Provenance verified!" && exit $COMMAND_RESULT
+fi
+
+echo "Verifying the provenance is valid and correct..."
+echo "Checking for source-uri of git+$SOURCE_URI"
+slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
+  --source-uri git+$SOURCE_URI \
+  --builder-id=$BUILDER_ID \
+  --provenance-path $PROVENANCE_PATH
+
+COMMAND_RESULT=$?
+if [[ $COMMAND_RESULT -eq 0 ]]; then
+  echo "Provenance verified!" && exit $COMMAND_RESULT
+fi
+
+echo "Failed to validate provenance." && exit $COMMAND_RESULT

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -34,11 +34,7 @@ FULLY_QUALIFIED_DIGEST=$(cat $PROVENANCE_PATH |
 # Note: jq is used in order to obtain the full artifact registry url from
 # the provenance metadata.
 echo "Verifying the provenance is valid and correct..."
-<<<<<<< HEAD
 echo "Checking for source-uri of $SOURCE_URI"
-=======
-echo "Checking for source-uri of https://github.com/flutter/cocoon"
->>>>>>> a5952fd0c5bdf2a1226143da6e2c38f49107c6b4
 slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
   --source-uri $SOURCE_URI \
   --builder-id=$BUILDER_ID \
@@ -53,11 +49,7 @@ if [[ $COMMAND_RESULT -eq 0 ]]; then
 fi
 
 echo "Verifying the provenance is valid and correct..."
-<<<<<<< HEAD
 echo "Checking for source-uri of git+$SOURCE_URI"
-=======
-echo "Checking for source-uri of git+https://github.com/flutter/cocoon"
->>>>>>> a5952fd0c5bdf2a1226143da6e2c38f49107c6b4
 slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
   --source-uri git+$SOURCE_URI \
   --builder-id=$BUILDER_ID \

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -43,6 +43,8 @@ slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
 # If the provenance failed, try again, but check for 'git+' in the source-uri
 # Context: Cloud Build is sometimes generating provenance with 'git+', but it
 # will eventually be generated for all builds.
+# TODO(drewroengoogle): Once the cloud build change is completely rolled out,
+# remove this logic and only check for 'git+'.
 COMMAND_RESULT=$?
 if [[ $COMMAND_RESULT -eq 0 ]]; then
   echo "Provenance verified!" && exit $COMMAND_RESULT


### PR DESCRIPTION
* Addresses https://github.com/flutter/flutter/issues/123657
* Cloud Builds are sometimes adding `git+` to the source uri. This will eventually be generated for all builds, but until then, check for the source-uri with `git+` and without so that our builds don't randomly fail.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
