### PR TITLE
Modify the glob regex replacement for the runIf clause for target collection

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -129,7 +129,7 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
 
     for (String glob in globs) {
       glob = glob.replaceAll('**', '[A-Za-z0-9_/.]+');
-      glob = glob.replaceAll('*', '[A-Za-z0-9_]+');
+      glob = glob.replaceAll('*', '[A-Za-z0-9_.]+');
       // If a file is found within a pre-set dir, the builder needs to run. No need to check further.
       final RegExp regExp = RegExp('^$glob\$');
       if (glob.isEmpty || files.any((String? file) => regExp.hasMatch(file!))) {

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -140,8 +140,8 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
   }
 
   log.info('Collected the following targets to run:');
-  for (var element in targetsToRun) {
-    log.info(element.value.name);
+  for (var target in targetsToRun) {
+    log.info(target.value.name);
   }
 
   return targetsToRun;

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -118,6 +118,7 @@ FutureOr<String> getUrl(
 ///
 /// [file] is based on repo root: `a/b/c.dart`.
 Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> files) async {
+  log.info('Getting targets to run from diff.');
   final List<Target> targetsToRun = <Target>[];
   for (Target target in targets) {
     final List<String> globs = target.value.runIf;
@@ -125,9 +126,10 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
     if (globs.isEmpty) {
       targetsToRun.add(target);
     }
+
     for (String glob in globs) {
-      glob = glob.replaceAll('**', '[a-zA-Z_/.]+');
-      glob = glob.replaceAll('*', '[a-zA-Z_]+');
+      glob = glob.replaceAll('**', '[A-Za-z0-9_/.]+');
+      glob = glob.replaceAll('*', '[A-Za-z0-9_]+');
       // If a file is found within a pre-set dir, the builder needs to run. No need to check further.
       final RegExp regExp = RegExp('^$glob\$');
       if (glob.isEmpty || files.any((String? file) => regExp.hasMatch(file!))) {
@@ -136,6 +138,12 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
       }
     }
   }
+
+  log.info('Collected the following targets to run:');
+  for (var element in targetsToRun) {
+    log.info(element.value.name);
+  }
+
   return targetsToRun;
 }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -425,6 +425,8 @@ class Scheduler {
       (Target target) =>
           target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
     );
+
+    log.info('Collected ${presubmitTargets.length} presubmit targets.');
     // Release branches should run every test.
     if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
       log.info('Release branch found, scheduling all targets for ${pullRequest.number}');

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -258,6 +258,70 @@ void main() {
         expect(result, targets);
       });
 
+      test('returns builders when run_if matches files with * and ** that contains digits', () async {
+        targets = <Target>[
+          generateTarget(
+            1,
+            runIf: <String>[
+              'dev/**',
+              'packages/flutter/**',
+              'packages/flutter_driver/**',
+              'packages/integration_test/**',
+              'packages/flutter_localizations/**/l10n/cupertino*.arb',
+              'packages/fuchsia_remote_debug_protocol/**',
+              'packages/flutter_test/**',
+              'packages/flutter_goldens/**',
+              'packages/flutter_tools/**',
+              'bin/**',
+              '.ci.yaml'
+            ],
+          ),
+        ];
+        files = <String>[
+          'packages/flutter_localizations/lib/src/l10n/material_es.arb',
+          'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
+          'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
+        ];
+        final List<Target> result = await getTargetsToRun(targets, files);
+        expect(result, targets);
+      });
+
+      test('returns builders when run_if matches files with * trailing glob', () async {
+        targets = <Target>[
+          generateTarget(
+            1,
+            runIf: <String>[
+              'packages/flutter_localizations/**/l10n/*',
+            ],
+          ),
+        ];
+        files = <String>[
+          'packages/flutter_localizations/lib/src/l10n/material_es.arb',
+          'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
+          'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
+        ];
+        final List<Target> result = await getTargetsToRun(targets, files);
+        expect(result, targets);
+      });
+
+      test('returns builders when run_if matches files with * trailing glob 2', () async {
+        targets = <Target>[
+          generateTarget(
+            1,
+            runIf: <String>[
+              'packages/flutter_localizations/**/l10n/cupertino*',
+            ],
+          ),
+        ];
+        files = <String>[
+          'packages/flutter_localizations/lib/src/l10n/material_es.arb',
+          'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
+          'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
+        ];
+        final List<Target> result = await getTargetsToRun(targets, files);
+        expect(result, targets);
+      });
+
       test('returns builders when run_if matches files with ** in the middle', () async {
         targets = <Target>[
           generateTarget(1, runIf: <String>['abc/**/hj.dart']),

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -194,28 +194,25 @@ void main() {
     });
 
     group('getFilteredBuilders', () {
-      List<String> files;
-      List<Target> targets;
-
       test('does not return builders when run_if does not match any file', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['cde/']),
         ];
-        files = <String>['abc/cde.py', 'cde/fgh.dart'];
+        final List<String> files = <String>['abc/cde.py', 'cde/fgh.dart'];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result.isEmpty, isTrue);
       });
 
       test('returns builders when run_if is null', () async {
-        files = <String>['abc/def.py', 'cde/dgh.dart'];
-        targets = <Target>[generateTarget(1)];
+        final List<String> files = <String>['abc/def.py', 'cde/dgh.dart'];
+        final List<Target> targets = <Target>[generateTarget(1)];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result, targets);
       });
 
       test('returns builders when run_if matches files using full path', () async {
-        files = <String>['abc/cde.py', 'cgh/dhj.dart'];
-        targets = <Target>[
+        final List<String> files = <String>['abc/cde.py', 'cgh/dhj.dart'];
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['abc/cde.py'])
         ];
         final List<Target> result = await getTargetsToRun(targets, files);
@@ -223,16 +220,16 @@ void main() {
       });
 
       test('returns builders when run_if matches files with **', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['abc/**']),
         ];
-        files = <String>['abc/cdf/hj.dart', 'abc/dej.dart'];
+        final List<String> files = <String>['abc/cdf/hj.dart', 'abc/dej.dart'];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result, targets);
       });
 
       test('returns builders when run_if matches files with ** that contain digits', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(
             1,
             runIf: <String>[
@@ -250,7 +247,7 @@ void main() {
             ],
           ),
         ];
-        files = <String>[
+        final List<String> files = <String>[
           'packages/flutter_localizations/lib/src/l10n/material_es.arb',
           'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb'
         ];
@@ -259,7 +256,7 @@ void main() {
       });
 
       test('returns builders when run_if matches files with * and ** that contains digits', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(
             1,
             runIf: <String>[
@@ -277,7 +274,7 @@ void main() {
             ],
           ),
         ];
-        files = <String>[
+        final List<String> files = <String>[
           'packages/flutter_localizations/lib/src/l10n/material_es.arb',
           'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
           'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
@@ -287,7 +284,7 @@ void main() {
       });
 
       test('returns builders when run_if matches files with * trailing glob', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(
             1,
             runIf: <String>[
@@ -295,7 +292,7 @@ void main() {
             ],
           ),
         ];
-        files = <String>[
+        final List<String> files = <String>[
           'packages/flutter_localizations/lib/src/l10n/material_es.arb',
           'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
           'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
@@ -305,7 +302,7 @@ void main() {
       });
 
       test('returns builders when run_if matches files with * trailing glob 2', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(
             1,
             runIf: <String>[
@@ -313,7 +310,7 @@ void main() {
             ],
           ),
         ];
-        files = <String>[
+        final List<String> files = <String>[
           'packages/flutter_localizations/lib/src/l10n/material_es.arb',
           'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb',
           'packages/flutter_localizations/lib/src/l10n/cupertino_cy.arb',
@@ -323,29 +320,29 @@ void main() {
       });
 
       test('returns builders when run_if matches files with ** in the middle', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['abc/**/hj.dart']),
         ];
-        files = <String>['abc/cdf/efg/hj.dart', 'abc/dej.dart'];
+        final List<String> files = <String>['abc/cdf/efg/hj.dart', 'abc/dej.dart'];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result, [targets[0]]);
       });
 
       test('returns builders when run_if matches files with both * and **', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['a/b*c/**']),
         ];
-        files = <String>['a/baddsc/defg.zz', 'c/d'];
+        final List<String> files = <String>['a/baddsc/defg.zz', 'c/d'];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result, targets);
       });
 
       test('returns correct builders when file and folder share the same name', () async {
-        targets = <Target>[
+        final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['a/b/']),
           generateTarget(2, runIf: <String>['a']),
         ];
-        files = <String>['a'];
+        final List<String> files = <String>['a'];
         final List<Target> result = await getTargetsToRun(targets, files);
         expect(result.length, 1);
         expect(result.single, targets[1]);

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -231,6 +231,33 @@ void main() {
         expect(result, targets);
       });
 
+      test('returns builders when run_if matches files with ** that contain digits', () async {
+        targets = <Target>[
+          generateTarget(
+            1,
+            runIf: <String>[
+              'dev/**',
+              'packages/flutter/**',
+              'packages/flutter_driver/**',
+              'packages/integration_test/**',
+              'packages/flutter_localizations/**',
+              'packages/fuchsia_remote_debug_protocol/**',
+              'packages/flutter_test/**',
+              'packages/flutter_goldens/**',
+              'packages/flutter_tools/**',
+              'bin/**',
+              '.ci.yaml'
+            ],
+          ),
+        ];
+        files = <String>[
+          'packages/flutter_localizations/lib/src/l10n/material_es.arb',
+          'packages/flutter_localizations/lib/src/l10n/material_en_ZA.arb'
+        ];
+        final List<Target> result = await getTargetsToRun(targets, files);
+        expect(result, targets);
+      });
+
       test('returns builders when run_if matches files with ** in the middle', () async {
         targets = <Target>[
           generateTarget(1, runIf: <String>['abc/**/hj.dart']),

--- a/codesign/pubspec.lock
+++ b/codesign/pubspec.lock
@@ -5,372 +5,425 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
+      url: "https://pub.dev"
     source: hosted
     version: "58.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
+      url: "https://pub.dev"
     source: hosted
     version: "5.10.0"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.7"
   args:
     dependency: "direct main"
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.3"
   crypto:
     dependency: "direct main"
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   fake_async:
     dependency: "direct main"
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   file:
     dependency: "direct main"
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   flutter_lints:
     dependency: "direct main"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: "direct main"
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.15"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   platform:
     dependency: "direct main"
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: c3120a968135aead39699267f4c74bc9a08e4e909e86bc1b0af5bfd78691123c
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: "direct main"
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "3dac9aecf2c3991d09b9cdde4f98ded7b30804a88a0d7e4e7e1678e78d6b97f4"
+      url: "https://pub.dev"
     source: hosted
     version: "1.24.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "5138dbffb77b2289ecb12b81c11ba46036590b72a64a7a90d6ffb880f1a29e93"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
+      url: "https://pub.dev"
     source: hosted
     version: "11.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "586678f20e112219ed0f73215f01bcdf1d769824ba2ebae45ad918a9bfde9bdb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   meta:
     dependency: transitive
     description:


### PR DESCRIPTION
The glob regex was not working correctly with localization files as they have digits in the file names. The regex was modified to collect these and was improved to allow trailing * for and file in a dir.

Also added more logging to aid with debugging.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/124140

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
