### PR TITLE
[codesign] skip symlink files

### DIFF
--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -105,7 +105,7 @@ Codesign test failed.
 
 We compared binary files in engine artifacts with those listed in
 entitlement.txt and withoutEntitlements.txt, and the binary files do not match.
-*entitlements.txt is the configuartion file encoded in engine artifact zip,
+*entitlements.txt is the configuration file encoded in engine artifact zip,
 built by BUILD.gn and Ninja, to detail the list of entitlement files.
 Either an expected file was not found in *entitlements.txt, or an unexpected
 file was found in entitlements.txt.
@@ -280,7 +280,7 @@ update these file paths accordingly.
     if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
         !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
       log.severe('The system has detected a binary file at $entitlementCurrentPath.'
-          'but it is not in the entitlements configuartion files you provided.'
+          'but it is not in the entitlements configuration files you provided.'
           'if this is a new engine artifact, please add it to one of the entitlements.txt files');
       throw CodesignException(fixItInstructions);
     }

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -199,12 +199,6 @@ update these file paths accordingly.
     required String parentVirtualPath,
   }) async {
     log.info('Visiting directory ${directory.absolute.path}');
-    final String symlinkOrFilename = await symlink(directory.absolute.path, processManager);
-    if (symlinkOrFilename != directory.absolute.path) {
-      log.info("current direcotry is a symlink to $symlinkOrFilename, "
-          "codesign is therefore skipped for the current directory");
-      return;
-    }
     if (directoriesVisited.contains(directory.absolute.path)) {
       log.warning(
         'Warning! You are visiting a directory that has been visited before, the directory is ${directory.absolute.path}',
@@ -276,6 +270,13 @@ update these file paths accordingly.
   Future<void> visitBinaryFile({required File binaryFile, required String parentVirtualPath}) async {
     final String currentFileName = binaryFile.basename;
     final String entitlementCurrentPath = joinEntitlementPaths(parentVirtualPath, currentFileName);
+
+    final String symlinkOrFilename = await symlink(binaryFile.path, processManager);
+    if (symlinkOrFilename != binaryFile.path) {
+      log.info("current file ${binaryFile.path} is a symlink to $symlinkOrFilename, "
+          "codesign is therefore skipped for the current file");
+      return;
+    }
 
     if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
         !fileWithoutEntitlements.contains(entitlementCurrentPath)) {

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -280,9 +280,10 @@ update these file paths accordingly.
 
     if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
         !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
-      log.severe('The system has detected a binary file at $entitlementCurrentPath.'
-          'but it is not in the entitlements configuration files you provided.'
-          'if this is a new engine artifact, please add it to one of the entitlements.txt files');
+      log.severe('the binary file $currentFileName is causing an issue');
+      log.severe('The system has detected a binary file at $entitlementCurrentPath. '
+          'But it is not in the entitlements configuration files you provided. '
+          'If this is a new engine artifact, please add it to one of the entitlements.txt files.');
       throw CodesignException(fixItInstructions);
     }
     log.info('signing file at path ${binaryFile.absolute.path}');

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -208,7 +208,7 @@ update these file paths accordingly.
     final List<FileSystemEntity> entities = await directory.list(followLinks: false).toList();
     for (FileSystemEntity entity in entities) {
       if (entity is io.Link) {
-        log.info("current file or direcotry ${entity.path} is a symlink to ${await (entity as io.Link).target()}, "
+        log.info("current file or direcotry ${entity.path} is a symlink to ${(entity as io.Link).targetSync()}, "
             "codesign is therefore skipped for the current file or directory.");
         continue;
       }
@@ -278,7 +278,8 @@ update these file paths accordingly.
 
     if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
         !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
-      log.severe('the binary file $currentFileName is causing an issue');
+      log.severe('the binary file $currentFileName is causing an issue. \n'
+          'This file is located at $entitlementCurrentPath in the flutter engine artifact.');
       log.severe('The system has detected a binary file at $entitlementCurrentPath. '
           'But it is not in the entitlements configuration files you provided. '
           'If this is a new engine artifact, please add it to one of the entitlements.txt files.');

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -199,6 +199,12 @@ update these file paths accordingly.
     required String parentVirtualPath,
   }) async {
     log.info('Visiting directory ${directory.absolute.path}');
+    final String symlinkOrFilename = await symlink(directory.absolute.path, processManager);
+    if (symlinkOrFilename != directory.absolute.path) {
+      log.info("current direcotry is a symlink to $symlinkOrFilename, "
+          "codesign is therefore skipped for the current directory");
+      return;
+    }
     if (directoriesVisited.contains(directory.absolute.path)) {
       log.warning(
         'Warning! You are visiting a directory that has been visited before, the directory is ${directory.absolute.path}',

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -30,6 +30,8 @@ enum FileType {
   }
 }
 
+// Return the symlink path if the input path is a symlink, and return the same
+// file path if the input path is not a symlink.
 Future<String> symlink(String folderPath, ProcessManager processManager) async {
   final ProcessResult result = processManager.runSync(
     <String>[

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -32,12 +32,12 @@ enum FileType {
 
 // Return the symlink path if the input path is a symlink, and return the same
 // file path if the input path is not a symlink.
-Future<String> symlink(String folderPath, ProcessManager processManager) async {
+Future<String> symlink(String filePath, ProcessManager processManager) async {
   final ProcessResult result = processManager.runSync(
     <String>[
       'readlink',
       '-f',
-      folderPath,
+      filePath,
     ],
   );
 

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -30,6 +30,18 @@ enum FileType {
   }
 }
 
+Future<String> symlink(String folderPath, ProcessManager processManager) async {
+  final ProcessResult result = processManager.runSync(
+    <String>[
+      'readlink',
+      '-f',
+      folderPath,
+    ],
+  );
+
+  return result.stdout as String;
+}
+
 Future<void> unzip({
   required FileSystemEntity inputZip,
   required Directory outDir,

--- a/codesign/lib/src/utils.dart
+++ b/codesign/lib/src/utils.dart
@@ -30,20 +30,6 @@ enum FileType {
   }
 }
 
-// Return the symlink path if the input path is a symlink, and return the same
-// file path if the input path is not a symlink.
-Future<String> symlink(String filePath, ProcessManager processManager) async {
-  final ProcessResult result = processManager.runSync(
-    <String>[
-      'readlink',
-      '-f',
-      filePath,
-    ],
-  );
-
-  return result.stdout as String;
-}
-
 Future<void> unzip({
   required FileSystemEntity inputZip,
   required Directory outDir,

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -131,10 +131,6 @@ void main() {
             ..file('${rootDirectory.path}/single_artifact/without_entitlements.txt').createSync(recursive: true),
         ),
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/single_artifact'],
-          stdout: '${rootDirectory.absolute.path}/single_artifact',
-        ),
-        FakeCommand(
           command: <String>[
             'zip',
             '--symlinks',
@@ -250,10 +246,6 @@ void main() {
         ..file('${rootDirectory.path}/remote_zip_0/file_c').createSync(recursive: true);
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_0'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_0',
-        ),
-        FakeCommand(
           command: <String>[
             'file',
             '--mime-type',
@@ -296,58 +288,12 @@ void main() {
       expect(messages, contains('Child file of directory remote_zip_0 is file_c'));
     });
 
-    test('visitDirectory skips symlink', () async {
-      fileSystem
-        ..file('${rootDirectory.path}/remote_zip_5/symlink_dir/file_a').createSync(recursive: true)
-        ..file('${rootDirectory.path}/remote_zip_5/file_b').createSync(recursive: true);
-      processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_5',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5/symlink_dir'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_5',
-        ),
-        FakeCommand(
-          command: <String>[
-            'file',
-            '--mime-type',
-            '-b',
-            '${rootDirectory.absolute.path}/remote_zip_5/file_b',
-          ],
-          stdout: 'other_files',
-        ),
-      ]);
-      final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_5');
-      await codesignVisitor.visitDirectory(
-        directory: testDirectory,
-        parentVirtualPath: 'a.zip',
-      );
-      final List<String> messages = records
-          .where((LogRecord record) => record.level == Level.INFO)
-          .map((LogRecord record) => record.message)
-          .toList();
-      expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_5'));
-      expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_5/symlink_dir'));
-      expect(messages, isNot(contains('Child file of directory remote_zip_5/symlink_dir is file_a')));
-      expect(
-          messages,
-          contains(
-              'current direcotry is a symlink to ${rootDirectory.path}/remote_zip_5, codesign is therefore skipped for the current directory'));
-      expect(messages, contains('Child file of directory remote_zip_5 is file_b'));
-    });
-
     test('visitDirectory recursively visits directory', () async {
       fileSystem
         ..file('${rootDirectory.path}/remote_zip_1/file_a').createSync(recursive: true)
         ..file('${rootDirectory.path}/remote_zip_1/folder_a/file_b').createSync(recursive: true);
       final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_1');
       processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_1'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_1',
-        ),
         FakeCommand(
           command: <String>[
             'file',
@@ -356,10 +302,6 @@ void main() {
             '${rootDirectory.absolute.path}/remote_zip_1/file_a',
           ],
           stdout: 'other_files',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_1/folder_a'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_1/folder_a',
         ),
         FakeCommand(
           command: <String>[
@@ -399,10 +341,6 @@ void main() {
           onRun: () => fileSystem
             ..file('${rootDirectory.path}/embedded_zip_${zipFileName.hashCode}/file_1').createSync(recursive: true)
             ..file('${rootDirectory.path}/embedded_zip_${zipFileName.hashCode}/file_2').createSync(recursive: true),
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/embedded_zip_${zipFileName.hashCode}'],
-          stdout: '${rootDirectory.absolute.path}/embedded_zip_${zipFileName.hashCode}',
         ),
         FakeCommand(
           command: <String>[
@@ -460,14 +398,6 @@ void main() {
       fileSystem.file(zipFileName).createSync(recursive: true);
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_4'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_4',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_4/folder_1'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_4/folder_1',
-        ),
-        FakeCommand(
           command: <String>[
             'file',
             '--mime-type',
@@ -486,10 +416,6 @@ void main() {
           onRun: () => fileSystem
               .directory('${rootDirectory.path}/embedded_zip_${zipFileName.hashCode}')
               .createSync(recursive: true),
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/embedded_zip_${zipFileName.hashCode}'],
-          stdout: '${rootDirectory.absolute.path}/embedded_zip_${zipFileName.hashCode}',
         ),
         FakeCommand(
           command: <String>[
@@ -530,10 +456,6 @@ void main() {
       fileSystem.file('${rootDirectory.path}/parent_1/child_1/file_1').createSync(recursive: true);
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/parent_1/child_1'],
-          stdout: '${rootDirectory.absolute.path}/parent_1/child_1',
-        ),
-        FakeCommand(
           command: <String>[
             'file',
             '--mime-type',
@@ -541,14 +463,6 @@ void main() {
             '${rootDirectory.absolute.path}/parent_1/child_1/file_1',
           ],
           stdout: 'other_files',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/parent_1'],
-          stdout: '${rootDirectory.absolute.path}/parent_1',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/parent_1/child_1'],
-          stdout: '${rootDirectory.absolute.path}/parent_1/child_1',
         ),
         FakeCommand(
           command: <String>[
@@ -587,6 +501,54 @@ void main() {
       );
     });
 
+    test('visitBinary skips file that is a symlink', () async {
+      fileSystem
+        ..file('${rootDirectory.path}/remote_zip_5/symlink_dir/file_a').createSync(recursive: true)
+        ..file('${rootDirectory.path}/remote_zip_5/file_b').createSync(recursive: true);
+      processManager.addCommands(<FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            'file',
+            '--mime-type',
+            '-b',
+            '${rootDirectory.absolute.path}/remote_zip_5/symlink_dir/file_a',
+          ],
+          stdout: 'application/x-mach-binary',
+        ),
+        FakeCommand(
+          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5/symlink_dir/file_a'],
+          stdout: '${rootDirectory.absolute.path}/remote_zip_5/file_b',
+        ),
+        FakeCommand(
+          command: <String>[
+            'file',
+            '--mime-type',
+            '-b',
+            '${rootDirectory.absolute.path}/remote_zip_5/file_b',
+          ],
+          stdout: 'other_files',
+        ),
+      ]);
+      final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_5');
+      await codesignVisitor.visitDirectory(
+        directory: testDirectory,
+        parentVirtualPath: 'a.zip',
+      );
+      final List<String> messages = records
+          .where((LogRecord record) => record.level == Level.INFO)
+          .map((LogRecord record) => record.message)
+          .toList();
+      expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_5'));
+      expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_5/symlink_dir'));
+      expect(
+        messages,
+        contains("current file ${rootDirectory.path}/remote_zip_5/symlink_dir/file_a"
+            " is a symlink to ${rootDirectory.path}/remote_zip_5/file_b, "
+            "codesign is therefore skipped for the current file"),
+      );
+      expect(messages, contains('Child file of directory remote_zip_5 is file_b'));
+    });
+
     test('visitBinary codesigns binary with / without entitlement', () async {
       codesignVisitor = cs.FileCodesignVisitor(
         codesignCertName: randomString,
@@ -607,26 +569,22 @@ void main() {
       codesignVisitor.fileWithEntitlements = <String>{'root/folder_a/file_a'};
       codesignVisitor.fileWithoutEntitlements = <String>{'root/folder_b/file_b'};
       fileSystem
-        ..file('${rootDirectory.path}/remote_zip_5/folder_a/file_a').createSync(recursive: true)
-        ..file('${rootDirectory.path}/remote_zip_5/folder_b/file_b').createSync(recursive: true);
-      final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_5');
+        ..file('${rootDirectory.path}/remote_zip_6/folder_a/file_a').createSync(recursive: true)
+        ..file('${rootDirectory.path}/remote_zip_6/folder_b/file_b').createSync(recursive: true);
+      final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_6');
       processManager.addCommands(<FakeCommand>[
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_5',
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5/folder_a'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_5/folder_a',
-        ),
         FakeCommand(
           command: <String>[
             'file',
             '--mime-type',
             '-b',
-            '${rootDirectory.absolute.path}/remote_zip_5/folder_a/file_a',
+            '${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a',
           ],
           stdout: 'application/x-mach-binary',
+        ),
+        FakeCommand(
+          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a'],
+          stdout: '${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a',
         ),
         FakeCommand(
           command: <String>[
@@ -634,7 +592,7 @@ void main() {
             '-f',
             '-s',
             randomString,
-            '${rootDirectory.absolute.path}/remote_zip_5/folder_a/file_a',
+            '${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a',
             '--timestamp',
             '--options=runtime',
             '--entitlements',
@@ -642,17 +600,17 @@ void main() {
           ],
         ),
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_5/folder_b'],
-          stdout: '${rootDirectory.absolute.path}/remote_zip_5/folder_b',
-        ),
-        FakeCommand(
           command: <String>[
             'file',
             '--mime-type',
             '-b',
-            '${rootDirectory.absolute.path}/remote_zip_5/folder_b/file_b',
+            '${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b',
           ],
           stdout: 'application/x-mach-binary',
+        ),
+        FakeCommand(
+          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b'],
+          stdout: '${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b',
         ),
         FakeCommand(
           command: <String>[
@@ -660,7 +618,7 @@ void main() {
             '-f',
             '-s',
             randomString,
-            '${rootDirectory.absolute.path}/remote_zip_5/folder_b/file_b',
+            '${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b',
             '--timestamp',
             '--options=runtime',
           ],
@@ -674,11 +632,11 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_5/folder_a/file_a'));
+      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a'));
       expect(messages, contains('the virtual entitlement path associated with file is root/folder_a/file_a'));
       expect(messages, contains('the decision to sign with entitlement is true'));
 
-      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_5/folder_b/file_b'));
+      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b'));
       expect(messages, contains('the virtual entitlement path associated with file is root/folder_b/file_b'));
       expect(messages, contains('the decision to sign with entitlement is false'));
     });
@@ -1147,10 +1105,6 @@ status: Invalid''',
             ..file('${rootDirectory.path}/single_artifact/without_entitlements.txt').createSync(recursive: true),
         ),
         FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/single_artifact'],
-          stdout: '${rootDirectory.absolute.path}/single_artifact',
-        ),
-        FakeCommand(
           command: <String>[
             'zip',
             '--symlinks',
@@ -1216,10 +1170,6 @@ status: Invalid''',
           onRun: () => fileSystem
             ..file('${rootDirectory.path}/single_artifact/entitlements.txt').createSync(recursive: true)
             ..file('${rootDirectory.path}/single_artifact/without_entitlements.txt').createSync(recursive: true),
-        ),
-        FakeCommand(
-          command: <String>['readlink', '-f', '${rootDirectory.absolute.path}/single_artifact'],
-          stdout: '${rootDirectory.absolute.path}/single_artifact',
         ),
         FakeCommand(
           command: <String>[


### PR DESCRIPTION
context: fixes https://github.com/flutter/flutter/issues/124656 , where symlink is followed and an exception was thrown.

Instead, if a file is a symlink that is pointing to another file, we will skip code signing this file.