### PR TITLE
Use locking on cache calls that come through the CacheRequestHandler Endpoint in Cocoon

### DIFF
--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -62,6 +62,7 @@ class CacheService {
 
     // If given createFn, update the cache value if the value returned was null.
     if (createFn != null && value == null) {
+      // Try creating the value
       value = await createFn();
       await set(
         subcacheName,


### PR DESCRIPTION
We ocassionally observe a 500 error when accessing cache values as the get performs both a get and set action. If the value is not present in the cache then a delegate will collect the necessary data and then the value will be populated into the cache. This I suspect is leading to a condition with Redis where we get a "Bad state: StreamSink is bound to a stream" error. 

This code relies upon neat-cache which already has a bug open but I believe that this could protect cocoon from seeing the issue.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/124613

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
