### PR TITLE
[device_doctor] ios_debug_symbol_doctor recover exit early if subprocess fails

### DIFF
--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -129,7 +129,7 @@ class RecoverCommand extends Command<bool> {
     final int runFirstLaunchCode = runFirstLaunchResult.exitCode;
     if (runFirstLaunchCode != 0) {
       logger.info('Failed running `xcodebuild -runFirstLaunch` with code $runFirstLaunchCode!');
-      //return false;
+      return false;
     }
 
     final Duration timeout = Duration(seconds: timeoutSeconds);

--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -129,6 +129,7 @@ class RecoverCommand extends Command<bool> {
     final int runFirstLaunchCode = runFirstLaunchResult.exitCode;
     if (runFirstLaunchCode != 0) {
       logger.info('Failed running `xcodebuild -runFirstLaunch` with code $runFirstLaunchCode!');
+      //return false;
     }
 
     final Duration timeout = Duration(seconds: timeoutSeconds);

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -93,7 +93,7 @@ Future<void> main() async {
       expect(logger.logs[Level.INFO], contains(_jsonWithNonFatalErrors));
     });
 
-    test('foo', () async {
+    test('recover returns early if xcodebuild -runFirstLaunch exits non-zero', () async {
       when(
         processManager.run(<String>['xcrun', 'xcodebuild', '-runFirstLaunch']),
       ).thenAnswer((_) async {
@@ -103,12 +103,6 @@ Future<void> main() async {
           '',
           'xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun',
         );
-      });
-
-      when( // TODO delete
-        processManager.run(<String>['open', '-n', '-F', '-W', xcworkspacePath]),
-      ).thenAnswer((_) async {
-        return ProcessResult(1, 0, '', '');
       });
 
       fakeAsync<void>((FakeAsync time) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/124749

Before this change, if the subprocess `xcrun xcodebuild -runFirstLaunch` exits non-zero, we'd log about it and then continue going, wasting CI time.