### PR TITLE
Cancel builds by pull request not sha

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -83,13 +83,14 @@ class LuciBuildService {
     return getBuilds(slug, sha, builderName, 'try', tags);
   }
 
+  /// Returns an Iterable of try Buildbucket [Build]s for a given [PullRequest].
   Future<Iterable<Build>> getTryBuildsByPullRequest(
-    github.RepositorySlug slug,
     github.PullRequest pullRequest,
   ) {
+    final github.RepositorySlug slug = pullRequest.base!.repo!.slug();
     final Map<String, List<String>> tags = <String, List<String>>{
       'buildset': <String>['pr/git/${pullRequest.number}'],
-      'github_link': <String>['https://github.com/${pullRequest.base!.repo!.fullName}/pull/${pullRequest.number}'],
+      'github_link': <String>['https://github.com/${slug.fullName}/pull/${pullRequest.number}'],
       'user_agent': const <String>['flutter-cocoon'],
     };
     return getBuilds(slug, null, null, 'try', tags);
@@ -221,7 +222,7 @@ class LuciBuildService {
       'Attempting to cancel builds for pullrequest ${pullRequest.base!.repo!.fullName}/${pullRequest.number}',
     );
 
-    final Iterable<Build> builds = await getTryBuildsByPullRequest(pullRequest.base!.repo!.slug(), pullRequest);
+    final Iterable<Build> builds = await getTryBuildsByPullRequest(pullRequest);
     log.info('Found ${builds.length} builds.');
 
     if (builds.isEmpty) {

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -83,6 +83,18 @@ class LuciBuildService {
     return getBuilds(slug, sha, builderName, 'try', tags);
   }
 
+  Future<Iterable<Build>> getTryBuildsByPullRequest(
+    github.RepositorySlug slug,
+    github.PullRequest pullRequest,
+  ) {
+    final Map<String, List<String>> tags = <String, List<String>>{
+      'buildset': <String>['pr/git/${pullRequest.number}'],
+      'github_link': <String>['https://github.com/${pullRequest.base!.repo!.fullName}/pull/${pullRequest.number}'],
+      'user_agent': const <String>['flutter-cocoon'],
+    };
+    return getBuilds(slug, null, null, 'try', tags);
+  }
+
   /// Returns an Iterable of prod BuildBucket build for a given Github [slug], [commitSha],
   /// [builderName] and [repo].
   Future<Iterable<Build>> getProdBuilds(
@@ -209,7 +221,7 @@ class LuciBuildService {
       'Attempting to cancel builds for pullrequest ${pullRequest.base!.repo!.fullName}/${pullRequest.number}',
     );
 
-    final Iterable<Build> builds = await getTryBuilds(pullRequest.base!.repo!.slug(), pullRequest.head!.sha!, null);
+    final Iterable<Build> builds = await getTryBuildsByPullRequest(pullRequest.base!.repo!.slug(), pullRequest);
     log.info('Found ${builds.length} builds.');
 
     if (builds.isEmpty) {

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -12,7 +12,6 @@ import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart' as gh;
 import 'package:github/hooks.dart';
-import 'package:gql/document.dart';
 import 'package:mockito/mockito.dart';
 import 'package:retry/retry.dart';
 import 'package:test/test.dart';

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -124,6 +124,24 @@ void main() {
       );
       expect(builds.first, linuxBuild);
     });
+
+    test('Existing try build', () async {
+      when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
+        return BatchResponse(
+          responses: <Response>[
+            Response(
+              searchBuilds: SearchBuildsResponse(
+                builds: <Build>[linuxBuild],
+              ),
+            ),
+          ],
+        );
+      });
+      final Iterable<Build> builds = await service.getTryBuildsByPullRequest(
+        PullRequest(id: 998, base: PullRequestHead(repo: Repository(fullName: 'flutter/cocoon'))),
+      );
+      expect(builds.first, linuxBuild);
+    });
   });
 
   group('getBuilders', () {


### PR DESCRIPTION
Initially to fix the cancel builds I made the mistake of cancelling by sha which does not work since if you use the head sha the builds are tied to that so it will find no builds each time to cancel.

I have validated the query by running the following on a previous pull request:
```
{
    "predicate": {
        "builder": {
            "project": "flutter",
            "bucket": "try",
            "builder": null
        },
        "tags": [
            {
                "key": "buildset",
                "value": "pr/git/2616"
            },
            {
                "key": "github_link",
                "value": "https://github.com/flutter/cocoon/pull/2616"
            }
        ]
    }
}
```

This returns the 4 builds that we need:

```
{
    "builds": [
        {
            "id": "8783897293298038209",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux ci_yaml roller"
            },
            "number": 3349,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:02:55.639837267Z",
            "startTime": "2023-04-13T21:18:04.664463Z",
            "endTime": "2023-04-13T21:19:53.421413969Z",
            "updateTime": "2023-04-13T21:19:53.421413969Z",
            "status": "SUCCESS",
            "input": {}
        },
        {
            "id": "8783897293298038225",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux Cocoon"
            },
            "number": 3680,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:02:55.639837267Z",
            "startTime": "2023-04-13T21:12:54.451279Z",
            "endTime": "2023-04-13T21:19:28.330790295Z",
            "updateTime": "2023-04-13T21:19:28.330790295Z",
            "status": "SUCCESS",
            "input": {}
        },
        {
            "id": "8783897364968071617",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux ci_yaml roller"
            },
            "number": 3348,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:01:47.289767436Z",
            "startTime": "2023-04-13T21:02:11.020212Z",
            "endTime": "2023-04-13T21:03:55.361630814Z",
            "updateTime": "2023-04-13T21:03:55.361630814Z",
            "status": "SUCCESS",
            "input": {}
        },
        {
            "id": "8783897364968071633",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux Cocoon"
            },
            "number": 3679,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:01:47.289767436Z",
            "startTime": "2023-04-13T21:04:05.103348Z",
            "endTime": "2023-04-13T21:12:44.785496047Z",
            "updateTime": "2023-04-13T21:12:44.785496047Z",
            "status": "SUCCESS",
            "input": {}
        }
    ]
}
```

Running by base sha only returns the following:

```
{
    "builds": [
        {
            "id": "8783897293298038209",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux ci_yaml roller"
            },
            "number": 3349,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:02:55.639837267Z",
            "startTime": "2023-04-13T21:18:04.664463Z",
            "endTime": "2023-04-13T21:19:53.421413969Z",
            "updateTime": "2023-04-13T21:19:53.421413969Z",
            "status": "SUCCESS",
            "input": {}
        },
        {
            "id": "8783897293298038225",
            "builder": {
                "project": "flutter",
                "bucket": "try",
                "builder": "Linux Cocoon"
            },
            "number": 3680,
            "createdBy": "user:flutter-dashboard@appspot.gserviceaccount.com",
            "createTime": "2023-04-13T21:02:55.639837267Z",
            "startTime": "2023-04-13T21:12:54.451279Z",
            "endTime": "2023-04-13T21:19:28.330790295Z",
            "updateTime": "2023-04-13T21:19:28.330790295Z",
            "status": "SUCCESS",
            "input": {}
        }
    ]
}
```

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
