### PR TITLE
[codesign] look for cert in designated keychain

### DIFF
--- a/codesign/bin/codesign.dart
+++ b/codesign/bin/codesign.dart
@@ -53,6 +53,11 @@ const String kCodesignTeamIDOption = 'codesign-team-id-file-path';
 /// [kCodesignCertNameOption] is public information. For codesigning flutter artifacts,
 /// a user can provide values for this variable as shown in the example below.
 ///
+/// Note: this tool uses Apple developer identity from keychain named build.keychain.
+/// You can create/delete build.keychain by following the steps below:
+/// /usr/bin/security create-keychain -p '' build.keychain         # for create
+/// /usr/bin/security delete-keychain build.keychain               # for delete
+///
 /// Usage:
 /// ```shell
 /// dart run bin/codesign.dart --[no-]dryrun

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -294,6 +294,8 @@ update these file paths accordingly.
     }
     final List<String> args = <String>[
       '/usr/bin/codesign',
+      '--keychain',
+      'build.keychain', // specify the keychain to look for cert
       '-f', // force
       '-s', // use the cert provided by next argument
       codesignCertName,

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -586,7 +586,7 @@ void main() {
           command: <String>[
             '/usr/bin/codesign',
             '--keychain',
-            'build.keychain', 
+            'build.keychain',
             '-f',
             '-s',
             randomString,
@@ -610,7 +610,7 @@ void main() {
           command: <String>[
             '/usr/bin/codesign',
             '--keychain',
-            'build.keychain', 
+            'build.keychain',
             '-f',
             '-s',
             randomString,

--- a/codesign/test/file_codesign_visitor_test.dart
+++ b/codesign/test/file_codesign_visitor_test.dart
@@ -585,6 +585,8 @@ void main() {
         FakeCommand(
           command: <String>[
             '/usr/bin/codesign',
+            '--keychain',
+            'build.keychain', 
             '-f',
             '-s',
             randomString,
@@ -607,6 +609,8 @@ void main() {
         FakeCommand(
           command: <String>[
             '/usr/bin/codesign',
+            '--keychain',
+            'build.keychain', 
             '-f',
             '-s',
             randomString,


### PR DESCRIPTION
Fix (hopefully) an inexplicable bug when codesign tool is used on chromium bots. Specify 'build.keychain' as the keychain to look for flutter identity.

Context: on luci runs, the flutter identity is correctly imported under 'build.keychain', and is listed as both 'matching identity' and 'valid identity' for codesign, and 'build.keychain' is set and verified to be the default keychain. However, when signing on chromium bots, there is this inexplicable flake (~30 percent of time) where the bots keep looking for flutter cert under 'login.keychain'. 

Open to suggestion:  if this works, we could supply '--keychain' as a parameter instead of hard coding it to be 'build.keychain'. And we can supply 'build.keychain' as a parameter on the recipe side.

I have tested the correctness of '--keychain' parameter locally: 1. remove flutter cert from login.keychain 2. add flutter cert to build.keychain 3. set build.keychain as default keychain. 4. codesign with '--keychain=build.keychain' argument would succeed. 