### PR TITLE
Apply branch filter regex from start of string.

### DIFF
--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -59,7 +59,7 @@ class GetBranches extends RequestHandler<Body> {
         )
         .toList();
     // From the dashboard point of view, these are the subset of branches we care about.
-    final RegExp branchRegex = RegExp(r'beta|stable|main|master|flutter-.+|fuchsia.+');
+    final RegExp branchRegex = RegExp(r'^beta|^stable|^main|^master|^flutter-.+|^fuchsia.+');
     branches = branches.where((branch) => branch.name.contains(branchRegex)).toList();
     return Body.forJson(branches);
   }

--- a/app_dart/test/request_handlers/get_branches_test.dart
+++ b/app_dart/test/request_handlers/get_branches_test.dart
@@ -64,6 +64,46 @@ void main() {
       expect(result, isEmpty);
     });
 
+    test('should filter out branches not in the interest subset', () async {
+      // main
+      const String mainId = 'flutter/flutter/main';
+      final int lastActivity = DateTime.now().millisecondsSinceEpoch;
+      final Key<String> mainBranchKey = db.emptyKey.append<String>(Branch, id: mainId);
+      final Branch mainBranch = Branch(
+        key: mainBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[mainBranch.key] = mainBranch;
+      // release candidate branch
+      const String releaseId = 'flutter/flutter/flutter-3.10-candidate.1';
+      final Key<String> releaseBranchKey = db.emptyKey.append<String>(Branch, id: releaseId);
+      final Branch releaseBranch = Branch(
+        key: releaseBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[releaseBranch.key] = releaseBranch;
+      // other
+      const String otherId = 'flutter/flutter/other-flutter-3.10-candidate.1';
+      final Key<String> otherBranchKey = db.emptyKey.append<String>(Branch, id: otherId);
+      final Branch otherBranch = Branch(
+        key: otherBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[otherBranch.key] = otherBranch;
+      final List<dynamic> result = (await decodeHandlerBody())!;
+      final List<dynamic> expected = [
+        {
+          'id': 'flutter/flutter/main',
+          'branch': <String, String>{'branch': 'main', 'repository': 'flutter/flutter'}
+        },
+        {
+          'id': 'flutter/flutter/flutter-3.10-candidate.1',
+          'branch': <String, String>{'branch': 'flutter-3.10-candidate.1', 'repository': 'flutter/flutter'}
+        }
+      ];
+      expect(result, expected);
+    });
+
     test('should retrieve branches with commit acitivities in the past week', () async {
       expect(db.values.values.whereType<Branch>().length, 1);
 


### PR DESCRIPTION
The regexes were applied from anywhere in the string causing unexpected results.

Bug: https://github.com/flutter/flutter/issues/125086


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
