### PR TITLE
i125244 exempt dev integration from test required tag

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -314,6 +314,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.endsWith('.md') ||
         // Exempt paths.
         filename.startsWith('dev/devicelab/lib/versions/gallery.dart') ||
+        filename.startsWith('dev/integration_tests') ||
         filename.startsWith('shell/platform/embedder/tests') ||
         filename.startsWith('shell/platform/embedder/fixtures');
   }

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -925,6 +925,7 @@ void main() {
       when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
         (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()..filename = 'dev/devicelab/lib/versions/gallery.dart',
+          PullRequestFile()..filename = 'dev/integration_tests/some_package/android/build.gradle',
           PullRequestFile()..filename = 'shell/platform/embedder/tests/embedder_test_context.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/fixtures/main.dart',
         ]),


### PR DESCRIPTION
- Ignore dev/integration_tests file changes in flutter/flutter since they are tests already
- Add test
https://github.com/flutter/flutter/issues/125244

Previous pr was removed because it contained sensitive data. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
