### PR TITLE
[cocoon] Remove user authentication when backend calls fail.

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -133,9 +133,16 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
               child: ListView(
                 children: <Widget>[
                   if (_smallScreen) ..._buildRepositorySelectionWidgets(context, buildState),
-                  TextButton(
-                    onPressed: buildState.refreshGitHubCommits,
-                    child: const Text('Vacuum GitHub Commits'),
+                  AnimatedBuilder(
+                    animation: buildState,
+                    builder: (context, child) {
+                      final bool isAuthenticated = buildState.authService.isAuthenticated;
+                      return TextButton(
+                        onPressed: isAuthenticated ? buildState.refreshGitHubCommits : null,
+                        child: child!,
+                      );
+                    },
+                    child: const Text('Refresh GitHub Commits'),
                   ),
                   Row(
                     children: [

--- a/dashboard/lib/widgets/task_overlay.dart
+++ b/dashboard/lib/widgets/task_overlay.dart
@@ -291,8 +291,20 @@ class TaskOverlayContents extends StatelessWidget {
                   if (qualifiedTask.isLuci)
                     Padding(
                       padding: const EdgeInsets.only(left: 8.0),
-                      child: ProgressButton(
-                        onPressed: _rerunTask,
+                      // The RERUN button is only enabled if the user is authenticated.
+                      child: AnimatedBuilder(
+                        animation: buildState,
+                        builder: (context, child) {
+                          final bool isAuthenticated = buildState.authService.isAuthenticated;
+                          return ProgressButton(
+                            onPressed: isAuthenticated
+                                ? () {
+                                    return _rerunTask(task);
+                                  }
+                                : null,
+                            child: child,
+                          );
+                        },
                         child: const Text('RERUN'),
                       ),
                     ),
@@ -305,7 +317,7 @@ class TaskOverlayContents extends StatelessWidget {
     );
   }
 
-  Future<void> _rerunTask() async {
+  Future<void> _rerunTask(Task task) async {
     final bool rerunResponse = await buildState.rerunTask(task);
     if (rerunResponse) {
       showSnackBarCallback(

--- a/dashboard/pubspec.lock
+++ b/dashboard/pubspec.lock
@@ -561,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   timing:
     dependency: transitive
     description:

--- a/dashboard/test/utils/mocks.mocks.dart
+++ b/dashboard/test/utils/mocks.mocks.dart
@@ -717,10 +717,10 @@ class MockGoogleSignInService extends _i1.Mock implements _i4.GoogleSignInServic
         returnValueForMissingStub: null,
       );
   @override
-  _i6.Future<bool> get isAuthenticated => (super.noSuchMethod(
+  bool get isAuthenticated => (super.noSuchMethod(
         Invocation.getter(#isAuthenticated),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: false,
+      ) as bool);
   @override
   _i6.Future<String> get idToken => (super.noSuchMethod(
         Invocation.getter(#idToken),
@@ -744,6 +744,15 @@ class MockGoogleSignInService extends _i1.Mock implements _i4.GoogleSignInServic
   _i6.Future<void> signOut() => (super.noSuchMethod(
         Invocation.method(
           #signOut,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> clearUser() => (super.noSuchMethod(
+        Invocation.method(
+          #clearUser,
           [],
         ),
         returnValue: _i6.Future<void>.value(),

--- a/dashboard/test/utils/wrapper.dart
+++ b/dashboard/test/utils/wrapper.dart
@@ -23,10 +23,10 @@ class FakeInserter extends StatelessWidget {
   Widget build(BuildContext context) {
     final MockGoogleSignInService fakeAuthService = MockGoogleSignInService();
     if (signedIn) {
-      when(fakeAuthService.isAuthenticated).thenAnswer((_) => Future<bool>.value(true));
+      when(fakeAuthService.isAuthenticated).thenReturn(true);
       when(fakeAuthService.user).thenReturn(FakeGoogleSignInAccount());
     } else {
-      when(fakeAuthService.isAuthenticated).thenAnswer((_) => Future<bool>.value(false));
+      when(fakeAuthService.isAuthenticated).thenReturn(false);
       when(fakeAuthService.user).thenReturn(null);
     }
 

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -27,7 +27,11 @@ import '../utils/golden.dart';
 import '../utils/task_icons.dart';
 
 class TestGrid extends StatelessWidget {
-  const TestGrid({required this.buildState, required this.task, super.key});
+  const TestGrid({
+    required this.buildState,
+    required this.task,
+    super.key,
+  });
 
   final BuildState buildState;
   final Task task;

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -61,12 +61,15 @@ void main() {
 
   Int64 int64FromDateTime(DateTime time) => Int64(time.millisecondsSinceEpoch);
 
-  final FakeBuildState buildState = FakeBuildState();
+  late FakeBuildState buildState;
+
+  setUp(() {
+    buildState = FakeBuildState();
+    when(buildState.authService.isAuthenticated).thenReturn(true);
+  });
 
   testWidgets('TaskOverlay shows on click', (WidgetTester tester) async {
     await precacheTaskIcons(tester);
-
-    when(buildState.authService.isAuthenticated).thenReturn(true);
 
     final Task expectedTask = Task()
       ..attempts = 3

--- a/dashboard/test/widgets/user_sign_in_test.dart
+++ b/dashboard/test/widgets/user_sign_in_test.dart
@@ -36,7 +36,7 @@ void main() {
   });
 
   testWidgets('SignInButton shows sign in when not authenticated', (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenAnswer((_) async => Future<bool>.value(false));
+    when(mockAuthService.isAuthenticated).thenReturn(false);
     when(mockAuthService.user).thenReturn(null);
 
     await tester.pumpWidget(
@@ -54,7 +54,7 @@ void main() {
   });
 
   testWidgets('SignInButton calls sign in on tap when not authenticated', (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenAnswer((_) async => Future<bool>.value(false));
+    when(mockAuthService.isAuthenticated).thenReturn(false);
     when(mockAuthService.user).thenReturn(null);
 
     await tester.pumpWidget(
@@ -74,7 +74,7 @@ void main() {
   });
 
   testWidgets('SignInButton shows avatar when authenticated', (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenAnswer((_) async => Future<bool>.value(true));
+    when(mockAuthService.isAuthenticated).thenReturn(true);
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);
@@ -96,7 +96,7 @@ void main() {
   });
 
   testWidgets('SignInButton calls sign out on tap when authenticated', (WidgetTester tester) async {
-    when(mockAuthService.isAuthenticated).thenAnswer((_) async => Future<bool>.value(true));
+    when(mockAuthService.isAuthenticated).thenReturn(true);
 
     final GoogleSignInAccount user = FakeGoogleSignInAccount();
     when(mockAuthService.user).thenReturn(user);


### PR DESCRIPTION
This PR updates the Build Dashboard to make sure its UI reflects the authentication state of the user more directly. The UI refreshes as "logged out" when calls to the backend that require a valid authentication fail.

Before this, it was not entirely clear why some actions failed (failing operations only raised a small snackbar at the bottom of the page, and there was no way to renew the user session other than full-page reloading). The app could be in an inconsistent state where it *seemed* to be logged-in, but the user authorization would have expired.

After this PR, the app will seemingly "kick the user out" when they attempt something that they don't have permission to do, so they can interactively re-authenticate. It will also disable the problematic buttons so they cannot be spammed once the backend deauthorizes a user.

The changes are:

* Stops asking "Google Sign In" plugin if the current user `isSignedIn`, it has no idea.
* Makes the `isAuthenticated` check local to Cocoon, and not async (`return user != null`)
  * Updates mocks (and tests) to account for the API changes.
* Adds a `clearUser` method to refresh the UI but not tell the plugin that the user has signed out, so re-login is faster.
  * Calls `clearUser` whenever any request to the server that has `idToken` fails.
    * Assumes that requests only fail for authentication reasons, which might not always be the case! Opportunity for improvement here!
    * Currently this applies only to two requests: `refreshGitHubCommits` and `rerunTask`.
* Minimizes the chances of users sending unauthorized requests to the server.
  * Disables the "RERUN" and "Refresh GitHub Commits" buttons when the user is deemed not authenticated, so they must re-login rather than being able to click forever.
  * Removes the logic that did `signIn` if `idToken` was missing. It doesn't work as intended anymore. Instead, harden the `idToken` getter so it *requires* `isAuthenticated`.
* Adds tests for all of the above.

## Issues

* Mitigates/Fixes https://github.com/flutter/flutter/issues/125171

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
