### PR TITLE
Switch to latest image and default to latest jq

### DIFF
--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -17,7 +17,7 @@ steps:
           unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
-  - name: 'golang:latest'
+  - name: 'golang:1.20'
     entrypoint: '/bin/bash'
     args:
       - '-c'

--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -17,7 +17,7 @@ steps:
           unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
-  - name: 'golang:stretch'
+  - name: 'golang:latest'
     entrypoint: '/bin/bash'
     args:
       - '-c'

--- a/auto_submit/cloudbuild_auto_submit_deploy.yaml
+++ b/auto_submit/cloudbuild_auto_submit_deploy.yaml
@@ -17,7 +17,7 @@ steps:
           unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
-  - name: 'golang:latest'
+  - name: 'golang:1.20'
     entrypoint: '/bin/bash'
     args:
       - '-c'

--- a/auto_submit/cloudbuild_auto_submit_deploy.yaml
+++ b/auto_submit/cloudbuild_auto_submit_deploy.yaml
@@ -17,7 +17,7 @@ steps:
           unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
-  - name: 'golang:stretch'
+  - name: 'golang:latest'
     entrypoint: '/bin/bash'
     args:
       - '-c'

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -13,7 +13,7 @@ SOURCE_URI=https://github.com/flutter/cocoon
 # Download the jq binary in order to obtain the artifact registry url from the
 # docker image provenance.
 echo "Installing jq using apt..."
-apt update && apt install jq=1.5+dfsg-1.3 -y
+apt update && apt install jq -y
 
 # Download slsa-verifier in order to validate the docker image provenance.
 # This takes the version of slsa-verifier defined in tooling/go.mod.


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/125423

Fixes a couple of issues:
* `golang:stretch` seemed to not be able to successfully run `apt update` anymore. I'm not exactly sure why, but to be safe we switched to `golang:latest`
* The pinned version of `jq` no longer exists, switched to the latest version of that as well.
* Tested the build and it passed successfully

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
