### PR TITLE
Fix review approval check ordering

### DIFF
--- a/auto_submit/lib/validations/approval.dart
+++ b/auto_submit/lib/validations/approval.dart
@@ -132,7 +132,7 @@ class Approver {
         //TODO this does not work since we are tracking two different sets.
         // probably need to track one set.
       } else if (state == CHANGES_REQUESTED_STATE && !_reviewAuthors.contains(authorLogin)) {
-         _changeRequestAuthors.add(authorLogin);
+        _changeRequestAuthors.add(authorLogin);
         if (_remainingReviews < targetReviewCount) {
           _remainingReviews++;
         }

--- a/auto_submit/lib/validations/approval.dart
+++ b/auto_submit/lib/validations/approval.dart
@@ -128,9 +128,6 @@ class Approver {
         if (_remainingReviews > 0) {
           _remainingReviews--;
         }
-        //_changeRequestAuthors.remove(authorLogin);
-        //TODO this does not work since we are tracking two different sets.
-        // probably need to track one set.
       } else if (state == CHANGES_REQUESTED_STATE && !_reviewAuthors.contains(authorLogin)) {
         _changeRequestAuthors.add(authorLogin);
         if (_remainingReviews < targetReviewCount) {

--- a/auto_submit/test/validations/approval_test_data.dart
+++ b/auto_submit/test/validations/approval_test_data.dart
@@ -61,8 +61,8 @@ String constructTwoReviewerReview({
   required String secondReviewerAuthorAssociation,
   required String reviewState,
   required String secondReviewState,
-  String author = 'author1',
-  String secondAuthor = 'author2',
+  String author = 'author2',
+  String secondAuthor = 'author3',
 }) {
   return '''
   {
@@ -189,3 +189,79 @@ String constructMultipleReviewerReview({
   }
   ''';
 }
+
+const String multipleReviewsSameAuthor = '''
+
+{
+    "repository": {
+      "pullRequest": {
+        "author": {
+          "login": "author1"
+        },
+        "authorAssociation": "MEMBER",
+        "id": "PR_kwDOA8VHis43rs4_",
+        "title": "[dependabot] Remove human reviewers",
+        "commits": {
+          "nodes":[
+            {
+              "commit": {
+                "abbreviatedOid": "4009ecc",
+                "oid": "4009ecc0b6dbf5cb19cb97472147063e7368ec10",
+                "committedDate": "2022-05-11T22:35:02Z",
+                "pushedDate": "2022-05-11T22:35:03Z",
+                "status": {
+                  "contexts":[
+                    {
+                      "context":"luci-flutter",
+                      "state":"SUCCESS",
+                      "targetUrl":"https://ci.example.com/1000/output"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "reviews": {
+          "nodes": [
+            {
+              "author": {
+                "login": "jmagman"
+              },
+              "state": "COMMENTED",
+              "authorAssociation": "MEMBER"
+            },
+            {
+              "author": {
+                "login": "keyonghan"
+              },
+              "state": "COMMENTED",
+              "authorAssociation": "MEMBER"
+            },
+            {
+              "author": {
+                "login": "jmagman"
+              },
+              "state": "APPROVED",
+              "authorAssociation": "MEMBER"
+            },
+            {
+              "author": {
+                "login": "jmagman"
+              },
+              "state": "CHANGES_REQUESTED",
+              "authorAssociation": "MEMBER"
+            },
+            {
+              "author": {
+                "login": "jmagman"
+              },
+              "state": "APPROVED",
+              "authorAssociation": "MEMBER"
+            }
+          ]
+        }
+      }
+    }
+  }
+''';


### PR DESCRIPTION
It was found that a review author can request changes be made then later approve the pull request. However Autosubmit was not honoring the chronological order of the reviews and was incorrectly blocking reviews that succeeded the original changes requested review. We now are traversing the reviews in reverse chronological order.

Also added a check so the pr author cannot review his own pull request.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/125280

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
