### PR TITLE
update dart path

### DIFF
--- a/codesign/tool/build.sh
+++ b/codesign/tool/build.sh
@@ -28,8 +28,8 @@ if [[ -d "build" ]]; then
 fi
 
 mkdir -p build
-tool/dart-sdk/bin/dart pub get
-tool/dart-sdk/bin/dart compile exe bin/codesign.dart -o build/codesign
+tool/bin/dart pub get
+tool/bin/dart compile exe bin/codesign.dart -o build/codesign
 
 cp -f LICENSE build/
 


### PR DESCRIPTION
update dart path for codesign build.

the path of dart cipd package has been updated. Now mac, linux, and windows share the same path.