### PR TITLE
Add code to collect the repository configuration for Configurable Autosubmit - Part 1

### DIFF
--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -20,15 +20,22 @@ class RepositoryConfiguration {
   static const String requiredCheckRunsOnRevertKey = 'required_checkruns_on_revert';
 
   RepositoryConfiguration({
-    this.allowConfigOverride,
-    this.defaultBranch,
-    this.autoApprovalAccounts,
-    this.approvingReviews,
-    this.approvalGroup,
-    this.runCi,
-    this.supportNoReviewReverts,
-    this.requiredCheckRunsOnRevert,
-  });
+    allowConfigOverride,
+    defaultBranch,
+    autoApprovalAccounts,
+    approvingReviews,
+    approvalGroup,
+    runCi,
+    supportNoReviewReverts,
+    requiredCheckRunsOnRevert,
+  })  : allowConfigOverride = allowConfigOverride ?? false,
+        defaultBranch = defaultBranch ?? 'main',
+        autoApprovalAccounts = autoApprovalAccounts ?? <String>{},
+        approvingReviews = approvingReviews ?? 2,
+        approvalGroup = approvalGroup ?? 'flutter-hackers',
+        runCi = runCi ?? true,
+        supportNoReviewReverts = supportNoReviewReverts ?? true,
+        requiredCheckRunsOnRevert = requiredCheckRunsOnRevert ?? <String>{};
 
   /// This flag allows the repository to override the org level configuration.
   bool? allowConfigOverride;
@@ -89,7 +96,7 @@ class RepositoryConfiguration {
         autoApprovalAccounts.add(element as String);
       }
     }
-    
+
     if (yamlDoc[approvalGroupKey] == null) {
       throw ConfigurationException('The approval group is a required field.');
     }
@@ -103,13 +110,13 @@ class RepositoryConfiguration {
     }
 
     return RepositoryConfiguration(
-      allowConfigOverride: yamlDoc[allowConfigOverrideKey] ?? false,
-      defaultBranch: yamlDoc[defaultBranchKey] ?? 'main',
+      allowConfigOverride: yamlDoc[allowConfigOverrideKey],
+      defaultBranch: yamlDoc[defaultBranchKey],
       autoApprovalAccounts: autoApprovalAccounts,
-      approvingReviews: yamlDoc[approvingReviewsKey] ?? 2,
+      approvingReviews: yamlDoc[approvingReviewsKey],
       approvalGroup: yamlDoc[approvalGroupKey],
-      runCi: yamlDoc[runCiKey] ?? true,
-      supportNoReviewReverts: yamlDoc[supportNoReviewRevertKey] ?? true,
+      runCi: yamlDoc[runCiKey],
+      supportNoReviewReverts: yamlDoc[supportNoReviewRevertKey],
       requiredCheckRunsOnRevert: requiredCheckRunsOnRevert,
     );
   }

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -5,56 +5,6 @@
 import 'package:auto_submit/exception/configuration_exception.dart';
 import 'package:yaml/yaml.dart';
 
-/// RepositoryConfigurationBuilder is used to build the RepositoryConfiguration
-/// object. It allows the default values or missing values to be configured for
-/// the configuration before sending it on for use.
-class RepositoryConfigurationBuilder {
-  bool? _allowConfigOverride = false;
-  String? _defaultBranch = '';
-  Set<String>? _autoApprovalAccounts = {};
-  int? _approvingReviews = 2;
-  String? _approvalGroup = '';
-  bool? _runCi = true;
-  bool? _supportNoReviewReverts = true;
-  Set<String>? _requiredCheckRunsOnRevert = {};
-
-  set allowConfigOverride(bool value) => _allowConfigOverride = value;
-
-  set defaultBranch(String value) => _defaultBranch = value;
-
-  set autoApprovalAccounts(Set<String>? value) {
-    if (value != null) {
-      _autoApprovalAccounts = value;
-    }
-  }
-
-  set approvingReviews(int? value) {
-    if (value != null) {
-      _approvingReviews = value;
-    }
-  }
-
-  set approvalGroup(String? value) => _approvalGroup = value;
-
-  set runCi(bool? value) {
-    if (value != null) {
-      _runCi = value;
-    }
-  }
-
-  set supportNoReviewReverts(bool? value) {
-    if (value != null) {
-      _supportNoReviewReverts = value;
-    }
-  }
-
-  set requiredCheckRunsOnRevert(Set<String>? value) {
-    if (value != null && value.isNotEmpty) {
-      _requiredCheckRunsOnRevert = value;
-    }
-  }
-}
-
 /// The RepositoryConfiguration stores the pertinent information that autosubmit
 /// will need when submiting and validating pull requests for a particular
 /// repository.
@@ -130,18 +80,7 @@ class RepositoryConfiguration {
   }
 
   static RepositoryConfiguration fromYaml(String yaml) {
-    final RepositoryConfigurationBuilder builder = RepositoryConfigurationBuilder();
-
     final dynamic yamlDoc = loadYaml(yaml);
-
-    if (yamlDoc[allowConfigOverrideKey] != null) {
-      builder.allowConfigOverride = yamlDoc[allowConfigOverrideKey];
-    }
-
-    // Default branch is required.
-    if (yamlDoc[defaultBranchKey] != null) {
-      builder.defaultBranch = yamlDoc[defaultBranchKey];
-    }
 
     final Set<String> autoApprovalAccounts = {};
     final YamlList? yamlAutoApprovalAccounts = yamlDoc[autoApprovalAccountsKey];
@@ -150,19 +89,10 @@ class RepositoryConfiguration {
         autoApprovalAccounts.add(element as String);
       }
     }
-    builder.autoApprovalAccounts = autoApprovalAccounts;
-
-    builder.approvingReviews = yamlDoc[approvingReviewsKey];
-
-    if (yamlDoc[approvalGroupKey] != null) {
-      builder.approvalGroup = yamlDoc[approvalGroupKey];
-    } else {
+    
+    if (yamlDoc[approvalGroupKey] == null) {
       throw ConfigurationException('The approval group is a required field.');
     }
-
-    builder.runCi = yamlDoc[runCiKey];
-
-    builder.supportNoReviewReverts = yamlDoc[supportNoReviewRevertKey];
 
     final Set<String> requiredCheckRunsOnRevert = {};
     final YamlList? yamlRequiredCheckRuns = yamlDoc[requiredCheckRunsOnRevertKey];
@@ -171,17 +101,16 @@ class RepositoryConfiguration {
         requiredCheckRunsOnRevert.add(element as String);
       }
     }
-    builder.requiredCheckRunsOnRevert = requiredCheckRunsOnRevert;
 
     return RepositoryConfiguration(
-      allowConfigOverride: builder._allowConfigOverride,
-      defaultBranch: builder._defaultBranch,
-      autoApprovalAccounts: builder._autoApprovalAccounts,
-      approvingReviews: builder._approvingReviews,
-      approvalGroup: builder._approvalGroup,
-      runCi: builder._runCi,
-      supportNoReviewReverts: builder._supportNoReviewReverts,
-      requiredCheckRunsOnRevert: builder._requiredCheckRunsOnRevert,
+      allowConfigOverride: yamlDoc[allowConfigOverrideKey] ?? false,
+      defaultBranch: yamlDoc[defaultBranchKey] ?? 'main',
+      autoApprovalAccounts: autoApprovalAccounts,
+      approvingReviews: yamlDoc[approvingReviewsKey] ?? 2,
+      approvalGroup: yamlDoc[approvalGroupKey],
+      runCi: yamlDoc[runCiKey] ?? true,
+      supportNoReviewReverts: yamlDoc[supportNoReviewRevertKey] ?? true,
+      requiredCheckRunsOnRevert: requiredCheckRunsOnRevert,
     );
   }
 }

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -9,7 +9,8 @@ import 'package:yaml/yaml.dart';
 /// will need when submiting and validating pull requests for a particular
 /// repository.
 class RepositoryConfiguration {
-  // Autosubmit configuration keys as found in the yaml configuraiton file.
+  // Autosubmit configuration keys as found in the both the global and local
+  // yaml configuraiton files.
   static const String allowConfigOverrideKey = 'allow_config_override';
   static const String defaultBranchKey = 'default_branch';
   static const String autoApprovalAccountsKey = 'auto_approval_accounts';
@@ -18,6 +19,16 @@ class RepositoryConfiguration {
   static const String runCiKey = 'run_ci';
   static const String supportNoReviewRevertKey = 'support_no_review_revert';
   static const String requiredCheckRunsOnRevertKey = 'required_checkruns_on_revert';
+
+  // Default values
+  static const bool allowConfigOverrideDefault = false;
+  static const String defaultBranchDefault = 'main';
+  static const Set<String> autoApprovalAccountsDefault = <String>{};
+  static const int approvingReviewsDefault = 2;
+  static const String approvalGroupDefault = 'flutter-hackers';
+  static const bool runCiDefault = true;
+  static const bool supportNoReviewRevertsDefault = true;
+  static const Set<String> requiredCheckRunsOnRevertDefault = <String>{};
 
   RepositoryConfiguration({
     allowConfigOverride,
@@ -89,11 +100,11 @@ class RepositoryConfiguration {
   static RepositoryConfiguration fromYaml(String yaml) {
     final dynamic yamlDoc = loadYaml(yaml);
 
-    final Set<String> autoApprovalAccounts = {};
+    final Set<String> autoApprovalAccounts = <String>{};
     final YamlList? yamlAutoApprovalAccounts = yamlDoc[autoApprovalAccountsKey];
     if (yamlAutoApprovalAccounts != null) {
-      for (var element in yamlAutoApprovalAccounts) {
-        autoApprovalAccounts.add(element as String);
+      for (YamlNode element in yamlAutoApprovalAccounts.nodes) {
+        autoApprovalAccounts.add(element.value as String);
       }
     }
 
@@ -101,11 +112,11 @@ class RepositoryConfiguration {
       throw ConfigurationException('The approval group is a required field.');
     }
 
-    final Set<String> requiredCheckRunsOnRevert = {};
+    final Set<String> requiredCheckRunsOnRevert = <String>{};
     final YamlList? yamlRequiredCheckRuns = yamlDoc[requiredCheckRunsOnRevertKey];
     if (yamlRequiredCheckRuns != null) {
-      for (var element in yamlRequiredCheckRuns) {
-        requiredCheckRunsOnRevert.add(element as String);
+      for (YamlNode element in yamlRequiredCheckRuns.nodes) {
+        requiredCheckRunsOnRevert.add(element.value as String);
       }
     }
 

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -1,0 +1,187 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/exception/configuration_exception.dart';
+import 'package:yaml/yaml.dart';
+
+/// RepositoryConfigurationBuilder is used to build the RepositoryConfiguration
+/// object. It allows the default values or missing values to be configured for
+/// the configuration before sending it on for use.
+class RepositoryConfigurationBuilder {
+  bool? _allowConfigOverride = false;
+  String? _defaultBranch = '';
+  Set<String>? _autoApprovalAccounts = {};
+  int? _approvingReviews = 2;
+  String? _approvalGroup = '';
+  bool? _runCi = true;
+  bool? _supportNoReviewReverts = true;
+  Set<String>? _requiredCheckRunsOnRevert = {};
+
+  set allowConfigOverride(bool value) => _allowConfigOverride = value;
+
+  set defaultBranch(String value) => _defaultBranch = value;
+
+  set autoApprovalAccounts(Set<String>? value) {
+    if (value != null && value.isNotEmpty) {
+      _autoApprovalAccounts = value;
+    }
+  }
+
+  set approvingReviews(int? value) {
+    if (value != null) {
+      _approvingReviews = value;
+    }
+  }
+
+  set approvalGroup(String? value) => _approvalGroup = value;
+
+  set runCi(bool? value) {
+    if (value != null) {
+      _runCi = value;
+    }
+  }
+
+  set supportNoReviewReverts(bool? value) {
+    if (value != null) {
+      _supportNoReviewReverts = value;
+    }
+  }
+
+  set requiredCheckRunsOnRevert(Set<String>? value) {
+    if (value != null && value.isNotEmpty) {
+      _requiredCheckRunsOnRevert = value;
+    }
+  }
+}
+
+/// The RepositoryConfiguration stores the pertinent information that autosubmit
+/// will need when submiting and validating pull requests for a particular
+/// repository.
+class RepositoryConfiguration {
+  // Autosubmit configuration keys as found in the yaml configuraiton file.
+  static const String ALLOW_CONFIG_OVERRIDE_KEY = 'allow_config_override';
+  static const String DEFAULT_BRANCH_KEY = 'default_branch';
+  static const String AUTO_APPROVAL_ACCOUNTS_KEY = 'auto_approval_accounts';
+  static const String APPROVING_REVIEWS_KEY = 'approving_reviews';
+  static const String APPROVAL_GROUP_KEY = 'approval_group';
+  static const String RUN_CI_KEY = 'run_ci';
+  static const String SUPPORT_NO_REVIEW_REVERT_KEY = 'support_no_review_revert';
+  static const String REQUIRED_CHECK_RUNS_KEY = 'required_checkruns_on_revert';
+
+  RepositoryConfiguration({
+    this.allowConfigOverride,
+    this.defaultBranch,
+    this.autoApprovalAccounts,
+    this.approvingReviews,
+    this.approvalGroup,
+    this.runCi,
+    this.supportNoReviewReverts,
+    this.requiredCheckRunsOnRevert,
+  });
+
+  /// This flag allows the repository to override the org level configuration.
+  bool? allowConfigOverride;
+
+  /// The default branch that pull requests will be merged into.
+  String? defaultBranch;
+
+  /// The accounts that have auto approval on their pull requests.
+  Set<String>? autoApprovalAccounts;
+
+  /// The number of reviews needed for a pull request. If the reviewer is part
+  /// of the approval group they will need (approvingReviews - 1) number of
+  /// reviews in order to merge the pull request, if they are not part of the
+  /// approval group the will need approvingReviews number of reviews.
+  int? approvingReviews;
+
+  /// The group that the pull request author will need pull requests from.
+  String? approvalGroup;
+
+  /// Flag to determine whether or not to wait for all the ci checks to finish
+  /// before allowing a merge of the pull request.
+  bool? runCi;
+
+  /// Flag that determines if reverts are allowed without a review.
+  bool? supportNoReviewReverts;
+
+  /// Set of checkruns that must complete before a revert pull request can be
+  /// merged.
+  Set<String>? requiredCheckRunsOnRevert;
+
+  @override
+  String toString() {
+    final StringBuffer stringBuffer = StringBuffer();
+    stringBuffer.writeln('$ALLOW_CONFIG_OVERRIDE_KEY: $allowConfigOverride');
+    stringBuffer.writeln('$DEFAULT_BRANCH_KEY: $defaultBranch');
+    stringBuffer.writeln('$AUTO_APPROVAL_ACCOUNTS_KEY:');
+    for (String account in autoApprovalAccounts!) {
+      stringBuffer.writeln('  - $account');
+    }
+    stringBuffer.writeln('$APPROVING_REVIEWS_KEY: $approvingReviews');
+    stringBuffer.writeln('$APPROVAL_GROUP_KEY: $approvalGroup');
+    stringBuffer.writeln('$RUN_CI_KEY: $runCi');
+    stringBuffer.writeln('$SUPPORT_NO_REVIEW_REVERT_KEY: $supportNoReviewReverts');
+    stringBuffer.writeln('$REQUIRED_CHECK_RUNS_KEY:');
+    for (String checkrun in requiredCheckRunsOnRevert!) {
+      stringBuffer.writeln('  - $checkrun');
+    }
+    return stringBuffer.toString();
+  }
+
+  static RepositoryConfiguration fromYaml(String yaml) {
+    final RepositoryConfigurationBuilder builder = RepositoryConfigurationBuilder();
+
+    final dynamic yamlDoc = loadYaml(yaml);
+
+    if (yamlDoc[ALLOW_CONFIG_OVERRIDE_KEY] != null) {
+      builder.allowConfigOverride = yamlDoc[ALLOW_CONFIG_OVERRIDE_KEY];
+    }
+
+    // Default branch is required.
+    if (yamlDoc[DEFAULT_BRANCH_KEY] != null) {
+      builder.defaultBranch = yamlDoc[DEFAULT_BRANCH_KEY];
+    }
+
+    final Set<String> autoApprovalAccounts = {};
+    final YamlList? yamlAutoApprovalAccounts = yamlDoc[AUTO_APPROVAL_ACCOUNTS_KEY];
+    if (yamlAutoApprovalAccounts != null) {
+      for (var element in yamlAutoApprovalAccounts) {
+        autoApprovalAccounts.add(element as String);
+      }
+    }
+    builder.autoApprovalAccounts = autoApprovalAccounts;
+
+    builder.approvingReviews = yamlDoc[APPROVING_REVIEWS_KEY];
+
+    if (yamlDoc[APPROVAL_GROUP_KEY] != null) {
+      builder.approvalGroup = yamlDoc[APPROVAL_GROUP_KEY];
+    } else {
+      throw ConfigurationException('The approval group is a required field.');
+    }
+
+    builder.runCi = yamlDoc[RUN_CI_KEY];
+
+    builder.supportNoReviewReverts = yamlDoc[SUPPORT_NO_REVIEW_REVERT_KEY];
+
+    final Set<String> requiredCheckRunsOnRevert = {};
+    final YamlList? yamlRequiredCheckRuns = yamlDoc[REQUIRED_CHECK_RUNS_KEY];
+    if (yamlRequiredCheckRuns != null) {
+      for (var element in yamlRequiredCheckRuns) {
+        requiredCheckRunsOnRevert.add(element as String);
+      }
+    }
+    builder.requiredCheckRunsOnRevert = requiredCheckRunsOnRevert;
+
+    return RepositoryConfiguration(
+      allowConfigOverride: builder._allowConfigOverride,
+      defaultBranch: builder._defaultBranch,
+      autoApprovalAccounts: builder._autoApprovalAccounts,
+      approvingReviews: builder._approvingReviews,
+      approvalGroup: builder._approvalGroup,
+      runCi: builder._runCi,
+      supportNoReviewReverts: builder._supportNoReviewReverts,
+      requiredCheckRunsOnRevert: builder._requiredCheckRunsOnRevert,
+    );
+  }
+}

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -23,7 +23,7 @@ class RepositoryConfigurationBuilder {
   set defaultBranch(String value) => _defaultBranch = value;
 
   set autoApprovalAccounts(Set<String>? value) {
-    if (value != null && value.isNotEmpty) {
+    if (value != null) {
       _autoApprovalAccounts = value;
     }
   }
@@ -60,14 +60,14 @@ class RepositoryConfigurationBuilder {
 /// repository.
 class RepositoryConfiguration {
   // Autosubmit configuration keys as found in the yaml configuraiton file.
-  static const String ALLOW_CONFIG_OVERRIDE_KEY = 'allow_config_override';
-  static const String DEFAULT_BRANCH_KEY = 'default_branch';
-  static const String AUTO_APPROVAL_ACCOUNTS_KEY = 'auto_approval_accounts';
-  static const String APPROVING_REVIEWS_KEY = 'approving_reviews';
-  static const String APPROVAL_GROUP_KEY = 'approval_group';
-  static const String RUN_CI_KEY = 'run_ci';
-  static const String SUPPORT_NO_REVIEW_REVERT_KEY = 'support_no_review_revert';
-  static const String REQUIRED_CHECK_RUNS_KEY = 'required_checkruns_on_revert';
+  static const String allowConfigOverrideKey = 'allow_config_override';
+  static const String defaultBranchKey = 'default_branch';
+  static const String autoApprovalAccountsKey = 'auto_approval_accounts';
+  static const String approvingReviewsKey = 'approving_reviews';
+  static const String approvalGroupKey = 'approval_group';
+  static const String runCiKey = 'run_ci';
+  static const String supportNoReviewRevertKey = 'support_no_review_revert';
+  static const String requiredCheckRunsOnRevertKey = 'required_checkruns_on_revert';
 
   RepositoryConfiguration({
     this.allowConfigOverride,
@@ -90,9 +90,9 @@ class RepositoryConfiguration {
   Set<String>? autoApprovalAccounts;
 
   /// The number of reviews needed for a pull request. If the reviewer is part
-  /// of the approval group they will need (approvingReviews - 1) number of
+  /// of the approval group they will need ([approvingReviews] - 1) number of
   /// reviews in order to merge the pull request, if they are not part of the
-  /// approval group the will need approvingReviews number of reviews.
+  /// approval group the will need [approvingReviews] number of reviews.
   int? approvingReviews;
 
   /// The group that the pull request author will need pull requests from.
@@ -112,17 +112,17 @@ class RepositoryConfiguration {
   @override
   String toString() {
     final StringBuffer stringBuffer = StringBuffer();
-    stringBuffer.writeln('$ALLOW_CONFIG_OVERRIDE_KEY: $allowConfigOverride');
-    stringBuffer.writeln('$DEFAULT_BRANCH_KEY: $defaultBranch');
-    stringBuffer.writeln('$AUTO_APPROVAL_ACCOUNTS_KEY:');
+    stringBuffer.writeln('$allowConfigOverrideKey: $allowConfigOverride');
+    stringBuffer.writeln('$defaultBranchKey: $defaultBranch');
+    stringBuffer.writeln('$autoApprovalAccountsKey:');
     for (String account in autoApprovalAccounts!) {
       stringBuffer.writeln('  - $account');
     }
-    stringBuffer.writeln('$APPROVING_REVIEWS_KEY: $approvingReviews');
-    stringBuffer.writeln('$APPROVAL_GROUP_KEY: $approvalGroup');
-    stringBuffer.writeln('$RUN_CI_KEY: $runCi');
-    stringBuffer.writeln('$SUPPORT_NO_REVIEW_REVERT_KEY: $supportNoReviewReverts');
-    stringBuffer.writeln('$REQUIRED_CHECK_RUNS_KEY:');
+    stringBuffer.writeln('$approvingReviewsKey: $approvingReviews');
+    stringBuffer.writeln('$approvalGroupKey: $approvalGroup');
+    stringBuffer.writeln('$runCiKey: $runCi');
+    stringBuffer.writeln('$supportNoReviewRevertKey: $supportNoReviewReverts');
+    stringBuffer.writeln('$requiredCheckRunsOnRevertKey:');
     for (String checkrun in requiredCheckRunsOnRevert!) {
       stringBuffer.writeln('  - $checkrun');
     }
@@ -134,17 +134,17 @@ class RepositoryConfiguration {
 
     final dynamic yamlDoc = loadYaml(yaml);
 
-    if (yamlDoc[ALLOW_CONFIG_OVERRIDE_KEY] != null) {
-      builder.allowConfigOverride = yamlDoc[ALLOW_CONFIG_OVERRIDE_KEY];
+    if (yamlDoc[allowConfigOverrideKey] != null) {
+      builder.allowConfigOverride = yamlDoc[allowConfigOverrideKey];
     }
 
     // Default branch is required.
-    if (yamlDoc[DEFAULT_BRANCH_KEY] != null) {
-      builder.defaultBranch = yamlDoc[DEFAULT_BRANCH_KEY];
+    if (yamlDoc[defaultBranchKey] != null) {
+      builder.defaultBranch = yamlDoc[defaultBranchKey];
     }
 
     final Set<String> autoApprovalAccounts = {};
-    final YamlList? yamlAutoApprovalAccounts = yamlDoc[AUTO_APPROVAL_ACCOUNTS_KEY];
+    final YamlList? yamlAutoApprovalAccounts = yamlDoc[autoApprovalAccountsKey];
     if (yamlAutoApprovalAccounts != null) {
       for (var element in yamlAutoApprovalAccounts) {
         autoApprovalAccounts.add(element as String);
@@ -152,20 +152,20 @@ class RepositoryConfiguration {
     }
     builder.autoApprovalAccounts = autoApprovalAccounts;
 
-    builder.approvingReviews = yamlDoc[APPROVING_REVIEWS_KEY];
+    builder.approvingReviews = yamlDoc[approvingReviewsKey];
 
-    if (yamlDoc[APPROVAL_GROUP_KEY] != null) {
-      builder.approvalGroup = yamlDoc[APPROVAL_GROUP_KEY];
+    if (yamlDoc[approvalGroupKey] != null) {
+      builder.approvalGroup = yamlDoc[approvalGroupKey];
     } else {
       throw ConfigurationException('The approval group is a required field.');
     }
 
-    builder.runCi = yamlDoc[RUN_CI_KEY];
+    builder.runCi = yamlDoc[runCiKey];
 
-    builder.supportNoReviewReverts = yamlDoc[SUPPORT_NO_REVIEW_REVERT_KEY];
+    builder.supportNoReviewReverts = yamlDoc[supportNoReviewRevertKey];
 
     final Set<String> requiredCheckRunsOnRevert = {};
-    final YamlList? yamlRequiredCheckRuns = yamlDoc[REQUIRED_CHECK_RUNS_KEY];
+    final YamlList? yamlRequiredCheckRuns = yamlDoc[requiredCheckRunsOnRevertKey];
     if (yamlRequiredCheckRuns != null) {
       for (var element in yamlRequiredCheckRuns) {
         requiredCheckRunsOnRevert.add(element as String);

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -38,33 +38,33 @@ class RepositoryConfiguration {
         requiredCheckRunsOnRevert = requiredCheckRunsOnRevert ?? <String>{};
 
   /// This flag allows the repository to override the org level configuration.
-  bool? allowConfigOverride;
+  bool allowConfigOverride;
 
   /// The default branch that pull requests will be merged into.
-  String? defaultBranch;
+  String defaultBranch;
 
   /// The accounts that have auto approval on their pull requests.
-  Set<String>? autoApprovalAccounts;
+  Set<String> autoApprovalAccounts;
 
   /// The number of reviews needed for a pull request. If the reviewer is part
   /// of the approval group they will need ([approvingReviews] - 1) number of
   /// reviews in order to merge the pull request, if they are not part of the
   /// approval group the will need [approvingReviews] number of reviews.
-  int? approvingReviews;
+  int approvingReviews;
 
   /// The group that the pull request author will need pull requests from.
-  String? approvalGroup;
+  String approvalGroup;
 
   /// Flag to determine whether or not to wait for all the ci checks to finish
   /// before allowing a merge of the pull request.
-  bool? runCi;
+  bool runCi;
 
   /// Flag that determines if reverts are allowed without a review.
-  bool? supportNoReviewReverts;
+  bool supportNoReviewReverts;
 
   /// Set of checkruns that must complete before a revert pull request can be
   /// merged.
-  Set<String>? requiredCheckRunsOnRevert;
+  Set<String> requiredCheckRunsOnRevert;
 
   @override
   String toString() {
@@ -72,7 +72,7 @@ class RepositoryConfiguration {
     stringBuffer.writeln('$allowConfigOverrideKey: $allowConfigOverride');
     stringBuffer.writeln('$defaultBranchKey: $defaultBranch');
     stringBuffer.writeln('$autoApprovalAccountsKey:');
-    for (String account in autoApprovalAccounts!) {
+    for (String account in autoApprovalAccounts) {
       stringBuffer.writeln('  - $account');
     }
     stringBuffer.writeln('$approvingReviewsKey: $approvingReviews');
@@ -80,7 +80,7 @@ class RepositoryConfiguration {
     stringBuffer.writeln('$runCiKey: $runCi');
     stringBuffer.writeln('$supportNoReviewRevertKey: $supportNoReviewReverts');
     stringBuffer.writeln('$requiredCheckRunsOnRevertKey:');
-    for (String checkrun in requiredCheckRunsOnRevert!) {
+    for (String checkrun in requiredCheckRunsOnRevert) {
       stringBuffer.writeln('  - $checkrun');
     }
     return stringBuffer.toString();

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -129,7 +129,6 @@ class RepositoryConfigurationManager {
     );
 
     // auto approval accounts, they should be empty if nothing was defined
-    mergedRepositoryConfiguration.autoApprovalAccounts = globalConfiguration.autoApprovalAccounts;
     if (localConfiguration.autoApprovalAccounts.isNotEmpty) {
       mergedRepositoryConfiguration.autoApprovalAccounts.addAll(localConfiguration.autoApprovalAccounts);
     }
@@ -161,7 +160,6 @@ class RepositoryConfigurationManager {
     }
 
     // required checkruns on revert, they should be empty if nothing was defined
-    mergedRepositoryConfiguration.requiredCheckRunsOnRevert = globalConfiguration.requiredCheckRunsOnRevert;
     if (localConfiguration.requiredCheckRunsOnRevert.isNotEmpty) {
       mergedRepositoryConfiguration.requiredCheckRunsOnRevert.addAll(localConfiguration.requiredCheckRunsOnRevert);
     }

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -1,0 +1,172 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/configuration/repository_configuration.dart';
+import 'package:auto_submit/service/config.dart';
+import 'package:auto_submit/service/github_service.dart';
+import 'package:auto_submit/service/log.dart';
+import 'package:github/github.dart';
+import 'package:mutex/mutex.dart';
+import 'package:neat_cache/neat_cache.dart';
+
+/// The [RepositoryConfigurationManager] is responsible for fetching and merging
+/// the autosubmit configuration from the Org level repository and if needed
+/// fetching the override configuration from the pull request repository.
+///
+/// It will attempt to access the cache first before repulling the configuraiton
+/// from the repositories. This is currently set at a 10 minute TTL.
+class RepositoryConfigurationManager {
+  final Mutex _mutex = Mutex();
+
+  static String fileSeparator = '/';
+  // This is the well named organization level repository and configuration file
+  // we will read before looking to see if there is a local file with
+  // overwrites.
+  static const String orgRepository = '.github';
+  static const String dirName = 'autosubmit';
+  static const String fileName = 'autosubmit.yml';
+
+  final Config config;
+  final Cache cache;
+
+  RepositoryConfigurationManager(this.config, this.cache);
+
+  /// Read the configuration from the cache given the slug, if the config is not
+  /// in the cache then go and get it from the repository and store it in the
+  /// cache.
+  ///
+  /// Entries will be stored in the cache as config/slug/autosubmit.yaml
+  Future<RepositoryConfiguration> readRepositoryConfiguration(
+    RepositorySlug slug,
+  ) async {
+    await _mutex.acquire();
+    try {
+      // Get the contents from the cache or go to github.
+      final cacheValue = await cache['${slug.fullName}$fileSeparator$fileName'].get(
+        () async => _getConfiguration(slug),
+        const Duration(minutes: 10),
+      );
+      final String cacheYaml = String.fromCharCodes(cacheValue);
+      log.info('Converting yaml to RepositoryConfiguration: $cacheYaml');
+      return RepositoryConfiguration.fromYaml(cacheYaml);
+    } finally {
+      _mutex.release();
+    }
+  }
+
+  /// Collect the configuration from github and handle the cache conversion to
+  /// bytes.
+  Future<List<int>> _getConfiguration(
+    RepositorySlug slug,
+  ) async {
+    // Read the org level configuraiton file first.
+    log.info('Getting org level configuration.');
+    // Get the Org level configuration.
+    final RepositorySlug orgSlug = RepositorySlug(slug.owner, orgRepository);
+    final GithubService githubService = await config.createGithubService(orgSlug);
+    final String orgLevelConfig = await githubService.getFileContents(orgSlug, '$dirName$fileSeparator$fileName');
+    final RepositoryConfiguration globalRepositoryConfiguration = RepositoryConfiguration.fromYaml(orgLevelConfig);
+
+    // Collect the default branch if it was not supplied.
+    if (globalRepositoryConfiguration.defaultBranch!.isEmpty) {
+      globalRepositoryConfiguration.defaultBranch = await githubService.getDefaultBranch(slug);
+    }
+    log.info('Default branch was found to be ${globalRepositoryConfiguration.defaultBranch} for ${slug.fullName}.');
+
+    // If the override flag is set to true we check the pull request's
+    // repository to collect any values that will override the global config.
+    if (globalRepositoryConfiguration.allowConfigOverride == true) {
+      log.info('Override is set, collecting and merging local repository configuration.');
+      final GithubService localGithubService = await config.createGithubService(slug);
+
+      String? localRepositoryConfigurationYaml;
+      try {
+        localRepositoryConfigurationYaml =
+            await localGithubService.getFileContents(slug, '$dirName$fileSeparator$fileName');
+        final RepositoryConfiguration localRepositoryConfiguration =
+            RepositoryConfiguration.fromYaml(localRepositoryConfigurationYaml);
+        final RepositoryConfiguration mergedRepositoryConfiguration = mergeConfigurations(
+          globalRepositoryConfiguration,
+          localRepositoryConfiguration,
+        );
+        return mergedRepositoryConfiguration.toString().codeUnits;
+      } on Exception {
+        log.warning(
+          'Configuration override was set but no local repository configuration file was found in ${slug.fullName}, using global configuration.',
+        );
+      }
+    }
+
+    return globalRepositoryConfiguration.toString().codeUnits;
+  }
+
+  /// Merge the local [RepositoryConfiguration] with the global
+  /// [RepositoryConfiguration].
+  ///
+  /// Values that are lists are additive. Values that are not lists overwrite
+  /// the value in the global configuration.
+  ///
+  /// The number of approving reviews in the local configuration cannot override
+  /// the global configuration if it is a lower value.
+  ///
+  /// We also do not need to allow the default branch override as it is
+  /// collected from the repository directly.
+  RepositoryConfiguration mergeConfigurations(
+    RepositoryConfiguration globalConfiguration,
+    RepositoryConfiguration localConfiguration,
+  ) {
+    final RepositoryConfiguration mergedRepositoryConfiguration = RepositoryConfiguration(
+      allowConfigOverride: globalConfiguration.allowConfigOverride,
+      defaultBranch: globalConfiguration.defaultBranch,
+      autoApprovalAccounts: globalConfiguration.autoApprovalAccounts,
+      approvingReviews: globalConfiguration.approvingReviews,
+      approvalGroup: globalConfiguration.approvalGroup,
+      runCi: globalConfiguration.runCi,
+      supportNoReviewReverts: globalConfiguration.supportNoReviewReverts,
+      requiredCheckRunsOnRevert: globalConfiguration.requiredCheckRunsOnRevert,
+    );
+
+    // auto approval accounts, they should be empty if nothing was defined
+    mergedRepositoryConfiguration.autoApprovalAccounts = globalConfiguration.autoApprovalAccounts;
+    if (localConfiguration.autoApprovalAccounts != null && localConfiguration.autoApprovalAccounts!.isNotEmpty) {
+      mergedRepositoryConfiguration.autoApprovalAccounts!.addAll(localConfiguration.autoApprovalAccounts!);
+    }
+
+    // approving reviews
+    // this may not be set lower than the global configuration value
+    final int? localApprovingReviews = localConfiguration.approvingReviews;
+    if (localApprovingReviews != null && localApprovingReviews > globalConfiguration.approvingReviews!) {
+      mergedRepositoryConfiguration.approvingReviews = localApprovingReviews;
+    }
+
+    // approval group
+    final String? localApprovalGroup = localConfiguration.approvalGroup;
+    if (localApprovalGroup != null && localApprovalGroup.isNotEmpty) {
+      mergedRepositoryConfiguration.approvalGroup = localApprovalGroup;
+    }
+
+    // run ci
+    // validates the checks runs
+    final bool? localRunCi = localConfiguration.runCi;
+    if (localRunCi != null && globalConfiguration.runCi != localRunCi) {
+      mergedRepositoryConfiguration.runCi = localRunCi;
+    }
+
+    // support no revert reviews - this will be a moot point after revert is updated
+    final bool? localSupportNoReviewReverts = localConfiguration.supportNoReviewReverts;
+    if (localSupportNoReviewReverts != null &&
+        localSupportNoReviewReverts != globalConfiguration.supportNoReviewReverts) {
+      mergedRepositoryConfiguration.supportNoReviewReverts = localSupportNoReviewReverts;
+    }
+
+    // required checkruns on revert, they should be empty if nothing was defined
+    mergedRepositoryConfiguration.requiredCheckRunsOnRevert = globalConfiguration.requiredCheckRunsOnRevert;
+    if (localConfiguration.requiredCheckRunsOnRevert != null &&
+        localConfiguration.requiredCheckRunsOnRevert!.isNotEmpty) {
+      mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.addAll(localConfiguration.requiredCheckRunsOnRevert!);
+    }
+
+    return mergedRepositoryConfiguration;
+  }
+}

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -19,7 +19,7 @@ import 'package:neat_cache/neat_cache.dart';
 class RepositoryConfigurationManager {
   final Mutex _mutex = Mutex();
 
-  static String fileSeparator = '/';
+  static const String fileSeparator = '/';
   // This is the well named organization level repository and configuration file
   // we will read before looking to see if there is a local file with
   // overwrites.

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -92,7 +92,7 @@ class RepositoryConfigurationManager {
           localRepositoryConfiguration,
         );
         return mergedRepositoryConfiguration.toString().codeUnits;
-      } on Exception {
+      } on GitHubError {
         log.warning(
           'Configuration override was set but no local repository configuration file was found in ${slug.fullName}, using global configuration.',
         );

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -17,7 +17,6 @@ import 'package:neat_cache/neat_cache.dart';
 /// It will attempt to access the cache first before repulling the configuraiton
 /// from the repositories. This is currently set at a 10 minute TTL.
 class RepositoryConfigurationManager {
-
   RepositoryConfigurationManager(this.config, this.cache);
 
   // Mutex protects the calls to cache while the [RepositoryConfiguration] is
@@ -83,8 +82,7 @@ class RepositoryConfigurationManager {
 
       String? localRepositoryConfigurationYaml;
       try {
-        localRepositoryConfigurationYaml =
-            await githubService.getFileContents(slug, '$dirName$fileSeparator$fileName');
+        localRepositoryConfigurationYaml = await githubService.getFileContents(slug, '$dirName$fileSeparator$fileName');
         final RepositoryConfiguration localRepositoryConfiguration =
             RepositoryConfiguration.fromYaml(localRepositoryConfigurationYaml);
         final RepositoryConfiguration mergedRepositoryConfiguration = mergeConfigurations(

--- a/auto_submit/lib/exception/configuration_exception.dart
+++ b/auto_submit/lib/exception/configuration_exception.dart
@@ -1,0 +1,13 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class ConfigurationException implements Exception {
+  /// Create a custom exception for Autosubmit Configuration Errors.
+  ConfigurationException(this.cause);
+
+  final String cause;
+
+  @override
+  String toString() => cause;
+}

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -81,6 +81,9 @@ class Config {
   /// https://github.com/flutter/cocoon/pull/2035/files#r938143840.
   int get kPubsubPullNumber => 5;
 
+  /// Repository configuration variables
+  Duration get repositoryConfigurationTtl => const Duration(minutes: 10);
+
   /// PubSub configs
   static const String pubsubTopicsPrefix = 'projects/flutter-dashboard/topics';
   static const String pubsubSubscriptionsPrefix = 'projects/flutter-dashboard/subscriptions';
@@ -103,9 +106,9 @@ class Config {
   /// Pull request approval message
   static const String pullRequestApprovalRequirementsMessage =
       '- Merge guidelines: You need at least one approved review if you are already '
-      'a MEMBER or two member reviews if you are not a MEMBER before re-applying the '
-      'autosubmit label. __Reviewers__: If you left a comment approving, please use '
-      'the "approve" review action instead.';
+      'part of flutter-hackers or two member reviews if you are not a flutter-hacker '
+      'before re-applying the autosubmit label. __Reviewers__: If you left a comment '
+      'approving, please use the "approve" review action instead.';
 
   /// Config object members
   final CacheProvider cacheProvider;

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -172,12 +172,13 @@ class GithubService {
   }
 
   /// Check to see if user is a member of team in org.
-  /// 
+  ///
   /// Note that we catch here as the api returns a 404 if the user has no
   /// membership in general or is not a member of the team.
   Future<bool> isTeamMember(String team, String user, String org) async {
     try {
-      final TeamMembershipState teamMembershipState = await github.organizations.getTeamMembershipByName(org, team, user);
+      final TeamMembershipState teamMembershipState =
+          await github.organizations.getTeamMembershipByName(org, team, user);
       return teamMembershipState.isActive;
     } on GitHubError {
       return false;

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -168,13 +168,20 @@ class GithubService {
       throw 'Contents do not point to a file.';
     }
     final String content = utf8.decode(base64.decode(repositoryContents.file!.content!.replaceAll('\n', '')));
-    log.info('githubService: $content');
     return content;
   }
 
+  /// Check to see if user is a member of team in org.
+  /// 
+  /// Note that we catch here as the api returns a 404 if the user has no
+  /// membership in general or is not a member of the team.
   Future<bool> isTeamMember(String team, String user, String org) async {
-    final TeamMembershipState teamMembershipState = await github.organizations.getTeamMembershipByName(org, team, user);
-    return teamMembershipState.isActive;
+    try {
+      final TeamMembershipState teamMembershipState = await github.organizations.getTeamMembershipByName(org, team, user);
+      return teamMembershipState.isActive;
+    } on GitHubError {
+      return false;
+    }
   }
 
   /// Get the definition of a single repository

--- a/auto_submit/lib/service/secrets.dart
+++ b/auto_submit/lib/service/secrets.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:auto_submit/service/config.dart';
 import 'package:appengine/appengine.dart';
 import 'package:googleapis/secretmanager/v1.dart';
 
@@ -23,7 +24,7 @@ abstract class SecretManager {
 class CloudSecretManager implements SecretManager {
   CloudSecretManager();
 
-  final String projectId = Platform.environment['APPLICATION_ID'] ?? 'flutter-dashboard';
+  final String projectId = Platform.environment['APPLICATION_ID'] ?? Config.flutterGcpProjectId;
 
   @override
   Future<String> get(

--- a/auto_submit/pubspec.lock
+++ b/auto_submit/pubspec.lock
@@ -481,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  mutex:
+    dependency: "direct main"
+    description:
+      name: mutex
+      sha256: "03116a4e46282a671b46c12de649d72c0ed18188ffe12a8d0fc63e83f4ad88f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   neat_cache:
     dependency: "direct main"
     description:
@@ -786,7 +794,7 @@ packages:
     source: hosted
     version: "1.2.0"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"

--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   crypto: ^3.0.2
   logging: ^1.1.0
   retry: ^3.1.1
+  yaml: ^3.1.1
+  mutex: ^3.0.1
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/auto_submit/test/configuration/repository_configuration_data.dart
+++ b/auto_submit/test/configuration/repository_configuration_data.dart
@@ -1,0 +1,33 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String sampleConfigNoOverride = '''
+  default_branch: main
+  allow_config_override: false
+  auto_approval_accounts:
+    - dependabot[bot]
+    - dependabot
+    - DartDevtoolWorkflowBot
+  approving_reviews: 2
+  approval_group: flutter-hackers
+  run_ci: true
+  support_no_review_revert: true
+  required_checkruns_on_revert:
+    - ci.yaml validation
+''';
+
+const String sampleConfigWithOverride = '''
+  default_branch: main
+  allow_config_override: true
+  auto_approval_accounts:
+    - dependabot[bot]
+    - dependabot
+    - DartDevtoolWorkflowBot
+  approving_reviews: 2
+  approval_group: flutter-hackers
+  run_ci: true
+  support_no_review_revert: true
+  required_checkruns_on_revert:
+    - ci.yaml validation
+''';

--- a/auto_submit/test/configuration/repository_configuration_manager_test.dart
+++ b/auto_submit/test/configuration/repository_configuration_manager_test.dart
@@ -1,0 +1,318 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/configuration/repository_configuration.dart';
+import 'package:auto_submit/configuration/repository_configuration_manager.dart';
+import 'package:github/github.dart';
+import 'package:neat_cache/cache_provider.dart';
+import 'package:neat_cache/neat_cache.dart';
+import 'package:test/test.dart';
+
+import '../src/service/fake_config.dart';
+import '../src/service/fake_github_service.dart';
+import 'repository_configuration_data.dart';
+
+void main() {
+  late RepositoryConfigurationManager repositoryConfigurationManager;
+  late CacheProvider cacheProvider;
+  late Cache cache;
+
+  late FakeGithubService githubService;
+  late FakeConfig config;
+
+  setUp(() {
+    cacheProvider = Cache.inMemoryCacheProvider(5);
+    cache = Cache<dynamic>(cacheProvider).withPrefix('config');
+    githubService = FakeGithubService();
+    config = FakeConfig(githubService: githubService);
+    repositoryConfigurationManager = RepositoryConfigurationManager(config, cache);
+  });
+
+  test('Verify cache storage', () async {
+    const String sampleConfig = '''
+      default_branch: main
+      auto_approval_accounts:
+        - dependabot[bot]
+        - dependabot
+        - DartDevtoolWorkflowBot
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - ci.yaml validation
+        - Google-testing
+        - test (ubuntu-latest, 2.18.0)
+        - cla/google
+    ''';
+
+    githubService.fileContentsMockList.add(sampleConfig);
+    final RepositoryConfiguration repositoryConfiguration =
+        await repositoryConfigurationManager.readRepositoryConfiguration(
+      RepositorySlug('flutter', 'cocoon'),
+    );
+
+    expect(repositoryConfiguration.allowConfigOverride, isFalse);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 4);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("test (ubuntu-latest, 2.18.0)"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("cla/google"), isTrue);
+  });
+
+  test('Omitted issues_repository assumes provided slug is for issues', () async {
+    const String sampleConfig = '''
+      default_branch: main
+      auto_approval_accounts:
+        - dependabot[bot]
+        - dependabot
+        - DartDevtoolWorkflowBot
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - ci.yaml validation
+        - Google-testing
+    ''';
+
+    githubService.fileContentsMockList.add(sampleConfig);
+    final RepositoryConfiguration repositoryConfiguration =
+        await repositoryConfigurationManager.readRepositoryConfiguration(
+      RepositorySlug('flutter', 'cocoon'),
+    );
+
+    expect(repositoryConfiguration.allowConfigOverride, isFalse);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
+  });
+
+  test('Default branch collected if omitted', () async {
+    const String sampleConfig = '''
+      auto_approval_accounts:
+        - dependabot[bot]
+        - dependabot
+        - DartDevtoolWorkflowBot
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - ci.yaml validation
+        - Google-testing
+    ''';
+
+    githubService.fileContentsMockList.add(sampleConfig);
+    githubService.defaultBranch = 'main';
+    final RepositoryConfiguration repositoryConfiguration =
+        await repositoryConfigurationManager.readRepositoryConfiguration(
+      RepositorySlug('flutter', 'cocoon'),
+    );
+
+    expect(repositoryConfiguration.allowConfigOverride, isFalse);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
+  });
+
+  group('Merging configurations tests', () {
+    // Sample configuration being used for these tests
+    /*
+      default_branch: main
+      allow_config_override: true
+      auto_approval_accounts:
+        - dependabot[bot]
+        - dependabot
+        - DartDevtoolWorkflowBot
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - ci.yaml validation
+    */
+
+    test('Global config merged with default local config', () {
+      final RepositoryConfiguration localRepositoryConfiguration = RepositoryConfiguration();
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.defaultBranch, 'main');
+      expect(mergedRepositoryConfiguration.allowConfigOverride, isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 3);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
+      expect(mergedRepositoryConfiguration.approvingReviews, 2);
+      expect(mergedRepositoryConfiguration.runCi, isTrue);
+      expect(mergedRepositoryConfiguration.supportNoReviewReverts, isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 1);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains('ci.yaml validation'), isTrue);
+    });
+
+    test('Auto approval accounts is additive, they cannot be removed', () {
+      const String expectedAddedApprovalAccount = 'flutter-roller-account';
+      const Set<String> localAutoApprovalAccounts = {expectedAddedApprovalAccount};
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(autoApprovalAccounts: localAutoApprovalAccounts);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 4);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains(expectedAddedApprovalAccount), isTrue);
+    });
+
+    test('Duplicate auto approval account is not added', () {
+      const String expectedAddedApprovalAccount = 'DartDevtoolWorkflowBot';
+      const Set<String> localAutoApprovalAccounts = {expectedAddedApprovalAccount};
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(autoApprovalAccounts: localAutoApprovalAccounts);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 3);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
+    });
+
+    test('Approving reviews is overridden by local config', () {
+      const int expectedApprovingReviews = 3;
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(approvingReviews: expectedApprovingReviews);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(globalRepositoryConfiguration.approvingReviews != mergedRepositoryConfiguration.approvingReviews, isTrue);
+      expect(mergedRepositoryConfiguration.approvingReviews, expectedApprovingReviews);
+    });
+
+    test('Approving reviews is not overridden if less than global config', () {
+      const int expectedApprovingReviews = 2;
+      final RepositoryConfiguration localRepositoryConfiguration = RepositoryConfiguration(approvingReviews: 1);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(globalRepositoryConfiguration.approvingReviews == mergedRepositoryConfiguration.approvingReviews, isTrue);
+      expect(mergedRepositoryConfiguration.approvingReviews, expectedApprovingReviews);
+    });
+
+    test('Approval group is overridden if defined', () {
+      const String expectedApprovalGroup = 'flutter-devs';
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(approvalGroup: expectedApprovalGroup);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.approvalGroup, expectedApprovalGroup);
+    });
+
+    test('RunCi is updated if it differs from global config', () {
+      const bool expectedRunCi = false;
+      final RepositoryConfiguration localRepositoryConfiguration = RepositoryConfiguration(runCi: expectedRunCi);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(globalRepositoryConfiguration.runCi != mergedRepositoryConfiguration.runCi, isTrue);
+      expect(mergedRepositoryConfiguration.runCi, expectedRunCi);
+    });
+
+    test('Support no review reverts is updated if it differs from global config', () {
+      const bool expectedSupportNoReviewReverts = false;
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(supportNoReviewReverts: expectedSupportNoReviewReverts);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(
+        globalRepositoryConfiguration.supportNoReviewReverts != mergedRepositoryConfiguration.supportNoReviewReverts,
+        isTrue,
+      );
+      expect(mergedRepositoryConfiguration.supportNoReviewReverts, expectedSupportNoReviewReverts);
+    });
+
+    test('Required check runs on revert is additive, they cannot be removed', () {
+      const String expectedRequiredCheckRun = 'Linux Device Doctor Validator';
+      const Set<String> localrequiredCheckRunsOnRevert = {expectedRequiredCheckRun};
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(requiredCheckRunsOnRevert: localrequiredCheckRunsOnRevert);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains('ci.yaml validation'), isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains(expectedRequiredCheckRun), isTrue);
+    });
+
+    test('Duplicate required check run on revert is not added', () {
+      const String expectedRequiredCheckRun = 'ci.yaml validation';
+      const Set<String> localRequiredCheckRunsOnRevert = {expectedRequiredCheckRun};
+      final RepositoryConfiguration localRepositoryConfiguration =
+          RepositoryConfiguration(requiredCheckRunsOnRevert: localRequiredCheckRunsOnRevert);
+      final RepositoryConfiguration globalRepositoryConfiguration =
+          RepositoryConfiguration.fromYaml(sampleConfigWithOverride);
+      final RepositoryConfiguration mergedRepositoryConfiguration = repositoryConfigurationManager.mergeConfigurations(
+        globalRepositoryConfiguration,
+        localRepositoryConfiguration,
+      );
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 1);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains(expectedRequiredCheckRun), isTrue);
+    });
+  });
+}

--- a/auto_submit/test/configuration/repository_configuration_manager_test.dart
+++ b/auto_submit/test/configuration/repository_configuration_manager_test.dart
@@ -55,18 +55,18 @@ void main() {
 
     expect(repositoryConfiguration.allowConfigOverride, isFalse);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.autoApprovalAccounts.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.length, 3);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 4);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("test (ubuntu-latest, 2.18.0)"), isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("cla/google"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.length, 4);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("Google-testing"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("test (ubuntu-latest, 2.18.0)"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("cla/google"), isTrue);
   });
 
   test('Omitted issues_repository assumes provided slug is for issues', () async {
@@ -93,16 +93,16 @@ void main() {
 
     expect(repositoryConfiguration.allowConfigOverride, isFalse);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.autoApprovalAccounts.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.length, 3);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.length, 2);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("Google-testing"), isTrue);
   });
 
   test('Default branch collected if omitted', () async {
@@ -129,16 +129,16 @@ void main() {
 
     expect(repositoryConfiguration.allowConfigOverride, isFalse);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.autoApprovalAccounts!.length, 3);
+    expect(repositoryConfiguration.autoApprovalAccounts.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.length, 3);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.approvalGroup, 'flutter-hackers');
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("ci.yaml validation"), isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.contains("Google-testing"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.length, 2);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("ci.yaml validation"), isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.contains("Google-testing"), isTrue);
   });
 
   group('Merging configurations tests', () {
@@ -168,15 +168,15 @@ void main() {
       );
       expect(mergedRepositoryConfiguration.defaultBranch, 'main');
       expect(mergedRepositoryConfiguration.allowConfigOverride, isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 3);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.length, 3);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('DartDevtoolWorkflowBot'), isTrue);
       expect(mergedRepositoryConfiguration.approvingReviews, 2);
       expect(mergedRepositoryConfiguration.runCi, isTrue);
       expect(mergedRepositoryConfiguration.supportNoReviewReverts, isTrue);
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 1);
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains('ci.yaml validation'), isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.length, 1);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.contains('ci.yaml validation'), isTrue);
     });
 
     test('Auto approval accounts is additive, they cannot be removed', () {
@@ -190,11 +190,11 @@ void main() {
         globalRepositoryConfiguration,
         localRepositoryConfiguration,
       );
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 4);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains(expectedAddedApprovalAccount), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.length, 4);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('DartDevtoolWorkflowBot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains(expectedAddedApprovalAccount), isTrue);
     });
 
     test('Duplicate auto approval account is not added', () {
@@ -208,10 +208,10 @@ void main() {
         globalRepositoryConfiguration,
         localRepositoryConfiguration,
       );
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.length, 3);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot[bot]'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('dependabot'), isTrue);
-      expect(mergedRepositoryConfiguration.autoApprovalAccounts!.contains('DartDevtoolWorkflowBot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.length, 3);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot[bot]'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('dependabot'), isTrue);
+      expect(mergedRepositoryConfiguration.autoApprovalAccounts.contains('DartDevtoolWorkflowBot'), isTrue);
     });
 
     test('Approving reviews is overridden by local config', () {
@@ -295,9 +295,9 @@ void main() {
         globalRepositoryConfiguration,
         localRepositoryConfiguration,
       );
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 2);
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains('ci.yaml validation'), isTrue);
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains(expectedRequiredCheckRun), isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.length, 2);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.contains('ci.yaml validation'), isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.contains(expectedRequiredCheckRun), isTrue);
     });
 
     test('Duplicate required check run on revert is not added', () {
@@ -311,8 +311,8 @@ void main() {
         globalRepositoryConfiguration,
         localRepositoryConfiguration,
       );
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.length, 1);
-      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert!.contains(expectedRequiredCheckRun), isTrue);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.length, 1);
+      expect(mergedRepositoryConfiguration.requiredCheckRunsOnRevert.contains(expectedRequiredCheckRun), isTrue);
     });
   });
 }

--- a/auto_submit/test/configuration/repository_configuration_test.dart
+++ b/auto_submit/test/configuration/repository_configuration_test.dart
@@ -1,0 +1,99 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/configuration/repository_configuration.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Parse config from yaml', () {
+    const String sampleConfig = '''
+      default_branch: main
+      auto_approval_accounts:
+        - dependabot[bot]
+        - dependabot
+        - DartDevtoolWorkflowBot
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - ci.yaml validation
+        - Google-testing
+    ''';
+
+    final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+  });
+
+  test('Parse config from yaml excluding auto approval accounts', () {
+    const String sampleConfig = '''
+      default_branch: main
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - “ci.yaml validation”
+        - “Google-testing”
+    ''';
+
+    final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+  });
+
+  test('Parse config from yaml with empty auto_approval_accounts field', () {
+    const String sampleConfig = '''
+      auto_approval_accounts:
+      approving_reviews: 2
+      approval_group: flutter-hackers
+      run_ci: true
+      support_no_review_revert: true
+      required_checkruns_on_revert:
+        - “ci.yaml validation”
+        - “Google-testing”
+    ''';
+
+    final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
+    // We will get the default branch later as it does not need to be added to
+    // the initial configuration.
+    repositoryConfiguration.defaultBranch = 'main';
+
+    expect(repositoryConfiguration.allowConfigOverride, false);
+    expect(repositoryConfiguration.defaultBranch, 'main');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+  });
+
+  test('Parse minimal configuration', () {
+    const String sampleConfig = '''
+      approval_group: flutter-hackers
+      issues_repository:
+        owner: flutter
+        repo: flutter
+    ''';
+
+    final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
+    repositoryConfiguration.defaultBranch = 'master';
+
+    expect(repositoryConfiguration.defaultBranch, 'master');
+    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.approvingReviews, 2);
+    expect(repositoryConfiguration.runCi, isTrue);
+    expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isEmpty, isTrue);
+  });
+}

--- a/auto_submit/test/configuration/repository_configuration_test.dart
+++ b/auto_submit/test/configuration/repository_configuration_test.dart
@@ -24,11 +24,11 @@ void main() {
 
     final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.isNotEmpty, isTrue);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
   });
 
   test('Parse config from yaml excluding auto approval accounts', () {
@@ -45,11 +45,11 @@ void main() {
 
     final RepositoryConfiguration repositoryConfiguration = RepositoryConfiguration.fromYaml(sampleConfig);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.isEmpty, isTrue);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
   });
 
   test('Parse config from yaml with empty auto_approval_accounts field', () {
@@ -71,11 +71,11 @@ void main() {
 
     expect(repositoryConfiguration.allowConfigOverride, false);
     expect(repositoryConfiguration.defaultBranch, 'main');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.isEmpty, isTrue);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isNotEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isNotEmpty, isTrue);
   });
 
   test('Parse minimal configuration', () {
@@ -90,10 +90,10 @@ void main() {
     repositoryConfiguration.defaultBranch = 'master';
 
     expect(repositoryConfiguration.defaultBranch, 'master');
-    expect(repositoryConfiguration.autoApprovalAccounts!.isEmpty, isTrue);
+    expect(repositoryConfiguration.autoApprovalAccounts.isEmpty, isTrue);
     expect(repositoryConfiguration.approvingReviews, 2);
     expect(repositoryConfiguration.runCi, isTrue);
     expect(repositoryConfiguration.supportNoReviewReverts, isTrue);
-    expect(repositoryConfiguration.requiredCheckRunsOnRevert!.isEmpty, isTrue);
+    expect(repositoryConfiguration.requiredCheckRunsOnRevert.isEmpty, isTrue);
   });
 }

--- a/auto_submit/test/src/configuration/fake_repository_configuration_manager.dart
+++ b/auto_submit/test/src/configuration/fake_repository_configuration_manager.dart
@@ -1,0 +1,38 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/configuration/repository_configuration.dart';
+import 'package:auto_submit/configuration/repository_configuration_manager.dart';
+import 'package:auto_submit/service/config.dart';
+import 'package:github/src/common/model/repos.dart';
+import 'package:neat_cache/neat_cache.dart';
+
+class FakeRepositoryConfigurationManager implements RepositoryConfigurationManager {
+  FakeRepositoryConfigurationManager(this.config, this.cache);
+
+  String? yamlConfig;
+
+  @override
+  final Cache cache;
+
+  @override
+  final Config config;
+
+  late RepositoryConfiguration? repositoryConfigurationMock;
+
+  late RepositoryConfiguration? mergedRepositoryConfigurationMock;
+
+  @override
+  Future<RepositoryConfiguration> readRepositoryConfiguration(RepositorySlug slug) async {
+    return repositoryConfigurationMock!;
+  }
+
+  @override
+  RepositoryConfiguration mergeConfigurations(
+    RepositoryConfiguration globalConfiguration,
+    RepositoryConfiguration localConfiguration,
+  ) {
+    return mergedRepositoryConfigurationMock!;
+  }
+}

--- a/auto_submit/test/src/service/fake_config.dart
+++ b/auto_submit/test/src/service/fake_config.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:auto_submit/configuration/repository_configuration.dart';
 import 'package:auto_submit/service/bigquery.dart';
 import 'package:auto_submit/service/config.dart';
 import 'package:auto_submit/service/github_service.dart';
@@ -38,6 +39,7 @@ class FakeConfig extends Config {
   String? webhookKey;
   int? kPubsubPullNumberValue;
   BigqueryService? bigqueryService;
+  RepositoryConfiguration? repositoryConfigurationMock;
 
   @override
   int get kPubsubPullNumber => kPubsubPullNumberValue ?? 1;
@@ -53,6 +55,7 @@ class FakeConfig extends Config {
 
   @override
   Future<GraphQLClient> createGitHubGraphQLClient(RepositorySlug slug) async => githubGraphQLClient!;
+
   @override
   Set<String> get rollerAccounts =>
       rollerAccountsValue ??
@@ -78,4 +81,7 @@ class FakeConfig extends Config {
 
   @override
   Future<BigqueryService> createBigQueryService() async => bigqueryService!;
+
+  @override
+  Future<RepositoryConfiguration> getRepositoryConfiguration(RepositorySlug slug) async => repositoryConfigurationMock!;
 }

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -35,6 +35,7 @@ class FakeGithubService implements GithubService {
   String? pullRequestMergeMock;
   String? pullRequestFilesJsonMock;
   Issue? githubIssueMock;
+  String? githubFileContents;
 
   bool useMergeRequestMockList = false;
   bool trackMergeRequestCalls = false;
@@ -312,5 +313,48 @@ class FakeGithubService implements GithubService {
       assert(expected.containsKey(key));
       assert(expected[key] == value);
     });
+  }
+
+  bool throwExceptionFileContents = false;
+
+  List<String> fileContentsMockList = [];
+
+  @override
+  Future<String> getFileContents(RepositorySlug slug, String path, {String? ref}) async {
+    if (throwExceptionFileContents) {
+      throw 'Contents do not point to a file.';
+    }
+
+    // Assume that the list is not empty.
+    return fileContentsMockList.removeAt(0);
+  }
+
+  TeamMembershipState? teamMembershipStateMock = TeamMembershipState('active');
+
+  String defaultBranch = 'main';
+  bool throwOnDefaultBranch = false;
+  Exception exception = Exception('Generic exception.');
+
+  @override
+  Future<String> getDefaultBranch(RepositorySlug slug) async {
+    if (throwOnDefaultBranch) {
+      throw exception;
+    } else {
+      return defaultBranch;
+    }
+  }
+
+  Repository repositoryMock = Repository();
+
+  @override
+  Future<Repository> getRepository(RepositorySlug slug) async {
+    return repositoryMock;
+  }
+
+  List<bool> isTeamMemberMockList = [];
+
+  @override
+  Future<bool> isTeamMember(String team, String user, String org) async {
+    return isTeamMemberMockList.removeAt(0);
   }
 }


### PR DESCRIPTION
Adding code to allow for autosubmit to collect it's configuration based on the Organization and Repository. 

This code is the basis of the remaining changes and is not currently active so it should be safe to merge.

*List which issues are fixed by this PR. You must list at least one issue.*
While this is not the fix for this feature this pr addresses the following:
Fixes https://github.com/flutter/flutter/issues/125685

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
