### PR TITLE
Make fake_http.dart abstract so it does not fail analysis

### DIFF
--- a/app_dart/test/src/request_handling/fake_http.dart
+++ b/app_dart/test/src/request_handling/fake_http.dart
@@ -453,7 +453,7 @@ abstract class FakeOutbound extends FakeTransport implements IOSink {
   set persistentConnection(bool value) => throw UnsupportedError('Unsupported');
 }
 
-class FakeCookie implements Cookie {
+abstract class FakeCookie implements Cookie {
   FakeCookie({
     required this.name,
     required this.value,


### PR DESCRIPTION
All the current rolls are failing due to this class not having the correct implementation or being abstract. Class is now made abstract to avoid the error.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
