### PR TITLE
Append osx_sdk property to devicelab tasks

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -149,6 +149,7 @@ class Target {
 
       if (iosPlatforms.contains(getPlatform())) {
         mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;
+        mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
       } else {
         mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
       }

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -102,6 +102,9 @@ void main() {
           '\$flutter/devicelab_osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
+          '\$flutter/osx_sdk': <String, Object>{
+            'sdk_version': '12abc',
+          },
           'xcode': '12abc',
         });
       });
@@ -148,6 +151,9 @@ void main() {
           '\$flutter/devicelab_osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
+          '\$flutter/osx_sdk': <String, Object>{
+            'sdk_version': '12abc',
+          },
           'xcode': '12abc',
         });
       });
@@ -163,6 +169,7 @@ void main() {
           'cleanup_xcode_cache': true,
           'dependencies': <String>[],
           '\$flutter/devicelab_osx_sdk': <String, Object>{'sdk_version': '12abc', 'cleanup_cache': true},
+          '\$flutter/osx_sdk': <String, Object>{'sdk_version': '12abc', 'cleanup_cache': true},
           'bringup': false,
         });
       });
@@ -228,26 +235,24 @@ void main() {
         });
       });
 
-      test('platform properties with xcode and runtime_versions on Mac_ios', () {
+      test('platform properties with xcode on Mac_ios', () {
         final Target target = generateTarget(
           1,
           platform: 'Mac_ios',
           platformProperties: <String, String>{
             'xcode': '12abc',
-            'runtime_versions': '["ios-13-0", "ios-15-0"]',
           },
         );
         expect(target.getProperties(), <String, Object>{
           'bringup': false,
           'dependencies': <String>[],
           '\$flutter/osx_sdk': <String, Object>{
-            'runtime_versions': ['ios-13-0', 'ios-15-0'],
+            'sdk_version': '12abc',
           },
           '\$flutter/devicelab_osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
           'xcode': '12abc',
-          'runtime_versions': ['ios-13-0', 'ios-15-0'],
         });
       });
 


### PR DESCRIPTION
This is a joint PR with https://flutter-review.googlesource.com/c/infra/+/43921, appending `osx_sdk` property to devicelab targets. This is to prepare osx_sdk and devicelab_osx_sdk recipe modules consolidation.

Part of https://github.com/flutter/flutter/issues/117541