### PR TITLE
Mark canceled builds as infra failure to close the tree

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -353,7 +353,7 @@ class Task extends Model<int> {
       case Result.success:
         return status = statusSucceeded;
       case Result.canceled:
-        return status = statusCancelled;
+        return status = statusInfraFailure;
       case Result.infraFailure:
         return status = statusInfraFailure;
       case Result.failure:

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -174,7 +174,7 @@ void main() {
 
         expect(task.status, Task.statusNew);
         task.updateFromBuild(build);
-        expect(task.status, Task.statusCancelled);
+        expect(task.status, Task.statusInfraFailure);
       });
     });
   });


### PR DESCRIPTION
Fix: https://github.com/flutter/flutter/issues/125012

Related: https://github.com/flutter/flutter/issues/126294