### PR TITLE
Add 1s delay between issue/pr creation

### DIFF
--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -88,6 +88,9 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     if (_shouldNotFileIssueAndPR(builderDetail, issue)) {
       return;
     }
+    // Manually add a 1s delay between consecutive GitHub requests to deal with secondary rate limit error.
+    // https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
+    await Future.delayed(config.githubRequestDelay);
     issue = await fileFlakyIssue(builderDetail: builderDetail, gitHub: gitHub, slug: slug, threshold: _threshold);
 
     if (builderDetail.type == BuilderType.shard ||


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/2201 added a 1s delay between PR creations for `check_flaky_builders` API. It doesn't seem to hit the secondary rate limit issue.

This PR adds the 1s delay to file_flaky_issue_and_pr.

Potentially helps with https://github.com/flutter/flutter/issues/126604