### PR TITLE
[dependabot] Remove labels, add analyze directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,96 +9,72 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/test_utilities"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
+      - "autosubmit"
+  - package-ecosystem: "pub"
+    directory: "/analyze"
+    schedule:
+      interval: "daily"
+    labels:
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/licenses"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/codesign"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/device_doctor"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/dashboard"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/app_dart"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "pub"
     directory: "/auto_submit"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "docker"
     directory: "/app_dart"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
-      - "autosubmit"
-  - package-ecosystem: "docker"
-    directory: "/release"
-    schedule:
-      interval: "daily"
-    labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "docker"
     directory: "/auto_submit"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
   - package-ecosystem: "gomod"
     directory: "/tooling"
     schedule:
       interval: "daily"
     labels:
-      - "team"
-      - "team: infra"
       - "autosubmit"
     allow:
       - dependency-name: "github.com/slsa-framework/slsa-verifier/v2"


### PR DESCRIPTION
* Cocoon doesn't use PR labels (at least for triage)
* Remove release directory