### PR TITLE
Teach comment analysis about gradle/groovy comments

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -37,6 +37,22 @@ const Set<String> kNeedsCheckLabelsAndTests = <String>{
 final RegExp kEngineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh)$');
 final List<String> kNeedsTestsLabels = <String>['needs tests'];
 
+// Extentions for files that use // for single line comments.
+// See [_allChangesAreCodeComments] for more.
+@visibleForTesting
+const Set<String> knownCommentCodeExtensions = <String>{
+  'cc',
+  'cpp',
+  'dart',
+  'gradle',
+  'groovy',
+  'java',
+  'kt',
+  'm',
+  'mm',
+  'swift',
+};
+
 /// Subscription for processing GitHub webhooks.
 ///
 /// The PubSub subscription is set up here:
@@ -660,20 +676,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       return false;
     }
 
-    // Ensure that the file is a language reconized by the check below.
-    const Set<String> codeExtensions = <String>{
-      'cc',
-      'cpp',
-      'dart',
-      'java',
-      'kt',
-      'm',
-      'mm',
-      'swift',
-    };
     final String filename = file.filename!;
     final String? extension = filename.contains('.') ? filename.split('.').last.toLowerCase() : null;
-    if (extension == null || !codeExtensions.contains(extension)) {
+    if (extension == null || !knownCommentCodeExtensions.contains(extension)) {
       return false;
     }
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1437,11 +1437,9 @@ void main() {
     });
 
     for (String extention in knownCommentCodeExtensions) {
-      test('Framework no comment if only comments changed .$extention',
-          () async {
+      test('Framework no comment if only comments changed .$extention', () async {
         const int issueNumber = 123;
-        tester.message =
-            generateGithubWebhookMessage(action: 'opened', number: issueNumber);
+        tester.message = generateGithubWebhookMessage(action: 'opened', number: issueNumber);
         final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
 
         const String patch = '''

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1436,12 +1436,15 @@ void main() {
       );
     });
 
-    test('Framework no comment if only comments changed', () async {
-      const int issueNumber = 123;
-      tester.message = generateGithubWebhookMessage(action: 'opened', number: issueNumber);
-      final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
+    for (String extention in knownCommentCodeExtensions) {
+      test('Framework no comment if only comments changed .$extention',
+          () async {
+        const int issueNumber = 123;
+        tester.message =
+            generateGithubWebhookMessage(action: 'opened', number: issueNumber);
+        final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
 
-      const String patch = '''
+        const String patch = '''
 @@ -128,7 +128,7 @@
 
 /// Insert interesting comment here.
@@ -1453,27 +1456,28 @@ void foo() {
   String baz = '';
 ''';
 
-      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()
-            ..filename = 'packages/foo/lib/foo.dart'
-            ..additionsCount = 1
-            ..deletionsCount = 1
-            ..changesCount = 2
-            ..patch = patch,
-        ]),
-      );
+        when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+          (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+            PullRequestFile()
+              ..filename = 'packages/foo/lib/foo.$extention'
+              ..additionsCount = 1
+              ..deletionsCount = 1
+              ..changesCount = 2
+              ..patch = patch,
+          ]),
+        );
 
-      await tester.post(webhook);
+        await tester.post(webhook);
 
-      verifyNever(
-        issuesService.createComment(
-          slug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
+        verifyNever(
+          issuesService.createComment(
+            slug,
+            issueNumber,
+            argThat(contains(config.missingTestsPullRequestMessageValue)),
+          ),
+        );
+      });
+    }
 
     test('Framework labels PRs, no comment if tests (dev/bots/test.dart)', () async {
       const int issueNumber = 123;


### PR DESCRIPTION

https://github.com/flutter/flutter/issues/126825
- Add gradle and groovy to the extensions understood by the comment excluder for test exempt then add tests for all languages

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
