### PR TITLE
Cleanup devicelab_osx_sdk property

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -146,13 +146,7 @@ class Target {
         if (mergedProperties.containsKey('cleanup_xcode_cache'))
           'cleanup_cache': mergedProperties['cleanup_xcode_cache']!
       };
-
-      if (iosPlatforms.contains(getPlatform())) {
-        mergedProperties['\$flutter/devicelab_osx_sdk'] = xcodeVersion;
-        mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
-      } else {
-        mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
-      }
+      mergedProperties['\$flutter/osx_sdk'] = xcodeVersion;
     }
     // runtime_versions is a special property
     if (mergedProperties.containsKey('runtime_versions')) {

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -99,9 +99,6 @@ void main() {
         expect(target.getProperties(), <String, Object>{
           'bringup': false,
           'dependencies': <String>[],
-          '\$flutter/devicelab_osx_sdk': <String, Object>{
-            'sdk_version': '12abc',
-          },
           '\$flutter/osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
@@ -148,9 +145,6 @@ void main() {
         expect(target.getProperties(), <String, Object>{
           'bringup': false,
           'dependencies': <String>[],
-          '\$flutter/devicelab_osx_sdk': <String, Object>{
-            'sdk_version': '12abc',
-          },
           '\$flutter/osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
@@ -168,7 +162,6 @@ void main() {
           'xcode': '12abc',
           'cleanup_xcode_cache': true,
           'dependencies': <String>[],
-          '\$flutter/devicelab_osx_sdk': <String, Object>{'sdk_version': '12abc', 'cleanup_cache': true},
           '\$flutter/osx_sdk': <String, Object>{'sdk_version': '12abc', 'cleanup_cache': true},
           'bringup': false,
         });
@@ -247,9 +240,6 @@ void main() {
           'bringup': false,
           'dependencies': <String>[],
           '\$flutter/osx_sdk': <String, Object>{
-            'sdk_version': '12abc',
-          },
-          '\$flutter/devicelab_osx_sdk': <String, Object>{
             'sdk_version': '12abc',
           },
           'xcode': '12abc',


### PR DESCRIPTION
This is not needed as the logic has been switched to osx_sdk: https://flutter-review.googlesource.com/c/recipes/+/43980