### PR TITLE
[codesign] remove metadata files for now

### DIFF
--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -335,13 +335,10 @@ update these file paths accordingly.
 
     final Set<String> fileWithEntitlements = <String>{};
 
-    try {
-      fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
-    } finally {
-      // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
-      // is resolved.
-      await fileSystem.file(entitlementFilePath).delete();
-    }
+    fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
+    // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
+    // is resolved.
+    await fileSystem.file(entitlementFilePath).delete();
 
     return fileWithEntitlements;
   }

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -335,6 +335,9 @@ update these file paths accordingly.
 
     final Set<String> fileWithEntitlements = <String>{};
     fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
+    // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
+    // is resolved.
+    await fileSystem.file(entitlementFilePath).delete();
     return fileWithEntitlements;
   }
 

--- a/codesign/lib/src/file_codesign_visitor.dart
+++ b/codesign/lib/src/file_codesign_visitor.dart
@@ -334,10 +334,15 @@ update these file paths accordingly.
     }
 
     final Set<String> fileWithEntitlements = <String>{};
-    fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
-    // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
-    // is resolved.
-    await fileSystem.file(entitlementFilePath).delete();
+
+    try {
+      fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
+    } finally {
+      // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
+      // is resolved.
+      await fileSystem.file(entitlementFilePath).delete();
+    }
+
     return fileWithEntitlements;
   }
 


### PR DESCRIPTION
Remove codesign metadata after parsing them.

Context: fix https://github.com/flutter/flutter/issues/126705 by removing codesign metadata after parsing them. When https://github.com/flutter/flutter/pull/126875 becomes ready, we could add back codesign metadata inside engine zips?

Sorry for the delay, was busy landing different cps during the day