### PR TITLE
Migrate away from pipelineOwner

### DIFF
--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -54,7 +54,7 @@ void main([List<String> args = const <String>[]]) {
     ),
   );
   // Enable extensions like Vimium to traverse the dashboard
-  RendererBinding.instance.pipelineOwner.ensureSemantics();
+  SemanticsBinding.instance.ensureSemantics();
 }
 
 class MyApp extends StatelessWidget {

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  collection: 1.17.1
+  collection: 1.17.2
   fixnum: 1.1.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
As part of https://flutter.dev/go/multiple-views we are deprecating `RendererBinding.pipelineOwner`. This PR migrates the dashboard away from it.

Also includes a bump of `package:collection` to work with the latest master version of Flutter.