### PR TITLE
Statically serve the canvaskit.wasm compressed for faster download

### DIFF
--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -29,10 +29,7 @@ found in the LICENSE file. -->
   window.addEventListener('load', function() {
     _flutter.loader.loadEntrypoint({
       onEntrypointLoaded: async function(engineInitializer) {
-        let appRunner = await engineInitializer.initializeEngine({
-          // Use the local build of CanvasKit rather than the CDN.
-          canvasKitBaseUrl: "/canvaskit/"
-        });
+        let appRunner = await engineInitializer.initializeEngine();
         appRunner.runApp();
       }
     })


### PR DESCRIPTION
Statically serving the canvaskit.wasm file compressed results in a 1.5 MB download instead of 5 MB download when serving from  https://flutter-dashboard.appspot.com/

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
