### PR TITLE
Add the mimetype for smcbin file extension

### DIFF
--- a/app_dart/lib/src/request_handling/static_file_handler.dart
+++ b/app_dart/lib/src/request_handling/static_file_handler.dart
@@ -40,6 +40,7 @@ class StaticFileHandler extends RequestHandler<Body> {
     final Map<String, String> mimeTypeMap = <String, String>{
       '.map': 'application/json',
       '': 'text/plain',
+      '.smcbin': 'application/octet-stream',
     };
 
     final String resultPath = filePath == '/' ? '/index.html' : filePath;

--- a/app_dart/test/request_handling/static_file_handler_test.dart
+++ b/app_dart/test/request_handling/static_file_handler_test.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
+import 'package:mime/mime.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/request_handler_tester.dart';
@@ -23,12 +24,14 @@ void main() {
     const String indexFileName = 'index.html';
     const String indexFileContent = 'some html';
     const String dartMapFileName = 'main.dart.js.map';
+    const String assetManifestSmcbin = 'AssetManifest.smcbin';
 
     setUp(() {
       tester = RequestHandlerTester();
       fs = MemoryFileSystem();
       fs.file('build/web/$indexFileName').createSync(recursive: true);
       fs.file('build/web/$indexFileName').writeAsStringSync(indexFileContent);
+      fs.file('build/web/$assetManifestSmcbin').writeAsStringSync(assetManifestSmcbin);
       fs.file('build/web/$dartMapFileName').writeAsStringSync('[{}]');
     });
 
@@ -58,6 +61,15 @@ void main() {
       expect(body, isNotNull);
       final String response = await decodeHandlerBody(body);
       expect(response, '[{}]');
+    });
+
+    test('smcbin file extension is handled correctly', () async {
+      final StaticFileHandler staticFileHandler = StaticFileHandler('/$assetManifestSmcbin', config: config, fs: fs);
+
+      final Body body = await tester.get(staticFileHandler);
+      expect(body, isNotNull);
+      final String response = await decodeHandlerBody(body);
+      expect(response, assetManifestSmcbin);
     });
 
     test('No extension files default to plain text', () async {

--- a/app_dart/test/request_handling/static_file_handler_test.dart
+++ b/app_dart/test/request_handling/static_file_handler_test.dart
@@ -9,7 +9,6 @@ import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:test/test.dart';
-import 'package:mime/mime.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/request_handler_tester.dart';


### PR DESCRIPTION
Changes were made to switch the file extension for AssetManifest.bin to smcbin which is not a normal file extension and therefore has no associated mimetype. This change can be found here: https://github.com/flutter/flutter/pull/126077

Without this change the dashboard fails to display all icons in the top column above the builds.
![image](https://github.com/flutter/cocoon/assets/32242716/7e6369d2-a560-4dfc-a789-17faefa548d3)

With the added mimetype the icons are present.
![image](https://github.com/flutter/cocoon/assets/32242716/15e85df1-2344-4780-8674-02cab39f62f8)

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/127038

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
