### PR TITLE
Support release branches with Autosubmit

### DIFF
--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -104,7 +104,6 @@ class CiSuccessful extends Validation {
     if (!Config.reposWithTreeStatus.contains(slug)) {
       return true;
     }
-    // TODO for repositories that are merging into a non default branch this should not matter.
     if (statuses.isEmpty) {
       return false;
     }

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -87,6 +87,7 @@ PullRequest generatePullRequest({
   String? body = 'Please pull these awesome changes in!',
   String title = 'Amazing new feature',
   bool? mergeable = true,
+  String baseRef = 'main',
 }) {
   return PullRequest.fromJson(
     json.decode('''{
@@ -130,7 +131,7 @@ PullRequest generatePullRequest({
       "base": {
         "label": "octocat:master",
         "label": "octocat:main",
-        "ref": "main",
+        "ref": "$baseRef",
         "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
         "repo": {
           "id": 1296269,

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -90,6 +90,95 @@ void main() {
     assert(pubsub.messagesQueue.isEmpty);
   });
 
+  // This tests for valid pull request into not default base branch which
+  // will ignore the tree status as it does not matter.
+  test('Processes successfully when base branch is not default', () async {
+    final PullRequestHelper flutterRequest = PullRequestHelper(
+      prNumber: 0,
+      lastCommitHash: oid,
+      reviews: <PullRequestReviewHelper>[
+        const PullRequestReviewHelper(
+          authorName: 'member',
+          state: ReviewState.APPROVED,
+          memberType: MemberType.OWNER,
+        )
+      ],
+    );
+    githubService.checkRunsData = checkRunsMock;
+    githubService.checkRunsMock = checkRunsMock;
+    githubService.createCommentData = createCommentMock;
+    githubService.isTeamMemberMockMap['author1'] = true;
+    githubService.isTeamMemberMockMap['member'] = true;
+    final FakePubSub pubsub = FakePubSub();
+    final PullRequest pullRequest = generatePullRequest(
+      prNumber: 0,
+      repoName: slug.name,
+      baseRef: 'feature_a',
+      mergeable: true,
+    );
+    unawaited(pubsub.publish('auto-submit-queue-sub', pullRequest));
+    final auto.QueryResult queryResult = createQueryResult(flutterRequest);
+    githubService.pullRequestMock = pullRequest;
+    githubService.mergeRequestMock = PullRequestMerge(
+      merged: true,
+      sha: 'asdfioefmasdf',
+      message: 'Merged successfully.',
+    );
+
+    await validationService.processPullRequest(
+      config: config,
+      result: queryResult,
+      messagePullRequest: pullRequest,
+      ackId: 'test',
+      pubsub: pubsub,
+    );
+
+    // These checks indicate that the pull request has been merged as the label
+    // is not removed and there was no issue coment generated and the message
+    // was acknowledged.
+    expect(githubService.issueComment, isNull);
+    expect(githubService.labelRemoved, false);
+    assert(pubsub.messagesQueue.isEmpty);
+  });
+
+  // This tests for valid pull request where tree status was not ready for
+  // processing, meaning no issueComment was created and the 'autosubmit' label
+  // is not removed and we do not ack the message.
+  test('Processing fails when base branch is default with no statuses', () async {
+    final PullRequestHelper flutterRequest = PullRequestHelper(
+      prNumber: 0,
+      lastCommitHash: oid,
+      reviews: <PullRequestReviewHelper>[
+        const PullRequestReviewHelper(
+          authorName: 'member',
+          state: ReviewState.APPROVED,
+          memberType: MemberType.OWNER,
+        )
+      ],
+      lastCommitStatuses: null,
+    );
+    githubService.checkRunsData = checkRunsMock;
+    githubService.createCommentData = createCommentMock;
+    githubService.isTeamMemberMockMap['author1'] = true;
+    githubService.isTeamMemberMockMap['member'] = true;
+    final FakePubSub pubsub = FakePubSub();
+    final PullRequest pullRequest = generatePullRequest(prNumber: 0);
+    unawaited(pubsub.publish('auto-submit-queue-sub', pullRequest));
+    final auto.QueryResult queryResult = createQueryResult(flutterRequest);
+
+    await validationService.processPullRequest(
+      config: config,
+      result: queryResult,
+      messagePullRequest: pullRequest,
+      ackId: 'test',
+      pubsub: pubsub,
+    );
+
+    expect(githubService.issueComment, isNull);
+    expect(githubService.labelRemoved, false);
+    assert(pubsub.messagesQueue.isNotEmpty);
+  });
+
   test('Remove label and post comment when no revert label.', () async {
     final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
@@ -121,7 +210,7 @@ void main() {
     assert(pubsub.messagesQueue.isEmpty);
   });
 
-  group('Processing revert reqeuests.', () {
+  group('Processing revert reqeuest tests', () {
     test('Merge valid revert request and message is acknowledged.', () async {
       final PullRequestHelper flutterRequest = PullRequestHelper(
         prNumber: 0,
@@ -571,7 +660,7 @@ void main() {
     });
   });
 
-  group('Process pull request', () {
+  group('Process pull request method tests', () {
     test('Should process message when autosubmit label exists and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       githubService.pullRequestData = pullRequest;

--- a/auto_submit/test/utilities/mocks.mocks.dart
+++ b/auto_submit/test/utilities/mocks.mocks.dart
@@ -2003,10 +2003,27 @@ class MockRepositoriesService extends _i1.Mock implements _i5.RepositoriesServic
         returnValue: _i6.Future<bool>.value(false),
       ) as _i6.Future<bool>);
   @override
-  _i6.Stream<_i5.RepositoryCommit> listCommits(_i5.RepositorySlug? slug) => (super.noSuchMethod(
+  _i6.Stream<_i5.RepositoryCommit> listCommits(
+    _i5.RepositorySlug? slug, {
+    String? sha,
+    String? path,
+    String? author,
+    String? committer,
+    DateTime? since,
+    DateTime? until,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCommits,
           [slug],
+          {
+            #sha: sha,
+            #path: path,
+            #author: author,
+            #committer: committer,
+            #since: since,
+            #until: until,
+          },
         ),
         returnValue: _i6.Stream<_i5.RepositoryCommit>.empty(),
       ) as _i6.Stream<_i5.RepositoryCommit>);

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -350,6 +350,29 @@ void main() {
       });
     });
 
+    // When branch is default we need to wait for the tree status if it is not
+    // present.
+    test('Commit has no statuses to verify.', () {
+      final Map<String, dynamic> queryResultJsonDecode = jsonDecode(noStatusInCommitJson) as Map<String, dynamic>;
+      final QueryResult queryResult = QueryResult.fromJson(queryResultJsonDecode);
+      expect(queryResult, isNotNull);
+      final PullRequest pr = queryResult.repository!.pullRequest!;
+      expect(pr, isNotNull);
+
+      final github.PullRequest npr = generatePullRequest();
+      githubService.checkRunsData = checkRunsMock;
+
+      ciSuccessful.validate(queryResult, npr).then((value) {
+        // fails because in this case there is only a single fail status
+        expect(false, value.result);
+        // Remove label.
+        expect(value.action, Action.IGNORE_TEMPORARILY);
+        expect(value.message, 'Hold to wait for the tree status ready.');
+      });
+    });
+
+    // Test for when the base branch is not default, we should not check the
+    // tree status as it does not apply.
     test('Commit has no statuses to verify and base branch is not default.', () {
       final Map<String, dynamic> queryResultJsonDecode = jsonDecode(noStatusInCommitJson) as Map<String, dynamic>;
       final QueryResult queryResult = QueryResult.fromJson(queryResultJsonDecode);

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 import 'package:auto_submit/validations/ci_successful.dart';
 import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/validations/validation.dart';
+import 'package:auto_submit/configuration/repository_configuration.dart';
 
 import '../utilities/utils.dart';
 import '../utilities/mocks.dart';
@@ -18,6 +19,7 @@ import '../src/service/fake_config.dart';
 import '../src/service/fake_github_service.dart';
 import '../src/service/fake_graphql_client.dart';
 import '../requests/github_webhook_test_data.dart';
+import '../configuration/repository_configuration_data.dart';
 
 void main() {
   late CiSuccessful ciSuccessful;
@@ -54,6 +56,7 @@ void main() {
     ciSuccessful = CiSuccessful(config: config);
     slug = github.RepositorySlug('octocat', 'flutter');
     failures = <FailureDetail>{};
+    config.repositoryConfigurationMock = RepositoryConfiguration.fromYaml(sampleConfigNoOverride);
   });
 
   group('validateCheckRuns', () {
@@ -347,6 +350,24 @@ void main() {
       });
     });
 
+    test('Commit has no statuses to verify and base branch is not default.', () {
+      final Map<String, dynamic> queryResultJsonDecode = jsonDecode(noStatusInCommitJson) as Map<String, dynamic>;
+      final QueryResult queryResult = QueryResult.fromJson(queryResultJsonDecode);
+      expect(queryResult, isNotNull);
+      final PullRequest pr = queryResult.repository!.pullRequest!;
+      expect(pr, isNotNull);
+
+      final github.PullRequest npr = generatePullRequest(baseRef: 'test_feature');
+      githubService.checkRunsData = checkRunsMock;
+
+      ciSuccessful.validate(queryResult, npr).then((value) {
+        expect(true, value.result);
+        // Remove label.
+        expect(value.action, Action.REMOVE_LABEL);
+        expect(value.message, isEmpty);
+      });
+    });
+
     test('Commit has statuses to verify, action remove label, no message.', () {
       final Map<String, dynamic> queryResultJsonDecode =
           jsonDecode(nonNullStatusSUCCESSCommitRepositoryJson) as Map<String, dynamic>;
@@ -423,6 +444,7 @@ void main() {
       config = FakeConfig(githubService: githubService);
       ciSuccessful = CiSuccessful(config: config);
       slug = github.RepositorySlug('flutter', 'cocoon');
+      config.repositoryConfigurationMock = RepositoryConfiguration.fromYaml(sampleConfigNoOverride);
     });
 
     test('returns correct message when validation fails', () async {


### PR DESCRIPTION
Add support for release/non-default base branches. Autosubmit can now merge pull requests into non-default base branches by ignoring the tree status check. It will still process all other checks as it would if merging into the base branch.

Example merge into base release candidate branch:
![image](https://github.com/flutter/cocoon/assets/32242716/8b899d65-d476-4ddd-9927-9c910c7a4b7f)

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/126282

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
