### PR TITLE
Do not filter main or master independently of age.

### DIFF
--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:cocoon_service/src/model/appengine/branch.dart';
-import 'package:github/github.dart' as gh;
 import 'package:process_runner/process_runner.dart';
 
 import '../../cocoon_service.dart';

--- a/app_dart/lib/src/request_handlers/get_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_branches.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:cocoon_service/src/model/appengine/branch.dart';
+import 'package:github/github.dart' as gh;
 import 'package:process_runner/process_runner.dart';
 
 import '../../cocoon_service.dart';
@@ -55,7 +56,9 @@ class GetBranches extends RequestHandler<Body> {
     List<Branch> branches = await datastore
         .queryBranches()
         .where(
-          (Branch b) => DateTime.now().millisecondsSinceEpoch - b.lastActivity! < kActiveBranchActivity.inMilliseconds,
+          (Branch b) =>
+              DateTime.now().millisecondsSinceEpoch - b.lastActivity! < kActiveBranchActivity.inMilliseconds ||
+              <String>['main', 'master'].contains(b.name),
         )
         .toList();
     // From the dashboard point of view, these are the subset of branches we care about.

--- a/app_dart/test/request_handlers/get_branches_test.dart
+++ b/app_dart/test/request_handlers/get_branches_test.dart
@@ -104,6 +104,46 @@ void main() {
       expect(result, expected);
     });
 
+    test('does not filter main branch independently of age', () async {
+      // main
+      const String mainId = 'flutter/flutter/main';
+      final int lastActivity = DateTime.now().millisecondsSinceEpoch - const Duration(days: 90).inMilliseconds;
+      final Key<String> mainBranchKey = db.emptyKey.append<String>(Branch, id: mainId);
+      final Branch mainBranch = Branch(
+        key: mainBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[mainBranch.key] = mainBranch;
+      // release candidate branch
+      const String releaseId = 'flutter/flutter/flutter-3.10-candidate.1';
+      final Key<String> releaseBranchKey = db.emptyKey.append<String>(Branch, id: releaseId);
+      final Branch releaseBranch = Branch(
+        key: releaseBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[releaseBranch.key] = releaseBranch;
+      // other
+      const String otherId = 'flutter/engine/master';
+      final Key<String> otherBranchKey = db.emptyKey.append<String>(Branch, id: otherId);
+      final Branch otherBranch = Branch(
+        key: otherBranchKey,
+        lastActivity: lastActivity,
+      );
+      db.values[otherBranch.key] = otherBranch;
+      final List<dynamic> result = (await decodeHandlerBody())!;
+      final List<dynamic> expected = [
+        {
+          'id': 'flutter/flutter/main',
+          'branch': <String, String>{'branch': 'main', 'repository': 'flutter/flutter'}
+        },
+        {
+          'id': 'flutter/engine/master',
+          'branch': {'branch': 'master', 'repository': 'flutter/engine'}
+        }
+      ];
+      expect(result, expected);
+    });
+
     test('should retrieve branches with commit acitivities in the past week', () async {
       expect(db.values.values.whereType<Branch>().length, 1);
 


### PR DESCRIPTION
In general master, main branches are really old and filtered out by the current query(filtering out branches older with no activity in the last 60 days).

Bug: https://github.com/flutter/flutter/issues/127452


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
