### PR TITLE
Add check for DevToolsSecurity

### DIFF
--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -55,7 +55,8 @@ class DiagnoseCommand extends Command<bool> {
     return true;
   }
 
-  Future<bool> checkDevToolsSecurity() async {
+  /// Log the status of DevToolsSecurity.
+  Future<void> checkDevToolsSecurity() async {
     final List<String> command = <String>['xcrun', 'DevToolsSecurity', '--status'];
     final io.ProcessResult result = await processManager.run(
       command,
@@ -64,12 +65,9 @@ class DiagnoseCommand extends Command<bool> {
       logger.severe(
         '$command failed with exit code ${result.exitCode}\n${result.stderr}',
       );
-      return false;
     }
     final String stdout = result.stdout as String;
     logger.info(stdout);
-
-    return true;
   }
 }
 

--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -26,6 +26,8 @@ class DiagnoseCommand extends Command<bool> {
   final String description = 'Diagnose whether attached iOS devices have errors.';
 
   Future<bool> run() async {
+    await checkDevToolsSecurity();
+
     final List<String> command = <String>['xcrun', 'xcdevice', 'list'];
     final io.ProcessResult result = await processManager.run(
       command,
@@ -49,8 +51,6 @@ class DiagnoseCommand extends Command<bool> {
       }
       return false;
     }
-
-    await checkDevToolsSecurity();
 
     return true;
   }

--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -50,6 +50,25 @@ class DiagnoseCommand extends Command<bool> {
       return false;
     }
 
+    await checkDevToolsSecurity();
+
+    return true;
+  }
+
+  Future<bool> checkDevToolsSecurity() async {
+    final List<String> command = <String>['xcrun', 'DevToolsSecurity', '--status'];
+    final io.ProcessResult result = await processManager.run(
+      command,
+    );
+    if (result.exitCode != 0) {
+      logger.severe(
+        '$command failed with exit code ${result.exitCode}\n${result.stderr}',
+      );
+      return false;
+    }
+    final String stdout = result.stdout as String;
+    logger.info(stdout);
+
     return true;
   }
 }


### PR DESCRIPTION
Adding to help debug https://github.com/flutter/flutter/issues/120808.

Currently it does not do anything other than print out the status. In the future, we may want to try a) changing the status or b) opening Xcode based off the status. First, we just want to observe what the status is when tests run.

It's currently piggybacking on the `ios_debug_symbol_doctor.dart diagnose` command. If this is something we want to keep and use, we should rename `ios_debug_symbol_doctor` or make this its own command.

I filed https://github.com/flutter/flutter/issues/127517 to make sure we follow up.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
