### PR TITLE
Do not filter out targets enabled only on release candidate branches.

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -27,8 +27,12 @@ class CiYaml {
     if (validate) {
       _validate(config, branch, totSchedulerConfig: totConfig?.config);
     }
-    totPresubmitTargetNames =
-        totConfig?.presubmitTargets.map((Target target) => target.value.name).toList() ?? <String>[];
+    // Do not filter bringup targets. They are required for backward compatibility
+    // with release candidate branches.
+    final Iterable<Target> totPresubmitTargets =
+        totConfig?._targets.where((Target target) => target.value.presubmit) ?? <Target>[];
+    final List<Target> totEnabledPresubmitTargets = _filterEnabledTargets(totPresubmitTargets);
+    totPresubmitTargetNames = totEnabledPresubmitTargets.map((Target target) => target.value.name).toList();
     totPostsubmitTargetNames =
         totConfig?.postsubmitTargets.map((Target target) => target.value.name).toList() ?? <String>[];
   }
@@ -54,7 +58,6 @@ class CiYaml {
   List<Target> get presubmitTargets {
     final Iterable<Target> presubmitTargets =
         _targets.where((Target target) => target.value.presubmit && !target.value.bringup);
-
     List<Target> enabledTargets = _filterEnabledTargets(presubmitTargets);
 
     if (enabledTargets.isEmpty) {
@@ -62,14 +65,7 @@ class CiYaml {
     }
     // Filter targets removed from main.
     if (totPresubmitTargetNames!.isNotEmpty) {
-      final String defaultBranch = Config.defaultBranch(slug);
-      enabledTargets = enabledTargets
-          .where(
-            (Target target) =>
-                (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
-                totPresubmitTargetNames!.contains(target.value.name),
-          )
-          .toList();
+      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totPresubmitTargetNames);
     }
     return enabledTargets;
   }
@@ -81,16 +77,24 @@ class CiYaml {
     List<Target> enabledTargets = _filterEnabledTargets(postsubmitTargets);
     // Filter targets removed from main.
     if (totPostsubmitTargetNames!.isNotEmpty) {
-      final String defaultBranch = Config.defaultBranch(slug);
-      enabledTargets = enabledTargets
-          .where(
-            (Target target) =>
-                (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
-                totPostsubmitTargetNames!.contains(target.value.name),
-          )
-          .toList();
+      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totPostsubmitTargetNames);
     }
     return enabledTargets;
+  }
+
+  /// Filters targets that were removed from main. [slug] is the gihub
+  /// slug for branch under test, [targets] is the list of targets from
+  /// the branch under test and [totTargetNames] is the list of target
+  /// names enabled on the default branch.
+  List<Target> filterOutdatedTargets(slug, targets, totTargetNames) {
+    final String defaultBranch = Config.defaultBranch(slug);
+    return targets
+        .where(
+          (Target target) =>
+              (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
+              totTargetNames!.contains(target.value.name),
+        )
+        .toList();
   }
 
   /// Filters [targets] to those that should be started immediately.

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -85,7 +85,7 @@ class CiYaml {
       enabledTargets = enabledTargets
           .where(
             (Target target) =>
-                !target.value.enabledBranches.contains(defaultBranch) ||
+                (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
                 totPostsubmitTargetNames!.contains(target.value.name),
           )
           .toList();

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -62,8 +62,14 @@ class CiYaml {
     }
     // Filter targets removed from main.
     if (totPresubmitTargetNames!.isNotEmpty) {
-      enabledTargets =
-          enabledTargets.where((Target target) => totPresubmitTargetNames!.contains(target.value.name)).toList();
+      final String defaultBranch = Config.defaultBranch(slug);
+      enabledTargets = enabledTargets
+          .where(
+            (Target target) =>
+                (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
+                totPresubmitTargetNames!.contains(target.value.name),
+          )
+          .toList();
     }
     return enabledTargets;
   }
@@ -75,8 +81,14 @@ class CiYaml {
     List<Target> enabledTargets = _filterEnabledTargets(postsubmitTargets);
     // Filter targets removed from main.
     if (totPostsubmitTargetNames!.isNotEmpty) {
-      enabledTargets =
-          enabledTargets.where((Target target) => totPostsubmitTargetNames!.contains(target.value.name)).toList();
+      final String defaultBranch = Config.defaultBranch(slug);
+      enabledTargets = enabledTargets
+          .where(
+            (Target target) =>
+                !target.value.enabledBranches.contains(defaultBranch) ||
+                totPostsubmitTargetNames!.contains(target.value.name),
+          )
+          .toList();
     }
     return enabledTargets;
   }

--- a/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
+++ b/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
@@ -103,7 +103,7 @@ void main() {
         scheduler: scheduler,
       );
       final List<Task> allGray = <Task>[
-        generateTask(1, name: 'Linux_android A', status: Task.statusNew),
+        generateTask(1, name: 'Linux_android B', status: Task.statusNew),
       ];
       db.addOnQuery<Task>((Iterable<Task> results) => allGray);
       await tester.get(handler);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -748,7 +748,26 @@ targets:
         );
       });
 
-      test('filters out presubmit targets that do not exist in main', () async {
+      test('filters out presubmit targets that do not exist in main and do not filter targets not in main', () async {
+        const String singleCiYaml = r'''
+enabled_branches:
+  - master
+  - main
+  - flutter-\d+\.\d+-candidate\.\d+
+targets:
+  - name: Linux A
+    properties:
+      custom: abc
+  - name: Linux B
+    enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
+    scheduler: luci
+  - name: Linux C
+    enabled_branches:
+      - main
+      - flutter-\d+\.\d+-candidate\.\d+
+    scheduler: luci
+''';
         const String totCiYaml = r'''
 enabled_branches:
   - main
@@ -788,7 +807,10 @@ targets:
           branch: 'flutter-3.10-candidate.1',
         );
         final List<Target> targets = await scheduler.getPresubmitTargets(pr);
-        expect(targets.single.value.name, 'Linux A');
+        expect(
+          targets.map((Target target) => target.value.name).toList(),
+          containsAll(<String>['Linux A', 'Linux B']),
+        );
       });
 
       test('triggers all presubmit build checks when diff cannot be found', () async {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -774,6 +774,7 @@ enabled_branches:
   - flutter-\d+\.\d+-candidate\.\d+
 targets:
   - name: Linux A
+    bringup: true
     properties:
       custom: abc
 ''';


### PR DESCRIPTION
Sometimes targets are explicitly enabled on release candidate branches and not in main. This PR updates the filtering logic to avoid filtering targets that are not enabled in main.

Bug: https://github.com/flutter/flutter/issues/127496


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
