### PR TITLE
Implement `onLevelChanged` to unblock logging version bump

### DIFF
--- a/device_doctor/pubspec.yaml
+++ b/device_doctor/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   analyzer: ^5.12.0
   args: 2.4.1
-  logging: 1.1.1
+  logging: ^1.1.1
   meta: 1.9.1
   path: 1.8.3
   process: 4.2.4

--- a/device_doctor/test/src/utils.dart
+++ b/device_doctor/test/src/utils.dart
@@ -91,6 +91,7 @@ class TestLogger implements Logger {
   Level get level => throw UnimplementedError('Unimplemented!');
   set level(Level? value) => throw UnimplementedError('Unimplemented!');
   Stream<LogRecord> get onRecord => throw UnimplementedError('Unimplemented!');
+  Stream<Level?> get onLevelChanged => throw UnimplementedError('Unimplemented!');
   final Logger? parent = null;
   final Map<String, Logger> children = const <String, Logger>{};
 


### PR DESCRIPTION
This is https://github.com/flutter/cocoon/pull/2790 with CI fix.