### PR TITLE
Revert "Add check for DevToolsSecurity (#2801)"

### DIFF
--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -26,8 +26,6 @@ class DiagnoseCommand extends Command<bool> {
   final String description = 'Diagnose whether attached iOS devices have errors.';
 
   Future<bool> run() async {
-    await checkDevToolsSecurity();
-
     final List<String> command = <String>['xcrun', 'xcdevice', 'list'];
     final io.ProcessResult result = await processManager.run(
       command,
@@ -53,21 +51,6 @@ class DiagnoseCommand extends Command<bool> {
     }
 
     return true;
-  }
-
-  /// Log the status of DevToolsSecurity.
-  Future<void> checkDevToolsSecurity() async {
-    final List<String> command = <String>['xcrun', 'DevToolsSecurity', '--status'];
-    final io.ProcessResult result = await processManager.run(
-      command,
-    );
-    if (result.exitCode != 0) {
-      logger.severe(
-        '$command failed with exit code ${result.exitCode}\n${result.stderr}',
-      );
-    }
-    final String stdout = result.stdout as String;
-    logger.info(stdout);
   }
 }
 

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -79,16 +79,11 @@ Future<void> main() async {
       fs.directory(xcworkspacePath).createSync(recursive: true);
     });
 
-    test('diagnose logs output of xcdevice list and DevToolsSecurity', () async {
+    test('diagnose logs output of xcdevice list', () async {
       when(
         processManager.run(<String>['xcrun', 'xcdevice', 'list']),
       ).thenAnswer((_) async {
         return ProcessResult(0, 0, _jsonWithNonFatalErrors, '');
-      });
-      when(
-        processManager.run(<String>['xcrun', 'DevToolsSecurity', '--status']),
-      ).thenAnswer((_) async {
-        return ProcessResult(0, 0, _developerModeDisabled, '');
       });
       final CommandRunner<bool> runner = _createTestRunner();
       final command = DiagnoseCommand(
@@ -98,7 +93,6 @@ Future<void> main() async {
       runner.addCommand(command);
       await runner.run(<String>['diagnose']);
       expect(logger.logs[Level.INFO], contains(_jsonWithNonFatalErrors));
-      expect(logger.logs[Level.INFO], contains(_developerModeDisabled));
     });
 
     test('recover returns early if xcodebuild -runFirstLaunch exits non-zero', () async {
@@ -111,11 +105,6 @@ Future<void> main() async {
           '',
           'xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun',
         );
-      });
-      when(
-        processManager.run(<String>['xcrun', 'DevToolsSecurity', '--status']),
-      ).thenAnswer((_) async {
-        return ProcessResult(0, 0, _developerModeEnabled, '');
       });
 
       fakeAsync<void>((FakeAsync time) {
@@ -266,7 +255,3 @@ String _jsonWithPreparingErrors(String name) => '''
   }
 ]
 ''';
-
-const String _developerModeDisabled = '''Developer mode is currently disabled.''';
-
-const String _developerModeEnabled = '''Developer mode is currently enabled.''';


### PR DESCRIPTION
This reverts commit 8c093a0194222d421c3c7f928f8b21ec6b923245.

We added a check for `DevToolsSecurity` as sources recommended enabling it could resolve issues like https://github.com/flutter/flutter/issues/120808. However,  after observing the output, it shows `DevToolsSecurity` is already enabled. I observed multiple tests, including ones that errored with before mentioned issue.
Example: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20hot_mode_dev_cycle_ios__benchmark/5298/overview

Fixes https://github.com/flutter/flutter/issues/127517.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
