### PR TITLE
Remove _GAE_PROMOTE variable in lieu of directly specifying --no-promote

### DIFF
--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -28,7 +28,7 @@ steps:
       - |-
         gcloud builds submit \
           --config app_dart/cloudbuild_app_dart_deploy.yaml \
-          --substitutions="_GAE_PROMOTE=$_GAE_PROMOTE,SHORT_SHA=$SHORT_SHA" \
+          --substitutions="SHORT_SHA=$SHORT_SHA" \
           --async
 
 timeout: 1200s

--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -35,7 +35,7 @@ steps:
         if [ "$latest_version" = "version-$SHORT_SHA" ]; then
           echo "No updates since last deployment."
         else
-          bash cloud_build/deploy_app_dart.sh $PROJECT_ID $SHORT_SHA $_GAE_PROMOTE
+          bash cloud_build/deploy_app_dart.sh $PROJECT_ID $SHORT_SHA
         fi
 
 timeout: 1200s

--- a/auto_submit/cloudbuild_auto_submit.yaml
+++ b/auto_submit/cloudbuild_auto_submit.yaml
@@ -20,7 +20,7 @@ steps:
       - |-
         gcloud builds submit \
           --config auto_submit/cloudbuild_auto_submit_deploy.yaml \
-          --substitutions="_GAE_PROMOTE=$_GAE_PROMOTE,SHORT_SHA=$SHORT_SHA" \
+          --substitutions="SHORT_SHA=$SHORT_SHA" \
           --async
 
 timeout: 1200s

--- a/auto_submit/cloudbuild_auto_submit_deploy.yaml
+++ b/auto_submit/cloudbuild_auto_submit_deploy.yaml
@@ -35,7 +35,7 @@ steps:
         if [ "$latest_version" = "version-$SHORT_SHA" ]; then
           echo "No updates since last deployment."
         else
-          bash cloud_build/deploy_auto_submit.sh $PROJECT_ID $SHORT_SHA $_GAE_PROMOTE
+          bash cloud_build/deploy_auto_submit.sh $PROJECT_ID $SHORT_SHA
         fi
 
 timeout: 1200s

--- a/cloud_build/deploy_app_dart.sh
+++ b/cloud_build/deploy_app_dart.sh
@@ -8,7 +8,7 @@
 pushd app_dart > /dev/null
 set -e
 # app_dart
-gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/default.version-$2"
+gcloud app deploy --project "$1" --version "version-$2" -q --no-promote --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/default.version-$2"
 gcloud app services set-traffic default --splits version-$2=1 --quiet
 # Google Cloud quota only allows 30 versions.
 # For daily builds, this will keep the 10 most recent versions, but wipe the rest.

--- a/cloud_build/deploy_auto_submit.sh
+++ b/cloud_build/deploy_auto_submit.sh
@@ -7,7 +7,7 @@
 
 pushd auto_submit > /dev/null
 # auto_submit
-gcloud app deploy --project "$1" --version "version-$2" -q "$3" --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/auto-submit.version-$2"
+gcloud app deploy --project "$1" --version "version-$2" -q --no-promote --no-stop-previous-version --image-url "us-docker.pkg.dev/$1/appengine/auto-submit.version-$2"
 gcloud app services set-traffic auto-submit --splits version-$2=1 --quiet
 # Google Cloud quota only allows 30 versions.
 # For daily builds, this will keep the 10 most recent versions, but wipe the rest.


### PR DESCRIPTION
* Remove the _GAE_PROMOTE variable, since we don't ever want to promote since we already promote on the line following the deployment
* Brings cocoon closer toward a SLSA 4 requirement of reproducible builds by simplifying the build process and removing a variable that can be changed during the deployment.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
