### PR TITLE
Delete symbols on ios_debug_symbol_doctor recover

### DIFF
--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -191,7 +191,13 @@ class RecoverCommand extends Command<bool> {
       return;
     }
     logger.info('Deleting iOS DeviceSupport...');
-    deviceSupportDirectory.deleteSync(recursive: true);
+    try {
+      deviceSupportDirectory.deleteSync(recursive: true);
+    } on FileSystemException catch (e) {
+      // Error that indicates why files cannot be deleted, such as
+      // another program having the files open.
+      logger.severe('${e.message}: ${e.osError}');
+    }
   }
 }
 

--- a/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -11,6 +11,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:process/process.dart';
 import 'package:logging/logging.dart';
+import 'package:platform/platform.dart';
 
 class DiagnoseCommand extends Command<bool> {
   DiagnoseCommand({
@@ -59,6 +60,7 @@ class RecoverCommand extends Command<bool> {
     this.processManager = const LocalProcessManager(),
     Logger? loggerOverride,
     this.fs = const LocalFileSystem(),
+    this.platform = const LocalPlatform(),
   }) : logger = loggerOverride ?? Logger.root {
     argParser
       ..addOption(
@@ -77,6 +79,7 @@ class RecoverCommand extends Command<bool> {
   final Logger logger;
   final ProcessManager processManager;
   final FileSystem fs;
+  final Platform platform;
 
   final String name = 'recover';
   final String description = 'Open Xcode UI to allow it to sync debug symbols from the iPhone';
@@ -109,6 +112,8 @@ class RecoverCommand extends Command<bool> {
     if (timeoutSeconds == null) {
       throw ArgumentError('Could not parse an integer from the option --timeout="${argResults!['timeout']}"');
     }
+
+    _deleteSymbols();
 
     // Prompt Xcode to first setup without opening the app.
     // This will return very quickly if there is no work to do.
@@ -169,6 +174,24 @@ class RecoverCommand extends Command<bool> {
       return false;
     }
     return true;
+  }
+
+  /// Delete all symbols by deleting the `iOS DeviceSupport` directory.
+  /// Xcode will regenerate this folder and symbols for connected devices
+  /// when Xcode is opened.
+  void _deleteSymbols() {
+    final String? home = platform.environment['HOME'];
+    if (home == null) {
+      logger.warning('\$HOME path was not found');
+      return;
+    }
+    final Directory deviceSupportDirectory = fs.directory('$home/Library/Developer/Xcode/iOS DeviceSupport');
+    if (!deviceSupportDirectory.existsSync()) {
+      logger.warning('iOS Device Support directory was not found at ${deviceSupportDirectory.path}');
+      return;
+    }
+    logger.info('Deleting iOS DeviceSupport...');
+    deviceSupportDirectory.deleteSync(recursive: true);
   }
 }
 

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -11,6 +11,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:file/memory.dart';
 import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 
 import 'package:test/test.dart';
 
@@ -71,12 +72,16 @@ Future<void> main() async {
     const String cocoonPath = '/path/to/cocoon';
     const String xcworkspacePath = '$cocoonPath/dashboard/ios/Runner.xcodeproj/project.xcworkspace';
     late MemoryFileSystem fs;
+    late Platform platform;
+    const String deviceSupportDirectory = '/User/username/Library/Developer/Xcode/iOS DeviceSupport';
 
     setUp(() {
       processManager = MockProcessManager();
       logger = TestLogger();
       fs = MemoryFileSystem();
       fs.directory(xcworkspacePath).createSync(recursive: true);
+      platform = MockPlatform();
+      platform.environment['HOME'] = '/User/username';
     });
 
     test('diagnose logs output of xcdevice list', () async {
@@ -96,6 +101,8 @@ Future<void> main() async {
     });
 
     test('recover returns early if xcodebuild -runFirstLaunch exits non-zero', () async {
+      final Directory symbolsDirectory = fs.directory('/User/username/Library/Developer/Xcode/iOS Temp');
+      symbolsDirectory.createSync(recursive: true);
       when(
         processManager.run(<String>['xcrun', 'xcodebuild', '-runFirstLaunch']),
       ).thenAnswer((_) async {
@@ -113,6 +120,7 @@ Future<void> main() async {
           processManager: processManager,
           loggerOverride: logger,
           fs: fs,
+          platform: platform,
         );
         runner.addCommand(command);
         bool? result;
@@ -122,7 +130,9 @@ Future<void> main() async {
       });
     });
 
-    test('recover opens Xcode, waits, then kills it', () async {
+    test('recover deletes symbols, opens Xcode, waits, then kills it', () async {
+      final Directory symbolsDirectory = fs.directory(deviceSupportDirectory);
+      symbolsDirectory.createSync(recursive: true);
       when(
         processManager.run(<String>['xcrun', 'xcodebuild', '-runFirstLaunch']),
       ).thenAnswer((_) async {
@@ -146,6 +156,7 @@ Future<void> main() async {
           processManager: processManager,
           loggerOverride: logger,
           fs: fs,
+          platform: platform,
         );
         runner.addCommand(command);
         bool? result;
@@ -157,6 +168,60 @@ Future<void> main() async {
         time.elapse(const Duration(seconds: 2));
         expect(result, isNotNull);
         expect(killedXcode, isTrue);
+        expect(logger.logs[Level.WARNING], isNull);
+        expect(symbolsDirectory.existsSync(), false);
+
+        return result!;
+      });
+      expect(result, isTrue);
+      expect(
+        logger.logs[Level.INFO],
+        containsAllInOrder(<String>[
+          'Running Xcode first launch...',
+          'Launching Xcode...',
+          'Waiting for 300 seconds',
+          'Waited for 300 seconds, now killing Xcode',
+        ]),
+      );
+    });
+
+    test('recover cannot find symbols but still opens Xcode, waits, then kills it', () async {
+      when(
+        processManager.run(<String>['xcrun', 'xcodebuild', '-runFirstLaunch']),
+      ).thenAnswer((_) async {
+        return ProcessResult(0, 0, '', '');
+      });
+      when(
+        processManager.run(<String>['open', '-n', '-F', '-W', xcworkspacePath]),
+      ).thenAnswer((_) async {
+        return ProcessResult(1, 0, '', '');
+      });
+      bool killedXcode = false;
+      when(
+        processManager.run(<String>['killall', '-9', 'Xcode']),
+      ).thenAnswer((_) async {
+        killedXcode = true;
+        return ProcessResult(2, 0, '', '');
+      });
+      final bool result = fakeAsync<bool>((FakeAsync time) {
+        final CommandRunner<bool> runner = _createTestRunner();
+        final command = RecoverCommand(
+          processManager: processManager,
+          loggerOverride: logger,
+          fs: fs,
+          platform: platform,
+        );
+        runner.addCommand(command);
+        bool? result;
+        runner.run(<String>['recover', '--cocoon-root=$cocoonPath']).then((bool? value) => result = value);
+        time.elapse(const Duration(seconds: 299));
+        // We have not yet reached the timeout, so Xcode should still be open
+        expect(result, isNull);
+        expect(killedXcode, isFalse);
+        time.elapse(const Duration(seconds: 2));
+        expect(result, isNotNull);
+        expect(killedXcode, isTrue);
+        expect(logger.logs[Level.WARNING], contains('iOS Device Support directory was not found at $deviceSupportDirectory'));
         return result!;
       });
       expect(result, isTrue);

--- a/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
+++ b/device_doctor/test/src/ios_debug_symbol_doctor_test.dart
@@ -221,7 +221,10 @@ Future<void> main() async {
         time.elapse(const Duration(seconds: 2));
         expect(result, isNotNull);
         expect(killedXcode, isTrue);
-        expect(logger.logs[Level.WARNING], contains('iOS Device Support directory was not found at $deviceSupportDirectory'));
+        expect(
+          logger.logs[Level.WARNING],
+          contains('iOS Device Support directory was not found at $deviceSupportDirectory'),
+        );
         return result!;
       });
       expect(result, isTrue);

--- a/device_doctor/test/src/utils.dart
+++ b/device_doctor/test/src/utils.dart
@@ -9,8 +9,13 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:process/process.dart';
+import 'package:platform/platform.dart';
 
-class MockPlatform extends Mock implements Platform {}
+class MockPlatform extends Mock implements Platform {
+
+  @override
+  Map<String, String> environment = <String, String>{};
+}
 
 class MockProcessManager extends Mock implements ProcessManager {
   @override

--- a/device_doctor/test/src/utils.dart
+++ b/device_doctor/test/src/utils.dart
@@ -12,7 +12,6 @@ import 'package:process/process.dart';
 import 'package:platform/platform.dart';
 
 class MockPlatform extends Mock implements Platform {
-
   @override
   Map<String, String> environment = <String, String>{};
 }


### PR DESCRIPTION
When a mac CI test times out, delete the device symbols and then open Xcode to allow Xcode to regenerate them.

Part of solution for https://github.com/flutter/flutter/issues/126412#issuecomment-1574304265.

In the long term, should move this logic to https://github.com/flutter/flutter/issues/128123 as explained in https://github.com/flutter/flutter/issues/126412#issuecomment-1574329205.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
