### PR TITLE
Frontend logic to display dart-internal build results

### DIFF
--- a/dashboard/lib/logic/qualified_task.dart
+++ b/dashboard/lib/logic/qualified_task.dart
@@ -14,12 +14,14 @@ class StageName {
   static const String legacyLuci = 'chromebot';
   static const String luci = 'luci';
   static const String googleTest = 'google_internal';
+  static const String dartInternal = 'dart-internal';
 }
 
 /// Base URLs for various endpoints that can relate to a [Task].
 const String _cirrusUrl = 'https://cirrus-ci.com/github/flutter/flutter';
 const String _luciUrl = 'https://ci.chromium.org/p/flutter';
 const String _googleTestUrl = 'https://flutter-rob.corp.google.com';
+const String _dartInternalUrl = 'https://ci.chromium.org/p/dart-internal';
 
 @immutable
 class QualifiedTask {
@@ -39,13 +41,15 @@ class QualifiedTask {
   /// Luci tasks are stored on Luci.
   /// Cirrus tasks are stored on Cirrus.
   String get sourceConfigurationUrl {
-    assert(isLuci || isCirrus || isGoogleTest);
+    assert(isLuci || isCirrus || isGoogleTest || isDartInternal);
     if (isCirrus) {
       return '$_cirrusUrl/master';
     } else if (isLuci) {
       return '$_luciUrl/builders/$pool/$task';
     } else if (isGoogleTest) {
       return _googleTestUrl;
+    } else if (isDartInternal) {
+      return '$_dartInternalUrl/builders/$pool/$task';
     }
     throw Exception('Failed to get source configuration url for $stage.');
   }
@@ -56,8 +60,11 @@ class QualifiedTask {
   /// Whether this task was run on Cirrus CI.
   bool get isCirrus => stage == StageName.cirrus;
 
-  /// Whether the task was run on the LUCI infrastructre.
+  /// Whether the task was run on the LUCI infrastructure.
   bool get isLuci => stage == StageName.cocoon || stage == StageName.legacyLuci || stage == StageName.luci;
+
+  /// Whether this task was run on internal infrastructure (example: luci dart-internal).
+  bool get isDartInternal => stage == StageName.dartInternal;
 
   @override
   bool operator ==(Object other) {

--- a/dashboard/lib/widgets/luci_task_attempt_summary.dart
+++ b/dashboard/lib/widgets/luci_task_attempt_summary.dart
@@ -23,6 +23,9 @@ class LuciTaskAttemptSummary extends StatelessWidget {
   @visibleForTesting
   static const String luciProdLogBase = 'https://ci.chromium.org/p/flutter/builders';
 
+  @visibleForTesting
+  static const String dartInternalLogBase = 'https://ci.chromium.org/p/dart-internal/builders';
+
   @override
   Widget build(BuildContext context) {
     final List<String> buildNumberList = task.buildNumberList.isEmpty ? <String>[] : task.buildNumberList.split(',');
@@ -31,7 +34,11 @@ class LuciTaskAttemptSummary extends StatelessWidget {
         return ElevatedButton(
           child: Text('OPEN LOG FOR BUILD #${buildNumberList[i]}'),
           onPressed: () {
-            launchUrl(_luciProdLogUrl(task.builderName, buildNumberList[i]));
+            if (task.stageName == 'dart-internal') {
+              launchUrl(_dartInternalLogUrl(task.builderName, buildNumberList[i]));
+            } else {
+              launchUrl(_luciProdLogUrl(task.builderName, buildNumberList[i]));
+            }
           },
         );
       }),
@@ -41,5 +48,9 @@ class LuciTaskAttemptSummary extends StatelessWidget {
   Uri _luciProdLogUrl(String builderName, String buildNumber) {
     final String pool = task.isFlaky ? 'staging' : 'prod';
     return Uri.parse('$luciProdLogBase/$pool/$builderName/$buildNumber');
+  }
+
+  Uri _dartInternalLogUrl(String builderName, String buildNumber) {
+    return Uri.parse('$dartInternalLogBase/flutter/$builderName/$buildNumber');
   }
 }

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -39,7 +39,7 @@ class TaskIcon extends StatelessWidget {
       );
     }
 
-    if (qualifiedTask.task == null || !qualifiedTask.isLuci) {
+    if (qualifiedTask.task == null || !(qualifiedTask.isLuci || qualifiedTask.isDartInternal)) {
       return Icon(
         Icons.help,
         color: blendFilter,

--- a/dashboard/lib/widgets/task_overlay.dart
+++ b/dashboard/lib/widgets/task_overlay.dart
@@ -270,7 +270,8 @@ class TaskOverlayContents extends StatelessWidget {
                             summaryText,
                             style: Theme.of(context).textTheme.bodyMedium,
                           ),
-                          if (QualifiedTask.fromTask(task).isLuci) LuciTaskAttemptSummary(task: task),
+                          if (QualifiedTask.fromTask(task).isLuci || QualifiedTask.fromTask(task).isDartInternal)
+                            LuciTaskAttemptSummary(task: task),
                         ],
                       ),
                     ),

--- a/dashboard/test/logic/qualified_task_test.dart
+++ b/dashboard/test/logic/qualified_task_test.dart
@@ -35,6 +35,15 @@ void main() {
     expect(QualifiedTask.fromTask(googleTestTask).sourceConfigurationUrl, 'https://flutter-rob.corp.google.com');
   });
 
+  test('QualifiedTask.sourceConfigurationUrl for dart-internal', () {
+    final Task dartInternalTask = Task()..stageName = 'dart-internal';
+
+    expect(
+      QualifiedTask.fromTask(dartInternalTask).sourceConfigurationUrl,
+      'https://ci.chromium.org/p/dart-internal/builders/luci.flutter.prod/',
+    );
+  });
+
   test('QualifiedTask.isLuci', () {
     expect(const QualifiedTask(stage: 'luci', task: 'abc').isLuci, true);
     expect(const QualifiedTask(stage: 'chromebot', task: 'abc').isLuci, true);

--- a/dashboard/test/widgets/luci_task_attempt_summary_test.dart
+++ b/dashboard/test/widgets/luci_task_attempt_summary_test.dart
@@ -115,5 +115,32 @@ void main() {
       expect(urlLauncher.launches, isNotEmpty);
       expect(urlLauncher.launches.single, '${LuciTaskAttemptSummary.luciProdLogBase}/prod/Linux/456');
     });
+
+    testWidgets('opens expected dart-internal log url', (WidgetTester tester) async {
+      final FakeUrlLauncher urlLauncher = FakeUrlLauncher();
+      UrlLauncherPlatform.instance = urlLauncher;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: <Widget>[
+              LuciTaskAttemptSummary(
+                task: Task()
+                  ..key = (RootKey()..child = (Key()..name = 'dart-internal-log'))
+                  ..buildNumberList = '123'
+                  ..builderName = 'Linux'
+                  ..stageName = 'dart-internal',
+              ),
+            ],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      expect(urlLauncher.launches, isNotEmpty);
+      expect(urlLauncher.launches.single, '${LuciTaskAttemptSummary.dartInternalLogBase}/flutter/Linux/123');
+    });
   });
 }

--- a/dashboard/test/widgets/task_icon_test.dart
+++ b/dashboard/test/widgets/task_icon_test.dart
@@ -211,4 +211,20 @@ void main() {
     expect(tester.widget(find.byType(Icon)) as Icon, isInstanceOf<Icon>());
     expect((tester.widget(find.byType(Icon)) as Icon).icon!.codePoint, const Icon(Icons.help).icon!.codePoint);
   });
+
+  testWidgets('TaskIcon shows the right icon for dart-internal linux', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: TaskIcon(
+            qualifiedTask:
+                QualifiedTask(stage: 'dart-internal', task: 'Linux dart-internal test', pool: 'luci.flutter.prod'),
+          ),
+        ),
+      ),
+    );
+
+    expect((tester.widget(find.byType(Image)) as Image).image, isInstanceOf<AssetImage>());
+    expect(((tester.widget(find.byType(Image)) as Image).image as AssetImage).assetName, 'assets/linux.png');
+  });
 }

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -346,6 +346,32 @@ void main() {
     expect(find.byType(LuciTaskAttemptSummary), findsOneWidget);
   });
 
+  testWidgets('TaskOverlay shows TaskAttemptSummary for dart-internal tasks', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Now.fixed(
+        dateTime: nowTime,
+        child: MaterialApp(
+          home: Scaffold(
+            body: TestGrid(
+              buildState: buildState,
+              task: Task()
+                ..stageName = 'dart-internal'
+                ..status = TaskBox.statusSucceeded
+                ..buildNumberList = '123',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(LuciTaskAttemptSummary), findsNothing);
+
+    await tester.tapAt(const Offset(TaskBox.cellSize * 1.5, TaskBox.cellSize * 1.5));
+    await tester.pump();
+
+    expect(find.byType(LuciTaskAttemptSummary), findsOneWidget);
+  });
+
   testWidgets('TaskOverlay: RERUN button disabled when user !isAuthenticated', (WidgetTester tester) async {
     final Task expectedTask = Task()
       ..attempts = 3


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/124631
* Adds logic to include links to a specific run
* Fixes linking to a dart-internal builder
* Fixes the icons for dart-internal build results

This is the first of two PR's. Once this is approved/merged, there will be a backend PR to follow.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
