### PR TITLE
Add retries to builds that are cancelled

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -87,7 +87,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
     final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task!.name);
-    if (task.status == Task.statusFailed || task.status == Task.statusInfraFailure || _taskTimedOut(task)) {
+    if (task.status == Task.statusFailed || task.status == Task.statusInfraFailure || task.status == Task.statusCancelled) {
       log.fine('Trying to auto-retry...');
       final bool retried = await scheduler.luciBuildService.checkRerunBuilder(
         commit: commit,
@@ -109,26 +109,5 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
 
     return Body.empty;
-  }
-
-  bool _taskTimedOut(Task task) {
-    if (task.timeoutInMinutes == null || task.timeoutInMinutes == 0) {
-      return false;
-    }
-
-    if (task.startTimestamp == null || task.startTimestamp == 0) {
-      return false;
-    }
-
-    if (task.endTimestamp == null || task.endTimestamp == 0) {
-      return false;
-    }
-
-    // If the time between start and end is longer than timeoutInMinutes, then
-    // it was canceled because it reached the timeout period.
-    final Duration buildTime = Duration(milliseconds: task.endTimestamp! - task.startTimestamp!);
-    final Duration timeout = Duration(minutes: task.timeoutInMinutes!);
-
-    return buildTime.compareTo(timeout) >= 0 && task.status == Task.statusCancelled;
   }
 }

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -87,7 +87,9 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
     final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task!.name);
-    if (task.status == Task.statusFailed || task.status == Task.statusInfraFailure || task.status == Task.statusCancelled) {
+    if (task.status == Task.statusFailed ||
+        task.status == Task.statusInfraFailure ||
+        task.status == Task.statusCancelled) {
       log.fine('Trying to auto-retry...');
       final bool retried = await scheduler.luciBuildService.checkRerunBuilder(
         commit: commit,

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -168,7 +168,7 @@ void main() {
     expect(task.attempts, 2);
   });
 
-    test('on builds resulting in an infra failure auto-rerun the build if they timed out', () async {
+  test('on builds resulting in an infra failure auto-rerun the build if they timed out', () async {
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -152,7 +152,6 @@ void main() {
       parent: commit,
       status: Task.statusNew,
     );
-    task.timeoutInMinutes = 2;
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
     tester.message = createBuildbucketPushMessage(
@@ -160,9 +159,6 @@ void main() {
       builderName: 'Linux A',
       result: 'CANCELED',
       userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
-      startTimestamp: 2000,
-      completedTimestamp: 1000000000000,
-      createdTimestamp: 1000,
     );
 
     expect(task.status, Task.statusNew);
@@ -172,7 +168,7 @@ void main() {
     expect(task.attempts, 2);
   });
 
-  test('on canceled builds do not auto-rerun the build if they did not time out', () async {
+    test('on builds resulting in an infra failure auto-rerun the build if they timed out', () async {
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -180,22 +176,20 @@ void main() {
       parent: commit,
       status: Task.statusNew,
     );
-    task.timeoutInMinutes = 2;
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       builderName: 'Linux A',
-      result: 'CANCELED',
+      result: 'INFRA_FAILURE',
       userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
-      startTimestamp: 2000,
-      completedTimestamp: 3000,
-      createdTimestamp: 1000,
     );
 
-    expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusCancelled);
+    expect(task.status, Task.statusNew);
     expect(task.attempts, 1);
+    expect(await tester.post(handler), Body.empty);
+    expect(task.status, Task.statusInProgress);
+    expect(task.attempts, 2);
   });
 
   test('fallback to build parameters if task_key is not present', () async {

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -144,6 +144,60 @@ void main() {
     expect(task.attempts, 2);
   });
 
+  test('on canceled builds auto-rerun the build if they timed out', () async {
+    final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
+    final Task task = generateTask(
+      4507531199512576,
+      name: 'Linux A',
+      parent: commit,
+      status: Task.statusNew,
+    );
+    task.timeoutInMinutes = 2;
+    config.db.values[task.key] = task;
+    config.db.values[commit.key] = commit;
+    tester.message = createBuildbucketPushMessage(
+      'COMPLETED',
+      builderName: 'Linux A',
+      result: 'CANCELED',
+      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      startTimestamp: 2000,
+      completedTimestamp: 1000000000000,
+      createdTimestamp: 1000,
+    );
+
+    expect(task.status, Task.statusNew);
+    expect(task.attempts, 1);
+    expect(await tester.post(handler), Body.empty);
+    expect(task.status, Task.statusInProgress);
+    expect(task.attempts, 2);
+  });
+
+  test('on canceled builds do not auto-rerun the build if they did not time out', () async {
+    final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
+    final Task task = generateTask(
+      4507531199512576,
+      name: 'Linux A',
+      parent: commit,
+      status: Task.statusNew,
+    );
+    task.timeoutInMinutes = 2;
+    config.db.values[task.key] = task;
+    config.db.values[commit.key] = commit;
+    tester.message = createBuildbucketPushMessage(
+      'COMPLETED',
+      builderName: 'Linux A',
+      result: 'CANCELED',
+      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      startTimestamp: 2000,
+      completedTimestamp: 3000,
+      createdTimestamp: 1000,
+    );
+
+    expect(await tester.post(handler), Body.empty);
+    expect(task.status, Task.statusCancelled);
+    expect(task.attempts, 1);
+  });
+
   test('fallback to build parameters if task_key is not present', () async {
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(

--- a/app_dart/test/src/utilities/push_message.dart
+++ b/app_dart/test/src/utilities/push_message.dart
@@ -18,6 +18,9 @@ PushMessage createBuildbucketPushMessage(
   int retries = 0,
   String? failureReason,
   String? userData = '',
+  int? createdTimestamp = 1565049186247524,
+  int? startTimestamp = 1565049193786080,
+  int? completedTimestamp = 1565049193786090,
 }) {
   return PushMessage(
     data: buildPushMessageJson(
@@ -28,6 +31,9 @@ PushMessage createBuildbucketPushMessage(
       retries: retries,
       failureReason: failureReason,
       userData: userData,
+      createdTimestamp: createdTimestamp,
+      startTimestamp: startTimestamp,
+      completedTimestamp: completedTimestamp,
     ),
     messageId: '123',
   );
@@ -62,6 +68,9 @@ String buildPushMessageJson(
   int retries = 0,
   String? failureReason,
   String? userData,
+  int? createdTimestamp = 1565049186247524,
+  int? startTimestamp = 1565049193786080,
+  int? completedTimestamp = 1565049193786090,
 }) =>
     base64.encode(
       utf8.encode(
@@ -73,6 +82,9 @@ String buildPushMessageJson(
           retries: retries,
           failureReason: failureReason,
           userData: userData,
+          createdTimestamp: createdTimestamp,
+          startTimestamp: startTimestamp,
+          completedTimestamp: completedTimestamp,
         ),
       ),
     );
@@ -106,6 +118,9 @@ String buildPushMessageString(
   int retries = 0,
   String? failureReason,
   String? userData,
+  int? createdTimestamp = 1565049186247524,
+  int? startTimestamp = 1565049193786080,
+  int? completedTimestamp = 1565049193786090,
 }) {
   return '''{
   "build": {
@@ -113,8 +128,8 @@ String buildPushMessageString(
     "canary": false,
     "canary_preference": "PROD",
     "created_by": "user:dnfield@google.com",
-    "created_ts": "1565049186247524",
-    "completed_ts": "1565049193786090",
+    "created_ts": "$createdTimestamp",
+    "completed_ts": "$completedTimestamp",
     "experimental": false,
     ${failureReason != null ? '"failure_reason": "$failureReason",' : ''}
     "id": "8905920700440101120",
@@ -123,7 +138,7 @@ String buildPushMessageString(
     ${result != null ? '"result": "$result",' : ''}
     "result_details_json": "{\\"properties\\": {}, \\"swarming\\": {\\"bot_dimensions\\": {\\"caches\\": [\\"flutter_openjdk_install\\", \\"git\\", \\"goma_v2\\", \\"vpython\\"], \\"cores\\": [\\"8\\"], \\"cpu\\": [\\"x86\\", \\"x86-64\\", \\"x86-64-Broadwell_GCE\\", \\"x86-64-avx2\\"], \\"gce\\": [\\"1\\"], \\"gpu\\": [\\"none\\"], \\"id\\": [\\"luci-flutter-prod-xenial-2-bnrz\\"], \\"image\\": [\\"chrome-xenial-19052201-9cb74617499\\"], \\"inside_docker\\": [\\"0\\"], \\"kvm\\": [\\"1\\"], \\"locale\\": [\\"en_US.UTF-8\\"], \\"machine_type\\": [\\"n1-standard-8\\"], \\"os\\": [\\"Linux\\", \\"Ubuntu\\", \\"Ubuntu-16.04\\"], \\"pool\\": [\\"luci.flutter.prod\\"], \\"python\\": [\\"2.7.12\\"], \\"server_version\\": [\\"4382-5929880\\"], \\"ssd\\": [\\"0\\"], \\"zone\\": [\\"us\\", \\"us-central\\", \\"us-central1\\", \\"us-central1-c\\"]}}}",
     "service_account": "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com",
-    "started_ts": "1565049193786080",
+    "started_ts": "$startTimestamp",
     "status": "$status",
     "status_changed_ts": "1565049194386647",
     "tags": [

--- a/app_dart/test/src/utilities/push_message.dart
+++ b/app_dart/test/src/utilities/push_message.dart
@@ -18,9 +18,6 @@ PushMessage createBuildbucketPushMessage(
   int retries = 0,
   String? failureReason,
   String? userData = '',
-  int? createdTimestamp = 1565049186247524,
-  int? startTimestamp = 1565049193786080,
-  int? completedTimestamp = 1565049193786090,
 }) {
   return PushMessage(
     data: buildPushMessageJson(
@@ -31,9 +28,6 @@ PushMessage createBuildbucketPushMessage(
       retries: retries,
       failureReason: failureReason,
       userData: userData,
-      createdTimestamp: createdTimestamp,
-      startTimestamp: startTimestamp,
-      completedTimestamp: completedTimestamp,
     ),
     messageId: '123',
   );
@@ -68,9 +62,6 @@ String buildPushMessageJson(
   int retries = 0,
   String? failureReason,
   String? userData,
-  int? createdTimestamp = 1565049186247524,
-  int? startTimestamp = 1565049193786080,
-  int? completedTimestamp = 1565049193786090,
 }) =>
     base64.encode(
       utf8.encode(
@@ -82,9 +73,6 @@ String buildPushMessageJson(
           retries: retries,
           failureReason: failureReason,
           userData: userData,
-          createdTimestamp: createdTimestamp,
-          startTimestamp: startTimestamp,
-          completedTimestamp: completedTimestamp,
         ),
       ),
     );
@@ -118,9 +106,6 @@ String buildPushMessageString(
   int retries = 0,
   String? failureReason,
   String? userData,
-  int? createdTimestamp = 1565049186247524,
-  int? startTimestamp = 1565049193786080,
-  int? completedTimestamp = 1565049193786090,
 }) {
   return '''{
   "build": {
@@ -128,8 +113,8 @@ String buildPushMessageString(
     "canary": false,
     "canary_preference": "PROD",
     "created_by": "user:dnfield@google.com",
-    "created_ts": "$createdTimestamp",
-    "completed_ts": "$completedTimestamp",
+    "created_ts": "1565049186247524",
+    "completed_ts": "1565049193786090",
     "experimental": false,
     ${failureReason != null ? '"failure_reason": "$failureReason",' : ''}
     "id": "8905920700440101120",
@@ -138,7 +123,7 @@ String buildPushMessageString(
     ${result != null ? '"result": "$result",' : ''}
     "result_details_json": "{\\"properties\\": {}, \\"swarming\\": {\\"bot_dimensions\\": {\\"caches\\": [\\"flutter_openjdk_install\\", \\"git\\", \\"goma_v2\\", \\"vpython\\"], \\"cores\\": [\\"8\\"], \\"cpu\\": [\\"x86\\", \\"x86-64\\", \\"x86-64-Broadwell_GCE\\", \\"x86-64-avx2\\"], \\"gce\\": [\\"1\\"], \\"gpu\\": [\\"none\\"], \\"id\\": [\\"luci-flutter-prod-xenial-2-bnrz\\"], \\"image\\": [\\"chrome-xenial-19052201-9cb74617499\\"], \\"inside_docker\\": [\\"0\\"], \\"kvm\\": [\\"1\\"], \\"locale\\": [\\"en_US.UTF-8\\"], \\"machine_type\\": [\\"n1-standard-8\\"], \\"os\\": [\\"Linux\\", \\"Ubuntu\\", \\"Ubuntu-16.04\\"], \\"pool\\": [\\"luci.flutter.prod\\"], \\"python\\": [\\"2.7.12\\"], \\"server_version\\": [\\"4382-5929880\\"], \\"ssd\\": [\\"0\\"], \\"zone\\": [\\"us\\", \\"us-central\\", \\"us-central1\\", \\"us-central1-c\\"]}}}",
     "service_account": "flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com",
-    "started_ts": "$startTimestamp",
+    "started_ts": "1565049193786080",
     "status": "$status",
     "status_changed_ts": "1565049194386647",
     "tags": [


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/128469

* Retries builds that are cancelled
* Adds a unit test to check for retrying a task on an infra failure

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
