### PR TITLE
Remove fake viewport from dashboard

### DIFF
--- a/dashboard/lib/widgets/lattice.dart
+++ b/dashboard/lib/widgets/lattice.dart
@@ -82,52 +82,27 @@ class LatticeScrollView extends StatelessWidget {
           onNotification: (notification) =>
               notification.metrics.axisDirection != AxisDirection.right &&
               notification.metrics.axisDirection != AxisDirection.left,
-          child: _FakeViewport(
-            child: Scrollbar(
-              thumbVisibility: true,
+          child: Scrollbar(
+            thumbVisibility: true,
+            controller: verticalController,
+            child: Scrollable(
+              dragStartBehavior: dragStartBehavior,
+              axisDirection: AxisDirection.down,
               controller: verticalController,
-              child: Scrollable(
-                dragStartBehavior: dragStartBehavior,
-                axisDirection: AxisDirection.down,
-                controller: verticalController,
-                physics: verticalPhysics,
-                scrollBehavior: _MouseDragScrollBehavior.instance,
-                viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _FakeViewport(
-                  child: _LatticeBody(
-                    textDirection: textDirection,
-                    horizontalOffset: horizontalOffset,
-                    verticalOffset: verticalOffset,
-                    cells: cells,
-                    cellSize: cellSize,
-                  ),
-                ),
+              physics: verticalPhysics,
+              scrollBehavior: _MouseDragScrollBehavior.instance,
+              viewportBuilder: (BuildContext context, ViewportOffset verticalOffset) => _LatticeBody(
+                textDirection: textDirection,
+                horizontalOffset: horizontalOffset,
+                verticalOffset: verticalOffset,
+                cells: cells,
+                cellSize: cellSize,
               ),
             ),
           ),
         ),
       ),
     );
-  }
-}
-
-class _FakeViewport extends SingleChildRenderObjectWidget {
-  const _FakeViewport({
-    super.child,
-  });
-
-  @override
-  _RenderFakeViewport createRenderObject(BuildContext context) => _RenderFakeViewport();
-}
-
-class _RenderFakeViewport extends RenderProxyBox implements RenderAbstractViewport {
-  _RenderFakeViewport({
-    RenderBox? child,
-  }) : super(child);
-
-  @override
-  RevealedOffset getOffsetToReveal(RenderObject target, double alignment, {Rect? rect}) {
-    // TODO(ianh): Implement this for real (and make these not be "Fake")
-    return RevealedOffset(offset: 0.0, rect: rect ?? target.paintBounds);
   }
 }
 


### PR DESCRIPTION
This removes the _FakeViewport from the build dashboard implementation. It was added in https://github.com/flutter/cocoon/pull/741, and we think it's sole purpose was the preserve the 1D expectations of widgets in the framework like scrollbars and overscroll indicators. Since adding support for 2D in the framework, the framework has been updated so that the fake viewport should no longer be necessary.

All of the tests pass, so I think this is safe to remove now that the framework is 2D compatible.

This came up as a test failure in https://github.com/flutter/flutter/pull/128812, where the function signature of getOffsetToReveal is being changed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
