### PR TITLE
Do not run release_build targets using cocoon scheduler.

### DIFF
--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -176,6 +176,35 @@ void main() {
         );
       });
 
+      test('filter release_build targets from release candidate branches', () {
+        final CiYaml releaseYaml = CiYaml(
+          slug: Config.flutterSlug,
+          branch: 'flutter-2.4-candidate.3',
+          config: pb.SchedulerConfig(
+            enabledBranches: <String>[
+              'flutter-2.4-candidate.3',
+            ],
+            targets: <pb.Target>[
+              pb.Target(
+                name: 'Linux A',
+                properties: <String, String>{'release_build': 'true'},
+              ),
+              pb.Target(
+                name: 'Linux B',
+              ),
+              pb.Target(
+                name: 'Mac A', // Should be ignored on release branches
+                bringup: true,
+              ),
+            ],
+          ),
+          totConfig: totCIYaml,
+        );
+        final List<Target> initialTargets = releaseYaml.postsubmitTargets;
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        expect(initialTargetNames, isEmpty);
+      });
+
       test('validates yaml config', () {
         expect(
           () => CiYaml(

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -205,6 +205,75 @@ void main() {
         expect(initialTargetNames, isEmpty);
       });
 
+      test('release_build targets for flutter-3.10-candidate.1 are not filtered', () {
+        final CiYaml releaseYaml = CiYaml(
+          slug: Config.flutterSlug,
+          branch: 'flutter-3.10-candidate.1',
+          config: pb.SchedulerConfig(
+            enabledBranches: <String>[
+              'flutter-3.10-candidate.1',
+            ],
+            targets: <pb.Target>[
+              pb.Target(
+                name: 'Linux A',
+                properties: <String, String>{'release_build': 'true'},
+              ),
+              pb.Target(
+                name: 'Linux B',
+              ),
+              pb.Target(
+                name: 'Mac A', // Should be ignored on release branches
+                bringup: true,
+              ),
+            ],
+          ),
+          totConfig: totCIYaml,
+        );
+        final List<Target> initialTargets = releaseYaml.postsubmitTargets;
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        expect(
+          initialTargetNames,
+          containsAll(
+            <String>[
+              'Linux A',
+            ],
+          ),
+        );
+      });
+
+      test('release_build targets for main are not filtered', () {
+        final CiYaml releaseYaml = CiYaml(
+          slug: Config.flutterSlug,
+          branch: 'main',
+          config: pb.SchedulerConfig(
+            targets: <pb.Target>[
+              pb.Target(
+                name: 'Linux A',
+                properties: <String, String>{'release_build': 'true'},
+              ),
+              pb.Target(
+                name: 'Linux B',
+              ),
+              pb.Target(
+                name: 'Mac A', // Should be ignored on release branches
+                bringup: true,
+              ),
+            ],
+          ),
+          totConfig: totCIYaml,
+        );
+        final List<Target> initialTargets = releaseYaml.postsubmitTargets;
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        expect(
+          initialTargetNames,
+          containsAll(
+            <String>[
+              'Linux A',
+            ],
+          ),
+        );
+      });
+
       test('validates yaml config', () {
         expect(
           () => CiYaml(


### PR DESCRIPTION
Targets with the release_build property are producing release artifacts and when running from release candidate branches it should run exclusively from dart_internal.

Bug: https://github.com/flutter/flutter/issues/128847

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
