### PR TITLE
Updated dashboard/test/widgets tests to handle useMaterial3:true by default

### DIFF
--- a/dashboard/test/widgets/commit_box_test.dart
+++ b/dashboard/test/widgets/commit_box_test.dart
@@ -23,6 +23,7 @@ void main() {
     ..sha = 'ShaShankRedemption';
   final String shortSha = expectedCommit.sha.substring(0, 7);
   final Widget basicApp = MaterialApp(
+    theme: ThemeData(useMaterial3: false),
     home: Material(
       child: Center(
         child: SizedBox(

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -61,6 +61,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: ValueProvider<BuildState>(
           value: buildState,
           child: const Material(
@@ -115,6 +116,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: ValueProvider<BuildState>(
           value: buildState,
           child: const Material(
@@ -192,7 +194,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.dark(),
+        theme: ThemeData.dark(useMaterial3: false),
         home: ValueProvider<BuildState>(
           value: buildState,
           child: const Material(
@@ -333,6 +335,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: TaskGrid(
             buildState: FakeBuildState(),
@@ -454,6 +457,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: TaskGrid(
             buildState: FakeBuildState(moreStatusesExist: false),
@@ -467,6 +471,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: TaskGrid(
             buildState: FakeBuildState(moreStatusesExist: true),
@@ -799,6 +804,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(useMaterial3: false),
         home: Material(
           child: TaskGrid(
             buildState: FakeBuildState(),

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -88,6 +88,7 @@ void main() {
       Now.fixed(
         dateTime: nowTime,
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: TestGrid(
               buildState: buildState,
@@ -146,6 +147,7 @@ void main() {
       Now.fixed(
         dateTime: nowTime,
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: TestGrid(
               buildState: buildState,
@@ -299,6 +301,7 @@ void main() {
       Now.fixed(
         dateTime: nowTime,
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: false),
           home: Scaffold(
             body: TestGrid(
               buildState: buildState,

--- a/dashboard/test/widgets/user_sign_in_test.dart
+++ b/dashboard/test/widgets/user_sign_in_test.dart
@@ -15,6 +15,7 @@ import '../utils/golden.dart';
 import '../utils/mocks.dart';
 
 final Widget testApp = MaterialApp(
+  theme: ThemeData(useMaterial3: false),
   home: Scaffold(
     appBar: AppBar(
       actions: const <Widget>[


### PR DESCRIPTION
Updated all of the golden image file tests in dashboard/test/widgets to specify `useMaterial3: false` to ensure that the images continue to match when the default for useMaterial3 is changed to true.