### PR TITLE
Do not dispose of the client in test check

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -258,15 +258,14 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     final GitHub gitHubClient = await config.createGitHubClient(pullRequest: pr);
     await _validateRefs(gitHubClient, pr);
     if (kNeedsTests.contains(slug) && isTipOfTree) {
-        switch (slug.name) {
-          case 'flutter':
-            return _applyFrameworkRepoLabels(gitHubClient, eventAction, pr);
-          case 'engine':
-            return _applyEngineRepoLabels(gitHubClient, eventAction, pr);
-          case 'packages':
-            return _applyPackageTestChecks(gitHubClient, eventAction, pr);
-        
-      } 
+      switch (slug.name) {
+        case 'flutter':
+          return _applyFrameworkRepoLabels(gitHubClient, eventAction, pr);
+        case 'engine':
+          return _applyEngineRepoLabels(gitHubClient, eventAction, pr);
+        case 'packages':
+          return _applyPackageTestChecks(gitHubClient, eventAction, pr);
+      }
     }
   }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -258,7 +258,6 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     final GitHub gitHubClient = await config.createGitHubClient(pullRequest: pr);
     await _validateRefs(gitHubClient, pr);
     if (kNeedsTests.contains(slug) && isTipOfTree) {
-      try {
         switch (slug.name) {
           case 'flutter':
             return _applyFrameworkRepoLabels(gitHubClient, eventAction, pr);
@@ -266,10 +265,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
             return _applyEngineRepoLabels(gitHubClient, eventAction, pr);
           case 'packages':
             return _applyPackageTestChecks(gitHubClient, eventAction, pr);
-        }
-      } finally {
-        gitHubClient.dispose();
-      }
+        
+      } 
     }
   }
 


### PR DESCRIPTION
When requests are made to the webhook_subscription there is one method that when called is disposing of the github client. In the _checkForTests methods it calls dispose on the github client which closes the connection while it is still in scope. This is the only part of the code that does this. This was killing the client for any pull request event for edited, opened, and reopened but not synchronized. 

The fix will be investigated further but this prevents .ci.yaml checks and other issues blocking checkRuns from starting.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes: https://github.com/flutter/flutter/issues/129134

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
