### PR TITLE
Update to use mergeable as mergeable_state is only partially documented

### DIFF
--- a/auto_submit/lib/validations/unknown_mergeable.dart
+++ b/auto_submit/lib/validations/unknown_mergeable.dart
@@ -12,8 +12,8 @@ class UnknownMergeable extends Validation {
     required super.config,
   });
 
-  @override
   /// Verifies the PR is in a known mergeable state.
+  @override
   Future<ValidationResult> validate(QueryResult result, github.PullRequest messagePullRequest) async {
     // This is used to skip landing until we are sure the PR is mergeable.
     final bool unknownMergeableState = messagePullRequest.mergeable == null;

--- a/auto_submit/lib/validations/unknown_mergeable.dart
+++ b/auto_submit/lib/validations/unknown_mergeable.dart
@@ -13,11 +13,10 @@ class UnknownMergeable extends Validation {
   });
 
   @override
-
   /// Verifies the PR is in a known mergeable state.
   Future<ValidationResult> validate(QueryResult result, github.PullRequest messagePullRequest) async {
     // This is used to skip landing until we are sure the PR is mergeable.
-    final bool unknownMergeableState = messagePullRequest.mergeableState == UNKNOWN_MERGE_STATE;
+    final bool unknownMergeableState = messagePullRequest.mergeable == null;
     return ValidationResult(!unknownMergeableState, Action.IGNORE_TEMPORARILY, '');
   }
 }


### PR DESCRIPTION
Updating our unknown mergeable check to use the mergeable field instead of mergeable_state as the mergeable state enum is only partially documented in the Graphql API.

https://docs.github.com/en/github-ae@latest/graphql/reference/enums#mergeablestate

Remove ambiguity with the check.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes: https://github.com/flutter/flutter/issues/129636

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
