### PR TITLE
Expose buildbucket status enums for easier translation to Github statuses.

### DIFF
--- a/packages/buildbucket-dart/CHANGELOG.md
+++ b/packages/buildbucket-dart/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+- Expose status enums and related status fields from the Build proto.
+
 # 1.0.1
 
 - Update required Dart revisions for sound null safety.

--- a/packages/buildbucket-dart/lib/buildbucket_pb.dart
+++ b/packages/buildbucket-dart/lib/buildbucket_pb.dart
@@ -5,5 +5,7 @@
 library buildbucket;
 
 export 'src/generated/go.chromium.org/luci/buildbucket/proto/build.pb.dart' show Build;
+export 'src/generated/go.chromium.org/luci/buildbucket/proto/common.pb.dart'
+    show Status, StatusDetails, StatusDetails_ResourceExhaustion, StatusDetails_Timeout;
 export 'src/generated/go.chromium.org/luci/buildbucket/proto/notification.pb.dart'
     show NotificationConfig, BuildsV2PubSub, PubSubCallBack;

--- a/packages/buildbucket-dart/pubspec.yaml
+++ b/packages/buildbucket-dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buildbucket
 description: LUCI Buildbucket library. Protos and utilities to communicate with LUCI buildbucket service.
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/flutter/cocoon/tree/main/packages/buildbucket-dart
 
 environment:


### PR DESCRIPTION
Exposing more of the status enums from the protos so we can more easily translate the statuses to github statuses for check runs.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
