### PR TITLE
Replacing luci-flutter with tree-status as context name in GitHub presubmit

### DIFF
--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -63,7 +63,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
         log.fine('Updating status of ${slug.fullName}#${pr.number} from ${update.status} to $status');
         final CreateStatus request = CreateStatus(status);
         request.targetUrl = 'https://flutter-dashboard.appspot.com/#/build?repo=${slug.name}';
-        request.context = 'luci-${slug.name}';
+        request.context = 'tree-status';
         if (status != GithubBuildStatusUpdate.statusSuccess) {
           request.description = config.flutterBuildDescription;
         }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -15,8 +15,11 @@ import '../service/log.dart';
 class CiSuccessful extends Validation {
   /// The status checks that are not related to changes in this PR.
   static const Set<String> notInAuthorsControl = <String>{
+    // TODO(keyonghan): Remove `luci-<repo>` when `tree-status` populates.
+    // https://github.com/flutter/flutter/issues/92931
     'luci-flutter', // flutter repo
     'luci-engine', // engine repo
+    'tree-status', // flutter/engine repo
     'submit-queue', // packages repo
   };
 
@@ -107,12 +110,14 @@ class CiSuccessful extends Validation {
     if (statuses.isEmpty) {
       return false;
     }
-    final String treeStatusName = 'luci-${slug.name}';
-    log.info('Validating tree status: ${slug.name}, statuses: $statuses');
+    // TODO(keyonghan): Remove `luci-<repo>` when `tree-status` populates.
+    // https://github.com/flutter/flutter/issues/92931
+    final List<String> treeStatusNames = ['luci-${slug.name}', 'tree-status'];
+    log.info('Validating tree status: ${slug.name}/tree-status, statuses: $statuses');
 
     /// Scan list of statuses to see if the tree status exists (this list is expected to be <5 items)
     for (ContextNode status in statuses) {
-      if (status.context == treeStatusName) {
+      if (treeStatusNames.contains(status.context)) {
         // Does only one tree status need to be set for the condition?
         treeStatusValid = true;
       }

--- a/auto_submit/test/requests/github_webhook_test_data.dart
+++ b/auto_submit/test/requests/github_webhook_test_data.dart
@@ -391,11 +391,11 @@ const String repositoryStatusesMock = '''{
   "statuses": [
     {
       "state": "success",
-      "context": "luci-flutter"
+      "context": "tree-status"
     },
     {
       "state": "success",
-      "context": "luci-flutter/flutter"
+      "context": "tree-status/flutter"
     }
   ]
 }''';
@@ -405,7 +405,7 @@ const String repositoryStatusesWithGoldMock = '''{
   "statuses": [
     {
       "state": "success",
-      "context": "luci-engine"
+      "context": "tree-status"
     },
     {
       "state": "PENDING",
@@ -419,7 +419,7 @@ const String repositoryStatusesWithFailedGoldMock = '''{
   "statuses": [
     {
       "state": "success",
-      "context": "luci-engine"
+      "context": "tree-status"
     },
     {
       "state": "failure",
@@ -448,12 +448,12 @@ const String failedAuthorsStatusesMock = '''{
   "statuses": [
     {
       "state": "failure",
-      "context": "luci-flutter",
+      "context": "tree-status",
       "targetUrl": "https://ci.example.com/1000/output"
     },
     {
       "state": "failure",
-      "context": "luci-engine",
+      "context": "tree-status",
       "targetUrl": "https://ci.example.com/2000/output"
     }
   ]

--- a/auto_submit/test/utilities/utils.dart
+++ b/auto_submit/test/utilities/utils.dart
@@ -14,8 +14,8 @@ const String title = 'some_title';
 class StatusHelper {
   const StatusHelper(this.name, this.state);
 
-  static const StatusHelper flutterBuildSuccess = StatusHelper('luci-flutter', 'SUCCESS');
-  static const StatusHelper flutterBuildFailure = StatusHelper('luci-flutter', 'FAILURE');
+  static const StatusHelper flutterBuildSuccess = StatusHelper('tree-status', 'SUCCESS');
+  static const StatusHelper flutterBuildFailure = StatusHelper('tree-status', 'FAILURE');
   static const StatusHelper otherStatusFailure = StatusHelper('other status', 'FAILURE');
 
   final String name;

--- a/auto_submit/test/validations/approval_test_data.dart
+++ b/auto_submit/test/validations/approval_test_data.dart
@@ -25,7 +25,7 @@ String constructSingleReviewerReview({
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"SUCCESS",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }
@@ -77,7 +77,7 @@ String constructTwoReviewerReview({
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"SUCCESS",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }
@@ -134,7 +134,7 @@ String constructMultipleReviewerReview({
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"SUCCESS",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }
@@ -192,7 +192,7 @@ const String multipleReviewsSameAuthor = '''
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"SUCCESS",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }

--- a/auto_submit/test/validations/ci_successful_test_data.dart
+++ b/auto_submit/test/validations/ci_successful_test_data.dart
@@ -107,7 +107,7 @@ const String nonNullStatusSUCCESSCommitRepositoryJson = """
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"SUCCESS",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }
@@ -154,7 +154,7 @@ const String nonNullStatusFAILURECommitRepositoryJson = """
                 "status": {
                   "contexts":[
                     {
-                      "context":"luci-flutter",
+                      "context":"tree-status",
                       "state":"FAILURE",
                       "targetUrl":"https://ci.example.com/1000/output"
                     }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/92931

Follow up is to clean up old `luci-flutter`/`luci-engine` names from auto-submit.