### PR TITLE
Remove legacy tree statuses from auto-submit

### DIFF
--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -15,10 +15,6 @@ import '../service/log.dart';
 class CiSuccessful extends Validation {
   /// The status checks that are not related to changes in this PR.
   static const Set<String> notInAuthorsControl = <String>{
-    // TODO(keyonghan): Remove `luci-<repo>` when `tree-status` populates.
-    // https://github.com/flutter/flutter/issues/92931
-    'luci-flutter', // flutter repo
-    'luci-engine', // engine repo
     'tree-status', // flutter/engine repo
     'submit-queue', // packages repo
   };
@@ -110,14 +106,12 @@ class CiSuccessful extends Validation {
     if (statuses.isEmpty) {
       return false;
     }
-    // TODO(keyonghan): Remove `luci-<repo>` when `tree-status` populates.
-    // https://github.com/flutter/flutter/issues/92931
-    final List<String> treeStatusNames = ['luci-${slug.name}', 'tree-status'];
+    const String treeStatusName = 'tree-status';
     log.info('Validating tree status: ${slug.name}/tree-status, statuses: $statuses');
 
     /// Scan list of statuses to see if the tree status exists (this list is expected to be <5 items)
     for (ContextNode status in statuses) {
-      if (treeStatusNames.contains(status.context)) {
+      if (status.context == treeStatusName) {
         // Does only one tree status need to be set for the condition?
         treeStatusValid = true;
       }


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/2875, and fixes: https://github.com/flutter/flutter/issues/92931

The new tree status has been populated:
<img width="1027" alt="Screenshot 2023-06-29 at 3 28 17 PM" src="https://github.com/flutter/cocoon/assets/54558023/5b067f69-41d9-4df0-8805-62c6f6f0a886">
