### PR TITLE
Update cocoon code for new label conventions

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -107,7 +107,7 @@ Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fi
 
   List<String> get issueLabels {
     final List<String> labels = <String>[
-      kSevereFlakeLabel,
+      kFlakeLabel,
       kP0Label,
     ];
     final String? teamLabel = getTeamLabelFromTeam(ownership.team);

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -15,8 +15,7 @@ import '../service/github_service.dart';
 import '../../protos.dart' as pb;
 
 // String constants.
-const String kTeamFlakeLabel = 'team: flakes';
-const String kSevereFlakeLabel = 'severe: flake';
+const String kFlakeLabel = 'c: flake';
 const String kFrameworkLabel = 'framework';
 const String kToolLabel = 'tool';
 const String kEngineLabel = 'engine';
@@ -108,7 +107,6 @@ Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fi
 
   List<String> get issueLabels {
     final List<String> labels = <String>[
-      kTeamFlakeLabel,
       kSevereFlakeLabel,
       kP0Label,
     ];
@@ -234,7 +232,7 @@ final RegExp shardTestOwners = RegExp('## Shards tests\n(?<$kOwnerGroupName>.+)'
 /// The state can be 'open', 'closed', or 'all'.
 Future<Map<String?, Issue>> getExistingIssues(GithubService gitHub, RepositorySlug slug, {String state = 'all'}) async {
   final Map<String?, Issue> nameToExistingIssue = <String?, Issue>{};
-  for (final Issue issue in await gitHub.listIssues(slug, state: state, labels: <String>[kTeamFlakeLabel])) {
+  for (final Issue issue in await gitHub.listIssues(slug, state: state, labels: <String>[kFlakeLabel])) {
     if (issue.htmlUrl.contains('pull') == true) {
       // For some reason, this github api may also return pull requests.
       continue;

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -34,7 +34,6 @@ Set<RepositorySlug> kNeedsTests = <RepositorySlug>{
 };
 
 final RegExp kEngineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh)$');
-final List<String> kNeedsTestsLabels = <String>['needs tests'];
 
 // Extentions for files that use // for single line comments.
 // See [_allChangesAreCodeComments] for more.
@@ -300,7 +299,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     if (pr.user!.login == 'fluttergithubbot') {
       needsTests = false;
-      labels.addAll(<String>['team', 'tech-debt', 'team: flakes']);
+      labels.addAll(<String>['c: tech-debt', 'c: flakes']);
     }
 
     if (labels.isNotEmpty) {
@@ -395,7 +394,6 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       final String body = config.missingTestsPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, body)) {
         await gitHubClient.issues.createComment(slug, pr.number!, body);
-        await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, kNeedsTestsLabels);
       }
     }
   }
@@ -457,7 +455,6 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       final String body = config.missingTestsPullRequestMessage;
       if (!await _alreadyCommented(gitHubClient, pr, body)) {
         await gitHubClient.issues.createComment(slug, pr.number!, body);
-        await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, kNeedsTestsLabels);
       }
     }
   }

--- a/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test_data.dart
@@ -199,8 +199,7 @@ final List<BuilderRecord> semanticsIntegrationTestRecordsFailed = <BuilderRecord
 
 const String expectedSemanticsIntegrationTestOwner = 'HansMuller';
 const List<String> expectedSemanticsIntegrationTestLabels = <String>[
-  'team: flakes',
-  'severe: flake',
+  'c: flake',
   'P0',
   'framework',
 ];

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test_data.dart
@@ -230,8 +230,7 @@ Please follow https://github.com/flutter/flutter/wiki/Reducing-Test-Flakiness#fi
 
 const String expectedSemanticsIntegrationTestResponseAssignee = 'HansMuller';
 const List<String> expectedSemanticsIntegrationTestResponseLabels = <String>[
-  'team: flakes',
-  'severe: flake',
+  'c: flake',
   'P0',
   'framework',
 ];
@@ -341,8 +340,7 @@ final List<BuilderStatistic> analyzeTestResponse = <BuilderStatistic>[
 ];
 const String expectedAnalyzeTestResponseAssignee = 'HansMuller';
 const List<String> expectedAnalyzeTestResponseLabels = <String>[
-  'team: flakes',
-  'severe: flake',
+  'c: flake',
   'P0',
   'framework',
 ];
@@ -374,8 +372,7 @@ final List<BuilderStatistic> unknownTestResponse = <BuilderStatistic>[
 ];
 const String expectedFrameworkTestResponseAssignee = 'HansMuller';
 const List<String> expectedFrameworkTestResponseLabels = <String>[
-  'team: flakes',
-  'severe: flake',
+  'c: flake',
   'P0',
   'framework',
 ];

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1325,14 +1325,6 @@ void foo() {
           argThat(contains(config.missingTestsPullRequestMessageValue)),
         ),
       );
-
-      verifyNever(
-        issuesService.addLabelsToIssue(
-          Config.engineSlug,
-          issueNumber,
-          <String>['needs tests'],
-        ),
-      );
     });
 
     test('Engine does not label PR for no tests if author is skia-flutter-autoroll', () async {
@@ -1364,14 +1356,6 @@ void foo() {
           Config.engineSlug,
           issueNumber,
           argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-
-      verifyNever(
-        issuesService.addLabelsToIssue(
-          Config.engineSlug,
-          issueNumber,
-          <String>['needs tests'],
         ),
       );
     });
@@ -1763,14 +1747,6 @@ void foo() {
           Config.packagesSlug,
           issueNumber,
           argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      ).called(1);
-
-      verify(
-        issuesService.addLabelsToIssue(
-          Config.packagesSlug,
-          issueNumber,
-          <String>['needs tests'],
         ),
       ).called(1);
     });

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -319,7 +319,7 @@ void main() {
       expect(commit, isNotNull);
       expect(commit.status, isNull);
 
-      final github.PullRequest npr = generatePullRequest(labelName: 'needs tests');
+      final github.PullRequest npr = generatePullRequest();
       githubService.checkRunsData = checkRunsMock;
 
       ciSuccessful.validate(queryResult, npr).then((value) {
@@ -338,7 +338,7 @@ void main() {
       final PullRequest pr = queryResult.repository!.pullRequest!;
       expect(pr, isNotNull);
 
-      final github.PullRequest npr = generatePullRequest(labelName: 'needs tests');
+      final github.PullRequest npr = generatePullRequest();
       githubService.checkRunsData = checkRunsMock;
 
       ciSuccessful.validate(queryResult, npr).then((value) {
@@ -402,7 +402,7 @@ void main() {
       expect(commit, isNotNull);
       expect(commit.status, isNotNull);
 
-      final github.PullRequest npr = generatePullRequest(labelName: 'needs tests');
+      final github.PullRequest npr = generatePullRequest();
       githubService.checkRunsData = checkRunsMock;
 
       ciSuccessful.validate(queryResult, npr).then((value) {


### PR DESCRIPTION
`team: flakes`, `severe: flake` -> `c: flake`
`needs tests` -> removed
`tech debt` -> `c: tech debt`