### PR TITLE
[autosubmit] Do not remove label when author is a member

### DIFF
--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -755,7 +755,8 @@ void main() {
       await checkPullRequest.get();
       expectedOptions.add(flutterOption);
       verifyQueries(expectedOptions);
-      assert(pubsub.messagesQueue.isEmpty);
+      // Re-add to queue to poll for reviews
+      assert(pubsub.messagesQueue.isNotEmpty);
     });
 
     test('All messages are pulled', () async {

--- a/auto_submit/test/service/validation_service_test.dart
+++ b/auto_submit/test/service/validation_service_test.dart
@@ -62,7 +62,7 @@ void main() {
     });
   });
 
-  test('Removes label and post comment when no approval', () async {
+  test('Removes label and post comment when no approval for non-flutter hacker', () async {
     final PullRequestHelper flutterRequest = PullRequestHelper(
       prNumber: 0,
       lastCommitHash: oid,
@@ -70,7 +70,7 @@ void main() {
     );
     githubService.checkRunsData = checkRunsMock;
     githubService.createCommentData = createCommentMock;
-    githubService.isTeamMemberMockMap['author1'] = true;
+    githubService.isTeamMemberMockMap['author1'] = false;
     githubService.isTeamMemberMockMap['member'] = true;
     final FakePubSub pubsub = FakePubSub();
     final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);

--- a/auto_submit/test/validations/approval_test.dart
+++ b/auto_submit/test/validations/approval_test.dart
@@ -99,7 +99,7 @@ void main() {
       final ValidationResult result = await computeValidationResult(review);
 
       expect(result.result, isFalse);
-      expect(result.action, Action.REMOVE_LABEL);
+      expect(result.action, Action.IGNORE_TEMPORARILY);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
       expect(result.message.contains('need 1 more review'), isTrue);
     });
@@ -149,7 +149,7 @@ void main() {
       final ValidationResult result = await computeValidationResult(review);
 
       expect(result.result, isFalse);
-      expect(result.action, Action.REMOVE_LABEL);
+      expect(result.action, Action.IGNORE_TEMPORARILY);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
       expect(result.message.contains('need 1 more review'), isTrue);
     });


### PR DESCRIPTION
This is a quality of life change. I often find myself needlessly coming back to PRs to only add the autosubmit label. Instead, I'd like to add when I open my trivial PRs.

This is to align with how Google's autosubmit works.