### PR TITLE
`c: flakes` was a typo

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -299,7 +299,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     if (pr.user!.login == 'fluttergithubbot') {
       needsTests = false;
-      labels.addAll(<String>['c: tech-debt', 'c: flakes']);
+      labels.addAll(<String>['c: tech-debt', 'c: flake']);
     }
 
     if (labels.isNotEmpty) {


### PR DESCRIPTION
The label is actually called `c: flake`.
