### PR TITLE
Remove retries datastore from our Datastore service wrapper

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -247,59 +247,39 @@ class DatastoreService {
   Future<void> insert(List<Model<dynamic>> rows) async {
     final List<List<Model<dynamic>>> shards = await shard(rows);
     for (List<Model<dynamic>> shard in shards) {
-      await runTransactionWithRetries(
-        () async {
-          await db.withTransaction<void>((Transaction transaction) async {
-            transaction.queueMutations(inserts: shard);
-            await transaction.commit();
-          });
-        },
-        retryOptions: retryOptions,
-      );
+      await db.withTransaction<void>((Transaction transaction) async {
+        transaction.queueMutations(inserts: shard);
+        await transaction.commit();
+      });
     }
   }
 
   /// Looks up registers by [keys].
   Future<List<T?>> lookupByKey<T extends Model<dynamic>>(List<Key<dynamic>> keys) async {
     List<T?> results = <T>[];
-    await runTransactionWithRetries(
-      () async {
-        await db.withTransaction<void>((Transaction transaction) async {
-          results = await transaction.lookup<T>(keys);
-          await transaction.commit();
-        });
-      },
-      retryOptions: retryOptions,
-    );
+    await db.withTransaction<void>((Transaction transaction) async {
+      results = await transaction.lookup<T>(keys);
+      await transaction.commit();
+    });
     return results;
   }
 
   /// Looks up registers by value using a single [key].
   Future<T> lookupByValue<T extends Model<dynamic>>(Key<dynamic> key, {T Function()? orElse}) async {
     late T result;
-    await runTransactionWithRetries(
-      () async {
-        await db.withTransaction<void>((Transaction transaction) async {
-          result = await db.lookupValue<T>(key, orElse: orElse);
-          await transaction.commit();
-        });
-      },
-      retryOptions: retryOptions,
-    );
+    await db.withTransaction<void>((Transaction transaction) async {
+      result = await db.lookupValue<T>(key, orElse: orElse);
+      await transaction.commit();
+    });
     return result;
   }
 
   /// Runs a function inside a transaction providing a [Transaction] parameter.
   Future<T?> withTransaction<T>(Future<T> Function(Transaction) handler) async {
     T? result;
-    await runTransactionWithRetries(
-      () async {
-        await db.withTransaction<void>((Transaction transaction) async {
-          result = await handler(transaction);
-        });
-      },
-      retryOptions: retryOptions,
-    );
+    await db.withTransaction<void>((Transaction transaction) async {
+      result = await handler(transaction);
+    });
     return result;
   }
 

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -246,7 +246,7 @@ class DatastoreService {
   // Note: please do not add retries to any of the following queries. The following
   // change was made to add retries to the appengine grpc implementation of the
   // datastore service: https://github.com/dart-lang/appengine/pull/167.
-  // Adding retries to the following queries will cause conflicts with commits 
+  // Adding retries to the following queries will cause conflicts with commits
   // and effectively prevent us from inserting update to Datastore.
   //
   // See this issue for a more detailed summary and analysis:

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -243,6 +243,15 @@ class DatastoreService {
     return shards;
   }
 
+  // Note: please do not add retries to any of the following queries. The following
+  // change was made to add retries to the appengine grpc implementation of the
+  // datastore service: https://github.com/dart-lang/appengine/pull/167.
+  // Adding retries to the following queries will cause conflicts with commits 
+  // and effectively prevent us from inserting update to Datastore.
+  //
+  // See this issue for a more detailed summary and analysis:
+  // https://github.com/flutter/flutter/issues/131310
+
   /// Inserts [rows] into datastore sharding the inserts if needed.
   Future<void> insert(List<Model<dynamic>> rows) async {
     final List<List<Model<dynamic>>> shards = await shard(rows);

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  collection: 1.17.2
+  collection: 1.18.0
   fixnum: 1.1.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/131310 for a detailed explanation of the problem this fix addresses. The main culprit was a change made to the Appengine dependency we use that added retries in the background.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/131192

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
