### PR TITLE
[app_dart] Remove DatastoreService.runTransactionsWithRetries

### DIFF
--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -7,12 +7,9 @@ import 'dart:math';
 
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:gcloud/datastore.dart' as gcloud_datastore;
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart' show RepositorySlug, PullRequest;
-import 'package:grpc/grpc.dart';
 import 'package:meta/meta.dart';
-import 'package:retry/retry.dart';
 
 import '../model/appengine/branch.dart';
 import '../model/appengine/commit.dart';
@@ -34,25 +31,6 @@ const int defaultTimeSeriesValuesNumber = 1500;
 /// Function signature for a [DatastoreService] provider.
 typedef DatastoreServiceProvider = DatastoreService Function(DatastoreDB db);
 
-/// Function signature that will be executed with retries.
-typedef RetryHandler = Function();
-
-/// Runs a db transaction with retries.
-///
-/// It uses quadratic backoff starting with 200ms and 3 max attempts.
-/// for context please read https://github.com/flutter/flutter/issues/54615.
-Future<void> runTransactionWithRetries(RetryHandler retryHandler, {RetryOptions? retryOptions}) {
-  final RetryOptions r = retryOptions ??
-      const RetryOptions(
-        maxDelay: Duration(seconds: 10),
-        maxAttempts: 3,
-      );
-  return r.retry(
-    retryHandler,
-    retryIf: (Exception e) => e is gcloud_datastore.TransactionAbortedError || e is GrpcError,
-  );
-}
-
 /// Service class for interacting with App Engine cloud datastore.
 ///
 /// This service exists to provide an API for common datastore queries made by
@@ -62,21 +40,13 @@ class DatastoreService {
   /// Creates a new [DatastoreService].
   ///
   /// The [db] argument must not be null.
-  const DatastoreService(this.db, this.maxEntityGroups, {RetryOptions? retryOptions})
-      : retryOptions = retryOptions ??
-            const RetryOptions(
-              maxDelay: Duration(seconds: 10),
-              maxAttempts: 3,
-            );
+  const DatastoreService(this.db, this.maxEntityGroups);
 
   /// Maximum number of entity groups to process at once.
   final int maxEntityGroups;
 
   /// The backing [DatastoreDB] object.
   final DatastoreDB db;
-
-  /// Transaction retry configurations.
-  final RetryOptions retryOptions;
 
   /// Creates and returns a [DatastoreService] using [db] and [maxEntityGroups].
   static DatastoreService defaultProvider(DatastoreDB db) {

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -18,7 +18,6 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
-import 'package:retry/retry.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -45,7 +45,6 @@ void main() {
     late MockClient mockHttpClient;
     late RepositorySlug slug;
     late RepositorySlug engineSlug;
-    late RetryOptions retryOptions;
 
     final List<LogRecord> records = <LogRecord>[];
 
@@ -60,12 +59,6 @@ void main() {
       );
       tester = ApiRequestHandlerTester(context: authContext);
       mockHttpClient = MockClient((_) async => http.Response('{}', HttpStatus.ok));
-      retryOptions = const RetryOptions(
-        delayFactor: Duration(microseconds: 1),
-        maxDelay: Duration(microseconds: 2),
-        maxAttempts: 2,
-      );
-
       githubGraphQLClient.mutateResultForOptions = (MutationOptions options) => createFakeQueryResult();
       githubGraphQLClient.queryResultForOptions = (QueryOptions options) {
         if (options.variables['sRepoName'] == slug.name) {
@@ -90,11 +83,7 @@ void main() {
         config: config,
         authenticationProvider: auth,
         datastoreProvider: (DatastoreDB db) {
-          return DatastoreService(
-            db,
-            5,
-            retryOptions: retryOptions,
-          );
+          return DatastoreService(db, 5);
         },
         goldClient: mockHttpClient,
         ingestionDelay: Duration.zero,
@@ -431,11 +420,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -839,11 +824,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -900,11 +881,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -961,11 +938,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -1031,11 +1004,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -1099,11 +1068,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -1181,11 +1146,7 @@ void main() {
             config: config,
             authenticationProvider: auth,
             datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
+              return DatastoreService(config.db, 5);
             },
             goldClient: mockHttpClient,
             ingestionDelay: Duration.zero,
@@ -1391,11 +1352,7 @@ void main() {
           config: config,
           authenticationProvider: auth,
           datastoreProvider: (DatastoreDB db) {
-            return DatastoreService(
-              config.db,
-              5,
-              retryOptions: retryOptions,
-            );
+            return DatastoreService(config.db, 5);
           },
           goldClient: mockHttpClient,
           ingestionDelay: Duration.zero,
@@ -1506,11 +1463,7 @@ void main() {
           config: config,
           authenticationProvider: auth,
           datastoreProvider: (DatastoreDB db) {
-            return DatastoreService(
-              config.db,
-              5,
-              retryOptions: retryOptions,
-            );
+            return DatastoreService(config.db, 5);
           },
           goldClient: mockHttpClient,
           ingestionDelay: Duration.zero,

--- a/app_dart/test/service/datastore_test.dart
+++ b/app_dart/test/service/datastore_test.dart
@@ -6,10 +6,7 @@ import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:gcloud/datastore.dart' as gcloud_datastore;
 import 'package:gcloud/db.dart';
-import 'package:grpc/grpc.dart';
-import 'package:retry/retry.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
@@ -184,59 +181,6 @@ void main() {
       });
       expect(expected, equals('success'));
       expect(config.db.values[commit.key], equals(commit));
-    });
-  });
-
-  group('RunTransactionWithRetry', () {
-    late RetryOptions retryOptions;
-
-    setUp(() {
-      retryOptions = const RetryOptions(
-        delayFactor: Duration(milliseconds: 1),
-        maxDelay: Duration(milliseconds: 2),
-        maxAttempts: 2,
-      );
-    });
-
-    test('retriesOnGrpcError', () async {
-      final Counter counter = Counter();
-      try {
-        await runTransactionWithRetries(
-          () async {
-            counter.increase();
-            throw const GrpcError.aborted();
-          },
-          retryOptions: retryOptions,
-        );
-      } catch (e) {
-        expect(e, isA<GrpcError>());
-      }
-      expect(counter.value(), greaterThan(1));
-    });
-    test('retriesTransactionAbortedError', () async {
-      final Counter counter = Counter();
-      try {
-        await runTransactionWithRetries(
-          () async {
-            counter.increase();
-            throw gcloud_datastore.TransactionAbortedError();
-          },
-          retryOptions: retryOptions,
-        );
-      } catch (e) {
-        expect(e, isA<gcloud_datastore.TransactionAbortedError>());
-      }
-      expect(counter.value(), greaterThan(1));
-    });
-    test('DoesNotRetryOnSuccess', () async {
-      final Counter counter = Counter();
-      await runTransactionWithRetries(
-        () async {
-          counter.increase();
-        },
-        retryOptions: retryOptions,
-      );
-      expect(counter.value(), equals(1));
     });
   });
 }


### PR DESCRIPTION
Clean up from https://github.com/flutter/cocoon/pull/2954 to remove the function as it's no longer used.