### PR TITLE
Restore auto rerun on failures

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -85,8 +85,9 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       task.updateFromBuild(build);
       await datastore.insert(<Task>[task]);
       log.fine('Updated datastore from $oldTaskStatus to ${task.status}');
+    } else {
+      log.fine('skip processing for build with status scheduled or task with status finished.');
     }
-    log.fine('skip processing for build with status scheduled or task with status finished.');
 
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -172,7 +172,7 @@ void main() {
       4507531199512576,
       name: 'Linux A',
       parent: commit,
-      status: Task.statusNew,
+      status: Task.statusFailed,
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
@@ -183,7 +183,7 @@ void main() {
       userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
     );
 
-    expect(task.status, Task.statusNew);
+    expect(task.status, Task.statusFailed);
     expect(task.attempts, 1);
     expect(await tester.post(handler), Body.empty);
     expect(task.status, Task.statusInProgress);
@@ -196,7 +196,7 @@ void main() {
       4507531199512576,
       name: 'Linux A',
       parent: commit,
-      status: Task.statusNew,
+      status: Task.statusInfraFailure,
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
@@ -207,7 +207,7 @@ void main() {
       userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
     );
 
-    expect(task.status, Task.statusNew);
+    expect(task.status, Task.statusInfraFailure);
     expect(task.attempts, 1);
     expect(await tester.post(handler), Body.empty);
     expect(task.status, Task.statusInProgress);
@@ -220,7 +220,7 @@ void main() {
       4507531199512576,
       name: 'Linux A',
       parent: commit,
-      status: Task.statusNew,
+      status: Task.statusInfraFailure,
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
@@ -231,7 +231,7 @@ void main() {
       userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
     );
 
-    expect(task.status, Task.statusNew);
+    expect(task.status, Task.statusInfraFailure);
     expect(task.attempts, 1);
     expect(await tester.post(handler), Body.empty);
     expect(task.status, Task.statusInProgress);


### PR DESCRIPTION
Follow up of https://github.com/flutter/cocoon/pull/2964, which exit early also for the failed case. It causes auto-retry skipped.

This PR reorg the logics and restores the rerun logic back for the failed case.