### PR TITLE
Add logic to handle a task for a commit that is missing

### DIFF
--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -108,6 +108,19 @@ class Commit extends Model<String> {
       ..write(')');
     return buf.toString();
   }
+
+  static Commit from(Commit commit) {
+    return Commit(
+      key: commit.key,
+      sha: commit.sha,
+      timestamp: commit.timestamp,
+      author: commit.author,
+      authorAvatarUrl: commit.authorAvatarUrl,
+      message: commit.message,
+      repository: commit.repository,
+      branch: commit.branch,
+    );
+  }
 }
 
 /// The serialized representation of a [Commit].

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -162,8 +162,7 @@ class Task extends Model<int> {
     final int endTime = build.endTime?.millisecondsSinceEpoch ?? 0;
     log.fine("Start/end time (ms): $startTime, $endTime");
 
-    if (commit == null)
-    {
+    if (commit == null) {
       final String id = '${slug.fullName}/$branch/$sha';
       final Key<String> commitKey = datastore.db.emptyKey.append<String>(Commit, id: id);
       commit = await datastore.db.lookupValue<Commit>(commitKey);

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -107,21 +107,21 @@ class DartInternalSubscription extends SubscriptionHandler {
     return Body.forJson(taskToInsert.toString());
   }
 
-  Future<Commit> _getOrCreateCommitForTask(DatastoreService datastore, Build build,) async {
-    log.info(
-        "Gathering commit associated with buildbucket result from the datastore");
-    final String repository =
-        build.input!.gitilesCommit!.project!.split('/')[1];
-    final String branch = build.input!.gitilesCommit!.ref!
-        .split('/')[2]; // Example: Pulling "stable" from "refs/heads/stable".
+  Future<Commit> _getOrCreateCommitForTask(
+    DatastoreService datastore,
+    Build build,
+  ) async {
+    log.info("Gathering commit associated with buildbucket result from the datastore");
+    final String repository = build.input!.gitilesCommit!.project!.split('/')[1];
+    final String branch =
+        build.input!.gitilesCommit!.ref!.split('/')[2]; // Example: Pulling "stable" from "refs/heads/stable".
     final String sha = build.input!.gitilesCommit!.hash!;
     final RepositorySlug slug = RepositorySlug("flutter", repository);
 
     final String id = '${slug.fullName}/$branch/$sha';
 
     late Commit commit;
-    final Key<String> commitKey =
-        datastore.db.emptyKey.append<String>(Commit, id: id);
+    final Key<String> commitKey = datastore.db.emptyKey.append<String>(Commit, id: id);
     try {
       commit = await datastore.db.lookupValue<Commit>(commitKey);
     } on KeyNotFoundException {
@@ -130,8 +130,7 @@ class DartInternalSubscription extends SubscriptionHandler {
       );
       final String defaultBranch = Config.defaultBranch(slug);
       final String defaultBranchId = '${slug.fullName}/$defaultBranch/$sha';
-      final Key<String> defaultBranchCommitKey =
-          datastore.db.emptyKey.append<String>(Commit, id: defaultBranchId);
+      final Key<String> defaultBranchCommitKey = datastore.db.emptyKey.append<String>(Commit, id: defaultBranchId);
       commit = await datastore.db.lookupValue<Commit>(defaultBranchCommitKey);
 
       log.info(

--- a/app_dart/test/model/commit_test.dart
+++ b/app_dart/test/model/commit_test.dart
@@ -62,15 +62,20 @@ void main() {
   group('Commit.from', () {
     test('runs successfully', () {
       final key = Commit.createKey(
-          db: FakeDatastoreDB(), slug: RepositorySlug('flutter', 'flutter'), gitBranch: 'main', sha: 'abc',);
+        db: FakeDatastoreDB(),
+        slug: RepositorySlug('flutter', 'flutter'),
+        gitBranch: 'main',
+        sha: 'abc',
+      );
 
       final Commit commit = Commit(
-          key: key,
-          author: "Sally",
-          authorAvatarUrl: "www.sally.com/url",
-          message: "This commit fixes prod",
-          repository: "flutter",
-          branch: "merging-branch",);
+        key: key,
+        author: "Sally",
+        authorAvatarUrl: "www.sally.com/url",
+        message: "This commit fixes prod",
+        repository: "flutter",
+        branch: "merging-branch",
+      );
       final Commit clonedCommit = Commit.from(commit);
 
       expect(commit.toString(), clonedCommit.toString());

--- a/app_dart/test/model/commit_test.dart
+++ b/app_dart/test/model/commit_test.dart
@@ -62,10 +62,7 @@ void main() {
   group('Commit.from', () {
     test('runs successfully', () {
       final key = Commit.createKey(
-          db: FakeDatastoreDB(),
-          slug: RepositorySlug('flutter', 'flutter'),
-          gitBranch: 'main',
-          sha: 'abc');
+          db: FakeDatastoreDB(), slug: RepositorySlug('flutter', 'flutter'), gitBranch: 'main', sha: 'abc');
 
       final Commit commit = Commit(
           key: key,

--- a/app_dart/test/model/commit_test.dart
+++ b/app_dart/test/model/commit_test.dart
@@ -62,7 +62,7 @@ void main() {
   group('Commit.from', () {
     test('runs successfully', () {
       final key = Commit.createKey(
-          db: FakeDatastoreDB(), slug: RepositorySlug('flutter', 'flutter'), gitBranch: 'main', sha: 'abc');
+          db: FakeDatastoreDB(), slug: RepositorySlug('flutter', 'flutter'), gitBranch: 'main', sha: 'abc',);
 
       final Commit commit = Commit(
           key: key,
@@ -70,7 +70,7 @@ void main() {
           authorAvatarUrl: "www.sally.com/url",
           message: "This commit fixes prod",
           repository: "flutter",
-          branch: "merging-branch");
+          branch: "merging-branch",);
       final Commit clonedCommit = Commit.from(commit);
 
       expect(commit.toString(), clonedCommit.toString());

--- a/app_dart/test/model/commit_test.dart
+++ b/app_dart/test/model/commit_test.dart
@@ -58,4 +58,25 @@ void main() {
       );
     });
   });
+
+  group('Commit.from', () {
+    test('runs successfully', () {
+      final key = Commit.createKey(
+          db: FakeDatastoreDB(),
+          slug: RepositorySlug('flutter', 'flutter'),
+          gitBranch: 'main',
+          sha: 'abc');
+
+      final Commit commit = Commit(
+          key: key,
+          author: "Sally",
+          authorAvatarUrl: "www.sally.com/url",
+          message: "This commit fixes prod",
+          repository: "flutter",
+          branch: "merging-branch");
+      final Commit clonedCommit = Commit.from(commit);
+
+      expect(commit.toString(), clonedCommit.toString());
+    });
+  });
 }

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -376,7 +376,7 @@ void main() {
       const String fakeCustomName = "Awesome test!";
       final Commit fakeCommit = generateCommit(1);
       final Task task = await Task.fromBuildbucketBuild(fakeBuild, DatastoreService(config.db, 5),
-          commit: fakeCommit, customName: fakeCustomName);
+          commit: fakeCommit, customName: fakeCustomName,);
       final Key<String> expectedKey = fakeCommit.key;
       final Task expectedTask = Task(
         commitKey: expectedKey,

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -375,7 +375,8 @@ void main() {
 
       const String fakeCustomName = "Awesome test!";
       final Commit fakeCommit = generateCommit(1);
-      final Task task = await Task.fromBuildbucketBuild(fakeBuild, DatastoreService(config.db, 5), commit: fakeCommit, customName: fakeCustomName);
+      final Task task = await Task.fromBuildbucketBuild(fakeBuild, DatastoreService(config.db, 5),
+          commit: fakeCommit, customName: fakeCustomName);
       final Key<String> expectedKey = fakeCommit.key;
       final Task expectedTask = Task(
         commitKey: expectedKey,

--- a/app_dart/test/model/task_test.dart
+++ b/app_dart/test/model/task_test.dart
@@ -375,8 +375,12 @@ void main() {
 
       const String fakeCustomName = "Awesome test!";
       final Commit fakeCommit = generateCommit(1);
-      final Task task = await Task.fromBuildbucketBuild(fakeBuild, DatastoreService(config.db, 5),
-          commit: fakeCommit, customName: fakeCustomName,);
+      final Task task = await Task.fromBuildbucketBuild(
+        fakeBuild,
+        DatastoreService(config.db, 5),
+        commit: fakeCommit,
+        customName: fakeCustomName,
+      );
       final Key<String> expectedKey = fakeCommit.key;
       final Task expectedTask = Task(
         commitKey: expectedKey,

--- a/app_dart/test/request_handlers/dart_internal_subscription_test.dart
+++ b/app_dart/test/request_handlers/dart_internal_subscription_test.dart
@@ -145,7 +145,101 @@ void main() {
       stageName: "dart-internal",
       startTimestamp: startTime.millisecondsSinceEpoch,
       status: "Succeeded",
-      key: commit.key.append(Task),
+      key: commitInDb.key.append(Task),
+      timeoutInMinutes: 0,
+      reason: '',
+      requiredCapabilities: [],
+      reservedForAgentId: '',
+    );
+
+    expect(
+      taskInDb.toString(),
+      equals(expectedTask.toString()),
+    );
+  });
+
+  test('creates a new task successfully if associated commit is not in the datastore', () async {
+    const String newBranch = "another-branch";
+    final Build fakeBuild = Build(
+      builderId: const BuilderId(project: project, bucket: bucket, builder: builder),
+      number: buildId,
+      id: 'fake-build-id',
+      status: Status.success,
+      startTime: startTime,
+      endTime: endTime,
+      input: const Input(
+        gitilesCommit: GitilesCommit(
+          project: "flutter/flutter",
+          hash: fakeHash,
+          ref: "refs/heads/$newBranch",
+        ),
+      ),
+    );
+    when(
+      buildBucketClient.getBuild(
+        any,
+        buildBucketUri: "https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds",
+      ),
+    ).thenAnswer((_) => Future<Build>.value(fakeBuild));
+
+    commit = generateCommit(
+      1,
+      sha: fakeHash,
+      branch: "master",
+      owner: "flutter",
+      repo: "flutter",
+      timestamp: 0,
+    );
+    final List<Commit> datastoreCommit = <Commit>[commit];
+    await config.db.commit(inserts: datastoreCommit);
+
+    tester.message = const push.PushMessage(data: fakePubsubMessage);
+
+    await tester.post(handler);
+
+    verify(
+      buildBucketClient.getBuild(any),
+    ).called(1);
+
+    // This is used for testing to pull the data out of the "datastore" so that
+    // we can verify what was saved.
+    late Task taskInDb;
+    late Commit commitInDb;
+    config.db.values.forEach((k, v) {
+      if (v is Task && v.buildNumberList == buildId.toString()) {
+        taskInDb = v;
+      }
+      if (v is Commit && v.branch == newBranch) {
+        commitInDb = v;
+      }
+    });
+
+    // Ensure the task has the correct parent and commit key
+    expect(
+      commitInDb.id,
+      equals(taskInDb.commitKey?.id),
+    );
+
+    expect(
+      commitInDb.id,
+      equals(taskInDb.parentKey?.id),
+    );
+
+    // Ensure the task in the db is exactly what we expect
+    final Task expectedTask = Task(
+      attempts: 1,
+      buildNumber: buildId,
+      buildNumberList: buildId.toString(),
+      builderName: builder,
+      commitKey: commitInDb.key,
+      createTimestamp: startTime.millisecondsSinceEpoch,
+      endTimestamp: endTime.millisecondsSinceEpoch,
+      luciBucket: bucket,
+      name: builder,
+      stageName: "dart-internal",
+      startTimestamp: startTime.millisecondsSinceEpoch,
+      status: "Succeeded",
+      key: commitInDb.key.append(Task),
       timeoutInMinutes: 0,
       reason: '',
       requiredCapabilities: [],
@@ -229,7 +323,7 @@ void main() {
       stageName: "dart-internal",
       startTimestamp: startTime.millisecondsSinceEpoch,
       status: "Succeeded",
-      key: commit.key.append(Task),
+      key: commitInDb.key.append(Task),
       timeoutInMinutes: 0,
       reason: '',
       requiredCapabilities: [],


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/132066
* Adds logic to dart-internal-subscription endpoint, where if there is no commit for the associated task from buildbucket, then create it and add it to the datastore. This is done by adding an optional parameter to the method that creates a Task from a buildbucket build, where you can specify a specific Commit you want use.

Small additional changes:
* Add a commit deep copy method `Commit.from()`
* Move away from the `hash` variable to `sha` since `hash` is reserved

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
