### PR TITLE
Remove flutter-3.10-candidate.1 exemption.

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -98,9 +98,7 @@ class CiYaml {
   /// Filters targets with release_build = true on release candidate branches.
   List<Target> _filterReleaseBuildTargets(List<Target> targets) {
     final List<Target> results = <Target>[];
-    // TODO(godofredoc): remove flutter-3.10-candidate.1 once dart-internal v2 artifacs are released to dart-internal.
-    // https://github.com/flutter/flutter/issues/128844
-    final bool releaseBranch = branch.contains(RegExp('^flutter-')) && (branch != 'flutter-3.10-candidate.1');
+    final bool releaseBranch = branch.contains(RegExp('^flutter-'));
     if (!releaseBranch) {
       return targets;
     }

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -220,42 +220,6 @@ void main() {
         expect(initialTargetNames, isEmpty);
       });
 
-      test('release_build targets for flutter-3.10-candidate.1 are not filtered', () {
-        final CiYaml releaseYaml = CiYaml(
-          slug: Config.flutterSlug,
-          branch: 'flutter-3.10-candidate.1',
-          config: pb.SchedulerConfig(
-            enabledBranches: <String>[
-              'flutter-3.10-candidate.1',
-            ],
-            targets: <pb.Target>[
-              pb.Target(
-                name: 'Linux A',
-                properties: <String, String>{'release_build': 'true'},
-              ),
-              pb.Target(
-                name: 'Linux B',
-              ),
-              pb.Target(
-                name: 'Mac A', // Should be ignored on release branches
-                bringup: true,
-              ),
-            ],
-          ),
-          totConfig: totCIYaml,
-        );
-        final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
-        expect(
-          initialTargetNames,
-          containsAll(
-            <String>[
-              'Linux A',
-            ],
-          ),
-        );
-      });
-
       test('release_build targets for main are not filtered', () {
         final CiYaml releaseYaml = CiYaml(
           slug: Config.flutterSlug,


### PR DESCRIPTION
As flutter-3.13-candidate.0 is promoted to stable the exemption is not needed anymore.

Bug: https://github.com/flutter/flutter/issues/128844

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
