### PR TITLE
Treat files of type `*test.py` as test files in the engine repo.

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -33,7 +33,7 @@ Set<RepositorySlug> kNeedsTests = <RepositorySlug>{
   Config.packagesSlug,
 };
 
-final RegExp kEngineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh)$');
+final RegExp kEngineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py)$');
 
 // Extentions for files that use // for single line comments.
 // See [_allChangesAreCodeComments] for more.

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -14,7 +14,7 @@ PushMessage generateGithubWebhookMessage({
   String event = 'pull_request',
   String action = 'merged',
   int number = 123,
-  String baseRef = kDefaultBranchName,
+  String? baseRef,
   String baseSha = '4cd12fc8b7d4cc2d8609182e1c4dea5cddc86890',
   String login = 'dash',
   String headRef = 'abc',
@@ -46,7 +46,7 @@ PushMessage generateGithubWebhookMessage({
 String _generatePullRequestEvent(
   String action,
   int number,
-  String baseRef, {
+  String? baseRef, {
   RepositorySlug? slug,
   String login = 'flutter',
   String baseSha = '4cd12fc8b7d4cc2d8609182e1c4dea5cddc86890',
@@ -58,6 +58,7 @@ String _generatePullRequestEvent(
   String mergeCommitSha = 'fd6b46416c18de36ce87d0241994b2da180cab4c',
 }) {
   slug ??= Config.flutterSlug;
+  baseRef ??= Config.defaultBranch(slug);
   return '''{
   "action": "$action",
   "number": $number,


### PR DESCRIPTION
I should also note that when I originally wrote the test, my test reported a false positive. This is because the `generateGithubWebhookMessage` utility was using the `master` branch as the default base branch for all repositories, even though some are actually `main` and some are `master`. This fixes that as well, so that the default value for the base branch in the generated webhook messages matches the actual default base branch for the specified repository.