### PR TITLE
Add some more logging to make it easier to find branches

### DIFF
--- a/app_dart/lib/src/request_handlers/github/branch_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/branch_subscription.dart
@@ -41,15 +41,18 @@ class GithubBranchWebhookSubscription extends SubscriptionHandler {
 
     final pb.GithubWebhookMessage webhook = pb.GithubWebhookMessage.fromJson(message.data!);
     if (webhook.event != kWebhookCreateEvent) {
+      log.fine('Github event is not a "create" event, so this event will not be processed');
       return Body.empty;
     }
 
     log.fine('Processing ${webhook.event}');
     final CreateEvent createEvent = CreateEvent.fromJson(json.decode(webhook.payload) as Map<String, dynamic>);
+    log.fine('Handling create request for branch ${createEvent.ref}');
     await branchService.handleCreateRequest(createEvent);
 
     final RegExp candidateBranchRegex = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
     if (candidateBranchRegex.hasMatch(createEvent.ref!)) {
+      log.fine('Branch ${createEvent.ref} is a candidate branch, creating new commit in the datastore');
       await commitService.handleCreateGithubRequest(createEvent);
     }
 

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -31,12 +31,14 @@ class CommitService {
     final DatastoreService datastore = datastoreProvider(config.db);
     final RepositorySlug slug = RepositorySlug.full(createEvent.repository!.fullName);
     final String branch = createEvent.ref!;
+    log.info('Creating commit object for branch $branch in repository ${slug.fullName}');
     final Commit commit = await _createCommitFromBranchEvent(datastore, slug, branch);
 
     try {
+      log.info('Checking for existing commit in the datastore');
       await datastore.lookupByValue<Commit>(commit.key);
     } on KeyNotFoundException {
-      log.info('commit does not exist in datastore, inserting into datastore');
+      log.info('Commit does not exist in datastore, inserting into datastore');
       await datastore.insert(<Commit>[commit]);
     }
   }


### PR DESCRIPTION
Since all github events are passed to this endpoint, but we only care about branch events, add some logging so that we can find information about a specific branch in the log explorer easier.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
