### PR TITLE
Update slsa verification logic

### DIFF
--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -3,12 +3,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set -e
+
 # This script is used to verify provenance of our artifacts using slsa-verifier.
 # If slsa-verifier is unable to ensure the provenance of the artifact is
 # legitimate, then the script will exit with a non-zero exit code.
 PROVENANCE_PATH=$1
 BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3
-SOURCE_URI=https://git+https://github.com/flutter/cocoon
+SOURCE_URI=https://github.com/flutter/cocoon
 
 # Download the jq binary in order to obtain the artifact registry url from the
 # docker image provenance.
@@ -39,27 +41,3 @@ slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
   --source-uri $SOURCE_URI \
   --builder-id=$BUILDER_ID \
   --provenance-path $PROVENANCE_PATH
-
-# If the provenance failed, try again, but check for 'git+' in the source-uri
-# Context: Cloud Build is sometimes generating provenance with 'git+', but it
-# will eventually be generated for all builds.
-# TODO(drewroengoogle): Once the cloud build change is completely rolled out,
-# remove this logic and only check for 'git+'.
-COMMAND_RESULT=$?
-if [[ $COMMAND_RESULT -eq 0 ]]; then
-  echo "Provenance verified!" && exit $COMMAND_RESULT
-fi
-
-echo "Verifying the provenance is valid and correct..."
-echo "Checking for source-uri of git+$SOURCE_URI"
-slsa-verifier verify-image $FULLY_QUALIFIED_DIGEST \
-  --source-uri $SOURCE_URI \
-  --builder-id=$BUILDER_ID \
-  --provenance-path $PROVENANCE_PATH
-
-COMMAND_RESULT=$?
-if [[ $COMMAND_RESULT -eq 0 ]]; then
-  echo "Provenance verified!" && exit $COMMAND_RESULT
-fi
-
-echo "Failed to validate provenance." && exit $COMMAND_RESULT


### PR DESCRIPTION
Newer versions of slsa-verifier have updated the way they check for source uris, and automatically apply the logic we were applying to our script directly. This PR removes the logic of trying both `git+(url)` and `(url)` since it is done automatically now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
