### PR TITLE
Move jq installation before the step to get provenance.

### DIFF
--- a/cloud_build/get_docker_image_provenance.sh
+++ b/cloud_build/get_docker_image_provenance.sh
@@ -9,6 +9,11 @@ OUTPUT_DIRECTORY=$2
 # Getting the docker image provenance can be flaky, so retry up to 3 times.
 MAX_ATTEMPTS=3
 
+# Download the jq binary in order to obtain the artifact registry url from the
+# docker image provenance.
+echo "Installing jq using apt..."
+apt update && apt install jq -y
+
 for attempt in $(seq 1 $MAX_ATTEMPTS)
 do
     echo "(Attempt $attempt) Obtaining provenance for $1"

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -12,16 +12,12 @@ PROVENANCE_PATH=$1
 BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3
 SOURCE_URI=github.com/flutter/cocoon
 
-# Download the jq binary in order to obtain the artifact registry url from the
-# docker image provenance.
-echo "Installing jq using apt..."
-apt update && apt install jq -y
-
 # Download slsa-verifier in order to validate the docker image provenance.
 # This takes the version of slsa-verifier defined in tooling/go.mod.
 echo "Installing slsa-verifier using go..."
+mkdir -p tooling
 pushd tooling
-go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
+go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.4.0
 popd
 
 FULLY_QUALIFIED_DIGEST=$(cat $PROVENANCE_PATH |


### PR DESCRIPTION
The get_provenance script now requires jq but it was not installed until later.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
