### PR TITLE
Remove the hardcoded builder_id version

### DIFF
--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -9,7 +9,7 @@ set -e
 # If slsa-verifier is unable to ensure the provenance of the artifact is
 # legitimate, then the script will exit with a non-zero exit code.
 PROVENANCE_PATH=$1
-BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker@v0.3
+BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker
 SOURCE_URI=github.com/flutter/cocoon
 
 # Download the jq binary in order to obtain the artifact registry url from the
@@ -22,7 +22,7 @@ apt update && apt install jq -y
 echo "Installing slsa-verifier using go..."
 mkdir -p tooling
 pushd tooling
-go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.4.0
+go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier
 popd
 
 FULLY_QUALIFIED_DIGEST=$(cat $PROVENANCE_PATH |


### PR DESCRIPTION
Somewhat related to https://github.com/flutter/flutter/issues/133376

It seems that occasionally the builds are failing because they are being built on a different version of Cloud Build. This is not actually providing any sort of security since we aren't explicitly specifying the version of cloud build when we trigger it, so instead we can just check that the artifact is built on cloud build at all.

Additionally, remove the hard pinned version of slsa-verifier, as it is already specified and updated by dependabot in the `tooling` folder

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
