### PR TITLE
Update the timestamp field to use the current data in the commit_service class

### DIFF
--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -53,7 +53,7 @@ class CommitService {
     final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     return Commit(
       key: key,
-      timestamp: commit.author?.createdAt?.millisecondsSinceEpoch,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
       repository: slug.fullName,
       sha: commit.sha,
       author: commit.author?.login,

--- a/app_dart/test/service/commit_service_test.dart
+++ b/app_dart/test/service/commit_service_test.dart
@@ -61,7 +61,6 @@ void main() {
           RepositoryCommit(
             sha: sha,
             author: User(
-              createdAt: DateTime.parse(dateTimeAsString),
               login: username,
               avatarUrl: avatarUrl,
             ),
@@ -78,7 +77,6 @@ void main() {
       expect(commit.repository, "$owner/$repository");
       expect(commit.message, message);
       expect(commit.key.id, "$owner/$repository/$branch/$sha");
-      expect(commit.timestamp, DateTime.parse(dateTimeAsString).millisecondsSinceEpoch);
       expect(commit.sha, sha);
       expect(commit.author, username);
       expect(commit.authorAvatarUrl, avatarUrl);


### PR DESCRIPTION
We are getting alert for 500 errors from the /api/github/webhook-branch-subscription endpoint when attempting to insert a commit for a release branch. The issue is with the timestamp presumably being null when we attempt to insert it into the database since it not a field in the return RepositoryCommit in the github lib.

```
"Failed to process Instance of 'PushMessage'. (500) Invalid argument(s): Error while encoding entity (Bad state: Property validation failed for property timestamp while trying to serialize entity of kind Commit. , #0      _ModelDescription._encodeProperty (package:gcloud/src/db/model_db_impl.dart:449:7)
#1      _ModelDescription.encodeModel.<anonymous closure> (package:gcloud/src/db/model_db_impl.dart:429:7)
#2      _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:625:13)
#3      _ModelDescription.encodeModel (package:gcloud/src/db/model_db_impl.dart:428:34)
#4      ModelDBImpl.toDatastoreEntity (package:gcloud/src/db/model_db_impl.dart:121:31)
#5      _commitHelper (package:gcloud/src/db/db.dart:434:38)
#6      Transaction.commit (package:gcloud/src/db/db.dart:118:14)
#7      DatastoreService.insert.<anonymous closure>.<anonymous closure> (package:cocoon_service/src/service/datastore.dart:254:31)
#8      DatastoreDB.withTransaction.<anonymous closure> (package:gcloud/src/db/db.dart:324:32)
#9      _rootRunUnary (dart:async/zone.dart:1407:47)
<asynchronous suspension>
#10     DatastoreService.insert.<anonymous closure> (package:cocoon_service/src/service/datastore.dart:252:11)
<asynchronous suspension>
#11     RetryOptions.retry (package:retry/retry.dart:131:16)
<asynchronous suspension>
#12     DatastoreService.insert (package:cocoon_service/src/service/datastore.dart:250:7)
<asynchronous suspension>
#13     CommitService.handleCreateGithubRequest (package:cocoon_service/src/service/commit_service.dart:42:7)
<asynchronous suspension>
#14     GithubBranchWebhookSubscription.post (package:cocoon_service/src/request_handlers/github/branch_subscription.dart:56:7)
<asynchronous suspension>
#15     RequestHandler.service.<anonymous closure> (package:cocoon_service/src/request_handling/request_handler.dart:53:24)
<asynchronous suspension>
#16     SubscriptionHandler.service (package:cocoon_service/src/request_handling/subscription_handler.dart:138:5)
<asynchronous suspension>
#17     main.<anonymous closure>.<anonymous closure> (file:///app/bin/server.dart:303:11)
<asynchronous suspension>
```

The data returned by the call in the Commit Service looks like this:

```
{
  "sha": "6fd42536b7697eb4bd2a698b19308e0aacac70c7",
  "node_id": "C_kwDOAeUeuNoAKDZmZDQyNTM2Yjc2OTdlYjRiZDJhNjk4YjE5MzA4ZTBhYWNhYzcwYzc",
  "commit": {
    "author": {
      "name": "Xilai Zhang",
      "email": "xilaizhang@google.com",
      "date": "2023-08-30T02:59:02Z"
    },
    "committer": {
      "name": "GitHub",
      "email": "noreply@github.com",
      "date": "2023-08-30T02:59:02Z"
    },
    "message": "[flutter roll] Revert \"Fix `Chip.shape`'s side is not used when provided in Material 3\" (#133615)\n\nReverts flutter/flutter#132941\r\ncontext: b/298110031\r\n\r\nThe rounded rectangle borders don't appear in some of the internal\r\ngolden image tests.",
    "tree": {
      "sha": "e5efe7f39155d9b8fc40ad0a59c72f6a36f8b66d",
      "url": "https://api.github.com/repos/flutter/flutter/git/trees/e5efe7f39155d9b8fc40ad0a59c72f6a36f8b66d"
    },

```

The author field in this case has no createdAt timestamp.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/133707

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
