### PR TITLE
Add a retry for checking for the GoB commit after PR merged

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -194,20 +194,15 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     final RepositorySlug slug = pr.base!.repo!.slug();
     final String sha = pr.mergeCommitSha!;
     GerritCommit? gobCommit;
-    try {
-      await Config.gobRetryOptions.retry(
-        () async {
-          gobCommit = await gerritService.findMirroredCommit(slug, sha);
-          if (gobCommit == null) {
-            throw const NotFoundException('Gob commit not found');
-          }
-        },
-        retryIf: (e) => e is NotFoundException,
-      );
-    } on NotFoundException {
-      // do nothing here as we are simply using the exception to retry but do
-      // not want to throw from here.
-    }
+    await Config.gobRetryOptions.retry(
+      () async {
+        gobCommit = await gerritService.findMirroredCommit(slug, sha);
+        if (gobCommit == null) {
+          throw const InternalServerError('Gob commit not found');
+        }
+      },
+      retryIf: (e) => e is InternalServerError,
+    );
     return gobCommit != null;
   }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -194,11 +194,11 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     final RepositorySlug slug = pr.base!.repo!.slug();
     final String sha = pr.mergeCommitSha!;
     GerritCommit? gobCommit;
-    await Config.gobRetryOptions.retry(
+    await config.getGobRetryOptions.retry(
       () async {
         gobCommit = await gerritService.findMirroredCommit(slug, sha);
         if (gobCommit == null) {
-          throw const InternalServerError('Gob commit not found');
+          throw InternalServerError('$sha was not found on GoB. Failing so this event can be retried...');
         }
       },
       retryIf: (e) => e is InternalServerError,

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -92,7 +92,7 @@ class Config {
   RetryOptions get getGobRetryOptions => _gobRetryOptions;
 
   set setGobRetryOptions(RetryOptions retryOptions) {
-    _gobRetryOptions = retryOptions; 
+    _gobRetryOptions = retryOptions;
   }
 
   /// Memorystore subcache name to store [CocoonConfig] values in.

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -84,10 +84,16 @@ class Config {
   }
 
   // GoB retry options
-  static const RetryOptions gobRetryOptions = RetryOptions(
+  RetryOptions _gobRetryOptions = const RetryOptions(
     maxAttempts: 4,
-    delayFactor: Duration(milliseconds: 500),
+    delayFactor: Duration(seconds: 30),
   );
+
+  RetryOptions get getGobRetryOptions => _gobRetryOptions;
+
+  set setGobRetryOptions(RetryOptions retryOptions) {
+    _gobRetryOptions = retryOptions; 
+  }
 
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -86,8 +86,7 @@ class Config {
   // GoB retry options
   static const RetryOptions gobRetryOptions = RetryOptions(
     maxAttempts: 4,
-    maxDelay: Duration(seconds: 1),
-    delayFactor: Duration(milliseconds: 300),
+    delayFactor: Duration(milliseconds: 500),
   );
 
   /// Memorystore subcache name to store [CocoonConfig] values in.

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -85,9 +85,9 @@ class Config {
 
   // GoB retry options
   static const RetryOptions gobRetryOptions = RetryOptions(
-    maxAttempts: 3,
+    maxAttempts: 4,
     maxDelay: Duration(seconds: 1),
-    delayFactor: Duration(milliseconds: 200),
+    delayFactor: Duration(milliseconds: 300),
   );
 
   /// Memorystore subcache name to store [CocoonConfig] values in.

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -83,6 +83,13 @@ class Config {
     return defaultBranches[slug] ?? kDefaultBranchName;
   }
 
+  // GoB retry options
+  static const RetryOptions gobRetryOptions = RetryOptions(
+    maxAttempts: 3,
+    maxDelay: Duration(seconds: 1),
+    delayFactor: Duration(milliseconds: 200),
+  );
+
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -14,6 +14,7 @@ import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart' as gh;
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:graphql/client.dart';
+import 'package:retry/retry.dart';
 
 import '../request_handling/fake_authentication.dart';
 import '../service/fake_github_service.dart';
@@ -106,6 +107,12 @@ class FakeConfig implements Config {
   Set<gh.RepositorySlug>? supportedReposValue;
   Set<gh.RepositorySlug>? postsubmitSupportedReposValue;
   Duration? githubRequestDelayValue;
+  
+  // GoB retry options
+  RetryOptions _gobRetryOptions = const RetryOptions(
+    maxAttempts: 1,
+    delayFactor: Duration(seconds: 0),
+  );
 
   @override
   Future<gh.GitHub> createGitHubClient({gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async => githubClient!;
@@ -298,5 +305,13 @@ class FakeConfig implements Config {
         ),
       ),
     );
+  }
+
+  @override
+  RetryOptions get getGobRetryOptions => _gobRetryOptions;
+
+  @override
+  set setGobRetryOptions(RetryOptions retryOptions) {
+    _gobRetryOptions = retryOptions;
   }
 }

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -107,7 +107,7 @@ class FakeConfig implements Config {
   Set<gh.RepositorySlug>? supportedReposValue;
   Set<gh.RepositorySlug>? postsubmitSupportedReposValue;
   Duration? githubRequestDelayValue;
-  
+
   // GoB retry options
   RetryOptions _gobRetryOptions = const RetryOptions(
     maxAttempts: 1,


### PR DESCRIPTION
We consistently get 500 errors when checking for commits on GoB. This is most likely due to some latency so adding a retry for up to a second should help in reducing the number of 500 errors we see from this.

![image](https://github.com/flutter/cocoon/assets/32242716/984f3590-ae16-46ac-bd77-dfa73e44638b)

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/134146

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
