### PR TITLE
Auto rerun presubmit

### DIFF
--- a/CI_YAML.md
+++ b/CI_YAML.md
@@ -179,6 +179,10 @@ Example
 test_timeout_secs: "2700"
 ```
 
+**presubmit_max_attempts** The max attempts the target will be auto executed. If it is not specified,
+the default value is `1` and it means no auto rerun will happen. If explicitly defined, it controls
+the max number of attempts. For example: `3` means it will be auto rescheduled two more times.
+
 ### Updating targets
 
 #### Properties

--- a/CI_YAML.md
+++ b/CI_YAML.md
@@ -179,9 +179,9 @@ Example
 test_timeout_secs: "2700"
 ```
 
-**presubmit_max_attempts** The max attempts the target will be auto executed. If it is not specified,
-the default value is `1` and it means no auto rerun will happen. If explicitly defined, it controls
-the max number of attempts. For example: `3` means it will be auto rescheduled two more times.
+**presubmit_max_attempts** The max attempts the target will be auto executed in presubmit. If it is
+not specified, the default value is `1` and it means no auto rerun will happen. If explicitly defined,
+it controls the max number of attempts. For example: `3` means it will be auto rescheduled two more times.
 
 ### Updating targets
 

--- a/app_dart/bin/server.dart
+++ b/app_dart/bin/server.dart
@@ -117,6 +117,7 @@ Future<void> main() async {
         buildBucketClient: buildBucketClient,
         luciBuildService: luciBuildService,
         githubChecksService: githubChecksService,
+        scheduler: scheduler,
       ),
       '/api/postsubmit-luci-subscription': PostsubmitLuciSubscription(
         cache: cache,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -194,6 +194,7 @@ class LuciBuildService {
         'check_run_id': checkRun.id,
         'commit_sha': sha,
         'commit_branch': pullRequest.base!.ref!.replaceAll('refs/heads/', ''),
+        'user_login': pullRequest.user!.login,
       };
 
       final Map<String, List<String>> tags = <String, List<String>>{
@@ -296,15 +297,25 @@ class LuciBuildService {
   /// The buildset, user_agent, and github_link tags are applied to match the
   /// original build. The build properties and user data from the original build
   /// are also preserved.
-  Future<Build> rescheduleBuild({
-    required String commitSha,
+  Future<Build> reschedulePresubmitBuild({
     required String builderName,
     required push_message.BuildPushMessage buildPushMessage,
+    retry = false,
   }) async {
     // Ensure we are using V2 bucket name istead of V1.
     // V1 bucket name  is "luci.flutter.prod" while the api
     // is expecting just the last part after "."(prod).
     final String bucketName = buildPushMessage.build!.bucket!.split('.').last;
+    final Map<String, List<String>> tags = <String, List<String>>{
+      'buildset': buildPushMessage.build!.tagsByName('buildset'),
+      'user_agent': buildPushMessage.build!.tagsByName('user_agent'),
+      'github_link': buildPushMessage.build!.tagsByName('github_link'),
+      'cipd_version': buildPushMessage.build!.tagsByName('cipd_version'),
+      'github_checkrun': buildPushMessage.build!.tagsByName('github_checkrun'),
+    };
+    if (retry) {
+      tags['retry'] = <String>['true'];
+    }
     return buildBucketClient.scheduleBuild(
       ScheduleBuildRequest(
         builderId: BuilderId(
@@ -312,11 +323,7 @@ class LuciBuildService {
           bucket: bucketName,
           builder: builderName,
         ),
-        tags: <String, List<String>>{
-          'buildset': buildPushMessage.build!.tagsByName('buildset'),
-          'user_agent': buildPushMessage.build!.tagsByName('user_agent'),
-          'github_link': buildPushMessage.build!.tagsByName('github_link'),
-        },
+        tags: tags,
         properties:
             (buildPushMessage.build!.buildParameters!['properties'] as Map<String, dynamic>).cast<String, String>(),
         notify: NotificationConfig(

--- a/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/luci/buildbucket.dart' as bb;
+import 'package:cocoon_service/src/model/luci/push_message.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -12,6 +14,7 @@ import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/subscription_tester.dart';
 import '../src/service/fake_buildbucket.dart';
 import '../src/service/fake_luci_build_service.dart';
+import '../src/service/fake_scheduler.dart';
 import '../src/utilities/mocks.dart';
 import '../src/utilities/push_message.dart';
 
@@ -26,12 +29,20 @@ void main() {
   late SubscriptionTester tester;
   late MockRepositoriesService mockRepositoriesService;
   late MockGithubChecksService mockGithubChecksService;
+  late MockLuciBuildService mockLuciBuildService;
+  late FakeScheduler scheduler;
 
   setUp(() async {
     config = FakeConfig();
     buildbucket = FakeBuildBucketClient();
+    mockLuciBuildService = MockLuciBuildService();
 
     mockGithubChecksService = MockGithubChecksService();
+    scheduler = FakeScheduler(
+      ciYaml: examplePresubmitRescheduleConfig,
+      config: config,
+      luciBuildService: mockLuciBuildService,
+    );
     handler = PresubmitLuciSubscription(
       cache: CacheService(inMemory: true),
       config: config,
@@ -39,6 +50,7 @@ void main() {
       luciBuildService: FakeLuciBuildService(config: config),
       githubChecksService: mockGithubChecksService,
       authProvider: FakeAuthenticationProvider(),
+      scheduler: scheduler,
     );
     request = FakeHttpRequest();
 
@@ -65,6 +77,7 @@ void main() {
 
   test('Requests with repo_owner and repo_name update checks', () async {
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.taskFailed(any)).thenAnswer((_) => false);
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       result: 'SUCCESS',
@@ -73,5 +86,76 @@ void main() {
     );
     await tester.post(handler);
     verify(mockGithubChecksService.updateCheckStatus(any, any, any)).called(1);
+  });
+
+  test('Requests when task failed but no need to reschedule', () async {
+    when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.taskFailed(any)).thenAnswer((_) => true);
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 1);
+    tester.message = createBuildbucketPushMessage(
+      'COMPLETED',
+      result: 'SUCCESS',
+      builderName: 'Linux A',
+      userData: '{\\"repo_owner\\": \\"flutter\\",'
+          '\\"commit_branch\\": \\"main\\",'
+          '\\"commit_sha\\": \\"abc\\",'
+          '\\"repo_name\\": \\"flutter\\"}',
+    );
+    when(
+      mockLuciBuildService.rescheduleBuild(
+        builderName: 'Linux Coverage',
+        buildPushMessage: BuildPushMessage.fromPushMessage(tester.message),
+        rescheduleAttempt: 0,
+      ),
+    ).thenAnswer(
+      (_) async => const bb.Build(
+        id: '8905920700440101120',
+        builderId: bb.BuilderId(bucket: 'luci.flutter.prod', project: 'flutter', builder: 'Linux Coverage'),
+      ),
+    );
+    await tester.post(handler);
+    verifyNever(
+      mockLuciBuildService.rescheduleBuild(
+        builderName: 'Linux Coverage',
+        buildPushMessage: BuildPushMessage.fromPushMessage(tester.message),
+        rescheduleAttempt: 0,
+      ),
+    );
+    verify(mockGithubChecksService.updateCheckStatus(any, any, any)).called(1);
+  });
+  test('Requests when task failed but need to reschedule', () async {
+    when(mockGithubChecksService.updateCheckStatus(any, any, any, rescheduled: true)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.taskFailed(any)).thenAnswer((_) => true);
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 0);
+    tester.message = createBuildbucketPushMessage(
+      'COMPLETED',
+      result: 'SUCCESS',
+      builderName: 'Linux B',
+      userData: '{\\"repo_owner\\": \\"flutter\\",'
+          '\\"commit_branch\\": \\"main\\",'
+          '\\"commit_sha\\": \\"abc\\",'
+          '\\"repo_name\\": \\"flutter\\"}',
+    );
+    when(
+      mockLuciBuildService.rescheduleBuild(
+        builderName: 'Linux Coverage',
+        buildPushMessage: BuildPushMessage.fromPushMessage(tester.message),
+        rescheduleAttempt: 1,
+      ),
+    ).thenAnswer(
+      (_) async => const bb.Build(
+        id: '8905920700440101120',
+        builderId: bb.BuilderId(bucket: 'luci.flutter.prod', project: 'flutter', builder: 'Linux B'),
+      ),
+    );
+    await tester.post(handler);
+    verifyNever(
+      mockLuciBuildService.rescheduleBuild(
+        builderName: 'Linux B',
+        buildPushMessage: BuildPushMessage.fromPushMessage(tester.message),
+        rescheduleAttempt: 1,
+      ),
+    );
+    verify(mockGithubChecksService.updateCheckStatus(any, any, any, rescheduled: true)).called(1);
   });
 }

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -99,6 +99,18 @@ void main() {
     });
     test('Userdata contain check_run_id', () async {
       when(mockGithubChecksUtil.getCheckRun(any, any, any)).thenAnswer((_) async => checkRun);
+      when(
+        mockLuciBuildService.getBuildById(
+          '8905920700440101120',
+          fields: 'id,builder,summaryMarkdown',
+        ),
+      ).thenAnswer(
+        (_) async => const Build(
+          id: '8905920700440101120',
+          builderId: BuilderId(bucket: 'luci.flutter.prod', project: 'flutter', builder: 'Linux Coverage'),
+          summaryMarkdown: 'test summary',
+        ),
+      );
       final push_message.BuildPushMessage buildPushMessage = push_message.BuildPushMessage.fromJson(
         jsonDecode(
           buildPushMessageJsonTemplate('{\\"check_run_id\\": 1,'

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -145,10 +145,10 @@ void main() {
         ) as Map<String, dynamic>,
       );
       when(
-        mockLuciBuildService.reschedulePresubmitBuild(
+        mockLuciBuildService.rescheduleBuild(
           builderName: 'Linux Coverage',
           buildPushMessage: buildPushMessage,
-          retry: true,
+          rescheduleAttempt: 1,
         ),
       ).thenAnswer(
         (_) async => const Build(
@@ -157,15 +157,7 @@ void main() {
         ),
       );
       expect(checkRun.status, github.CheckRunStatus.completed);
-      await githubChecksService.updateCheckStatus(buildPushMessage, mockLuciBuildService, slug);
-      // Validates the task is rescheduled.
-      verify(
-        mockLuciBuildService.reschedulePresubmitBuild(
-          builderName: 'Linux Coverage',
-          buildPushMessage: buildPushMessage,
-          retry: true,
-        ),
-      ).called(1);
+      await githubChecksService.updateCheckStatus(buildPushMessage, mockLuciBuildService, slug, rescheduled: true);
       final List<dynamic> captured = verify(
         mockGithubChecksUtil.updateCheckRun(
           any,
@@ -192,10 +184,10 @@ void main() {
         ) as Map<String, dynamic>,
       );
       when(
-        mockLuciBuildService.reschedulePresubmitBuild(
+        mockLuciBuildService.rescheduleBuild(
           builderName: 'Linux Coverage',
           buildPushMessage: buildPushMessage,
-          retry: true,
+          rescheduleAttempt: 1,
         ),
       ).thenAnswer(
         (_) async => const Build(
@@ -216,14 +208,6 @@ void main() {
         ),
       );
       await githubChecksService.updateCheckStatus(buildPushMessage, mockLuciBuildService, slug);
-      // Validates the task is not rescheduled.
-      verifyNever(
-        mockLuciBuildService.reschedulePresubmitBuild(
-          builderName: 'Linux Coverage',
-          buildPushMessage: buildPushMessage,
-          retry: true,
-        ),
-      );
       final List<dynamic> captured = verify(
         mockGithubChecksUtil.updateCheckRun(
           any,

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -122,7 +122,7 @@ void main() {
       expect(builds.first, linuxBuild);
     });
 
-    test('Existing try build', () async {
+    test('Existing try build by pull request', () async {
       when(mockBuildBucketClient.batch(any)).thenAnswer((_) async {
         return BatchResponse(
           responses: <Response>[
@@ -318,7 +318,6 @@ void main() {
         'repo_name': 'flutter',
         'user_agent': 'flutter-cocoon',
         'check_run_id': 1,
-        'user_login': 'dash',
         'commit_sha': 'abc',
         'commit_branch': 'master',
         'builder_name': 'Linux 1',
@@ -890,18 +889,18 @@ void main() {
 
     test('Reschedule an existing build', () async {
       when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((_) async => generateBuild(1));
-      final build = await service.reschedulePresubmitBuild(
+      final build = await service.rescheduleBuild(
         builderName: 'mybuild',
         buildPushMessage: buildPushMessage,
-        retry: true,
+        rescheduleAttempt: 2,
       );
       expect(build.id, '1');
       expect(build.status, Status.success);
       final List<dynamic> captured = verify(mockBuildBucketClient.scheduleBuild(captureAny)).captured;
       expect(captured.length, 1);
       final ScheduleBuildRequest scheduleBuildRequest = captured[0] as ScheduleBuildRequest;
-      expect(scheduleBuildRequest.tags!.containsKey('retry'), true);
-      expect(scheduleBuildRequest.tags!['retry'], <String>['true']);
+      expect(scheduleBuildRequest.tags!.containsKey('current_attempt'), true);
+      expect(scheduleBuildRequest.tags!['current_attempt'], <String>['2']);
     });
   });
 

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -318,6 +318,7 @@ void main() {
         'repo_name': 'flutter',
         'user_agent': 'flutter-cocoon',
         'check_run_id': 1,
+        'user_login': 'dash',
         'commit_sha': 'abc',
         'commit_branch': 'master',
         'builder_name': 'Linux 1',
@@ -889,14 +890,18 @@ void main() {
 
     test('Reschedule an existing build', () async {
       when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((_) async => generateBuild(1));
-      final build = await service.rescheduleBuild(
-        commitSha: 'abc',
+      final build = await service.reschedulePresubmitBuild(
         builderName: 'mybuild',
         buildPushMessage: buildPushMessage,
+        retry: true,
       );
       expect(build.id, '1');
       expect(build.status, Status.success);
-      verify(mockBuildBucketClient.scheduleBuild(any)).called(1);
+      final List<dynamic> captured = verify(mockBuildBucketClient.scheduleBuild(captureAny)).captured;
+      expect(captured.length, 1);
+      final ScheduleBuildRequest scheduleBuildRequest = captured[0] as ScheduleBuildRequest;
+      expect(scheduleBuildRequest.tags!.containsKey('retry'), true);
+      expect(scheduleBuildRequest.tags!['retry'], <String>['true']);
     });
   });
 

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -172,6 +172,26 @@ CiYaml exampleBackfillConfig = CiYaml(
   ),
 );
 
+CiYaml examplePresubmitRescheduleConfig = CiYaml(
+  slug: Config.flutterSlug,
+  branch: Config.defaultBranch(Config.flutterSlug),
+  config: pb.SchedulerConfig(
+    enabledBranches: <String>[
+      Config.defaultBranch(Config.flutterSlug),
+    ],
+    targets: <pb.Target>[
+      pb.Target(
+        name: 'Linux A',
+      ),
+      pb.Target(
+        name: 'Linux B',
+        postsubmit: true,
+        properties: {'presubmit_retry': '1'},
+      ),
+    ],
+  ),
+);
+
 final CiYaml batchPolicyConfig = CiYaml(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -1506,14 +1506,6 @@ class MockCommitService extends _i1.Mock implements _i28.CommitService {
         ),
       ) as _i3.Config);
   @override
-  _i8.RetryOptions get retryOptions => (super.noSuchMethod(
-        Invocation.getter(#retryOptions),
-        returnValue: _FakeRetryOptions_7(
-          this,
-          Invocation.getter(#retryOptions),
-        ),
-      ) as _i8.RetryOptions);
-  @override
   _i10.DatastoreServiceProvider get datastoreProvider => (super.noSuchMethod(
         Invocation.getter(#datastoreProvider),
         returnValue: (_i12.DatastoreDB db) => _FakeDatastoreService_12(
@@ -2991,6 +2983,14 @@ class MockGithubChecksService extends _i1.Mock implements _i24.GithubChecksServi
         ),
         returnValue: _i20.Future<bool>.value(false),
       ) as _i20.Future<bool>);
+  @override
+  bool shouldRerun(_i36.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+        Invocation.method(
+          #shouldRerun,
+          [buildPushMessage],
+        ),
+        returnValue: false,
+      ) as bool);
   @override
   String getGithubSummary(String? summary) => (super.noSuchMethod(
         Invocation.method(
@@ -5793,30 +5793,30 @@ class MockLuciBuildService extends _i1.Mock implements _i24.LuciBuildService {
         returnValue: _i20.Future<List<_i9.Build?>>.value(<_i9.Build?>[]),
       ) as _i20.Future<List<_i9.Build?>>);
   @override
-  _i20.Future<_i9.Build> rescheduleBuild({
-    required String? commitSha,
+  _i20.Future<_i9.Build> reschedulePresubmitBuild({
     required String? builderName,
     required _i36.BuildPushMessage? buildPushMessage,
+    dynamic retry = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
-          #rescheduleBuild,
+          #reschedulePresubmitBuild,
           [],
           {
-            #commitSha: commitSha,
             #builderName: builderName,
             #buildPushMessage: buildPushMessage,
+            #retry: retry,
           },
         ),
         returnValue: _i20.Future<_i9.Build>.value(_FakeBuild_8(
           this,
           Invocation.method(
-            #rescheduleBuild,
+            #reschedulePresubmitBuild,
             [],
             {
-              #commitSha: commitSha,
               #builderName: builderName,
               #buildPushMessage: buildPushMessage,
+              #retry: retry,
             },
           ),
         )),

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -2970,8 +2970,9 @@ class MockGithubChecksService extends _i1.Mock implements _i24.GithubChecksServi
   _i20.Future<bool> updateCheckStatus(
     _i36.BuildPushMessage? buildPushMessage,
     _i24.LuciBuildService? luciBuildService,
-    _i14.RepositorySlug? slug,
-  ) =>
+    _i14.RepositorySlug? slug, {
+    bool? rescheduled = false,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateCheckStatus,
@@ -2980,17 +2981,26 @@ class MockGithubChecksService extends _i1.Mock implements _i24.GithubChecksServi
             luciBuildService,
             slug,
           ],
+          {#rescheduled: rescheduled},
         ),
         returnValue: _i20.Future<bool>.value(false),
       ) as _i20.Future<bool>);
   @override
-  bool shouldRerun(_i36.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  bool taskFailed(_i36.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
         Invocation.method(
-          #shouldRerun,
+          #taskFailed,
           [buildPushMessage],
         ),
         returnValue: false,
       ) as bool);
+  @override
+  int currentAttempt(_i36.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+        Invocation.method(
+          #currentAttempt,
+          [buildPushMessage],
+        ),
+        returnValue: 0,
+      ) as int);
   @override
   String getGithubSummary(String? summary) => (super.noSuchMethod(
         Invocation.method(
@@ -5793,30 +5803,30 @@ class MockLuciBuildService extends _i1.Mock implements _i24.LuciBuildService {
         returnValue: _i20.Future<List<_i9.Build?>>.value(<_i9.Build?>[]),
       ) as _i20.Future<List<_i9.Build?>>);
   @override
-  _i20.Future<_i9.Build> reschedulePresubmitBuild({
+  _i20.Future<_i9.Build> rescheduleBuild({
     required String? builderName,
     required _i36.BuildPushMessage? buildPushMessage,
-    dynamic retry = false,
+    required int? rescheduleAttempt,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
-          #reschedulePresubmitBuild,
+          #rescheduleBuild,
           [],
           {
             #builderName: builderName,
             #buildPushMessage: buildPushMessage,
-            #retry: retry,
+            #rescheduleAttempt: rescheduleAttempt,
           },
         ),
         returnValue: _i20.Future<_i9.Build>.value(_FakeBuild_8(
           this,
           Invocation.method(
-            #reschedulePresubmitBuild,
+            #rescheduleBuild,
             [],
             {
               #builderName: builderName,
               #buildPushMessage: buildPushMessage,
-              #retry: retry,
+              #rescheduleAttempt: rescheduleAttempt,
             },
           ),
         )),


### PR DESCRIPTION
Reland of https://github.com/flutter/cocoon/pull/3018.

The only difference is documentation about the property: `presubmit_max_attempts`.

The blocking bug is fixed: https://github.com/flutter/flutter/issues/134438 