### PR TITLE
Automatic Revert (Part 3): Add supporting test files for the automatic revert feature

### DIFF
--- a/auto_submit/lib/model/auto_submit_query_result.dart
+++ b/auto_submit/lib/model/auto_submit_query_result.dart
@@ -146,6 +146,7 @@ class PullRequest {
     this.reviews,
     this.commits,
     this.mergeable,
+    this.number,
   });
   final Author? author;
   @JsonKey(name: 'authorAssociation')
@@ -155,6 +156,7 @@ class PullRequest {
   final String? body;
   final Reviews? reviews;
   final Commits? commits;
+  final int? number;
   // https://docs.github.com/en/graphql/reference/enums#mergeablestate
   final MergeableState? mergeable;
 

--- a/auto_submit/lib/model/auto_submit_query_result.g.dart
+++ b/auto_submit/lib/model/auto_submit_query_result.g.dart
@@ -96,6 +96,7 @@ PullRequest _$PullRequestFromJson(Map<String, dynamic> json) => PullRequest(
       reviews: json['reviews'] == null ? null : Reviews.fromJson(json['reviews'] as Map<String, dynamic>),
       commits: json['commits'] == null ? null : Commits.fromJson(json['commits'] as Map<String, dynamic>),
       mergeable: $enumDecodeNullable(_$MergeableStateEnumMap, json['mergeable']),
+      number: json['number'] as int?,
     );
 
 Map<String, dynamic> _$PullRequestToJson(PullRequest instance) => <String, dynamic>{
@@ -106,6 +107,7 @@ Map<String, dynamic> _$PullRequestToJson(PullRequest instance) => <String, dynam
       'body': instance.body,
       'reviews': instance.reviews,
       'commits': instance.commits,
+      'number': instance.number,
       'mergeable': _$MergeableStateEnumMap[instance.mergeable],
     };
 

--- a/auto_submit/test/src/validations/fake_approval.dart
+++ b/auto_submit/test/src/validations/fake_approval.dart
@@ -1,0 +1,20 @@
+import 'package:auto_submit/model/auto_submit_query_result.dart';
+
+import 'package:auto_submit/validations/approval.dart';
+import 'package:auto_submit/validations/validation.dart';
+import 'package:github/github.dart' as github;
+
+class FakeApproval extends Approval {
+  FakeApproval({required super.config});
+
+  ValidationResult? validationResult;
+
+  @override
+  String get name => 'FakeApproval';
+
+  /// Implements the code review approval logic.
+  @override
+  Future<ValidationResult> validate(QueryResult result, github.PullRequest messagePullRequest) async {
+    return validationResult ?? ValidationResult(true, Action.REMOVE_LABEL, '');
+  }
+}

--- a/auto_submit/test/src/validations/fake_approval.dart
+++ b/auto_submit/test/src/validations/fake_approval.dart
@@ -1,3 +1,7 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:auto_submit/model/auto_submit_query_result.dart';
 
 import 'package:auto_submit/validations/approval.dart';

--- a/auto_submit/test/src/validations/fake_mergeable.dart
+++ b/auto_submit/test/src/validations/fake_mergeable.dart
@@ -1,0 +1,18 @@
+import 'package:auto_submit/model/auto_submit_query_result.dart';
+import 'package:auto_submit/validations/mergeable.dart';
+import 'package:auto_submit/validations/validation.dart';
+import 'package:github/github.dart' as github;
+
+class FakeMergeable extends Mergeable {
+  FakeMergeable({required super.config});
+
+  ValidationResult? validationResult;
+
+  @override
+  String get name => 'FakeMergeable';
+
+  @override
+  Future<ValidationResult> validate(QueryResult result, github.PullRequest messagePullRequest) async {
+    return validationResult ?? ValidationResult(true, Action.REMOVE_LABEL, '');
+  }
+}

--- a/auto_submit/test/src/validations/fake_mergeable.dart
+++ b/auto_submit/test/src/validations/fake_mergeable.dart
@@ -1,3 +1,7 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/validations/mergeable.dart';
 import 'package:auto_submit/validations/validation.dart';

--- a/auto_submit/test/src/validations/fake_required_check_runs.dart
+++ b/auto_submit/test/src/validations/fake_required_check_runs.dart
@@ -1,3 +1,7 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:auto_submit/validations/required_check_runs.dart';
 import 'package:auto_submit/model/auto_submit_query_result.dart' as auto;
 

--- a/auto_submit/test/src/validations/fake_required_check_runs.dart
+++ b/auto_submit/test/src/validations/fake_required_check_runs.dart
@@ -1,0 +1,19 @@
+import 'package:auto_submit/validations/required_check_runs.dart';
+import 'package:auto_submit/model/auto_submit_query_result.dart' as auto;
+
+import 'package:auto_submit/validations/validation.dart';
+import 'package:github/github.dart' as github;
+
+class FakeRequiredCheckRuns extends RequiredCheckRuns {
+  FakeRequiredCheckRuns({required super.config});
+
+  ValidationResult? validationResult;
+
+  @override
+  String get name => 'FakeRequiredCheckRuns';
+
+  @override
+  Future<ValidationResult> validate(auto.QueryResult result, github.PullRequest messagePullRequest) async {
+    return validationResult ?? ValidationResult(true, Action.REMOVE_LABEL, '');
+  }
+}

--- a/auto_submit/test/src/validations/fake_validation_filter.dart
+++ b/auto_submit/test/src/validations/fake_validation_filter.dart
@@ -1,3 +1,7 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:auto_submit/validations/validation.dart';
 import 'package:auto_submit/validations/validation_filter.dart';
 

--- a/auto_submit/test/src/validations/fake_validation_filter.dart
+++ b/auto_submit/test/src/validations/fake_validation_filter.dart
@@ -1,0 +1,15 @@
+import 'package:auto_submit/validations/validation.dart';
+import 'package:auto_submit/validations/validation_filter.dart';
+
+class FakeValidationFilter implements ValidationFilter {
+  final Set<Validation> validations = {};
+
+  void registerValidation(Validation newValidation) {
+    validations.add(newValidation);
+  }
+
+  @override
+  Set<Validation> getValidations() {
+    return validations;
+  }
+}


### PR DESCRIPTION
Add supporting fake classes for testing and a new field for the autosubmit query result.

*List which issues are fixed by this PR. You must list at least one issue.*
Part of https://github.com/flutter/flutter/issues/113867

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
