### PR TITLE
Fix push handling by removing the PushEvent in favor of Map

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -114,13 +114,13 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         }
         break;
       case 'push':
-        final PushEvent pushEvent = PushEvent.fromJson(json.decode(webhook.payload) as Map<String, dynamic>);
-        final String branch = pushEvent.ref!.split('/')[2]; // Eg: refs/heads/beta would return beta.
-        final String repository = pushEvent.repository!.name;
+        final Map<String, dynamic> event = jsonDecode(webhook.payload) as Map<String, dynamic>;
+        final String branch = event["ref"].split('/')[2]; // Eg: refs/heads/beta would return beta.
+        final String repository = event["repository"]["name"];
         // If the branch is beta/stable, then a commit wasn't created through a PR,
         // meaning the commit needs to be added to the datastore here instead.
         if (repository == 'flutter' && (branch == 'stable' || branch == 'beta')) {
-          await commitService.handlePushGithubRequest(pushEvent);
+          await commitService.handlePushGithubRequest(event);
         }
         break;
     }

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -115,8 +115,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         break;
       case 'push':
         final Map<String, dynamic> event = jsonDecode(webhook.payload) as Map<String, dynamic>;
-        final String branch = event["ref"].split('/')[2]; // Eg: refs/heads/beta would return beta.
-        final String repository = event["repository"]["name"];
+        final String branch = event['ref'].split('/')[2]; // Eg: refs/heads/beta would return beta.
+        final String repository = event['repository']['name'];
         // If the branch is beta/stable, then a commit wasn't created through a PR,
         // meaning the commit needs to be added to the datastore here instead.
         if (repository == 'flutter' && (branch == 'stable' || branch == 'beta')) {

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -42,7 +42,7 @@ class CommitService {
     final DatastoreService datastore = datastoreProvider(config.db);
     final RepositorySlug slug = RepositorySlug.full(pushEvent['repository']['full_name']);
     final String sha = pushEvent['head_commit']['id'];
-    final String branch = pushEvent["ref"].split('/')[2];
+    final String branch = pushEvent['ref'].split('/')[2];
     final String id = '${slug.fullName}/$branch/$sha';
     final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit commit = Commit(

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -40,21 +40,21 @@ class CommitService {
   /// https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
   Future<void> handlePushGithubRequest(Map<String, dynamic> pushEvent) async {
     final DatastoreService datastore = datastoreProvider(config.db);
-    final RepositorySlug slug = RepositorySlug.full(pushEvent["repository"]["full_name"]);
-    final String sha = pushEvent["head_commit"]["id"];
+    final RepositorySlug slug = RepositorySlug.full(pushEvent['repository']['full_name']);
+    final String sha = pushEvent['head_commit']['id'];
     final String branch = pushEvent["ref"].split('/')[2];
     final String id = '${slug.fullName}/$branch/$sha';
     final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit commit = Commit(
       key: key,
-      timestamp: DateTime.parse(pushEvent["head_commit"]["timestamp"]).millisecondsSinceEpoch,
+      timestamp: DateTime.parse(pushEvent['head_commit']['timestamp']).millisecondsSinceEpoch,
       repository: slug.fullName,
       sha: sha,
-      author: pushEvent["sender"]["login"],
-      authorAvatarUrl: pushEvent["sender"]["avatar_url"],
+      author: pushEvent['sender']['login'],
+      authorAvatarUrl: pushEvent['sender']['avatar_url'],
       // The field has a size of 1500 we need to ensure the commit message
       // is at most 1500 chars long.
-      message: truncate(pushEvent["head_commit"]["message"], 1490, omission: '...'),
+      message: truncate(pushEvent['head_commit']['message'], 1490, omission: '...'),
       branch: branch,
     );
     await _insertCommitIntoDatastore(datastore, commit);

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -36,24 +36,25 @@ class CommitService {
     await _insertCommitIntoDatastore(datastore, commit);
   }
 
-  /// Add a commit based on a [PushEvent] to the Datastore.
-  Future<void> handlePushGithubRequest(PushEvent pushEvent) async {
+  /// Add a commit based on a Push event to the Datastore.
+  /// https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
+  Future<void> handlePushGithubRequest(Map<String, dynamic> pushEvent) async {
     final DatastoreService datastore = datastoreProvider(config.db);
-    final RepositorySlug slug = RepositorySlug.full(pushEvent.repository!.fullName);
-    final String sha = pushEvent.headCommit!.id!;
-    final String branch = pushEvent.ref!.split('/')[2];
+    final RepositorySlug slug = RepositorySlug.full(pushEvent["repository"]["full_name"]);
+    final String sha = pushEvent["head_commit"]["id"];
+    final String branch = pushEvent["ref"].split('/')[2];
     final String id = '${slug.fullName}/$branch/$sha';
     final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit commit = Commit(
       key: key,
-      timestamp: pushEvent.headCommit!.timestamp!.millisecondsSinceEpoch,
+      timestamp: DateTime.parse(pushEvent["head_commit"]["timestamp"]).millisecondsSinceEpoch,
       repository: slug.fullName,
-      sha: pushEvent.headCommit?.id,
-      author: pushEvent.sender?.login,
-      authorAvatarUrl: pushEvent.sender?.avatarUrl,
+      sha: sha,
+      author: pushEvent["sender"]["login"],
+      authorAvatarUrl: pushEvent["sender"]["avatar_url"],
       // The field has a size of 1500 we need to ensure the commit message
       // is at most 1500 chars long.
-      message: truncate(pushEvent.headCommit!.message!, 1490, omission: '...'),
+      message: truncate(pushEvent["head_commit"]["message"], 1490, omission: '...'),
       branch: branch,
     );
     await _insertCommitIntoDatastore(datastore, commit);

--- a/app_dart/test/service/commit_service_test.dart
+++ b/app_dart/test/service/commit_service_test.dart
@@ -130,7 +130,7 @@ void main() {
     test('adds commit to db if it does not exist in the datastore', () async {
       expect(db.values.values.whereType<Commit>().length, 0);
 
-      final PushEvent pushEvent = generatePushEvent(
+      final Map<String, dynamic> pushEvent = generatePushEvent(
         branch,
         owner,
         repository,
@@ -165,7 +165,7 @@ void main() {
       await config.db.commit(inserts: datastoreCommit);
       expect(db.values.values.whereType<Commit>().length, 1);
 
-      final PushEvent pushEvent = generatePushEvent(
+      final Map<String, dynamic> pushEvent = generatePushEvent(
         branch,
         owner,
         repository,

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -1523,7 +1523,7 @@ class MockCommitService extends _i1.Mock implements _i28.CommitService {
         returnValueForMissingStub: _i20.Future<void>.value(),
       ) as _i20.Future<void>);
   @override
-  _i20.Future<void> handlePushGithubRequest(_i27.PushEvent? pushEvent) => (super.noSuchMethod(
+  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) => (super.noSuchMethod(
         Invocation.method(
           #handlePushGithubRequest,
           [pushEvent],
@@ -1551,6 +1551,22 @@ class MockConfig extends _i1.Mock implements _i3.Config {
         Invocation.getter(#postsubmitSupportedRepos),
         returnValue: <_i14.RepositorySlug>{},
       ) as Set<_i14.RepositorySlug>);
+  @override
+  _i8.RetryOptions get getGobRetryOptions => (super.noSuchMethod(
+        Invocation.getter(#getGobRetryOptions),
+        returnValue: _FakeRetryOptions_7(
+          this,
+          Invocation.getter(#getGobRetryOptions),
+        ),
+      ) as _i8.RetryOptions);
+  @override
+  set setGobRetryOptions(_i8.RetryOptions? retryOptions) => super.noSuchMethod(
+        Invocation.setter(
+          #setGobRetryOptions,
+          retryOptions,
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   _i11.Logging get loggingService => (super.noSuchMethod(
         Invocation.getter(#loggingService),
@@ -1857,20 +1873,6 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           this,
           Invocation.method(
             #createGitHubGraphQLClient,
-            [],
-          ),
-        )),
-      ) as _i20.Future<_i15.GraphQLClient>);
-  @override
-  _i20.Future<_i15.GraphQLClient> createCirrusGraphQLClient() => (super.noSuchMethod(
-        Invocation.method(
-          #createCirrusGraphQLClient,
-          [],
-        ),
-        returnValue: _i20.Future<_i15.GraphQLClient>.value(_FakeGraphQLClient_18(
-          this,
-          Invocation.method(
-            #createCirrusGraphQLClient,
             [],
           ),
         )),

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -1036,10 +1036,10 @@ Map<String, dynamic> generatePushEvent(
   String branch,
   String organization,
   String repository, {
-  String sha = "def456def456def456",
-  String message = "Commit-message",
-  String avatarUrl = "https://fakegithubcontent.com/google_profile",
-  String username = "googledotcom",
+  String sha = 'def456def456def456',
+  String message = 'Commit-message',
+  String avatarUrl = 'https://fakegithubcontent.com/google_profile',
+  String username = 'googledotcom',
 }) =>
     jsonDecode('''
 {

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -1027,12 +1027,12 @@ CreateEvent generateCreateBranchEvent(String branchName, String repository, {boo
     );
 
 PushMessage generatePushMessage(String branch, String organization, String repository) {
-  final PushEvent event = generatePushEvent(branch, organization, repository);
+  final Map<String, dynamic> event = generatePushEvent(branch, organization, repository);
   final pb.GithubWebhookMessage message = pb.GithubWebhookMessage(event: 'push', payload: jsonEncode(event));
   return PushMessage(data: message.writeToJson(), messageId: 'abc123');
 }
 
-PushEvent generatePushEvent(
+Map<String, dynamic> generatePushEvent(
   String branch,
   String organization,
   String repository, {
@@ -1041,8 +1041,7 @@ PushEvent generatePushEvent(
   String avatarUrl = "https://fakegithubcontent.com/google_profile",
   String username = "googledotcom",
 }) =>
-    PushEvent.fromJson(
-      jsonDecode('''
+    jsonDecode('''
 {
   "ref": "refs/heads/$branch",
   "before": "abc123abc123abc123",
@@ -1070,5 +1069,4 @@ PushEvent generatePushEvent(
     "full_name": "$organization/$repository"
   }
 }
-'''),
-    );
+''');


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/134746

* The github `Push` event has discrepancies to other similar objects sent and returned by Github, which was causing the automatic conversion from json to fail. Instead of adding more bloat to the github package through adding extensions of objects, use a map since there are only a few values we need from the webhook.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
