### PR TITLE
[dashboard] Show release branches regardless of repo

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -268,7 +268,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
             ),
           ),
           ...buildState.branches
-              .where((Branch b) => b.repository == buildState.currentRepo && b.branch != buildState.currentBranch)
+              .where((Branch b) => b.branch != buildState.currentBranch)
               .map<DropdownMenuItem<String>>((Branch b) {
             final String branchPrefix = (b.channel != 'HEAD') ? '${b.channel}: ' : '';
             return DropdownMenuItem<String>(

--- a/dashboard/lib/logic/qualified_task.dart
+++ b/dashboard/lib/logic/qualified_task.dart
@@ -18,7 +18,6 @@ class StageName {
 }
 
 /// Base URLs for various endpoints that can relate to a [Task].
-const String _cirrusUrl = 'https://cirrus-ci.com/github/flutter/flutter';
 const String _luciUrl = 'https://ci.chromium.org/p/flutter';
 const String _googleTestUrl = 'https://flutter-rob.corp.google.com';
 const String _dartInternalUrl = 'https://ci.chromium.org/p/dart-internal';

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -126,19 +126,20 @@ class DevelopmentCocoonService implements CocoonService {
 
   @override
   Future<CocoonResponse<List<Branch>>> fetchFlutterBranches() async {
-    final List<Branch> fakeBranches = <Branch>[];
-    for (String repo in _repos) {
-      fakeBranches.add(
-        Branch()
-          ..repository = repo
-          ..branch = defaultBranches[repo]!,
-      );
-      fakeBranches.add(
-        Branch()
-          ..repository = repo
-          ..branch = '$repo-release',
-      );
-    }
+    final List<Branch> fakeBranches = <Branch>[
+      Branch()
+        ..channel = 'HEAD'
+        ..branch = 'master',
+      Branch()
+        ..channel = 'stable'
+        ..branch = 'flutter-3.13-candidate.0',
+      Branch()
+        ..channel = 'beta'
+        ..branch = 'flutter-3.15-candidate.5',
+      Branch()
+        ..channel = 'dev'
+        ..branch = 'flutter-3.15-candidate.12',
+    ];
     return CocoonResponse<List<Branch>>.data(fakeBranches);
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/133622

Release branches are generic to the repos. Remove the legacy check for the specific repo, which is no longer returned.

Updated the fake data to properly reflect the expected state.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
