### PR TITLE
Revert "Add a retry for checking for the GoB commit after PR merged"

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -208,16 +208,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
   Future<bool> _commitExistsInGob(PullRequest pr) async {
     final RepositorySlug slug = pr.base!.repo!.slug();
     final String sha = pr.mergeCommitSha!;
-    GerritCommit? gobCommit;
-    await config.getGobRetryOptions.retry(
-      () async {
-        gobCommit = await gerritService.findMirroredCommit(slug, sha);
-        if (gobCommit == null) {
-          throw InternalServerError('$sha was not found on GoB. Failing so this event can be retried...');
-        }
-      },
-      retryIf: (e) => e is InternalServerError,
-    );
+    final GerritCommit? gobCommit = await gerritService.findMirroredCommit(slug, sha);
     return gobCommit != null;
   }
 

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -80,18 +80,6 @@ class Config {
     return defaultBranches[slug] ?? kDefaultBranchName;
   }
 
-  // GoB retry options
-  RetryOptions _gobRetryOptions = const RetryOptions(
-    maxAttempts: 4,
-    delayFactor: Duration(seconds: 30),
-  );
-
-  RetryOptions get getGobRetryOptions => _gobRetryOptions;
-
-  set setGobRetryOptions(RetryOptions retryOptions) {
-    _gobRetryOptions = retryOptions;
-  }
-
   /// Memorystore subcache name to store [CocoonConfig] values in.
   static const String configCacheName = 'config';
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -14,7 +14,6 @@ import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart' as gh;
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:graphql/client.dart';
-import 'package:retry/retry.dart';
 
 import '../request_handling/fake_authentication.dart';
 import '../service/fake_github_service.dart';
@@ -105,12 +104,6 @@ class FakeConfig implements Config {
   Set<gh.RepositorySlug>? supportedReposValue;
   Set<gh.RepositorySlug>? postsubmitSupportedReposValue;
   Duration? githubRequestDelayValue;
-
-  // GoB retry options
-  RetryOptions _gobRetryOptions = const RetryOptions(
-    maxAttempts: 1,
-    delayFactor: Duration(seconds: 0),
-  );
 
   @override
   Future<gh.GitHub> createGitHubClient({gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async => githubClient!;
@@ -303,13 +296,5 @@ class FakeConfig implements Config {
         ),
       ),
     );
-  }
-
-  @override
-  RetryOptions get getGobRetryOptions => _gobRetryOptions;
-
-  @override
-  set setGobRetryOptions(RetryOptions retryOptions) {
-    _gobRetryOptions = retryOptions;
   }
 }


### PR DESCRIPTION
Reverts flutter/cocoon#3042

Fixes https://github.com/flutter/flutter/issues/135518

This was preventing messages from being processed as if copybara is latent we can get in a loop of retrying for the commit while blocking reprocessing from pubsub. This will result in unacked messages and will cause them to be retried on exponential backoff.

![before_retry_removal](https://github.com/flutter/cocoon/assets/32242716/5641f9c1-62ee-4704-93ca-47cf9bf8a510)

Removing the retry we can see that the unacked messages are being retried now as we are not passing the ack deadline.

![image](https://github.com/flutter/cocoon/assets/32242716/071d8882-d3c2-4b1b-9178-7464180c985e)
