### PR TITLE
Adding a log for builders found vs build name in presubmit subscription

### DIFF
--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -130,6 +130,16 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       rethrow;
     }
 
+    // alternative solution, just not reschedule.
+    // This might be allowable. We are checking tip of tree but I don't think the 
+    // target has been deleted.
+
+    // if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
+    //   // do not reschedule
+    //   return 1;
+    // }
+    // final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
+
     final Map<String, Object> properties = target.getProperties();
     
     if (!properties.containsKey('presubmit_max_attempts')) {

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -120,28 +120,17 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       ciYaml = await scheduler.getCiYaml(commit);
     }
 
-    Target target;
-    try {
-      target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
-    } on Exception {
+    // Do not block on the target not found. 
+    if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
+      // do not reschedule
       log.warning('Did not find builder with name: $builderName in ciYaml for ${commit.sha}');
       final List<String> availableBuilderList = ciYaml.presubmitTargets.map((Target e) => e.value.name).toList();
       log.warning('ciYaml presubmit targets found: $availableBuilderList');
-      rethrow;
+      return 1;
     }
-
-    // alternative solution, just not reschedule.
-    // This might be allowable. We are checking tip of tree but I don't think the
-    // target has been deleted.
-
-    // if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
-    //   // do not reschedule
-    //   return 1;
-    // }
-    // final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
-
+    
+    final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
     final Map<String, Object> properties = target.getProperties();
-
     if (!properties.containsKey('presubmit_max_attempts')) {
       return 1;
     }

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -120,7 +120,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       ciYaml = await scheduler.getCiYaml(commit);
     }
 
-    // Do not block on the target not found. 
+    // Do not block on the target not found.
     if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
       // do not reschedule
       log.warning('Did not find builder with name: $builderName in ciYaml for ${commit.sha}');
@@ -128,7 +128,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       log.warning('ciYaml presubmit targets found: $availableBuilderList');
       return 1;
     }
-    
+
     final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
     final Map<String, Object> properties = target.getProperties();
     if (!properties.containsKey('presubmit_max_attempts')) {

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -131,7 +131,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     }
 
     // alternative solution, just not reschedule.
-    // This might be allowable. We are checking tip of tree but I don't think the 
+    // This might be allowable. We are checking tip of tree but I don't think the
     // target has been deleted.
 
     // if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
@@ -141,7 +141,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     // final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
 
     final Map<String, Object> properties = target.getProperties();
-    
+
     if (!properties.containsKey('presubmit_max_attempts')) {
       return 1;
     }


### PR DESCRIPTION
Occasionally we hit an issue where we cannot get an element from the ciYaml and then cannot update an existing task in presubmit. This implies that we found none or more than one task. This log message will let us know which it is if hit again.

*List which issues are fixed by this PR. You must list at least one issue.*
Related to https://github.com/flutter/flutter/issues/135640

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
