### PR TITLE
Skip get check run API call when updating check runs

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -93,7 +93,7 @@ class GithubChecksService {
       'id': buildPushMessage.userData['check_run_id'] as int?,
       'status': status,
       'check_suite': const {'id': null},
-      'started_at': build.createdTimestamp.toString(),
+      'started_at': build.startedTimestamp.toString(),
       'conclusion': null,
       'name': build.buildParameters!['builder_name'],
     });

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -85,16 +85,21 @@ class GithubChecksService {
       );
       return false;
     }
-    final github.CheckRun checkRun = await githubChecksUtil.getCheckRun(
-      config,
-      slug,
-      buildPushMessage.userData['check_run_id'] as int?,
-    );
     github.CheckRunStatus status = statusForResult(build!.status);
+    // Only `id` and `name` in the CheckRun are needed.
+    // Instead of making an API call to get the details of each check run, we
+    // generate the check run with only necessary info.
+    final github.CheckRun checkRun = github.CheckRun.fromJson({
+      'id': buildPushMessage.userData['check_run_id'] as int?,
+      'status': status,
+      'check_suite': const {'id': null},
+      'started_at': build.createdTimestamp.toString(),
+      'conclusion': null,
+      'name': build.buildParameters!['builder_name'],
+    });
     github.CheckRunConclusion? conclusion =
         (buildPushMessage.build!.result != null) ? conclusionForResult(buildPushMessage.build!.result) : null;
-    // Do not override url for completed status.
-    final String? url = status == github.CheckRunStatus.completed ? checkRun.detailsUrl : buildPushMessage.build!.url;
+    final String? url = buildPushMessage.build!.url;
     github.CheckRunOutput? output;
     // If status has completed with failure then provide more details.
     if (taskFailed(buildPushMessage)) {

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -50,7 +50,7 @@ void main() {
     );
     checkRun = github.CheckRun.fromJson(
       jsonDecode(
-        '{"name": "Cocoon", "id": 123, "external_id": "678", "status": "completed", "started_at": "2020-05-10T02:49:31Z", "head_sha": "the_sha", "check_suite": {"id": 456}}',
+        '{"name": "Linux Coverage", "id": 123, "external_id": "678", "status": "completed", "started_at": "2020-05-10T02:49:31Z", "head_sha": "the_sha", "check_suite": {"id": 456}}',
       ) as Map<String, dynamic>,
     );
     final Map<String, github.CheckRun> checkRuns = <String, github.CheckRun>{'Cocoon': checkRun};
@@ -113,26 +113,25 @@ void main() {
       );
       final push_message.BuildPushMessage buildPushMessage = push_message.BuildPushMessage.fromJson(
         jsonDecode(
-          buildPushMessageJsonTemplate('{\\"check_run_id\\": 1,'
+          buildPushMessageJsonTemplate('{\\"check_run_id\\": 123,'
               '\\"repo_owner\\": \\"flutter\\",'
               '\\"repo_name\\": \\"cocoon\\"}'),
         ) as Map<String, dynamic>,
       );
       await githubChecksService.updateCheckStatus(buildPushMessage, mockLuciBuildService, slug);
-      expect(
-        verify(
-          mockGithubChecksUtil.updateCheckRun(
-            any,
-            any,
-            captureAny,
-            status: anyNamed('status'),
-            conclusion: anyNamed('conclusion'),
-            detailsUrl: anyNamed('detailsUrl'),
-            output: anyNamed('output'),
-          ),
-        ).captured,
-        <github.CheckRun>[checkRun],
-      );
+      final github.CheckRun checkRunCaptured = await verify(
+        mockGithubChecksUtil.updateCheckRun(
+          any,
+          any,
+          captureAny,
+          status: anyNamed('status'),
+          conclusion: anyNamed('conclusion'),
+          detailsUrl: anyNamed('detailsUrl'),
+          output: anyNamed('output'),
+        ),
+      ).captured.first;
+      expect(checkRunCaptured.id, checkRun.id);
+      expect(checkRunCaptured.name, checkRun.name);
     });
     test('Should rerun a failed task for a roller account', () async {
       when(mockGithubChecksUtil.getCheckRun(any, any, any)).thenAnswer((_) async => checkRun);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/132616.

This PR updates checkrun based on the one generated via check_run_id from build.user_data, instead of gets all detailed checkrun by calling the API.

The motivation is reduce API quota use.