### PR TITLE
Create engine artifact cleaner

### DIFF
--- a/dev/gcs_cleaner/README.md
+++ b/dev/gcs_cleaner/README.md
@@ -1,0 +1,35 @@
+# GCS Cleaner
+
+Scrapes Flutter's Google Cloud Storage for artifacts that should no longer be
+retained. Due to Flutter's release process uploading artifacts to the same place
+as HEAD, we can't use a built in retention plan.
+
+## Retention Policy
+
+1. Never delete an artifact that was shipped in a release
+   A. For any framework tag, we will retain the artifacts from the engine commit it shipped
+2. Only retain artifacts from the past 6 months (subject to change)
+
+## Overview
+
+1. Generate the list of engine commits that were shipped in a release
+   A. List all tags from flutter/flutter, and lookup their engine version
+2. List all commits in gs://flutter_infra_release/flutter older than a year
+3. Delete commit if not in (1)
+
+## Permissions
+
+Due to the infrequency this needs to run, this is intended to be run on a
+human workstation. Multi-party approval is required, which requires a Googler
+to run.
+
+GCP owners access is required, see go/flutter-aod.
+
+## Running
+
+```**sh**
+dart bin cleaner.dart \
+  --token=$(gcloud auth print-identity-token) \
+  --framework=$HOME/flutter
+  # --no-dryrun to implement retention policy
+```

--- a/dev/gcs_cleaner/analysis_options.yaml
+++ b/dev/gcs_cleaner/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  language:
+    strict-casts: false
+    strict-raw-types: false

--- a/dev/gcs_cleaner/bin/cleaner.dart
+++ b/dev/gcs_cleaner/bin/cleaner.dart
@@ -1,0 +1,63 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/args.dart';
+import 'package:file/local.dart';
+import 'package:gcloud/storage.dart';
+import 'package:gcs_cleaner/cleaner.dart';
+import 'package:gcs_cleaner/git.dart';
+import 'package:googleapis_auth/googleapis_auth.dart';
+import 'package:process/process.dart';
+
+final ArgParser parser = ArgParser()
+  ..addFlag(
+    'dryrun',
+    help: 'By default, this will list the artifacts that will be deleted.\n'
+        'Passing --no-dryrun will delete the artifacts from GCS',
+  )
+  ..addOption(
+    'engine',
+    help: 'Path to the local engine checkout',
+  )
+  ..addOption(
+    'framework',
+    help: 'Path to a local framework checkout',
+  )
+  ..addOption(
+    'token',
+    help: 'GCS access token',
+  )
+  ..addOption(
+    'ttl',
+    help: 'Duration in days for age of artifacts that should be retained',
+  );
+
+Future<void> main(List<String> args) async {
+  final flags = parser.parse(args);
+
+  final Git frameworkGit = Git(
+    path: flags['framework'],
+    pm: const LocalProcessManager(),
+  );
+  final Git engineGit = Git(
+    path: flags['engine'],
+    pm: const LocalProcessManager(),
+  );
+
+  // Read the service account credentials from the file.
+  final client = clientViaApiKey(flags['token']);
+  final gcs = Storage(client, 'flutter-infra');
+  // Default retention is 1 year.
+  final ttl = Duration(days: int.tryParse(flags['ttl']) ?? 365);
+  final Cleaner cleaner = Cleaner(
+    fs: const LocalFileSystem(),
+    gcs: gcs,
+    engineGit: engineGit,
+    frameworkGit: frameworkGit,
+    isDryrun: flags['dryrun'],
+    ttl: ttl,
+  );
+
+  await cleaner.clean();
+}

--- a/dev/gcs_cleaner/lib/cleaner.dart
+++ b/dev/gcs_cleaner/lib/cleaner.dart
@@ -1,0 +1,157 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:gcloud/storage.dart';
+import 'package:meta/meta.dart';
+
+import 'git.dart';
+import 'log.dart';
+
+/// Cleans engine artifacts that are outside the retention policy.
+class Cleaner {
+  Cleaner({
+    required this.fs,
+    required this.engineGit,
+    required this.frameworkGit,
+    required this.gcs,
+    required this.ttl,
+    this.isDryrun = true,
+    DateTime? now,
+  }) : _now = now;
+
+  final Storage gcs;
+
+  final FileSystem fs;
+
+  final Git engineGit;
+  final Git frameworkGit;
+
+  /// Whether calculated artifacts should be deleted.
+  ///
+  /// Default value is to run in dry run.
+  final bool isDryrun;
+
+  /// Injectable [DateTime] for testing.
+  final DateTime? _now;
+
+  /// Retention policy for how long artifacts can stay before they are deleted.
+  final Duration ttl;
+
+  /// Number of commits scanned.
+  int totalCount = 0;
+
+  /// Number of commits scanned that will not be deleted due to TTL.
+  int totalNewCount = 0;
+
+  int totalErrors = 0;
+
+  Bucket get artifactBucket => gcs.bucket('flutter_infra_release');
+
+  Future<void> clean() async {
+    final Map<String, String> frameworkCommitTags = await frameworkGit.tags();
+    final Map<String, String> engineCommitTags = <String, String>{};
+    for (final frameworkCommit in frameworkCommitTags.keys) {
+      final engineCommit = await frameworkGit.lookupEngineCommit(frameworkCommit);
+      if (engineCommit != null) {
+        // While unlikely, a single engine commit may be shipped in multiple releases.
+        engineCommitTags[engineCommit] = frameworkCommitTags[frameworkCommit]!;
+      }
+    }
+
+    final toBeDeleted = <String>{};
+
+    final lsStream = artifactBucket.list(prefix: 'flutter/');
+    log.info('Scanning gs://flutter_infra_release...');
+    final items = await lsStream.toList();
+    log.info('gs://flutter_infra_release has ${items.length} items');
+    for (final item in items) {
+      final commit = await processEngineArtifact(
+        bucket: artifactBucket,
+        item: item,
+        engineCommitTags: engineCommitTags,
+      );
+      if (commit != null) {
+        toBeDeleted.add(commit);
+      }
+    }
+
+    log.info('$totalCount commits scanned from gs://flutter_infra_release');
+    log.info('${engineCommitTags.keys.length} commits that are permanently retained');
+    log.info('$totalErrors errors');
+    log.info('$totalNewCount commits are younger than $ttl');
+    log.info('${toBeDeleted.length} to be deleted');
+
+    if (isDryrun) {
+      final file = fs.currentDirectory.childFile('results_${_now?.toIso8601String()}.csv')..createSync();
+      file.writeAsStringSync(toBeDeleted.join('\n'));
+      log.info('Wrote ${file.absolute} with to be deleted files');
+      log.info('Dryrun complete!');
+      return;
+    }
+
+    final toDeleteFutures = <Future>[];
+    for (final commit in toBeDeleted) {
+      toDeleteFutures.add(deletePrefix('flutter/$commit'));
+    }
+    await Future.wait(toDeleteFutures);
+  }
+
+  /// If [BucketEntry] should be deleted, returns the associated commit hash.
+  ///
+  /// The given policy is enforced for retaining objects:
+  /// 1. If an object cannot be translated to a commit
+  /// 2. If object is a release engine version
+  /// 3. If object's commit is newer than [ttl]
+  @visibleForTesting
+  Future<String?> processEngineArtifact({
+    required Bucket bucket,
+    required BucketEntry item,
+    required Map<String, String> engineCommitTags,
+  }) async {
+    final parts = item.name.split('/');
+    if (parts.length < 2) {
+      return null;
+    }
+    final commit = parts[1];
+    if (!item.isDirectory) {
+      // There's stricter checks we could follow but skip for non commit folders
+      return null;
+    }
+
+    totalCount++;
+    if (totalCount % 1000 == 0) {
+      log.info('Scanned $totalCount commits, still scanning...');
+    }
+
+    if (engineCommitTags.containsKey(commit)) {
+      return null;
+    }
+
+    final commitTime = await engineGit.lookupCommitTime(commit);
+    if (commitTime == null) {
+      totalErrors++;
+      return null;
+    }
+    final now = _now ?? DateTime.now();
+    final Duration age = now.difference(commitTime);
+    if (age < ttl) {
+      totalNewCount++;
+      if (totalNewCount % 500 == 0) {
+        log.info('Scanned $totalNewCount new commits, still scanning...');
+      }
+      return null;
+    }
+    return commit;
+  }
+
+  /// Recursively go through the given prefix and delete all objects under it.
+  Future<void> deletePrefix(String path) async {
+    final page = await artifactBucket.page(prefix: path, pageSize: 1000);
+    for (final item in page.items) {
+      log.info('Deleting ${item.name}...');
+      await artifactBucket.delete(item.name);
+    }
+  }
+}

--- a/dev/gcs_cleaner/lib/exceptions.dart
+++ b/dev/gcs_cleaner/lib/exceptions.dart
@@ -1,0 +1,21 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class GcsCleanerException implements Exception {
+  GcsCleanerException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'GCS Cleaner Exception: $message';
+}
+
+class GitException implements Exception {
+  GitException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'Git Exception: $message';
+}

--- a/dev/gcs_cleaner/lib/git.dart
+++ b/dev/gcs_cleaner/lib/git.dart
@@ -1,0 +1,86 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcs_cleaner/exceptions.dart';
+import 'package:process/process.dart';
+
+class Git {
+  const Git({
+    required this.path,
+    required this.pm,
+  });
+
+  /// Path of the framework repo.
+  final String path;
+
+  /// Current process manager to use.
+  final ProcessManager pm;
+
+  /// Generates a map of commits pointing to their associated tag.
+  ///
+  /// If a commit does not exist in the map, it indicates the commit was never
+  /// shipped to users.
+  Future<Map<String, String>> tags() async {
+    final result = await _run(<String>['show-ref', '--tags']);
+    final Map<String, String> commitTags = <String, String>{};
+    for (final line in result.split('\n')) {
+      final List<String> parts = line.split(' ');
+      final sha = parts.first;
+      final tag = parts[1];
+      // A commit with duplicate tags isn't relevant as it's going to be retained.
+      commitTags[sha] = tag;
+    }
+    return commitTags;
+  }
+
+  /// Returns the engine commit associated with [frameworkCommit].
+  ///
+  /// The framework pins its engine dependencie in `bin/internal/engine.version`.
+  Future<String?> lookupEngineCommit(String frameworkCommit) async {
+    try {
+      final result = await _run(<String>['show', '$frameworkCommit:bin/internal/engine.version']);
+      return result;
+    } on GitException {
+      // Tags circa 2015 will not have bin/internal/engine.version
+      return null;
+    }
+  }
+
+  /// Returns the [DateTime] when a commit was pushed.
+  Future<DateTime?> lookupCommitTime(String sha) async {
+    try {
+      // %cs is committer date in YYYY-MM-DD
+      final result = await _run(<String>[
+        'show',
+        sha,
+        '--pretty=%cs',
+        '--no-patch',
+        '--no-notes',
+      ]);
+      return DateTime.tryParse(result.trim());
+    } on GitException {
+      return null;
+    }
+  }
+
+  /// Runs the given git command in the existing checkout path.
+  Future<String> _run(List<String> command) async {
+    final result = await pm.run(
+      <String>['git', ...command],
+      workingDirectory: path,
+    );
+    if (result.exitCode != 0) {
+      throw GitException(
+        'git $command failed with exit code ${result.exitCode}\n'
+        'stdout: ${result.stdout}\n'
+        'stderr: ${result.stderr}',
+      );
+    }
+
+    final stdout = result.stdout as String;
+    return stdout.trim();
+  }
+}

--- a/dev/gcs_cleaner/lib/log.dart
+++ b/dev/gcs_cleaner/lib/log.dart
@@ -1,0 +1,11 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+
+final Logger log = Logger('gcs_cleaner')
+  ..onRecord.listen((record) {
+    // ignore: avoid_print
+    print('${record.level.name}: ${record.time}: ${record.message}');
+  });

--- a/dev/gcs_cleaner/pubspec.yaml
+++ b/dev/gcs_cleaner/pubspec.yaml
@@ -1,0 +1,21 @@
+name: gcs_cleaner
+description: CLI tool for removing engine artifacts from GCS that are not used
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.1.0
+
+dependencies:
+  args: ^2.4.2
+  file: ^6.1.4
+  gcloud: ^0.8.11
+  googleapis_auth: ^1.4.1
+  logging: ^1.2.0
+  meta: ^1.11.0
+  process: ^4.2.4
+
+dev_dependencies:
+  flutter_lints: ^2.0.3
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/dev/gcs_cleaner/test/cleaner_test.dart
+++ b/dev/gcs_cleaner/test/cleaner_test.dart
@@ -1,0 +1,43 @@
+import 'package:file/memory.dart';
+import 'package:gcloud/storage.dart';
+import 'package:gcs_cleaner/cleaner.dart';
+import 'package:test/test.dart';
+
+import 'src/fake_gcs.dart';
+import 'src/fake_git.dart';
+
+void main() {
+  group(Cleaner, () {
+    group('processEngineArtifact', () {
+      const Bucket bucket = FakeBucket('fake_bucket');
+      final Map<String, String> engineCommitTags = <String, String>{
+        'release': '3.0.0',
+      };
+      final Cleaner cleaner = Cleaner(
+        fs: MemoryFileSystem(),
+        gcs: FakeGcs(),
+        engineGit: FakeGit(),
+        frameworkGit: FakeGit(),
+        ttl: const Duration(days: 365),
+        now: DateTime(2023, 10, 10),
+      );
+
+      <BucketEntry, String?>{
+        const FakeBucketItem(name: 'random_file'): null,
+        const FakeBucketItem(name: 'flutter/release'): null,
+        const FakeBucketItem(name: 'flutter/old_sha'): 'old_sha',
+        const FakeBucketItem(name: 'flutter/new_sha'): null,
+        const FakeBucketItem(name: 'flutter/old_file', isDirectory: false): null,
+      }.forEach((key, value) {
+        test('${key.name} returns $value', () async {
+          final got = await cleaner.processEngineArtifact(
+            bucket: bucket,
+            item: key,
+            engineCommitTags: engineCommitTags,
+          );
+          expect(got, value);
+        });
+      });
+    });
+  });
+}

--- a/dev/gcs_cleaner/test/src/fake_gcs.dart
+++ b/dev/gcs_cleaner/test/src/fake_gcs.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:gcloud/storage.dart';
+
+class FakeGcs implements Storage {
+  @override
+  Bucket bucket(String bucketName, {PredefinedAcl? defaultPredefinedObjectAcl, Acl? defaultObjectAcl}) {
+    return FakeBucket(bucketName);
+  }
+
+  @override
+  Future<bool> bucketExists(String bucketName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BucketInfo> bucketInfo(String bucketName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future copyObject(String src, String dest) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future createBucket(String bucketName, {PredefinedAcl? predefinedAcl, Acl? acl}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future deleteBucket(String bucketName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<String> listBucketNames() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Page<String>> pageBucketNames({int pageSize = 50}) {
+    throw UnimplementedError();
+  }
+}
+
+class FakeBucket implements Bucket {
+  const FakeBucket(this.bucketName);
+
+  @override
+  String absoluteObjectName(String objectName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  final String bucketName;
+
+  @override
+  Future delete(String name) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ObjectInfo> info(String name) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<BucketEntry> list({String? prefix, String? delimiter}) {
+    // TODO(chillers): Implement list.
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Page<BucketEntry>> page({String? prefix, String? delimiter, int pageSize = 50}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<List<int>> read(String objectName, {int? offset, int? length}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future updateMetadata(String objectName, ObjectMetadata metadata) {
+    throw UnimplementedError();
+  }
+
+  @override
+  StreamSink<List<int>> write(
+    String objectName, {
+    int? length,
+    ObjectMetadata? metadata,
+    Acl? acl,
+    PredefinedAcl? predefinedAcl,
+    String? contentType,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ObjectInfo> writeBytes(
+    String name,
+    List<int> bytes, {
+    ObjectMetadata? metadata,
+    Acl? acl,
+    PredefinedAcl? predefinedAcl,
+    String? contentType,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class FakeBucketItem implements BucketEntry {
+  const FakeBucketItem({
+    required this.name,
+    this.isDirectory = true,
+  });
+
+  @override
+  final bool isDirectory;
+
+  @override
+  bool get isObject => throw UnimplementedError();
+
+  @override
+  final String name;
+}

--- a/dev/gcs_cleaner/test/src/fake_git.dart
+++ b/dev/gcs_cleaner/test/src/fake_git.dart
@@ -1,0 +1,27 @@
+import 'package:gcs_cleaner/git.dart';
+import 'package:process/src/interface/process_manager.dart';
+
+class FakeGit implements Git {
+  @override
+  Future<String?> lookupEngineCommit(String frameworkCommit) async => 'eeeee';
+
+  @override
+  String get path => '/home/user/flutter';
+
+  @override
+  ProcessManager get pm => throw UnimplementedError();
+
+  @override
+  Future<Map<String, String>> tags() async => <String, String>{
+        '3.0.0': 'abc123',
+      };
+
+  @override
+  Future<DateTime?> lookupCommitTime(String sha) async {
+    if (sha.contains('old')) {
+      return DateTime(2020, 10, 1);
+    }
+
+    return DateTime(2023, 10, 1);
+  }
+}


### PR DESCRIPTION
* Script to delete flutter_infra_releases artifacts that are no longer relevant
* This script was used to calculate some statistics
* 659 commits that are permanently retained

1 year retention policy
Scanned 43721 commits in gs://flutter_infra_release
2900 errors
Commits that are too young to be deleted: 8454
Proposing to delete 31709

180 day policy
Proposing to delete 36520
