### PR TITLE
Use build createdTimestamp for checkrun start time

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -93,7 +93,7 @@ class GithubChecksService {
       'id': buildPushMessage.userData['check_run_id'] as int?,
       'status': status,
       'check_suite': const {'id': null},
-      'started_at': build.startedTimestamp.toString(),
+      'started_at': build.createdTimestamp.toString(),
       'conclusion': null,
       'name': build.buildParameters!['builder_name'],
     });


### PR DESCRIPTION
This fixes the issue with https://github.com/flutter/flutter/issues/132616#issuecomment-1761973681.

Checkrun's start time is the build created time.