### PR TITLE
Fix scheduling issue via priority control for new targets

### DIFF
--- a/app_dart/lib/src/service/scheduler/policy.dart
+++ b/app_dart/lib/src/service/scheduler/policy.dart
@@ -64,8 +64,8 @@ class BatchPolicy implements SchedulerPolicy {
     // Ensure task isn't considered in recentTasks
     recentTasks.removeWhere((Task t) => t.commitKey == task.commitKey);
     if (recentTasks.length < kBatchSize) {
-      log.warning('${task.name} has less than $kBatchSize, triggerring all builds regardless of policy');
-      return LuciBuildService.kDefaultPriority;
+      log.warning('${task.name} has less than $kBatchSize, skip scheduling to wait for ci.yaml roll.');
+      return null;
     }
 
     // Prioritize tasks that recently failed.

--- a/app_dart/test/service/scheduler/policy_test.dart
+++ b/app_dart/test/service/scheduler/policy_test.dart
@@ -78,7 +78,7 @@ void main() {
       db.addOnQuery<Task>((Iterable<Task> results) => allPending);
       expect(
         await policy.triggerPriority(task: generateTask(4), datastore: datastore),
-        LuciBuildService.kDefaultPriority,
+        null,
       );
     });
 

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -244,8 +244,11 @@ void main() {
             toBeScheduled: captureAnyNamed('toBeScheduled'),
           ),
         ).thenAnswer((_) => Future<List<Tuple<Target, Task, int>>>.value(<Tuple<Target, Task, int>>[]));
-        buildStatusService =
-            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[])]);
+        buildStatusService = FakeBuildStatusService(
+          commitStatuses: <CommitStatus>[
+            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[]),
+          ],
+        );
         scheduler = Scheduler(
           cache: cache,
           config: config,
@@ -294,8 +297,11 @@ void main() {
             ],
           );
         });
-        buildStatusService =
-            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[])]);
+        buildStatusService = FakeBuildStatusService(
+          commitStatuses: <CommitStatus>[
+            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[]),
+          ],
+        );
         config.batchSizeValue = 1;
         scheduler = Scheduler(
           cache: cache,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -408,67 +408,6 @@ targets:
         expect(db.values.values.whereType<Task>().where((Task task) => task.status == Task.statusInProgress).length, 1);
       });
 
-      test('skip scheduling bringup true targets for BatchPolicy', () async {
-        final PullRequest mergedPr = generatePullRequest();
-
-        httpClient = MockClient((http.Request request) async {
-          if (request.url.path.contains('.ci.yaml')) {
-            return http.Response(
-              '''
-enabled_branches:
-  - master
-targets:
-  - name: Linux A
-    scheduler: cocoon
-  - name: Linux B
-    scheduler: cocoon
-    bringup: true
-          ''',
-              200,
-            );
-          }
-          throw Exception('Failed to find ${request.url.path}');
-        });
-        await scheduler.addPullRequest(mergedPr);
-        expect(db.values.values.whereType<Commit>().length, 1);
-        expect(db.values.values.whereType<Task>().length, 2);
-        final Task taskA = db.values.values.whereType<Task>().where((task) => task.name == 'Linux A').single;
-        final Task taskB = db.values.values.whereType<Task>().where((task) => task.name == 'Linux B').single;
-        expect(taskA.status, Task.statusInProgress);
-        expect(taskB.status, Task.statusNew);
-      });
-
-      test('schedule bringup true targets for GuaranteedPolicy', () async {
-        final PullRequest mergedPr = generatePullRequest(repo: 'engine', branch: 'main');
-
-        httpClient = MockClient((http.Request request) async {
-          if (request.url.path.contains('.ci.yaml')) {
-            return http.Response(
-              '''
-enabled_branches:
-  - main
-targets:
-  - name: Linux A
-    scheduler: cocoon
-  - name: Linux B
-    scheduler: cocoon
-    bringup: true
-
-          ''',
-              200,
-            );
-          }
-          throw Exception('Failed to find ${request.url.path}');
-        });
-        await scheduler.addPullRequest(mergedPr);
-        expect(db.values.values.whereType<Commit>().length, 1);
-        expect(db.values.values.whereType<Task>().length, 2);
-        final Task taskA = db.values.values.whereType<Task>().where((task) => task.name == 'Linux A').single;
-        final Task taskB = db.values.values.whereType<Task>().where((task) => task.name == 'Linux B').single;
-        expect(taskA.status, Task.statusInProgress);
-        expect(taskB.status, Task.statusInProgress);
-      });
-
       test('does not schedule tasks against non-merged PRs', () async {
         final PullRequest notMergedPr = generatePullRequest(merged: false);
         await scheduler.addPullRequest(notMergedPr);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -149,14 +149,15 @@ void main() {
       List<Commit> createCommitList(
         List<String> shas, {
         String repo = 'flutter',
+        String branch = 'master',
       }) {
         return List<Commit>.generate(
           shas.length,
           (int index) => Commit(
             author: 'Username',
             authorAvatarUrl: 'http://example.org/avatar.jpg',
-            branch: 'master',
-            key: db.emptyKey.append(Commit, id: 'flutter/$repo/master/${shas[index]}'),
+            branch: branch,
+            key: db.emptyKey.append(Commit, id: 'flutter/$repo/$branch/${shas[index]}'),
             message: 'commit message',
             repository: 'flutter/$repo',
             sha: shas[index],
@@ -244,7 +245,7 @@ void main() {
           ),
         ).thenAnswer((_) => Future<List<Tuple<Target, Task, int>>>.value(<Tuple<Target, Task, int>>[]));
         buildStatusService =
-            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[])]);
         scheduler = Scheduler(
           cache: cache,
           config: config,
@@ -255,7 +256,7 @@ void main() {
           luciBuildService: luciBuildService,
         );
 
-        await scheduler.addCommits(createCommitList(<String>['1']));
+        await scheduler.addCommits(createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
         final List<dynamic> captured = verify(
           luciBuildService.schedulePostsubmitBuilds(
             commit: anyNamed('commit'),
@@ -294,7 +295,7 @@ void main() {
           );
         });
         buildStatusService =
-            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[])]);
         config.batchSizeValue = 1;
         scheduler = Scheduler(
           cache: cache,
@@ -306,7 +307,7 @@ void main() {
           luciBuildService: luciBuildService,
         );
 
-        await scheduler.addCommits(createCommitList(<String>['1']));
+        await scheduler.addCommits(createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
         expect(pubsub.messages.length, 2);
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/136487

Context:
https://github.com/flutter/cocoon/pull/3108 skipped scheduling bringup: true targets from webook for all repos
https://github.com/flutter/cocoon/pull/3139 restores scheduling bringup:true targets for guranteed policy repos (engine/pacakges)

With above two PR patches, we still hit https://github.com/flutter/flutter/issues/136487

This PR proposes a more concise way to solve via priority control.
1) restores the above two PRs
2) returns `null` priority when existing number of tasks < `kBatchSize`.