### PR TITLE
Support multiple different locations for binary paths.

### DIFF
--- a/cipd_packages/device_doctor/test/src/utils_test.dart
+++ b/cipd_packages/device_doctor/test/src/utils_test.dart
@@ -89,24 +89,6 @@ void main() {
       processManager = MockProcessManager();
     });
 
-    test('returns path when binary does not exist by default but exists in M1 homebrew bin', () async {
-      final String path = '$kM1BrewBinPath/ideviceinstaller';
-      output = <List<int>>[utf8.encode(path)];
-      final Process processM1 = FakeProcess(0, out: output);
-      final Process processDefault = FakeProcess(1, out: <List<int>>[]);
-      when(processManager.start(<String>['which', 'ideviceinstaller'], workingDirectory: anyNamed('workingDirectory')))
-          .thenAnswer((_) => Future.value(processDefault));
-      when(
-        processManager.start(
-          <String>['which', '$kM1BrewBinPath/ideviceinstaller'],
-          workingDirectory: anyNamed('workingDirectory'),
-        ),
-      ).thenAnswer((_) => Future.value(processM1));
-
-      final String result = await getMacBinaryPath('ideviceinstaller', processManager: processManager);
-      expect(result, '$kM1BrewBinPath/ideviceinstaller');
-    });
-
     test('returns path when binary exists by default', () async {
       const String path = '/abc/def/ideviceinstaller';
       output = <List<int>>[utf8.encode(path)];
@@ -125,7 +107,7 @@ void main() {
           .thenAnswer((_) => Future.value(processDefault));
       when(
         processManager.start(
-          <String>['which', '$kM1BrewBinPath/ideviceinstaller'],
+          <String>['which', 'ideviceinstaller'],
           workingDirectory: anyNamed('workingDirectory'),
         ),
       ).thenAnswer((_) => Future.value(processM1));


### PR DESCRIPTION
This is to fix a problem with brew binaries being installed in different locations with new versions of brew.

Bug: https://github.com/flutter/flutter/issues/136587

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
