### PR TITLE
Adding a wait for device ready before deleting packages.

### DIFF
--- a/cipd_packages/device_doctor/lib/src/android_device.dart
+++ b/cipd_packages/device_doctor/lib/src/android_device.dart
@@ -453,6 +453,8 @@ class AndroidDevice implements Device {
     processManager ??= LocalProcessManager();
     final int timeoutSecs = 60;
     print('Device recovery: deleting package caches...');
+    await eval('adb', <String>['wait-for-device'], canFail: false, processManager: processManager)
+        .timeout(Duration(seconds: timeoutSecs));
     await deletePackageCache();
     await eval('adb', <String>['wait-for-device'], canFail: false, processManager: processManager)
         .timeout(Duration(seconds: timeoutSecs));


### PR DESCRIPTION
Adding an additional wait, since we experienced a package manager not ready error.

Bug:flutter/flutter#135035

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
