### PR TITLE
Create a new commit in the datastore on branch creation for candidate branches

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -123,6 +123,16 @@ class GithubWebhookSubscription extends SubscriptionHandler {
           await commitService.handlePushGithubRequest(event);
         }
         break;
+      case 'create':
+        final CreateEvent createEvent = CreateEvent.fromJson(json.decode(webhook.payload) as Map<String, dynamic>);
+        final RegExp candidateBranchRegex = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
+        // Create a commit object for candidate branches in the datastore so
+        // dart-internal builds that are triggered by the initial branch
+        // creation have an associated commit.
+        if (candidateBranchRegex.hasMatch(createEvent.ref!)) {
+          log.fine('Branch ${createEvent.ref} is a candidate branch, creating new commit in the datastore');
+          await commitService.handleCreateGithubRequest(createEvent);
+        }
     }
 
     return Body.empty;

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2292,4 +2292,28 @@ void foo() {
       verifyNever(commitService.handlePushGithubRequest(any)).called(0);
     });
   });
+
+  group('github webhook create event', () {
+    test('Does not create a new commit due to not being a candidate branch', () async {
+      tester.message = generateCreateBranchMessage(
+        'cool-branch',
+        'flutter/flutter',
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(commitService.handleCreateGithubRequest(any)).called(0);
+    });
+
+    test('Creates a new commit due to being a candidate branch', () async {
+      tester.message = generateCreateBranchMessage(
+        'flutter-1.2-candidate.3',
+        'flutter/flutter',
+      );
+
+      await tester.post(webhook);
+
+      verify(commitService.handleCreateGithubRequest(any)).called(1);
+    });
+  });
 }


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter/issues/135991

This is pulling the logic over from https://github.com/flutter/cocoon/pull/3005 that got accidentally removed, and adding it into the webhook_subscription class instead.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
