### PR TITLE
Remove all third_party apps in recovery mode.

### DIFF
--- a/cipd_packages/device_doctor/lib/src/android_device.dart
+++ b/cipd_packages/device_doctor/lib/src/android_device.dart
@@ -428,11 +428,7 @@ class AndroidDevice implements Device {
       if (packageMatch != null) {
         final packageName = packageMatch.group(1);
         if (packageName != null) {
-          if (packageName.contains('/data/app/com.example') |
-              packageName.contains('/data/app/com.yourcompany') |
-              packageName.contains('flutter')) {
-            packages.add(packageName);
-          }
+          packages.add(packageName);
         }
       }
     });


### PR DESCRIPTION
The filters were incorrect and given that we are alredy getting only the list of third_party apps we are removing the unnecessary filter.

Bug: https://github.com/flutter/flutter/issues/135035

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
