### PR TITLE
Keep screen awake on Android

### DIFF
--- a/dashboard/android/app/src/main/kotlin/com/example/dashboard/MainActivity.kt
+++ b/dashboard/android/app/src/main/kotlin/com/example/dashboard/MainActivity.kt
@@ -1,6 +1,13 @@
 package com.example.dashboard
 
+import android.os.Bundle
+import android.view.WindowManager
+
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    }
 }


### PR DESCRIPTION
This keeps the screen saver from coming on when you leave the dashboard running on a TV

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
