### PR TITLE
Add log warning when GitHub API usage exceeds half of the limit

### DIFF
--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -38,9 +38,11 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
 
     final int remainingQuota = quotaUsage['remaining'] as int;
     const int quotaLimitSLO = 7500; // Half of the quota limit 15000.
-    if(remainingQuota < quotaLimitSLO) {
-      log.warning('Remaining GitHub quota is $remainingQuota, which is less than $quotaLimitSLO (half of the quotaLimit 15000).');
+    if (remainingQuota < quotaLimitSLO) {
+      log.warning(
+          'Remaining GitHub quota is $remainingQuota, which is less than $quotaLimitSLO (half of the quotaLimit 15000).');
     }
+
     /// Insert quota usage to BigQuery
     const String githubQuotaTable = 'GithubQuotaUsage';
     await insertBigquery(githubQuotaTable, quotaUsage, await config.createTabledataResourceApi());

--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -37,10 +37,12 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
     quotaUsage['timestamp'] = DateTime.now().toIso8601String();
 
     final int remainingQuota = quotaUsage['remaining'] as int;
-    const int quotaLimitSLO = 7500; // Half of the quota limit 15000.
-    if (remainingQuota < quotaLimitSLO) {
+    final int quotaLimit = quotaUsage['limit'] as int;
+    const double githubQuotaUsageSLO = 0.5;
+    if (remainingQuota < githubQuotaUsageSLO * quotaLimit) {
       log.warning(
-          'Remaining GitHub quota is $remainingQuota, which is less than $quotaLimitSLO (half of the quotaLimit 15000).');
+        'Remaining GitHub quota is $remainingQuota, which is less than quota usage SLO ${githubQuotaUsageSLO * quotaLimit} (${githubQuotaUsageSLO * 100}% of the limit $quotaLimit)).',
+      );
     }
 
     /// Insert quota usage to BigQuery


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/132616.

This is to help triage and prepare for alert setup in GCP.