### PR TITLE
Make Impeller test harnesses + fixtures test exempt in the engine repo.

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -379,6 +379,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         // Exempt paths.
         filename.startsWith('dev/devicelab/lib/versions/gallery.dart') ||
         filename.startsWith('dev/integration_tests') ||
+        filename.startsWith('impeller/fixtures') ||
+        filename.startsWith('impeller/golden_tests') ||
+        filename.startsWith('impeller/playground') ||
         filename.startsWith('shell/platform/embedder/tests') ||
         filename.startsWith('shell/platform/embedder/fixtures');
   }

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -609,6 +609,9 @@ void main() {
         (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()..filename = 'dev/devicelab/lib/versions/gallery.dart',
           PullRequestFile()..filename = 'dev/integration_tests/some_package/android/build.gradle',
+          PullRequestFile()..filename = 'impeller/fixtures/dart_tests.dart',
+          PullRequestFile()..filename = 'impeller/golden_tests/golden_tests.cc',
+          PullRequestFile()..filename = 'impeller/playground/playground.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/tests/embedder_test_context.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/fixtures/main.dart',
         ]),


### PR DESCRIPTION
* `impeller/fixtures` contains only test fixtures.
* `impeller/golden_tests` contains a test harness for goldens.
* `impeller/playground` contains a test harness that spawns Impeller backends. Also used for capturing goldens.

Patch where this was noticed: https://github.com/flutter/engine/pull/47781

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
