### PR TITLE
[github actions] actions to perform a manual engine->framework roll

### DIFF
--- a/.github/workflows/manual-engine-flutter-roll.yml
+++ b/.github/workflows/manual-engine-flutter-roll.yml
@@ -43,8 +43,6 @@ jobs:
             git log --no-decorate --oneline $PREV_VERSION..${{ github.event.inputs.engine_sha }}
             echo EOF
           } >> "$GITHUB_ENV"
-        env:
-          ENGINE_SHA: ${{ github.event.inputs.engine_sha }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
         with:

--- a/.github/workflows/manual-engine-flutter-roll.yml
+++ b/.github/workflows/manual-engine-flutter-roll.yml
@@ -1,0 +1,61 @@
+on: 
+  workflow_dispatch:
+    inputs:
+      engine_sha:
+        description: 'engine hash'     
+        required: true
+      branch:
+        description: 'the release branch name where engine->flutter roll happens'     
+        required: true
+
+jobs:
+  roll-engine-to-framework:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Framework Branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          repository: flutter/flutter
+          token: ${{ github.token }}
+          path: flutter
+      - name: Update Engine version
+        working-directory: ./flutter
+        run: |
+          echo "PREV_VERSION=$(cat bin/internal/engine.version | tr -d '\n')" >> $GITHUB_ENV
+          echo "${{ github.event.inputs.engine_sha }}" > bin/internal/engine.version
+      - name: Checkout Engine History
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          repository: flutter/engine
+          token: ${{ github.token }}
+          path: engine
+          fetch-depth: 100
+      - name: Log Engine Commits
+        working-directory: ./engine
+        run: |
+          git branch
+          git log --oneline -10
+          git log --no-decorate --oneline $PREV_VERSION..${{ github.event.inputs.engine_sha }}
+          {
+            echo 'COMMIT_HISTORY<<EOF'
+            git log --no-decorate --oneline $PREV_VERSION..${{ github.event.inputs.engine_sha }}
+            echo EOF
+          } >> "$GITHUB_ENV"
+        env:
+          ENGINE_SHA: ${{ github.event.inputs.engine_sha }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        with:
+          path: flutter
+          token: ${{ secrets.PAT }}
+          commit-message: Roll engine to ${{ github.event.inputs.engine_sha }}
+          committer: GitHub <noreply@github.com>
+          title: 'Roll engine to ${{ github.event.inputs.engine_sha }}'
+          body: |
+            flutter engine->framework roll
+            - branch: ${{ github.event.inputs.branch }}
+            - engine hash: ${{ github.event.inputs.engine_sha }}
+            commit history: 
+            ${{ env.COMMIT_HISTORY }}


### PR DESCRIPTION
Update 11/08: Migrating https://github.com/flutter/engine/pull/47734 to cocoon based on feedback from https://github.com/flutter/engine/pull/47734#discussion_r1386839129

Update 11/07: Added workarounds to fetch commit history. https://github.com/flutter/flutter/pull/138058, [sample workflow](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/6794034996/job/18469839842)

Context: Synced with Casey and Kevin and did more researches on evaluating approaches to fetch green post submit builds. Updated design doc.

Approach
This workflow takes engine_sha and release branch as inputs to run. To invoke this workflow, users run command from terminal, e.g. gh workflow run --repo flutter/engine -F engine_sha="123456" -F branch=flutter-3.16-candidate.0 manual.yml. [example workflow](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/6713135026/job/18244110301) and https://github.com/flutter/flutter/pull/137974

TOKEN
Needs installation of a PAT token to run.

Default ${{ github.token }} with permissions: write-all would fail with Error: Resource not accessible by integration. [example workflow](https://github.com/XilaiZhang/miscellaneous-side-project/actions/runs/6778715356/job/18424634593)

Alternatives & Cons

cron job approach : inefficient and hard to maintain
skia auto roller : intrinsically cron job to scrape gcs bucket
post submit check runs : not enough github api quota
Each alternative has its drawbacks, and is discussed in more details in [design doc](https://github.com/flutter/engine/pull/go/flutter-actions). For engine->flutter roll for now, we will skip the automation of getting green post submit engine builds, and let human handle this part.
