### PR TITLE
Modify engine repo "needs test" label logic to properly check if a pr contains only deleted code

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -399,11 +399,11 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     await for (PullRequestFile file in files) {
       final String filename = file.filename!.toLowerCase();
-      if (_fileContainsAddedCode(file) && filename.endsWith('.dart') ||
+      if (_fileContainsAddedCode(file) && (filename.endsWith('.dart') ||
           filename.endsWith('.mm') ||
           filename.endsWith('.m') ||
           filename.endsWith('.java') ||
-          filename.endsWith('.cc')) {
+          filename.endsWith('.cc'))) {
         needsTests = !_allChangesAreCodeComments(file);
       }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -399,11 +399,12 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     await for (PullRequestFile file in files) {
       final String filename = file.filename!.toLowerCase();
-      if (_fileContainsAddedCode(file) && (filename.endsWith('.dart') ||
-          filename.endsWith('.mm') ||
-          filename.endsWith('.m') ||
-          filename.endsWith('.java') ||
-          filename.endsWith('.cc'))) {
+      if (_fileContainsAddedCode(file) &&
+          (filename.endsWith('.dart') ||
+              filename.endsWith('.mm') ||
+              filename.endsWith('.m') ||
+              filename.endsWith('.java') ||
+              filename.endsWith('.cc'))) {
         needsTests = !_allChangesAreCodeComments(file);
       }
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1692,6 +1692,11 @@ void foo() {
             ..deletionsCount = 20
             ..additionsCount = 0
             ..changesCount = 20,
+          PullRequestFile()
+            ..filename = 'flutter/lib/ui/bar.java'
+            ..deletionsCount = 20
+            ..additionsCount = 0
+            ..changesCount = 20,
         ]),
       );
 


### PR DESCRIPTION
I believe the group of booleans representing whether a file ends in a given suffix should have been wrapped in parentheses (unless we specifically care only about not applying the label when we delete dart code, and not code in other languages). 

This was sort of already tested, but it just happened that the language we tested was the only language the existing (bugged) logic would have acted correctly for. I changed the test to be a test of a pr with files of different languages, as it keeps the same initial coverage and also would have caught this case.

Context https://github.com/flutter/engine/pull/47841, [and discord discussion](https://discord.com/channels/608014603317936148/608018585025118217/1171970676391940157).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
