### PR TITLE
Default engine to requiring tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -371,6 +371,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.contains('analysis_options.yaml') ||
         filename.contains('AUTHORS') ||
         filename.contains('CODEOWNERS') ||
+        filename == 'DEPS' ||
         filename.contains('TESTOWNERS') ||
         filename.contains('pubspec.yaml') ||
         // Exempt categories.
@@ -398,12 +399,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     bool needsTests = false;
 
     await for (PullRequestFile file in files) {
-      final String filename = file.filename!.toLowerCase();
-      if (_fileContainsAddedCode(file) && filename.endsWith('.dart') ||
-          filename.endsWith('.mm') ||
-          filename.endsWith('.m') ||
-          filename.endsWith('.java') ||
-          filename.endsWith('.cc')) {
+      final String filename = file.filename!;
+      if (_fileContainsAddedCode(file) && !_isTestExempt(filename)) {
         needsTests = !_allChangesAreCodeComments(file);
       }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -400,7 +400,11 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     await for (PullRequestFile file in files) {
       final String filename = file.filename!;
-      if (_fileContainsAddedCode(file) && !_isTestExempt(filename)) {
+      if (_fileContainsAddedCode(file) &&
+          !_isTestExempt(filename) &&
+          // Build files don't need unit tests.
+          !filename.endsWith('.gn') &&
+          !filename.endsWith('.gni')) {
         needsTests = !_allChangesAreCodeComments(file);
       }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -408,7 +408,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         needsTests = !_allChangesAreCodeComments(file);
       }
 
-      if (kEngineTestRegExp.hasMatch(filename)) {
+      if (kEngineTestRegExp.hasMatch(filename.toLowerCase())) {
         hasTests = true;
       }
     }

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1256,6 +1256,40 @@ void foo() {
       ).called(1);
     });
 
+    test('Engine labels PRs, comment if no tests for unknown file', () async {
+      const int issueNumber = 123;
+
+      tester.message = generateGithubWebhookMessage(
+        action: 'opened',
+        number: issueNumber,
+        slug: Config.engineSlug,
+        baseRef: Config.defaultBranch(Config.engineSlug),
+      );
+      final RepositorySlug slug = RepositorySlug('flutter', 'engine');
+
+      when(pullRequestsService.listFiles(slug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.value(
+          PullRequestFile()..filename = 'foo/bar/baz.madeupextension',
+        ),
+      );
+
+      when(issuesService.listCommentsByIssue(slug, issueNumber)).thenAnswer(
+        (_) => Stream<IssueComment>.value(
+          IssueComment()..body = 'some other comment',
+        ),
+      );
+
+      await tester.post(webhook);
+
+      verify(
+        issuesService.createComment(
+          slug,
+          issueNumber,
+          argThat(contains(config.missingTestsPullRequestMessageValue)),
+        ),
+      ).called(1);
+    });
+
     group('Auto-roller accounts do not label Engine PR with test label or comment.', () {
       final Set<String> inputs = {
         'engine-flutter-autoroll',
@@ -1365,7 +1399,7 @@ void foo() {
       );
     });
 
-    test('Engine labels PRs, no code files', () async {
+    test('Engine labels PRs, no comment if DEPS-only', () async {
       const int issueNumber = 123;
 
       tester.message = generateGithubWebhookMessage(
@@ -1689,6 +1723,11 @@ void foo() {
         (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()
             ..filename = 'flutter/lib/ui/foo.dart'
+            ..deletionsCount = 20
+            ..additionsCount = 0
+            ..changesCount = 20,
+          PullRequestFile()
+            ..filename = 'shell/platform/darwin/ios/platform_view_ios.mm'
             ..deletionsCount = 20
             ..additionsCount = 0
             ..changesCount = 20,

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1434,6 +1434,42 @@ void foo() {
       );
     });
 
+    test('Engine labels PRs, no comment if build-file-only', () async {
+      const int issueNumber = 123;
+
+      tester.message = generateGithubWebhookMessage(
+        action: 'opened',
+        number: issueNumber,
+        baseRef: 'main',
+        slug: Config.engineSlug,
+      );
+
+      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+          PullRequestFile()..filename = 'shell/config.gni',
+          PullRequestFile()..filename = 'shell/BUILD.gn',
+        ]),
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(
+        issuesService.addLabelsToIssue(
+          Config.engineSlug,
+          issueNumber,
+          any,
+        ),
+      );
+
+      verifyNever(
+        issuesService.createComment(
+          Config.engineSlug,
+          issueNumber,
+          any,
+        ),
+      );
+    });
+
     test('Engine labels PRs, no comment if Java tests', () async {
       const int issueNumber = 123;
 


### PR DESCRIPTION
The current engine rules are the reverse of the framework and packages repos; those assume that any file that has not been explicitly exempted needs tests, whereas the engine only requires tests for a specific set of files. This is prone to false negatives (e.g., if/when we start adding Swift files, someone would have had to remember to come update this rule, which probably wouldn't have happened).

This flips the engine to be consistent with the other repositories. This will almost certainly cause a lot of false positives in the short term while the set of files that should be exempted is worked out.

Also fixes a bug where the removal-only case was only being applied to Dart files, not other languages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
