### PR TITLE
Add a feature that allows treating `presubmit: false`  as `true`, conditionally.

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -179,6 +179,20 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
   return targetsToRun;
 }
 
+/// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
+/// 
+/// This is an **experimental** feature that is only enabled for the
+/// `flutter/engine` repository if a specific label is present on the PR.
+bool includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+  if (ciYaml.slug != Config.engineSlug) {
+    return false;
+  }
+  if (pullRequest.labels?.any((label) => label.name.contains('run-postsubmit-as-presubmit')) ?? false) {
+    return true;
+  }
+  return false;
+}
+
 Future<void> insertBigquery(String tableName, Map<String, dynamic> data, TabledataResource tabledataResourceApi) async {
   // Define const variables for [BigQuery] operations.
   const String projectId = 'flutter-dashboard';

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -179,20 +179,6 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
   return targetsToRun;
 }
 
-/// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-///
-/// This is an **experimental** feature that is only enabled for the
-/// `flutter/engine` repository if a specific label is present on the PR.
-bool includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
-  if (ciYaml.slug != Config.engineSlug) {
-    return false;
-  }
-  if (pullRequest.labels?.any((label) => label.name.contains('run-postsubmit-as-presubmit')) ?? false) {
-    return true;
-  }
-  return false;
-}
-
 Future<void> insertBigquery(String tableName, Map<String, dynamic> data, TabledataResource tabledataResourceApi) async {
   // Define const variables for [BigQuery] operations.
   const String projectId = 'flutter-dashboard';

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -180,7 +180,7 @@ Future<List<Target>> getTargetsToRun(Iterable<Target> targets, List<String?> fil
 }
 
 /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-/// 
+///
 /// This is an **experimental** feature that is only enabled for the
 /// `flutter/engine` repository if a specific label is present on the PR.
 bool includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -447,7 +447,9 @@ class Scheduler {
       log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in ciYaml.postsubmitTargets) {
-        if (!target.value.presubmit) {
+        // We don't want to include a presubmit twice
+        // We don't want to run the builder_cache target as a presubmit
+        if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
           presubmitTargets.add(target);
         }
       }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -436,10 +436,12 @@ class Scheduler {
     log.info('Collecting presubmit targets for ${pullRequest.number}');
 
     // Filter out schedulers targets with schedulers different than luci or cocoon.
-    final List<Target> presubmitTargets = ciYaml.presubmitTargets.where(
-      (Target target) =>
-          target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
-    ).toList();
+    final List<Target> presubmitTargets = ciYaml.presubmitTargets
+        .where(
+          (Target target) =>
+              target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
+        )
+        .toList();
 
     // Experimental feature to run postsubmit as presubmit for the engine.
     // See https://github.com/flutter/flutter/issues/138430.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -443,9 +443,8 @@ class Scheduler {
         )
         .toList();
 
-    // Experimental feature to run postsubmit as presubmit for the engine.
     // See https://github.com/flutter/flutter/issues/138430.
-    if (includePostsubmitAsPresubmit(ciYaml, pullRequest)) {
+    if (_includePostsubmitAsPresubmit(ciYaml, pullRequest)) {
       log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in ciYaml.postsubmitTargets) {
@@ -476,6 +475,14 @@ class Scheduler {
       return presubmitTargets.toList();
     }
     return getTargetsToRun(presubmitTargets, files);
+  }
+
+  /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
+  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
+      return true;
+    }
+    return false;
   }
 
   /// Reschedules a failed build using a [CheckRunEvent]. The CheckRunEvent is

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -479,6 +479,11 @@ class Scheduler {
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
   static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+    // Only allow this for flutter/engine.
+    // See https://github.com/flutter/cocoon/pull/3256#issuecomment-1811624351.
+    if (ciYaml.slug != Config.engineSlug) {
+      return false;
+    }
     if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
       return true;
     }

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -706,6 +706,11 @@ targets:
     - name: Linux Postsubmit
       presubmit: false
       scheduler: luci
+    - name: Linux Cache
+      presubmit: false
+      scheduler: luci
+      properties:
+        cache_name: "builder"
   ''',
   200,
   );

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -706,7 +706,7 @@ targets:
     - name: Linux Postsubmit
       presubmit: false
       scheduler: luci
-  ''', 
+  ''',
   200,
   );
             }
@@ -716,7 +716,7 @@ targets:
 
         test('in the engine repo with a specific label', () async {
           final enginePr = generatePullRequest(
-            repo: Config.engineSlug.name, 
+            repo: Config.engineSlug.name,
             labels: <IssueLabel>[postAsPreSubmit],
           );
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -691,7 +691,7 @@ targets:
       });
 
       group('treats postsubmit as presubmit if a label is present', () {
-        final IssueLabel postAsPreSubmit = IssueLabel(name: 'run-postsubmit-as-presubmit');
+        final IssueLabel runAllTests = IssueLabel(name: 'test: all');
         setUp(() async {
           httpClient = MockClient((http.Request request) async {
             if (request.url.path.contains('.ci.yaml')) {
@@ -719,10 +719,9 @@ targets:
           });
         });
 
-        test('in the engine repo with a specific label', () async {
+        test('with a specific label', () async {
           final enginePr = generatePullRequest(
-            repo: Config.engineSlug.name,
-            labels: <IssueLabel>[postAsPreSubmit],
+            labels: <IssueLabel>[runAllTests],
           );
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(
@@ -731,21 +730,8 @@ targets:
           );
         });
 
-        test('but not in the framework repo even with a specific label', () async {
+        test('without a specific label', () async {
           final enginePr = generatePullRequest(
-            repo: Config.flutterSlug.name,
-            labels: <IssueLabel>[postAsPreSubmit],
-          );
-          final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
-          expect(
-            presubmitTargets.map((Target target) => target.value.name).toList(),
-            (<String>['Linux Presubmit']),
-          );
-        });
-
-        test('but not in the engine repo without a specific label', () async {
-          final enginePr = generatePullRequest(
-            repo: Config.engineSlug.name,
             labels: <IssueLabel>[],
           );
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -719,9 +719,10 @@ targets:
           });
         });
 
-        test('with a specific label', () async {
+        test('with a specific label in the flutter/engine repo', () async {
           final enginePr = generatePullRequest(
             labels: <IssueLabel>[runAllTests],
+            repo: Config.engineSlug.name,
           );
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(
@@ -730,9 +731,22 @@ targets:
           );
         });
 
+        test('with a specific label in the flutter/flutter repo', () async {
+          final enginePr = generatePullRequest(
+            labels: <IssueLabel>[runAllTests],
+            repo: Config.flutterSlug.name,
+          );
+          final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
+          expect(
+            presubmitTargets.map((Target target) => target.value.name).toList(),
+            <String>['Linux Presubmit'],
+          );
+        });
+
         test('without a specific label', () async {
           final enginePr = generatePullRequest(
             labels: <IssueLabel>[],
+            repo: Config.engineSlug.name,
           );
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -712,8 +712,8 @@ targets:
       properties:
         cache_name: "builder"
   ''',
-  200,
-  );
+                200,
+              );
             }
             throw Exception('Failed to find ${request.url.path}');
           });


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/138430 and I believe https://github.com/flutter/flutter/issues/111418.

As @CaseyHillers mentions in https://github.com/flutter/flutter/issues/138430, this would _not_ be sufficient to understand the addition of a label (only if the PR is _first created_ with a label, or a commit is pushed after the label is added), but it might be worth merging as-is (assuming I got all of the assumptions correct).
