### PR TITLE
[dashboard] show error in dropdown and suppress snackbar error when branch file 404

### DIFF
--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -141,8 +141,10 @@ class BranchService {
           ref: branchName,
         )
         .then((String value) => value.trim())
-        // return empty branch name if branch version file doesn't exist
-        .onError((e, _) => '');
+        .onError((e, _) {
+      log.severe('Could not fetch release version file: $e');
+      return '';
+    });
   }
 
   /// Retrieve the latest canidate branch from all candidate branches.

--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -134,17 +134,14 @@ class BranchService {
     required gh.RepositorySlug slug,
     required String branchName,
   }) async {
-    String branchNameFromFile;
-    try {
-      branchNameFromFile = await githubService.getFileContent(
-        slug,
-        'bin/internal/release-candidate-branch.version',
-        ref: branchName,
-      );
-    } catch (e) {
-      return '$branchName: 404 file not found';
-    }
-    return branchNameFromFile.trim();
+    return githubService
+        .getFileContent(
+          slug,
+          'bin/internal/release-candidate-branch.version',
+          ref: branchName,
+        )
+        .then((String value) => value.trim())
+        .onError((e, _) => '');
   }
 
   /// Retrieve the latest canidate branch from all candidate branches.

--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -141,6 +141,7 @@ class BranchService {
           ref: branchName,
         )
         .then((String value) => value.trim())
+        // return empty branch name if branch version file doesn't exist
         .onError((e, _) => '');
   }
 

--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -134,12 +134,17 @@ class BranchService {
     required gh.RepositorySlug slug,
     required String branchName,
   }) async {
-    return (await githubService.getFileContent(
-      slug,
-      'bin/internal/release-candidate-branch.version',
-      ref: branchName,
-    ))
-        .trim();
+    String branchNameFromFile;
+    try {
+      branchNameFromFile = await githubService.getFileContent(
+        slug,
+        'bin/internal/release-candidate-branch.version',
+        ref: branchName,
+      );
+    } catch (e) {
+      return '$branchName: 404 file not found';
+    }
+    return branchNameFromFile.trim();
   }
 
   /// Retrieve the latest canidate branch from all candidate branches.

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -62,10 +62,6 @@ void main() {
       when(mockRepositoriesService.getContents(any, any)).thenAnswer((Invocation invocation) {
         throw Exception('404 file not found');
       });
-      // when(githubService.getBranchNameFromFile(any)).thenAnswer((Invocation invocation) {
-      //   return Stream.fromIterable([candidateBranch]);
-      // });
-      // Cocoon flug throws 404 file not found exceptions.
       final List<Map<String, String>> result =
           await branchService.getReleaseBranches(githubService: githubService, slug: Config.cocoonSlug);
       final betaBranch = result.singleWhere((Map<String, String> branch) => branch['name'] == 'beta');

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -53,6 +53,20 @@ void main() {
       when(githubService.github.repositories).thenReturn(mockRepositoriesService);
     });
 
+    test('return 404 when branch version file does not exist', () async {
+      final gh.Branch candidateBranch = generateBranch(3, name: 'flutter-3.4-candidate.5', sha: '789dev');
+      when(mockRepositoriesService.listBranches(any)).thenAnswer((Invocation invocation) {
+        return Stream.fromIterable([candidateBranch]);
+      });
+      // Cocoon flug throws 404 file not found exceptions.
+      final List<Map<String, String>> result =
+          await branchService.getReleaseBranches(githubService: githubService, slug: Config.cocoonSlug);
+      final betaBranch = result.singleWhere((Map<String, String> branch) => branch['name'] == 'beta');
+      expect(betaBranch['branch'], 'beta: 404 file not found');
+      final stableBranch = result.singleWhere((Map<String, String> branch) => branch['name'] == 'stable');
+      expect(stableBranch['branch'], 'stable: 404 file not found');
+    });
+
     test('return beta, stable, and latest candidate branches', () async {
       final gh.Branch stableBranch = generateBranch(1, name: 'flutter-2.13-candidate.0', sha: '123stable');
       final gh.Branch betaBranch = generateBranch(2, name: 'flutter-3.2-candidate.5', sha: '456beta');

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -77,21 +77,6 @@ class FakeGithubService implements GithubService {
   @override
   Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
     return GithubService(github).getFileContent(slug, path, ref: ref);
-    //   if (path == 'bin/internal/release-candidate-branch.version') {
-    //     // Test error handling when branch version file isn't available.
-    //     // https://github.com/flutter/flutter/issues/138755
-    //     if (slug.name != 'flutter') {
-    //       throw Exception('404 file not exist');
-    //     }
-    //     if (ref == 'beta') {
-    //       return 'flutter-3.2-candidate.5\n';
-    //     } else if (ref == 'stable') {
-    //       return 'flutter-2.13-candidate.0\n';
-    //     }
-    //     return Future<String>.value('');
-    //   } else {
-    //     return Future<String>.value('');
-    //   }
   }
 
   @override

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart';
 
@@ -77,6 +79,11 @@ class FakeGithubService implements GithubService {
   @override
   Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
     if (path == 'bin/internal/release-candidate-branch.version') {
+      // Test error handling when branch version file isn't available.
+      // https://github.com/flutter/flutter/issues/138755
+      if (slug.name != 'flutter') {
+        throw Exception('404 file not exist');
+      }
       if (ref == 'beta') {
         return 'flutter-3.2-candidate.5\n';
       } else if (ref == 'stable') {

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart';
 
@@ -78,21 +76,22 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
-    if (path == 'bin/internal/release-candidate-branch.version') {
-      // Test error handling when branch version file isn't available.
-      // https://github.com/flutter/flutter/issues/138755
-      if (slug.name != 'flutter') {
-        throw Exception('404 file not exist');
-      }
-      if (ref == 'beta') {
-        return 'flutter-3.2-candidate.5\n';
-      } else if (ref == 'stable') {
-        return 'flutter-2.13-candidate.0\n';
-      }
-      return Future<String>.value('');
-    } else {
-      return Future<String>.value('');
-    }
+    return GithubService(github).getFileContent(slug, path, ref: ref);
+    //   if (path == 'bin/internal/release-candidate-branch.version') {
+    //     // Test error handling when branch version file isn't available.
+    //     // https://github.com/flutter/flutter/issues/138755
+    //     if (slug.name != 'flutter') {
+    //       throw Exception('404 file not exist');
+    //     }
+    //     if (ref == 'beta') {
+    //       return 'flutter-3.2-candidate.5\n';
+    //     } else if (ref == 'stable') {
+    //       return 'flutter-2.13-candidate.0\n';
+    //     }
+    //     return Future<String>.value('');
+    //   } else {
+    //     return Future<String>.value('');
+    //   }
   }
 
   @override


### PR DESCRIPTION
temporary fix before the next beta is pushed.
when branch version file such as https://github.com/flutter/flutter/blob/beta/bin/internal/release-candidate-branch.version isn't available, show error in the branch selection drop down of flutter dashboard, instead of popping up snackbar errors.

context: https://github.com/flutter/flutter/issues/138755, https://github.com/flutter/flutter/issues/138738, https://github.com/flutter/flutter/issues/138747