### PR TITLE
Change autosubmit comment from 'You' to 'The PR author'

### DIFF
--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -127,8 +127,8 @@ class Config {
 
   /// Pull request approval message
   static const String pullRequestApprovalRequirementsMessage =
-      '- Merge guidelines: You need at least one approved review if you are already '
-      'part of flutter-hackers or two member reviews if you are not a flutter-hacker '
+      '- Merge guidelines: A PR needs at least one approved review if the author is already '
+      'part of flutter-hackers or two member reviews if the author is not a flutter-hacker '
       'before re-applying the autosubmit label. __Reviewers__: If you left a comment '
       'approving, please use the "approve" review action instead.';
 

--- a/auto_submit/lib/validations/approval.dart
+++ b/auto_submit/lib/validations/approval.dart
@@ -69,7 +69,7 @@ class Approval extends Validation {
         // No changes were requested so check approval count.
         approvedMessage = approved
             ? 'This PR has met approval requirements for merging.\n'
-            : 'This PR has not met approval requirements for merging. $flutterHackerMessage and need ${approver.remainingReviews} more review(s) in order to merge this PR.\n';
+            : 'This PR has not met approval requirements for merging. $flutterHackerMessage and needs ${approver.remainingReviews} more review(s) in order to merge this PR.\n';
         if (!approved && authorIsFlutterHacker) {
           // Flutter hackers are aware of the review requirements, and can add
           // the autosubmit label without waiting on review.

--- a/auto_submit/lib/validations/approval.dart
+++ b/auto_submit/lib/validations/approval.dart
@@ -57,14 +57,14 @@ class Approval extends Validation {
 
       String approvedMessage;
       final String flutterHackerMessage = (authorIsFlutterHacker)
-          ? 'You are a member of ${repositoryConfiguration.approvalGroup}'
-          : 'You are not a member of ${repositoryConfiguration.approvalGroup}';
+          ? 'The PR author is a member of ${repositoryConfiguration.approvalGroup}'
+          : 'The PR author is not a member of ${repositoryConfiguration.approvalGroup}';
       // Changes were requested, review count does not matter.
       if (approver.changeRequestAuthors.isNotEmpty) {
         approved = false;
         approvedMessage =
             'This PR has not met approval requirements for merging. Changes were requested by ${approver.changeRequestAuthors}, please make the needed changes and resubmit this PR.\n'
-            '$flutterHackerMessage and need ${approver.remainingReviews} more review(s) in order to merge this PR.\n';
+            '$flutterHackerMessage and needs ${approver.remainingReviews} more review(s) in order to merge this PR.\n';
       } else {
         // No changes were requested so check approval count.
         approvedMessage = approved

--- a/auto_submit/test/validations/approval_test.dart
+++ b/auto_submit/test/validations/approval_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(result.message.contains('This PR has met approval requirements for merging.'), isTrue);
     });
 
-    test('Author is a NON member and reviewer is a member, need 1 more review', () async {
+    test('Author is a NON member and reviewer is a member, needs 1 more review', () async {
       // githubService.isTeamMemberMockList = [true, true];
       githubService.isTeamMemberMockMap['author1'] = false;
       githubService.isTeamMemberMockMap['keyonghan'] = true;
@@ -69,10 +69,10 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.REMOVE_LABEL);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 1 more review'), isTrue);
+      expect(result.message.contains('needs 1 more review'), isTrue);
     });
 
-    test('Author is a NON member and reviewer is a NON member, need 2 more reviews', () async {
+    test('Author is a NON member and reviewer is a NON member, needs 2 more reviews', () async {
       // githubService.isTeamMemberMockList = [true, true];
       githubService.isTeamMemberMockMap['author1'] = false;
       githubService.isTeamMemberMockMap['keyonghan'] = false;
@@ -85,10 +85,10 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.REMOVE_LABEL);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 2 more review'), isTrue);
+      expect(result.message.contains('needs 2 more review'), isTrue);
     });
 
-    test('Author is a member and reviewer is NON member, need 1 more review', () async {
+    test('Author is a member and reviewer is NON member, needs 1 more review', () async {
       // githubService.isTeamMemberMockList = [true, true];
       githubService.isTeamMemberMockMap['author1'] = true;
       githubService.isTeamMemberMockMap['keyonghan'] = false;
@@ -101,7 +101,7 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.IGNORE_TEMPORARILY);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 1 more review'), isTrue);
+      expect(result.message.contains('needs 1 more review'), isTrue);
     });
 
     test('Author is NON member and reviewers are members, pr approved', () async {
@@ -120,7 +120,7 @@ void main() {
       expect(result.message.contains('This PR has met approval requirements for merging.'), isTrue);
     });
 
-    test('Author is NON member and one reviewer is a NON member, need 1 more review', () async {
+    test('Author is NON member and one reviewer is a NON member, needs 1 more review', () async {
       githubService.isTeamMemberMockMap['author1'] = false;
       githubService.isTeamMemberMockMap['author2'] = true;
       githubService.isTeamMemberMockMap['author3'] = false;
@@ -134,10 +134,10 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.REMOVE_LABEL);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 1 more review'), isTrue);
+      expect(result.message.contains('needs 1 more review'), isTrue);
     });
 
-    test('Author is member and reviewers are NON members, need 1 more review', () async {
+    test('Author is member and reviewers are NON members, needs 1 more review', () async {
       githubService.isTeamMemberMockMap['author1'] = true;
       githubService.isTeamMemberMockMap['author2'] = false;
       githubService.isTeamMemberMockMap['author3'] = false;
@@ -151,10 +151,10 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.IGNORE_TEMPORARILY);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 1 more review'), isTrue);
+      expect(result.message.contains('needs 1 more review'), isTrue);
     });
 
-    test('Author is NON member and reviewers are NON members, need 2 reviews', () async {
+    test('Author is NON member and reviewers are NON members, needs 2 reviews', () async {
       githubService.isTeamMemberMockMap['author1'] = false;
       githubService.isTeamMemberMockMap['author2'] = false;
       githubService.isTeamMemberMockMap['author3'] = false;
@@ -168,7 +168,7 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.REMOVE_LABEL);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 2 more review'), isTrue);
+      expect(result.message.contains('needs 2 more review'), isTrue);
     });
 
     test('Verify author review count does not go negative', () async {
@@ -187,7 +187,7 @@ void main() {
       expect(result.result, isFalse);
       expect(result.action, Action.REMOVE_LABEL);
       expect(result.message.contains('This PR has not met approval requirements for merging.'), isTrue);
-      expect(result.message.contains('need 2 more review'), isTrue);
+      expect(result.message.contains('needs 2 more review'), isTrue);
     });
 
     test('Verify author review count does not go negative', () async {
@@ -256,7 +256,7 @@ void main() {
       expect(result.action, Action.REMOVE_LABEL);
       expect(
         result.message.contains(
-          'This PR has not met approval requirements for merging. You are not a member of flutter-hackers and need 1 more review(s) in order to merge this PR.',
+          'This PR has not met approval requirements for merging. The PR author is not a member of flutter-hackers and needs 1 more review(s) in order to merge this PR.',
         ),
         isTrue,
       );
@@ -288,7 +288,7 @@ void main() {
       expect(result.action, Action.REMOVE_LABEL);
       expect(
         result.message.contains(
-          'This PR has not met approval requirements for merging. You are not a member of flutter-hackers',
+          'This PR has not met approval requirements for merging. The PR author is not a member of flutter-hackers',
         ),
         isTrue,
       );


### PR DESCRIPTION
Example of the current bot comment:
>auto label is removed for flutter/flutter/138973, due to This PR has not met approval requirements for merging. You are not a member of flutter-hackers and need 1 more review(s) in order to merge this PR.
>
>Merge guidelines: You need at least one approved review if you are already part of flutter-hackers or two member reviews if you are not a flutter-hacker before re-applying the autosubmit label. Reviewers: If you left a comment approving, please use the "approve" review action instead.

This message is confusing when the person adding the "autosubmit" label is not the author of the PR (which is common in the case that the author is not a regular contributor), because the use of 'you' can be interpreted as 'the person who added the label'.

Context https://discord.com/channels/608014603317936148/608021351567065092/1179214124538921100

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
