### PR TITLE
Pin google_sign_in_web

### DIFF
--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   fixnum: 1.1.0
   google_sign_in: 6.1.6
   google_sign_in_platform_interface: any # Match google_sign_in
-  google_sign_in_web: 0.12.1
+  google_sign_in_web: 0.12.2+1
   http: 1.1.2
   protobuf: 3.1.0
   provider: 6.1.1

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   fixnum: 1.1.0
   google_sign_in: 6.1.6
   google_sign_in_platform_interface: any # Match google_sign_in
-  google_sign_in_web: any # Match google_sign_in
+  google_sign_in_web: 0.12.1
   http: 1.1.2
   protobuf: 3.1.0
   provider: 6.1.1


### PR DESCRIPTION
For future ease of issue resolution, this change pins google_sign_in_web to the latest version rather than using `any`. Dependabot will be able to bump versions moving forward 

Related to: https://github.com/flutter/flutter/issues/139382

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
