### PR TITLE
Unpin dependencies that are pinned by the Flutter SDK

### DIFF
--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -5,83 +5,37 @@
 name: flutter_dashboard
 description: The Flutter dashboard.
 publish_to: none
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
 environment:
   sdk: ^3.1.0
 
 dependencies:
-  collection: 1.18.0
   flutter:
     sdk: flutter
-  fixnum: 1.1.0
-  google_sign_in: 6.1.6
+  collection: any # Match Flutter SDK
+  fixnum: 1.1.0 # Rolled by dependabot
+  flutter_app_icons: 0.0.8 # Rolled by dependabot
+  google_sign_in: 6.1.6 # Rolled by dependabot
   google_sign_in_platform_interface: any # Match google_sign_in
-  google_sign_in_web: 0.12.2+1
-  http: 1.1.2
-  protobuf: 3.1.0
-  provider: 6.1.1
-  url_launcher: 6.2.1
-  flutter_app_icons: 0.0.8
-  truncate: 3.0.1
-  url_launcher_web: 2.2.1
+  google_sign_in_web: 0.12.2+1 # Rolled by dependabot
+  http: 1.1.2 # Rolled by dependabot
+  protobuf: 3.1.0 # Rolled by dependabot
+  provider: 6.1.1 # Rolled by dependabot
+  truncate: 3.0.1 # Rolled by dependabot
+  url_launcher: 6.2.1 # Rolled by dependabot
+  url_launcher_platform_interface: 2.2.0 # Rolled by dependabot
+  url_launcher_web: 2.2.1 # Rolled by dependabot
 
 dev_dependencies:
-  build_runner: 2.4.7
-  flutter_lints: 3.0.1
   flutter_test:
     sdk: flutter
+  build_runner: 2.4.7 # Rolled by dependabot
+  flutter_lints: 3.0.1 # Rolled by dependabot
   mockito: 5.4.3 # Remember to run ./regen_mocks.sh!
-  path: 1.8.3
-  url_launcher_platform_interface: 2.2.0
+  path: any # Match Flutter SDK
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
   assets:
     - assets/
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
These pins otherwise prevent us from rolling the pins in the Flutter SDK because this is a a presubmit test for that repo.

- also, cleanup boilerplate comments
- also, add breadcrumbs for the next person who wonders how these dependencies roll
- also, alphabetize the dependencies