### PR TITLE
[codesign] hide codesign credentials from logs

### DIFF
--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -117,6 +117,7 @@ void main() {
       codesignVisitor.appSpecificPassword = fakePassword;
       codesignVisitor.codesignAppstoreId = fakeAppleID;
       codesignVisitor.codesignTeamId = fakeTeamID;
+      codesignVisitor.redactPasswords();
     });
 
     test('procesRemotezip triggers correct workflow', () async {
@@ -204,8 +205,8 @@ void main() {
       expect(
         messages,
         contains(
-          'uploading to notary: xcrun notarytool submit ${codesignVisitor.outputZipPath} --apple-id <appleID> --password <appSpecificPassword> '
-          '--team-id <teamID> --verbose',
+          'uploading to notary: xcrun notarytool submit ${codesignVisitor.outputZipPath} --apple-id <appleID-redacted> --password <appSpecificPassword-redacted> '
+          '--team-id <teamID-redacted> --verbose',
         ),
       );
       expect(
@@ -215,8 +216,8 @@ void main() {
       expect(
         messages,
         contains(
-          'checking notary info: xcrun notarytool info $uuid --apple-id <appleID> --password <appSpecificPassword> '
-          '--team-id <teamID>',
+          'checking notary info: xcrun notarytool info $uuid --apple-id <appleID-redacted> --password <appSpecificPassword-redacted> '
+          '--team-id <teamID-redacted>',
         ),
       );
       expect(
@@ -769,6 +770,7 @@ file_c''',
       codesignVisitor.appSpecificPassword = fakePassword;
       codesignVisitor.codesignAppstoreId = fakeAppleID;
       codesignVisitor.codesignTeamId = fakeTeamID;
+      codesignVisitor.redactPasswords();
     });
 
     test('successful notarization check returns true', () async {
@@ -944,7 +946,7 @@ status: Invalid''',
         messages,
         contains('Failed to upload to the notary service with args: '
             'xcrun notarytool submit ${rootDirectory.absolute.path}/temp '
-            '--apple-id <appleID> --password <appSpecificPassword> --team-id <teamID> '
+            '--apple-id <appleID-redacted> --password <appSpecificPassword-redacted> --team-id <teamID-redacted> '
             '--verbose'),
       );
       expect(

--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -16,6 +16,10 @@ import './src/fake_process_manager.dart';
 
 void main() {
   const String randomString = 'abcd1234';
+  const String fakeAppleID = 'flutter-appleID';
+  const String fakePassword = 'flutter-password';
+  const String fakeTeamID = 'flutter-teamID';
+  const String uuid = 'uuid';
   const String appSpecificPasswordFilePath = '/tmp/passwords.txt';
   const String codesignAppstoreIDFilePath = '/tmp/appID.txt';
   const String codesignTeamIDFilePath = '/tmp/teamID.txt';
@@ -110,9 +114,9 @@ void main() {
         outputZipPath: outputZipPath,
       );
       codesignVisitor.directoriesVisited.clear();
-      codesignVisitor.appSpecificPassword = randomString;
-      codesignVisitor.codesignAppstoreId = randomString;
-      codesignVisitor.codesignTeamId = randomString;
+      codesignVisitor.appSpecificPassword = fakePassword;
+      codesignVisitor.codesignAppstoreId = fakeAppleID;
+      codesignVisitor.codesignTeamId = fakeTeamID;
     });
 
     test('procesRemotezip triggers correct workflow', () async {
@@ -148,27 +152,27 @@ void main() {
             'submit',
             codesignVisitor.outputZipPath,
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
-          stdout: 'id: $randomString',
+          stdout: 'id: $uuid',
         ),
         const FakeCommand(
           command: <String>[
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: 'status: Accepted',
         ),
@@ -200,19 +204,19 @@ void main() {
       expect(
         messages,
         contains(
-          'uploading xcrun notarytool submit ${codesignVisitor.outputZipPath} --apple-id $randomString --password $randomString '
-          '--team-id $randomString --verbose',
+          'uploading to notary: xcrun notarytool submit ${codesignVisitor.outputZipPath} --apple-id <appleID> --password <appSpecificPassword> '
+          '--team-id <teamID> --verbose',
         ),
       );
       expect(
         messages,
-        contains('RequestUUID for ${codesignVisitor.outputZipPath} is: $randomString'),
+        contains('RequestUUID for ${codesignVisitor.outputZipPath} is: $uuid'),
       );
       expect(
         messages,
         contains(
-          'checking notary status with xcrun notarytool info $randomString --password $randomString --apple-id $randomString '
-          '--team-id $randomString',
+          'checking notary info: xcrun notarytool info $uuid --apple-id <appleID> --password <appSpecificPassword> '
+          '--team-id <teamID>',
         ),
       );
       expect(
@@ -762,9 +766,9 @@ file_c''',
         rootDirectory: rootDirectory,
       );
       codesignVisitor.directoriesVisited.clear();
-      codesignVisitor.appSpecificPassword = randomString;
-      codesignVisitor.codesignAppstoreId = randomString;
-      codesignVisitor.codesignTeamId = randomString;
+      codesignVisitor.appSpecificPassword = fakePassword;
+      codesignVisitor.codesignAppstoreId = fakeAppleID;
+      codesignVisitor.codesignTeamId = fakeTeamID;
     });
 
     test('successful notarization check returns true', () async {
@@ -774,13 +778,13 @@ file_c''',
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: '''createdDate: 2021-04-29T01:38:09.498Z
 id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
@@ -790,7 +794,7 @@ status: Accepted''',
       ]);
 
       expect(
-        codesignVisitor.checkNotaryJobFinished(randomString),
+        codesignVisitor.checkNotaryJobFinished(uuid),
         true,
       );
     });
@@ -802,13 +806,13 @@ status: Accepted''',
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: '''RequestUUID: 2EFE2717-52EF-43A5-96DC-0797E4CA1041
 Date: 2021-07-02 20:32:01 +0000
@@ -820,7 +824,7 @@ Status Message: Package Invalid''',
       ]);
 
       expect(
-        () => codesignVisitor.checkNotaryJobFinished(randomString),
+        () => codesignVisitor.checkNotaryJobFinished(uuid),
         throwsA(
           isA<CodesignException>(),
         ),
@@ -834,13 +838,13 @@ Status Message: Package Invalid''',
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: '''createdDate: 2021-04-29T01:38:09.498Z
 id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
@@ -850,7 +854,7 @@ status: In Progress''',
       ]);
 
       expect(
-        codesignVisitor.checkNotaryJobFinished(randomString),
+        codesignVisitor.checkNotaryJobFinished(uuid),
         false,
       );
     });
@@ -862,13 +866,13 @@ status: In Progress''',
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: '''createdDate: 2021-04-29T01:38:09.498Z
 id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
@@ -878,7 +882,7 @@ status: Invalid''',
       ]);
 
       expect(
-        () => codesignVisitor.checkNotaryJobFinished(randomString),
+        () => codesignVisitor.checkNotaryJobFinished(uuid),
         throwsA(
           isA<CodesignException>(),
         ),
@@ -895,11 +899,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Error uploading file.
@@ -913,11 +917,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Successfully uploaded file.
@@ -940,7 +944,7 @@ status: Invalid''',
         messages,
         contains('Failed to upload to the notary service with args: '
             'xcrun notarytool submit ${rootDirectory.absolute.path}/temp '
-            '--apple-id abcd1234 --password abcd1234 --team-id abcd1234 '
+            '--apple-id <appleID> --password <appSpecificPassword> --team-id <teamID> '
             '--verbose'),
       );
       expect(
@@ -959,11 +963,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Error uploading file.
@@ -995,11 +999,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Error uploading file.
@@ -1013,11 +1017,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Error uploading file.
@@ -1031,11 +1035,11 @@ status: Invalid''',
             'submit',
             '${rootDirectory.absolute.path}/temp',
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
           stdout: '''Error uploading file.
@@ -1083,18 +1087,18 @@ status: Invalid''',
         notarizationTimerDuration: const Duration(seconds: 0),
       );
       codesignVisitor.directoriesVisited.clear();
-      codesignVisitor.appSpecificPassword = randomString;
-      codesignVisitor.codesignAppstoreId = randomString;
-      codesignVisitor.codesignTeamId = randomString;
+      codesignVisitor.appSpecificPassword = fakePassword;
+      codesignVisitor.codesignAppstoreId = fakeAppleID;
+      codesignVisitor.codesignTeamId = fakeTeamID;
       fileSystem.file(codesignAppstoreIDFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync(randomString);
+        ..writeAsStringSync(fakeAppleID);
       fileSystem.file(codesignTeamIDFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync(randomString);
+        ..writeAsStringSync(fakeTeamID);
       fileSystem.file(appSpecificPasswordFilePath)
         ..createSync(recursive: true)
-        ..writeAsStringSync(randomString);
+        ..writeAsStringSync(fakePassword);
     });
 
     test('codesign optional switches artifacts when dryrun is true', () async {
@@ -1128,27 +1132,27 @@ status: Invalid''',
             'submit',
             codesignVisitor.outputZipPath,
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
-          stdout: 'id: $randomString',
+          stdout: 'id: $uuid',
         ),
         const FakeCommand(
           command: <String>[
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: 'status: Accepted',
         ),
@@ -1196,27 +1200,27 @@ status: Invalid''',
             'submit',
             codesignVisitor.outputZipPath,
             '--apple-id',
-            randomString,
+            fakeAppleID,
             '--password',
-            randomString,
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
             '--verbose',
           ],
-          stdout: 'id: $randomString',
+          stdout: 'id: $uuid',
         ),
         const FakeCommand(
           command: <String>[
             'xcrun',
             'notarytool',
             'info',
-            randomString,
-            '--password',
-            randomString,
+            uuid,
             '--apple-id',
-            randomString,
+            fakeAppleID,
+            '--password',
+            fakePassword,
             '--team-id',
-            randomString,
+            fakeTeamID,
           ],
           stdout: 'status: Accepted',
         ),
@@ -1234,9 +1238,9 @@ status: Invalid''',
         notarizationTimerDuration: const Duration(seconds: 0),
         dryrun: false,
       );
-      codesignVisitor.appSpecificPassword = randomString;
-      codesignVisitor.codesignAppstoreId = randomString;
-      codesignVisitor.codesignTeamId = randomString;
+      codesignVisitor.appSpecificPassword = fakePassword;
+      codesignVisitor.codesignAppstoreId = fakeAppleID;
+      codesignVisitor.codesignTeamId = fakeTeamID;
       codesignVisitor.directoriesVisited.clear();
       await codesignVisitor.validateAll();
       final Set<String> messages = records


### PR DESCRIPTION
context: b/311427184

replace codesign credentials in logs with placeholders. 
The log will now look like `this command failed: blah blah ... --apple-id <appleID> --password <appSpecificPassword> --team-id <teamID> ... blah blah` instead of printing the literal passwords.

refactored test to be more stable and reliable.