### PR TITLE
[scheduler] Verify runIf includes foundational files

### DIFF
--- a/app_dart/integration_test/common.dart
+++ b/app_dart/integration_test/common.dart
@@ -18,7 +18,7 @@ void expectNoDiff(String path) {
 
 /// Wrapper class to make it easy to add new repos + branches to the validation suite.
 class SupportedConfig {
-  SupportedConfig(this.slug, [this.branch = 'master']);
+  SupportedConfig(this.slug, [this.branch = 'main']);
 
   final RepositorySlug slug;
   final String branch;

--- a/app_dart/integration_test/validate_all_ci_configs_test.dart
+++ b/app_dart/integration_test/validate_all_ci_configs_test.dart
@@ -18,10 +18,10 @@ import 'common.dart';
 
 /// List of repositories that have supported .ci.yaml config files.
 final List<SupportedConfig> configs = <SupportedConfig>[
-  SupportedConfig(RepositorySlug('flutter', 'cocoon'), 'main'),
-  SupportedConfig(RepositorySlug('flutter', 'engine'), 'main'),
+  SupportedConfig(RepositorySlug('flutter', 'cocoon')),
+  SupportedConfig(RepositorySlug('flutter', 'engine')),
   SupportedConfig(RepositorySlug('flutter', 'flutter')),
-  SupportedConfig(RepositorySlug('flutter', 'packages'), 'main'),
+  SupportedConfig(RepositorySlug('flutter', 'packages')),
 ];
 
 Future<void> main() async {
@@ -57,6 +57,12 @@ Future<void> main() async {
         );
         final YamlMap configYaml = loadYaml(configContent) as YamlMap;
         final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
+        final CiYaml ciYaml = CiYaml(
+          slug: config.slug,
+          branch: config.branch,
+          config: schedulerConfig,
+          validate: true,
+        );
 
         final List<String> githubBranches = getBranchesForRepository(config.slug);
 
@@ -81,11 +87,6 @@ Future<void> main() async {
           }
         }
 
-        if (config.slug.name == 'engine') {
-          print(githubBranches);
-          print(validEnabledBranches);
-        }
-
         // Verify the enabled branches
         for (String enabledBranch in validEnabledBranches.keys) {
           expect(
@@ -95,7 +96,6 @@ Future<void> main() async {
           );
         }
       },
-      skip: config.slug.name == 'flutter',
     );
   }
 }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -251,6 +251,15 @@ class CiYaml {
             }
           }
         }
+        // Verify runIf includes foundational files.
+        if (target.runIf.isNotEmpty) {
+          if (!target.runIf.contains('.ci.yaml')) {
+            exceptions.add('ERROR: ${target.name} is missing `.ci.yaml` in runIf');
+          }
+          if (slug == Config.engineSlug && !target.runIf.contains('DEPS')) {
+            exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
+          }
+        }
       }
 
       /// Check the dependencies for the current target if it is viable and to


### PR DESCRIPTION
Occasionally bugs come in where targets should run, but the runIf is missing critical files (like ci.yaml). Adding this assertion here, and will update the downstream ci.yamls to be fixed.

Fixed the integration test to use the ci_yaml.dart validation suite.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
