### PR TITLE
Flag stale PRs for engine to framework roller

### DIFF
--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -618,7 +618,7 @@ void main() {
     });
 
     test('when it is engine roller', () async {
-      final bool isEngineRoller = ciSuccessful.isEngineRoller(
+      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
         Author(login: 'engine-flutter-autoroll'),
         github.RepositorySlug('flutter', 'engine'),
       );
@@ -626,13 +626,41 @@ void main() {
     });
     test('when it is not from roller', () async {
       final bool isEngineRoller =
-          ciSuccessful.isEngineRoller(Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'engine'));
+          ciSuccessful.isToEngineRoller(Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'engine'));
       expect(isEngineRoller, false);
     });
     test('when it is not from engine', () async {
-      final bool isEngineRoller = ciSuccessful.isEngineRoller(
+      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
         Author(login: 'engine-flutter-autoroll'),
         github.RepositorySlug('flutter', 'flutter'),
+      );
+      expect(isEngineRoller, false);
+    });
+  });
+
+  group('Validate if an engine to framework roller', () {
+    setUp(() {
+      githubService = FakeGithubService(client: MockGitHub());
+      config = FakeConfig(githubService: githubService);
+      ciSuccessful = CiSuccessful(config: config);
+    });
+
+    test('when it is engine roller', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'framework'),
+      );
+      expect(isEngineRoller, true);
+    });
+    test('when it is not from roller', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+          Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'framework'));
+      expect(isEngineRoller, false);
+    });
+    test('when it is not from framework', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'engine'),
       );
       expect(isEngineRoller, false);
     });

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -648,13 +648,15 @@ void main() {
     test('when it is engine roller', () async {
       final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
         Author(login: 'engine-flutter-autoroll'),
-        github.RepositorySlug('flutter', 'framework'),
+        github.RepositorySlug('flutter', 'flutter'),
       );
       expect(isEngineRoller, true);
     });
     test('when it is not from roller', () async {
       final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
-          Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'framework'));
+        Author(login: 'testAuthor'),
+        github.RepositorySlug('flutter', 'flutter'),
+      );
       expect(isEngineRoller, false);
     });
     test('when it is not from framework', () async {


### PR DESCRIPTION
Following up of https://github.com/flutter/cocoon/pull/3332/files#r1423217355

This PR does:
1) supports engine to framework roller
2) change stale logic to focus on `queued` status. There are cases where GitHub check runs have finished a while ago, and we do not want to trigger alerts for them.