### PR TITLE
Update and reenable periodic task vacuum

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -40,9 +40,9 @@ class BatchBackfiller extends RequestHandler {
   Future<Body> get() async {
     final List<Future<void>> futures = <Future<void>>[];
 
-    // for (RepositorySlug slug in config.supportedRepos) {
-      futures.add(backfillRepository(RepositorySlug('flutter', 'flutter')));
-    // }
+    for (RepositorySlug slug in config.supportedRepos) {
+      futures.add(backfillRepository(slug));
+    }
 
     // Process all repos asynchronously
     await Future.wait<void>(futures);
@@ -55,28 +55,60 @@ class BatchBackfiller extends RequestHandler {
     final List<FullTask> tasks =
         await (datastore.queryRecentTasks(slug: slug, commitLimit: config.backfillerCommitLimit)).toList();
 
-    print(tasks.length);
-    final Set<String> shaList = <String>{};
-    tasks.forEach((element) {shaList.add(element.commit.sha!);});
-    final List<Task> inProgressTasks = <Task>[];
-    for (String sha in shaList) {
-      final List<Task> onlyTasks = tasks.where((element) => element.commit.sha == sha).map((e) => e.task).toList();
-      inProgressTasks.addAll(onlyTasks.where((element) => element.status == Task.statusInProgress && element.buildNumber == null).toList());
+    // Construct Task columns to scan for backfilling
+    final Map<String, List<FullTask>> taskMap = <String, List<FullTask>>{};
+    for (FullTask fullTask in tasks) {
+      if (taskMap.containsKey(fullTask.task.name)) {
+        taskMap[fullTask.task.name]!.add(fullTask);
+      } else {
+        taskMap[fullTask.task.name!] = <FullTask>[fullTask];
+      }
     }
 
-    // final List<Task> onlyTasks = tasks.where((element) => element.commit.sha == 'f6c20db64bb896bdec6a8883fae5b956e33b3860').map((e) => e.task).toList();
-    // print(onlyTasks.length);
-    // final List<Task> inProgressTasks = onlyTasks.where((element) => element.status == Task.statusInProgress && element.buildNumber == null).toList();
-    print(inProgressTasks.length);
-    for (Task inProgressTask in inProgressTasks) {
-      print (inProgressTask.builderName);
-      inProgressTask.status = Task.statusNew;
+    // Check if should be scheduled (there is no yellow runs). Run the most recent gray.
+    List<Tuple<Target, FullTask, int>> backfill = <Tuple<Target, FullTask, int>>[];
+    for (List<FullTask> taskColumn in taskMap.values) {
+      final FullTask task = taskColumn.first;
+      final CiYaml ciYaml = await scheduler.getCiYaml(task.commit);
+      final List<Target> ciYamlTargets = ciYaml.backfillTargets;
+      // Skips scheduling if the task is not in TOT commit anymore.
+      final bool taskInToT = ciYamlTargets.map((Target target) => target.value.name).toList().contains(task.task.name);
+      if (!taskInToT) {
+        continue;
+      }
+      final Target target = ciYamlTargets.singleWhere((target) => target.value.name == task.task.name);
+      if (target.schedulerPolicy is! BatchPolicy) {
+        continue;
+      }
+      final FullTask? backfillTask = _backfillTask(target, taskColumn);
+      final int? priority = backfillPriority(taskColumn.map((e) => e.task).toList());
+      if (priority != null && backfillTask != null) {
+        backfill.add(Tuple<Target, FullTask, int>(target, backfillTask, priority));
+      }
     }
-    await datastore.insert(inProgressTasks);
 
-    // await datastore.withTransaction<void>((Transaction transaction) async {
-    //     transaction.queueMutations(inserts: inProgressTasks);
-    //   });
+    // Get the number of targets to be backfilled in each cycle.
+    backfill = getFilteredBackfill(backfill);
+
+    log.fine('Backfilling ${backfill.length} builds');
+    log.fine(backfill.map<String>((Tuple<Target, FullTask, int> tuple) => tuple.first.value.name));
+
+    // Update tasks status as in progress to avoid duplicate scheduling.
+    final List<Task> backfillTasks = backfill.map((Tuple<Target, FullTask, int> tuple) => tuple.second.task).toList();
+    try {
+      await datastore.withTransaction<void>((Transaction transaction) async {
+        transaction.queueMutations(inserts: backfillTasks);
+        await transaction.commit();
+        log.fine(
+          'Updated ${backfillTasks.length} tasks: ${backfillTasks.map((e) => e.name).toList()} when backfilling.',
+        );
+      });
+      // Schedule all builds asynchronously.
+      // Schedule after db updates to avoid duplicate scheduling when db update fails.
+      await _scheduleWithRetries(backfill);
+    } catch (error) {
+      log.severe('Failed to update tasks when backfilling: $error');
+    }
   }
 
   /// Filters [config.backfillerTargetLimit] targets to backfill.
@@ -168,10 +200,16 @@ class BatchBackfiller extends RequestHandler {
 
   /// Returns priority for back filled targets.
   ///
+  /// Skips scheduling newly created targets whose available entries are
+  /// less than `BatchPolicy.kBatchSize`.
+  ///
   /// Uses a higher priority if there is an earlier failed build. Otherwise,
   /// uses default `LuciBuildService.kBackfillPriority`
-  int backfillPriority(List<Task> tasks, int pastTaskNumber) {
-    if (shouldRerunPriority(tasks, pastTaskNumber)) {
+  int? backfillPriority(List<Task> tasks) {
+    if (tasks.length < BatchPolicy.kBatchSize) {
+      return null;
+    }
+    if (shouldRerunPriority(tasks, BatchPolicy.kBatchSize)) {
       return LuciBuildService.kRerunPriority;
     }
     return LuciBuildService.kBackfillPriority;

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 
 import '../../model/appengine/task.dart';
 import '../../service/datastore.dart';
+import '../../service/logging.dart';
 
 /// Vacuum stale tasks.
 ///
@@ -52,7 +53,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
     final DatastoreService datastore = datastoreProvider(config.db);
 
     final List<FullTask> tasks = await datastore.queryRecentTasks(slug: slug).toList();
-    final Set<Task> tasksToBeReset = <Task>{};
+    final List<Task> tasksToBeReset = <Task>[];
     for (FullTask fullTask in tasks) {
       final Task task = fullTask.task;
       if (task.status == Task.statusInProgress && task.buildNumber == null) {
@@ -61,6 +62,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
         tasksToBeReset.add(task);
       }
     }
-    await datastore.insert(tasksToBeReset.toList());
+    log.info('Vacuuming stale tasks: $tasksToBeReset');
+    await datastore.insert(tasksToBeReset);
   }
 }

--- a/cron.yaml
+++ b/cron.yaml
@@ -7,12 +7,11 @@ cron:
   url: /api/vacuum-github-commits
   schedule: every 6 hours
 
-# Disabled for https://github.com/flutter/flutter/issues/121989
 # TODO(keyonghan): will delete if `In Progress` hanging issue is resolved:
 # https://github.com/flutter/flutter/issues/120395#issuecomment-1444810718
-#- description: vacuum stale tasks
-#  url: /api/scheduler/vacuum-stale-tasks
-#  schedule: every 10 minutes
+- description: vacuum stale tasks
+ url: /api/scheduler/vacuum-stale-tasks
+ schedule: every day 08:00 # PST 12:00am
 
 - description: backfills builds
   url: /api/scheduler/batch-backfiller

--- a/cron.yaml
+++ b/cron.yaml
@@ -11,7 +11,7 @@ cron:
 # https://github.com/flutter/flutter/issues/120395#issuecomment-1444810718
 - description: vacuum stale tasks
  url: /api/scheduler/vacuum-stale-tasks
- schedule: every day 08:00 # PST 12:00am
+ schedule: every 12 hours
 
 - description: backfills builds
   url: /api/scheduler/batch-backfiller


### PR DESCRIPTION
We should enable the task vaccum process before https://github.com/flutter/flutter/issues/122117 is fixed, especially when there is limited gardener support.

This PR:
1) updates the vacuum logic to be based on `task.status` is `in progress` and `builder` is null, instead of being based on `created time` which caused https://github.com/flutter/flutter/issues/121989.
2) enables as a daily cronjob running 12:00 PST