### PR TITLE
Engine scenario_app as a test, avoid needs-tests comment

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -34,8 +34,6 @@ Set<RepositorySlug> kNeedsTests = <RepositorySlug>{
   Config.packagesSlug,
 };
 
-final RegExp kEngineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py)$');
-
 // Extentions for files that use // for single line comments.
 // See [_allChangesAreCodeComments] for more.
 @visibleForTesting
@@ -319,7 +317,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       }
 
       // Check to see if tests were submitted with this PR.
-      if (_isATest(filename)) {
+      if (_isAFrameworkTest(filename)) {
         hasTests = true;
       }
     }
@@ -346,7 +344,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     }
   }
 
-  bool _isATest(String filename) {
+  bool _isAFrameworkTest(String filename) {
     if (kNotActuallyATest.any(filename.endsWith)) {
       return false;
     }
@@ -412,7 +410,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         needsTests = !_allChangesAreCodeComments(file);
       }
 
-      if (kEngineTestRegExp.hasMatch(filename.toLowerCase())) {
+      if (_isAnEngineTest(filename)) {
         hasTests = true;
       }
     }
@@ -428,6 +426,14 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         await gitHubClient.issues.createComment(slug, pr.number!, body);
       }
     }
+  }
+
+  bool _isAnEngineTest(String filename) {
+    final RegExp engineTestRegExp = RegExp(r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py)$');
+    return filename.contains('IosBenchmarks') ||
+        filename.contains('IosUnitTests') ||
+        filename.contains('scenario_app') ||
+        engineTestRegExp.hasMatch(filename.toLowerCase());
   }
 
   bool _fileContainsAddedCode(PullRequestFile file) {

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1558,167 +1558,63 @@ void foo() {
       );
     });
 
-    test('Engine labels PRs, no comment if Java tests', () async {
-      const int issueNumber = 123;
+    test('Engine labels PRs, no comment if tested', () async {
+      final List<List<String>> pullRequestFileList = [
+        <String>[
+          // Java tests.
+          'shell/platform/android/io/flutter/Blah.java',
+          'shell/platform/android/test/io/flutter/BlahTest.java',
+        ],
+        <String>[
+          // Script tests.
+          'fml/blah.cc',
+          'fml/testing/blah_test.sh',
+        ],
+        <String>[
+          // cc tests.
+          'fml/blah.cc',
+          'fml/blah_unittests.cc',
+        ],
+        <String>[
+          // cc benchmarks.
+          'fml/blah.cc',
+          'fml/blah_benchmarks.cc',
+        ],
+        <String>[
+          // py tests.
+          'tools/font-subset/main.cc',
+          'tools/font-subset/test.py',
+        ],
+        <String>[
+          // scenario app is a test.
+          'scenario_app/project.pbxproj',
+          'scenario_app/Info_Impeller.plist',
+        ],
+      ];
 
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-        slug: Config.engineSlug,
-      );
+      for (int issueNumber = 0; issueNumber < pullRequestFileList.length; issueNumber++) {
+        tester.message = generateGithubWebhookMessage(
+          action: 'opened',
+          number: issueNumber,
+          slug: Config.engineSlug,
+        );
 
-      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'shell/platform/android/io/flutter/Blah.java',
-          PullRequestFile()..filename = 'shell/platform/android/test/io/flutter/BlahTest.java',
-        ]),
-      );
+        when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
+          (_) => Stream<PullRequestFile>.fromIterable(
+            pullRequestFileList[issueNumber].map((String filename) => PullRequestFile()..filename = filename),
+          ),
+        );
 
-      await tester.post(webhook);
+        await tester.post(webhook);
 
-      verifyNever(
-        issuesService.addLabelsToIssue(Config.engineSlug, issueNumber, any),
-      );
-
-      verifyNever(
-        issuesService.createComment(
-          Config.engineSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
-
-    test('Engine labels PRs, no comment if script tests', () async {
-      const int issueNumber = 123;
-
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-        slug: Config.engineSlug,
-      );
-
-      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'fml/blah.cc',
-          PullRequestFile()..filename = 'fml/testing/blah_test.sh',
-        ]),
-      );
-
-      await tester.post(webhook);
-
-      verifyNever(
-        issuesService.createComment(
-          Config.engineSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
-
-    test('Engine labels PRs, no comment if cc tests', () async {
-      const int issueNumber = 123;
-
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-        slug: Config.engineSlug,
-      );
-
-      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'fml/blah.cc',
-          PullRequestFile()..filename = 'fml/blah_unittests.cc',
-        ]),
-      );
-
-      await tester.post(webhook);
-
-      verifyNever(
-        issuesService.addLabelsToIssue(
-          Config.engineSlug,
-          issueNumber,
-          any,
-        ),
-      );
-
-      verifyNever(
-        issuesService.createComment(
-          Config.engineSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
-
-    test('Engine labels PRs, no comment if py tests', () async {
-      const int issueNumber = 123;
-
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-        slug: Config.engineSlug,
-      );
-
-      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'tools/font-subset/main.cc',
-          PullRequestFile()..filename = 'tools/font-subset/test.py',
-        ]),
-      );
-
-      await tester.post(webhook);
-
-      verifyNever(
-        issuesService.addLabelsToIssue(
-          Config.engineSlug,
-          issueNumber,
-          any,
-        ),
-      );
-
-      verifyNever(
-        issuesService.createComment(
-          Config.engineSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
-
-    test('Engine labels PRs, no comment if cc benchmarks', () async {
-      const int issueNumber = 123;
-
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-        slug: Config.engineSlug,
-      );
-
-      when(pullRequestsService.listFiles(Config.engineSlug, issueNumber)).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          PullRequestFile()..filename = 'fml/blah.cc',
-          PullRequestFile()..filename = 'fml/blah_benchmarks.cc',
-        ]),
-      );
-
-      await tester.post(webhook);
-
-      verifyNever(
-        issuesService.addLabelsToIssue(
-          Config.engineSlug,
-          issueNumber,
-          any,
-        ),
-      );
-
-      verifyNever(
-        issuesService.createComment(
-          Config.engineSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
+        verifyNever(
+          issuesService.createComment(
+            Config.engineSlug,
+            issueNumber,
+            argThat(contains(config.missingTestsPullRequestMessageValue)),
+          ),
+        );
+      }
     });
 
     test('Engine labels PRs, no comments if pr is for release branches', () async {


### PR DESCRIPTION
Treat [engine `scenario_app`](https://github.com/flutter/engine/tree/main/testing/scenario_app) as a test and do not add needs-test comment.  Example:  https://github.com/flutter/engine/pull/49066#issuecomment-1857181226

Refactor tests, put all the code/test combo checks into one test to reduce boilerplate, otherwise I would have needed to add a new test for the `scenario_app` check.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
