### PR TITLE
[codesign] codesign framework bundle

### DIFF
--- a/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
+++ b/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
@@ -256,8 +256,8 @@ update these file paths accordingly.
       log.info('Child file of directory ${directory.basename} is ${entity.basename}');
     }
     final String directoryExtension = directory.basename.split('.').last;
-    if( directoryExtension == 'framework' || directoryExtension == 'xcframework'){
-        final List<String> args = <String>[
+    if (directoryExtension == 'framework' || directoryExtension == 'xcframework') {
+      final List<String> args = <String>[
         '/usr/bin/codesign',
         '--keychain',
         'build.keychain', // specify the keychain to look for cert
@@ -275,12 +275,12 @@ update these file paths accordingly.
           return;
         }
 
-      throw CodesignException(
-        'Failed to codesign bundle ${directory.absolute.path} with args: ${args.join(' ')}\n'
-        'stdout:\n${(result.stdout as String).trim()}'
-        'stderr:\n${(result.stderr as String).trim()}',
-      );
-    });
+        throw CodesignException(
+          'Failed to codesign bundle ${directory.absolute.path} with args: ${args.join(' ')}\n'
+          'stdout:\n${(result.stdout as String).trim()}'
+          'stderr:\n${(result.stderr as String).trim()}',
+        );
+      });
     }
   }
 

--- a/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
+++ b/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
@@ -257,30 +257,7 @@ update these file paths accordingly.
     }
     final String directoryExtension = directory.basename.split('.').last;
     if (directoryExtension == 'framework' || directoryExtension == 'xcframework') {
-      final List<String> args = <String>[
-        '/usr/bin/codesign',
-        '--keychain',
-        'build.keychain', // specify the keychain to look for cert
-        '-f', // force. Possible re-signing of FlutterMacOS.framework, Flutter.xcframework/ios-arm64/Flutter.framework etc.
-        '-s', // use the cert provided by next argument
-        codesignCertName,
-        directory.absolute.path,
-        '--timestamp', // add a secure timestamp
-      ];
-
-      await retryOptions.retry(() async {
-        log.info('Code signing framework bundle: ${args.join(' ')}\n');
-        final io.ProcessResult result = await processManager.run(args);
-        if (result.exitCode == 0) {
-          return;
-        }
-
-        throw CodesignException(
-          'Failed to codesign bundle ${directory.absolute.path} with args: ${args.join(' ')}\n'
-          'stdout:\n${(result.stdout as String).trim()}'
-          'stderr:\n${(result.stderr as String).trim()}',
-        );
-      });
+      await codesignAtPath(binaryOrBundlePath: directory.absolute.path);
     }
   }
 
@@ -341,17 +318,24 @@ update these file paths accordingly.
     if (dryrun) {
       return;
     }
+    await codesignAtPath(binaryOrBundlePath: binaryFile.absolute.path, entitlementCurrentPath: entitlementCurrentPath);
+  }
+
+  Future<void> codesignAtPath({
+    required String binaryOrBundlePath,
+    String? entitlementCurrentPath,
+  }) async {
     final List<String> args = <String>[
       '/usr/bin/codesign',
       '--keychain',
       'build.keychain', // specify the keychain to look for cert
-      '-f', // force
+      '-f', // force. Needed to overwrite signature if major executable of bundle is already signed before bundle is signed.
       '-s', // use the cert provided by next argument
       codesignCertName,
-      binaryFile.absolute.path,
+      binaryOrBundlePath,
       '--timestamp', // add a secure timestamp
       '--options=runtime', // hardened runtime
-      if (fileWithEntitlements.contains(entitlementCurrentPath)) ...<String>[
+      if (entitlementCurrentPath != '' && fileWithEntitlements.contains(entitlementCurrentPath)) ...<String>[
         '--entitlements',
         entitlementsFile.absolute.path,
       ],
@@ -365,7 +349,7 @@ update these file paths accordingly.
       }
 
       throw CodesignException(
-        'Failed to codesign ${binaryFile.absolute.path} with args: ${args.join(' ')}\n'
+        'Failed to codesign binary or bundle at $binaryOrBundlePath with args: ${args.join(' ')}\n'
         'stdout:\n${(result.stdout as String).trim()}'
         'stderr:\n${(result.stderr as String).trim()}',
       );

--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -622,16 +622,22 @@ void main() {
           .map((LogRecord record) => record.message)
           .toList();
       expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_6/non_bundle'));
-      expect(messages,
-          contains('Visiting directory ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework'));
       expect(
-          messages,
-          contains(
-              'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp\n'));
+        messages,
+        contains('Visiting directory ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework'),
+      );
       expect(
-          messages,
-          contains(
-              'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp\n'));
+        messages,
+        contains(
+          'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp\n',
+        ),
+      );
+      expect(
+        messages,
+        contains(
+          'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp\n',
+        ),
+      );
     });
 
     test('visitBinary codesigns binary with / without entitlement', () async {

--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -564,7 +564,8 @@ void main() {
     test('visitDirectory codesigns framework bundle', () async {
       fileSystem
         ..file('${rootDirectory.path}/remote_zip_6/non_bundle/file_a').createSync(recursive: true)
-        ..file('${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework/file_b').createSync(recursive: true);
+        ..file('${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework/file_b')
+            .createSync(recursive: true);
       final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_6');
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
@@ -621,9 +622,16 @@ void main() {
           .map((LogRecord record) => record.message)
           .toList();
       expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_6/non_bundle'));
-      expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework'));
-      expect(messages, contains('Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp\n'));
-      expect(messages, contains('Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp\n'));
+      expect(messages,
+          contains('Visiting directory ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework'));
+      expect(
+          messages,
+          contains(
+              'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp\n'));
+      expect(
+          messages,
+          contains(
+              'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp\n'));
     });
 
     test('visitBinary codesigns binary with / without entitlement', () async {

--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -596,6 +596,7 @@ void main() {
             randomString,
             '${rootDirectory.absolute.path}/remote_zip_6/bundle.xcframework/bundle.framework',
             '--timestamp',
+            '--options=runtime',
           ],
           exitCode: 0,
         ),
@@ -609,6 +610,7 @@ void main() {
             randomString,
             '${rootDirectory.absolute.path}/remote_zip_6/bundle.xcframework',
             '--timestamp',
+            '--options=runtime',
           ],
           exitCode: 0,
         ),
@@ -617,10 +619,10 @@ void main() {
         directory: testDirectory,
         parentVirtualPath: '',
       );
-      final List<String> messages = records
+      final Set<String> messages = records
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
-          .toList();
+          .toSet();
       expect(messages, contains('Visiting directory ${rootDirectory.path}/remote_zip_6/non_bundle'));
       expect(
         messages,
@@ -629,13 +631,13 @@ void main() {
       expect(
         messages,
         contains(
-          'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp\n',
+          'Executing: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework/bundle.framework --timestamp --options=runtime\n',
         ),
       );
       expect(
         messages,
         contains(
-          'Code signing framework bundle: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp\n',
+          'Executing: /usr/bin/codesign --keychain build.keychain -f -s $randomString ${rootDirectory.path}/remote_zip_6/bundle.xcframework --timestamp --options=runtime\n',
         ),
       );
     });


### PR DESCRIPTION
**context:** 
https://github.com/flutter/flutter/issues/140934

**what I learnt:**
1. out of our current [release bundles downloaded from gcs](https://pantheon.corp.google.com/storage/browser/flutter_infra_release/flutter/4f18bb4dcb99d7e0d94aeff2ffa74e6ddef301cd;tab=objects?authuser=0&project=flutter-infra&prefix=&forceOnObjectsSortingFiltering=false), only Flutter.xcframework is not codesigned. Both FlutterMacOS.framework and Flutter.xcframework/*/Flutter.framework are already codesigned. I will explain in more details on why this happens in bullet point 5 below. <br />
The existing bundles are verified using `codesign --verify --verbose --display <path to codesign bundle>`. 

2. According to Eskimo's reply in [this post](https://developer.apple.com/forums/thread/661852) and [this other post](https://developer.apple.com/forums/thread/129678). For nested bundle / framework we should codesign them from the inside-out. And thus in this PR, we codesign the binaries and sub-bundles inside our bundle first, and then codesign the entire bundle.

3. Both .xcframework and .framework direcotry/folders qualify as bundles. <br />
According to the [in-depth developer doc on code signing](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html):
`Bundles must have their Info.plist in the proper location. For app bundles, this is in Contents. For frameworks, this is in Versions/Current/Resources.`
So from the look of our folders, FluttMacOs.framework and Flutter.xcframework/*/Flutter.framework seem to qualify as bundles, but Flutter.xcframework doesn't. 
However, when running the codesign tool it recognizes Flutter.xcframework as bundle: `Flutter.xcframework/: signed bundle`.

4. We are currently signing version `Current` in the bundle, which I think would be good enough. <br />
According to the [in-depth developer doc on code signing](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html):
`When you manually code sign a framework, only the current version, the one pointed at by the Versions/Current symbolic link, is signed by default.` For our bundle, we only have Version A and Version Current, and since Version Current is a symlink to Version A, we codesigned all of our versions. 

5. [my theory] some bundles are already codesigned because the main executable of the bundle is codesigned <br />
Eskimo hinted in [this post](https://developer.apple.com/forums/thread/129678) that `The only exception to this is the main executable of a bundle, where signing the bundle takes care of signing its main executable`. 
And [Apple Technical Note 2206](https://developer.apple.com/library/archive/technotes/tn2206/_index.html) pointed out that `Most frameworks contain a single version and can in fact be signed directly.`<br />
This could provide a theory on how our `FlutterMacOS.framework` bundle is already code signed because the major executable` Versions/A/FlutterMacOS` is codesigned. And our `Flutter.xcFramework/*/Flutter.framework` bundle is codesigned because the major executable `Flutter.xcFramework/*/Flutter.framework/Flutter` is code signed. 
However, .xcFramework itself is not already codesigned and will be included through the change in this PR.

**Tested**:
The output artifact of this PR is [built and tested](https://github.com/flutter/cocoon/tree/main/cipd_packages/codesign)
The output artifact contains a code signed xcFramework, verified using the command mentioned in bullet point 1.


**TODO**: 
deploy this current version of codesign and set cipd label to 'live' when this PR is merged.