### PR TITLE
[dashboard] Fix Log-In button not showing up.

### DIFF
--- a/dashboard/lib/widgets/sign_in_button/sign_in_button_web.dart
+++ b/dashboard/lib/widgets/sign_in_button/sign_in_button_web.dart
@@ -3,9 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-
-import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
-import 'package:google_sign_in_web/google_sign_in_web.dart';
+import 'package:google_sign_in_web/web_only.dart' as gsi_web;
 
 /// Widget that users can click to initiate the Sign In process.
 class SignInButton extends StatelessWidget {
@@ -13,6 +11,6 @@ class SignInButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return (GoogleSignInPlatform.instance as GoogleSignInPlugin).renderButton();
+    return gsi_web.renderButton();
   }
 }

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -19,8 +19,7 @@ dependencies:
   fixnum: 1.1.0 # Rolled by dependabot
   flutter_app_icons: 0.0.9 # Rolled by dependabot
   google_sign_in: 6.2.1 # Rolled by dependabot
-  google_sign_in_platform_interface: any # Match google_sign_in
-  google_sign_in_web: 0.12.3 # Rolled by dependabot
+  google_sign_in_web: 0.12.3+2 # Rolled by dependabot
   http: 1.2.0 # Rolled by dependabot
   protobuf: 3.1.0 # Rolled by dependabot
   provider: 6.1.1 # Rolled by dependabot


### PR DESCRIPTION
Cocoon's dependabot seems to be ignoring "patch" (`+z`) releases in packages with version < `1.0.0`.

That's caused them to miss [a fix in how the Google Sign In button renders into the app](https://github.com/flutter/packages/pull/5660) that was released as a "patch" version (`0.12.3+1`).

This PR updates the cocoon dependency to the fixed version of the package, so the Google Sign In button renders normally again.

(It also uses a new API introduced in 0.12.3 to access `web_only` components much more easily than before, which allows to remove an intermediate dependency).

## Issues

* Fixes https://github.com/flutter/flutter/issues/142195

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
