### PR TITLE
Initialize Firestore client and service

### DIFF
--- a/app_dart/lib/src/service/access_client_provider.dart
+++ b/app_dart/lib/src/service/access_client_provider.dart
@@ -16,10 +16,10 @@ class AccessClientProvider {
 }
 
 /// Creates a Firestore base client for none (default) database.
-/// 
+///
 /// A default header is required for none (default) Firestore API calls.
 /// Both `project_id` and `database_id` are required.
-/// 
+///
 /// https://firebase.google.com/docs/firestore/manage-databases#access_a_named_database_with_a_client_library
 class FirestoreBaseClient extends BaseClient {
   FirestoreBaseClient({

--- a/app_dart/lib/src/service/access_client_provider.dart
+++ b/app_dart/lib/src/service/access_client_provider.dart
@@ -9,7 +9,32 @@ class AccessClientProvider {
   /// Returns an OAuth 2.0 authenticated access client for the device lab service account.
   Future<Client> createAccessClient({
     List<String> scopes = const <String>['https://www.googleapis.com/auth/cloud-platform'],
+    Client? baseClient,
   }) async {
-    return clientViaApplicationDefaultCredentials(scopes: scopes);
+    return clientViaApplicationDefaultCredentials(scopes: scopes, baseClient: baseClient);
+  }
+}
+
+/// Creates a Firestore base client for none (default) database.
+/// 
+/// A default header is required for none (default) Firestore API calls.
+/// Both `project_id` and `database_id` are required.
+/// 
+/// https://firebase.google.com/docs/firestore/manage-databases#access_a_named_database_with_a_client_library
+class FirestoreBaseClient extends BaseClient {
+  FirestoreBaseClient({
+    required this.projectId,
+    required this.databaseId,
+  });
+  final String databaseId;
+  final String projectId;
+  final Client client = Client();
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    final Map<String, String> defaultHeaders = <String, String>{
+      'x-goog-request-params': 'project_id=$projectId&database_id=$databaseId',
+    };
+    request.headers.addAll(defaultHeaders);
+    return client.send(request);
   }
 }

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -93,6 +93,12 @@ class Config {
   /// Default properties when rerunning a prod build.
   static const Map<String, Object> defaultProperties = <String, Object>{'force_upload': true};
 
+  /// GCP project ID.
+  static const String flutterGcpProjectId = 'flutter-dashboard';
+
+  // GCP Firestore native database ID.
+  static const String flutterGcpFirestoreDatabase = 'cocoon';
+
   @visibleForTesting
   static const Duration configCacheTtl = Duration(hours: 12);
 

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -1,0 +1,30 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:googleapis/firestore/v1.dart';
+import 'package:http/http.dart';
+
+import 'access_client_provider.dart';
+import 'config.dart';
+
+class FirestoreService {
+  const FirestoreService(this.accessClientProvider);
+
+  /// AccessClientProvider for OAuth 2.0 authenticated access client
+  final AccessClientProvider accessClientProvider;
+
+  /// Return a [ProjectsDatabasesDocumentsResource] with an authenticated [client]
+  Future<ProjectsDatabasesDocumentsResource> documentResource() async {
+    final Client client = await accessClientProvider.createAccessClient(
+      scopes: const <String>[FirestoreApi.datastoreScope],
+      baseClient: FirestoreBaseClient(
+        projectId: Config.flutterGcpProjectId,
+        databaseId: Config.flutterGcpFirestoreDatabase,
+      ),
+    );
+    return FirestoreApi(client).projects.databases.documents;
+  }
+}


### PR DESCRIPTION
The very first step to support Firestore. Part of https://github.com/flutter/flutter/issues/142951

This PR:
1) Creates a client support with customized header support
2) Adds a basic FirestoreService based on the client