### PR TITLE
Remove `builderNumber` when adding new tasks

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -54,7 +54,6 @@ List<Document> targetsToTaskDocuments(Commit commit, List<Target> targets) {
     (Target target) => Document(
       name: '$kDatabase/documents/tasks/${commit.sha}_${target.value.name}_1',
       fields: <String, Value>{
-        'builderNumber': Value(integerValue: ''),
         'createTimestamp': Value(integerValue: commit.timestamp!.toString()),
         'endTimestamp': Value(integerValue: '0'),
         'bringup': Value(booleanValue: target.value.bringup),

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -22,7 +22,6 @@ void main() {
     final List<Document> taskDocuments = targetsToTaskDocuments(commit, targets);
     expect(taskDocuments.length, 2);
     expect(taskDocuments[0].name, '$kDatabase/documents/tasks/${commit.sha}_${targets[0].value.name}_1');
-    expect(taskDocuments[0].fields!['builderNumber']!.integerValue, '');
     expect(taskDocuments[0].fields!['createTimestamp']!.integerValue, commit.timestamp.toString());
     expect(taskDocuments[0].fields!['endTimestamp']!.integerValue, '0');
     expect(taskDocuments[0].fields!['bringup']!.booleanValue, false);


### PR DESCRIPTION
Follow up of https://github.com/flutter/cocoon/pull/3473.

It turns out that Firestore doesn't accept null/empty values for `integerValue`.
This PR removes the field when adding new tasks. The `builderNumber` field will be added when updating task statuses, where the real build number will be available until then.

Fixes: https://github.com/flutter/flutter/issues/143187
More context: https://github.com/flutter/flutter/issues/142951