### PR TITLE
Add original PR number in revert PR title

### DIFF
--- a/auto_submit/lib/service/revert_issue_body_formatter.dart
+++ b/auto_submit/lib/service/revert_issue_body_formatter.dart
@@ -35,7 +35,7 @@ class RevertIssueBodyFormatter {
   RevertIssueBodyFormatter get format {
     // Create the title for the revert issue.
     prToRevertTitle ??= 'No title provided.';
-    revertPrTitle = 'Reverts "$prToRevertTitle"';
+    revertPrTitle = 'Reverts "$prToRevertTitle (#$prToRevertNumber)"';
 
     // create the reverts Link for the body. Looks like Reverts flutter/cocoon#123 but will render as a link.
     revertPrLink = 'Reverts ${slug.fullName}#$prToRevertNumber';

--- a/auto_submit/test/service/revert_issue_body_formatter_test.dart
+++ b/auto_submit/test/service/revert_issue_body_formatter_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 void main() {
   // Calls are made as they are done in git_cli_revert_method.dart.
   test('Allow nullable fields in formatter.', () {
-    final PullRequest pullRequest = PullRequest(number: 123456, body: null, title: 'Interesting title.');
+    final PullRequest pullRequest = PullRequest(number: 54, body: null, title: 'Interesting title.');
     const String sender = 'RevertAuthor';
     const String reason = 'Revert reason: test xyz has began failing constantly.';
     const String originalPrAuthor = 'caradune';
@@ -30,6 +30,7 @@ void main() {
     );
     revertIssueBodyFormatter!.format;
     expect(revertIssueBodyFormatter, isNotNull);
+    expect(revertIssueBodyFormatter!.revertPrTitle, 'Reverts "Interesting title. (#54)"');
     expect(revertIssueBodyFormatter!.revertPrBody!.contains('No description provided.'), isTrue);
     expect(revertIssueBodyFormatter!.formattedRevertPrBody!.contains(originalPrAuthor), isTrue);
     expect(revertIssueBodyFormatter!.formattedRevertPrBody!.contains('Mando'), isTrue);


### PR DESCRIPTION
* Consistent with how GitHub generates revert PRs
* Google testing relies on this to know when a PR was reverted upstream

For Googlers, see b/324342695 which was generated as the PR didn't include the original info.

I'm open to suggestions on a better way of figuring out the original PR from a revert.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
