### PR TITLE
Treat `flutter-gold` failures in `flutter/engine` as failures.

### DIFF
--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -153,7 +153,7 @@ class CiSuccessful extends Validation {
         if (status.state == STATUS_FAILURE && !notInAuthorsControl.contains(name)) {
           failures.add(FailureDetail(name!, status.targetUrl!));
         }
-        if (status.state == STATUS_PENDING && isStale(status.createdAt!) && supportStale(author, slug)) {
+        if (status.state == STATUS_PENDING && status.createdAt != null && isStale(status.createdAt!) && supportStale(author, slug)) {
           staleStatuses.add(status);
         }
       }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -79,7 +79,7 @@ class CiSuccessful extends Validation {
     }
 
     /// Validate if all checkRuns have succeeded.
-    allSuccess = validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess);
+    allSuccess = validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess, author);
 
     if (!allSuccess && failures.isEmpty) {
       return ValidationResult(allSuccess, Action.IGNORE_TEMPORARILY, '');
@@ -140,6 +140,7 @@ class CiSuccessful extends Validation {
     final String overrideTreeStatusLabel = config.overrideTreeStatusLabel;
     log.info('Validating name: ${slug.name}/$prNumber, statuses: $statuses');
 
+    final List<ContextNode> staleStatuses = <ContextNode>[];
     for (ContextNode status in statuses) {
       // How can name be null but presumed to not be null below when added to failure?
       final String? name = status.context;
@@ -152,7 +153,15 @@ class CiSuccessful extends Validation {
         if (status.state == STATUS_FAILURE && !notInAuthorsControl.contains(name)) {
           failures.add(FailureDetail(name!, status.targetUrl!));
         }
+        if (status.state == STATUS_PENDING && isStale(status.createdAt!) && supportStale(author, slug)) {
+          staleStatuses.add(status);
+        }
       }
+    }
+    if (staleStatuses.isNotEmpty) {
+      log.warning(
+        'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleStatuses.map((e) => e.context).toList()}',
+      );
     }
 
     return allSuccess;
@@ -168,9 +177,11 @@ class CiSuccessful extends Validation {
     List<github.CheckRun> checkRuns,
     Set<FailureDetail> failures,
     bool allSuccess,
+    Author author,
   ) {
     log.info('Validating name: ${slug.name}/$prNumber, checkRuns: $checkRuns');
 
+    final List<github.CheckRun> staleCheckRuns = <github.CheckRun>[];
     for (github.CheckRun checkRun in checkRuns) {
       final String? name = checkRun.name;
 
@@ -184,10 +195,40 @@ class CiSuccessful extends Validation {
         // checkrun has failed.
         log.info('${slug.name}/$prNumber: CheckRun $name failed.');
         failures.add(FailureDetail(name!, checkRun.detailsUrl as String));
+      } else if (checkRun.status == github.CheckRunStatus.queued) {
+        if (isStale(checkRun.startedAt) && supportStale(author, slug)) {
+          staleCheckRuns.add(checkRun);
+        }
       }
       allSuccess = false;
     }
+    if (staleCheckRuns.isNotEmpty) {
+      log.warning(
+        'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleCheckRuns.map((e) => e.name).toList()}',
+      );
+    }
 
     return allSuccess;
+  }
+
+  // Treat any GitHub check run as stale if created over [Config.kGitHubCheckStaleThreshold] hours ago.
+  bool isStale(DateTime dateTime) {
+    return dateTime.compareTo(DateTime.now().subtract(const Duration(hours: Config.kGitHubCheckStaleThreshold))) < 0;
+  }
+
+  /// Perform stale check only on Engine related rolled PRs.
+  ///
+  /// This includes those rolled PRs from upstream to Engine repo and those
+  /// rolled PRs from Engine to Framework.
+  bool supportStale(Author author, github.RepositorySlug slug) {
+    return isToEngineRoller(author, slug) || isEngineToFrameworkRoller(author, slug);
+  }
+
+  bool isToEngineRoller(Author author, github.RepositorySlug slug) {
+    return config.rollerAccounts.contains(author.login!) && slug == Config.engineSlug;
+  }
+
+  bool isEngineToFrameworkRoller(Author author, github.RepositorySlug slug) {
+    return author.login! == 'engine-flutter-autoroll' && slug == Config.flutterSlug;
   }
 }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -29,8 +29,7 @@ class CiSuccessful extends Validation {
   @override
 
   /// Implements the CI build/tests validations.
-  Future<ValidationResult> validate(
-      QueryResult result, github.PullRequest messagePullRequest) async {
+  Future<ValidationResult> validate(QueryResult result, github.PullRequest messagePullRequest) async {
     bool allSuccess = true;
     final github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
     final int prNumber = messagePullRequest.number!;
@@ -47,8 +46,7 @@ class CiSuccessful extends Validation {
       statuses.addAll(commit.status!.contexts!);
     }
 
-    final RepositoryConfiguration repositoryConfiguration =
-        await config.getRepositoryConfiguration(slug);
+    final RepositoryConfiguration repositoryConfiguration = await config.getRepositoryConfiguration(slug);
     final String targetBranch = repositoryConfiguration.defaultBranch;
     // Check tree status of repos. If the tree status is not ready,
     // we want to hold and wait for the status, same as waiting
@@ -57,25 +55,20 @@ class CiSuccessful extends Validation {
     if (baseBranch == targetBranch) {
       // Only validate tree status where base branch is the default branch.
       if (!treeStatusCheck(slug, prNumber, statuses)) {
-        log.warning(
-            'Statuses were not ready for ${slug.fullName}/$prNumber, sha: $commit.');
-        return ValidationResult(false, Action.IGNORE_TEMPORARILY,
-            'Hold to wait for the tree status ready.');
+        log.warning('Statuses were not ready for ${slug.fullName}/$prNumber, sha: $commit.');
+        return ValidationResult(false, Action.IGNORE_TEMPORARILY, 'Hold to wait for the tree status ready.');
       }
     } else {
-      log.info(
-          'Target branch is $baseBranch for ${slug.fullName}/$prNumber, skipping tree status check.');
+      log.info('Target branch is $baseBranch for ${slug.fullName}/$prNumber, skipping tree status check.');
     }
 
     // List of labels associated with the pull request.
-    final List<String> labelNames =
-        (messagePullRequest.labels as List<github.IssueLabel>)
-            .map<String>((github.IssueLabel labelMap) => labelMap.name)
-            .toList();
+    final List<String> labelNames = (messagePullRequest.labels as List<github.IssueLabel>)
+        .map<String>((github.IssueLabel labelMap) => labelMap.name)
+        .toList();
 
     /// Validate if all statuses have been successful.
-    allSuccess = validateStatuses(
-        slug, prNumber, author, labelNames, statuses, failures, allSuccess);
+    allSuccess = validateStatuses(slug, prNumber, author, labelNames, statuses, failures, allSuccess);
 
     final GithubService gitHubService = await config.createGithubService(slug);
     final String? sha = commit.oid;
@@ -86,8 +79,7 @@ class CiSuccessful extends Validation {
     }
 
     /// Validate if all checkRuns have succeeded.
-    allSuccess = validateCheckRuns(
-        slug, prNumber, checkRuns, failures, allSuccess, author);
+    allSuccess = validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess, author);
 
     if (!allSuccess && failures.isEmpty) {
       return ValidationResult(allSuccess, Action.IGNORE_TEMPORARILY, '');
@@ -96,14 +88,12 @@ class CiSuccessful extends Validation {
     final StringBuffer buffer = StringBuffer();
     if (failures.isNotEmpty) {
       for (FailureDetail detail in failures) {
-        buffer.writeln(
-            '- The status or check suite ${detail.markdownLink} has failed. Please fix the '
+        buffer.writeln('- The status or check suite ${detail.markdownLink} has failed. Please fix the '
             'issues identified (or deflake) before re-applying this label.');
       }
     }
-    final Action action = labelNames.contains(config.overrideTreeStatusLabel)
-        ? Action.IGNORE_FAILURE
-        : Action.REMOVE_LABEL;
+    final Action action =
+        labelNames.contains(config.overrideTreeStatusLabel) ? Action.IGNORE_FAILURE : Action.REMOVE_LABEL;
     return ValidationResult(allSuccess, action, buffer.toString());
   }
 
@@ -112,8 +102,7 @@ class CiSuccessful extends Validation {
   /// If a repo has a tree status, we should wait for it to show up instead of posting
   /// a failure to GitHub pull request.
   /// If a repo doesn't have a tree status, simply return `true`.
-  bool treeStatusCheck(
-      github.RepositorySlug slug, int prNumber, List<ContextNode> statuses) {
+  bool treeStatusCheck(github.RepositorySlug slug, int prNumber, List<ContextNode> statuses) {
     bool treeStatusValid = false;
     if (!Config.reposWithTreeStatus.contains(slug)) {
       return true;
@@ -122,8 +111,7 @@ class CiSuccessful extends Validation {
       return false;
     }
     const String treeStatusName = 'tree-status';
-    log.info(
-        '${slug.fullName}/$prNumber: Validating tree status for ${slug.name}/tree-status, statuses: $statuses');
+    log.info('${slug.fullName}/$prNumber: Validating tree status for ${slug.name}/tree-status, statuses: $statuses');
 
     /// Scan list of statuses to see if the tree status exists (this list is expected to be <5 items)
     for (ContextNode status in statuses) {
@@ -158,13 +146,11 @@ class CiSuccessful extends Validation {
       final String? name = status.context;
 
       if (status.state != STATUS_SUCCESS) {
-        if (notInAuthorsControl.contains(name) &&
-            labelNames.contains(overrideTreeStatusLabel)) {
+        if (notInAuthorsControl.contains(name) && labelNames.contains(overrideTreeStatusLabel)) {
           continue;
         }
         allSuccess = false;
-        if (status.state == STATUS_FAILURE &&
-            !notInAuthorsControl.contains(name)) {
+        if (status.state == STATUS_FAILURE && !notInAuthorsControl.contains(name)) {
           failures.add(FailureDetail(name!, status.targetUrl!));
         }
         if (status.state == STATUS_PENDING &&
@@ -230,9 +216,7 @@ class CiSuccessful extends Validation {
 
   // Treat any GitHub check run as stale if created over [Config.kGitHubCheckStaleThreshold] hours ago.
   bool isStale(DateTime dateTime) {
-    return dateTime.compareTo(DateTime.now().subtract(
-            const Duration(hours: Config.kGitHubCheckStaleThreshold))) <
-        0;
+    return dateTime.compareTo(DateTime.now().subtract(const Duration(hours: Config.kGitHubCheckStaleThreshold))) < 0;
   }
 
   /// Perform stale check only on Engine related rolled PRs.
@@ -240,17 +224,14 @@ class CiSuccessful extends Validation {
   /// This includes those rolled PRs from upstream to Engine repo and those
   /// rolled PRs from Engine to Framework.
   bool supportStale(Author author, github.RepositorySlug slug) {
-    return isToEngineRoller(author, slug) ||
-        isEngineToFrameworkRoller(author, slug);
+    return isToEngineRoller(author, slug) || isEngineToFrameworkRoller(author, slug);
   }
 
   bool isToEngineRoller(Author author, github.RepositorySlug slug) {
-    return config.rollerAccounts.contains(author.login!) &&
-        slug == Config.engineSlug;
+    return config.rollerAccounts.contains(author.login!) && slug == Config.engineSlug;
   }
 
   bool isEngineToFrameworkRoller(Author author, github.RepositorySlug slug) {
-    return author.login! == 'engine-flutter-autoroll' &&
-        slug == Config.flutterSlug;
+    return author.login! == 'engine-flutter-autoroll' && slug == Config.flutterSlug;
   }
 }

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -79,7 +79,7 @@ class CiSuccessful extends Validation {
     }
 
     /// Validate if all checkRuns have succeeded.
-    allSuccess = validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess, author);
+    allSuccess = validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess);
 
     if (!allSuccess && failures.isEmpty) {
       return ValidationResult(allSuccess, Action.IGNORE_TEMPORARILY, '');
@@ -140,16 +140,9 @@ class CiSuccessful extends Validation {
     final String overrideTreeStatusLabel = config.overrideTreeStatusLabel;
     log.info('Validating name: ${slug.name}/$prNumber, statuses: $statuses');
 
-    final List<ContextNode> staleStatuses = <ContextNode>[];
     for (ContextNode status in statuses) {
       // How can name be null but presumed to not be null below when added to failure?
       final String? name = status.context;
-
-      // If the account author is a roller account do not block merge on flutter-gold check.
-      if (isToEngineRoller(author, slug) && name == 'flutter-gold') {
-        log.info('Skipping status check for flutter-gold for ${slug.fullName}/$prNumber, pr author: $author.');
-        continue;
-      }
 
       if (status.state != STATUS_SUCCESS) {
         if (notInAuthorsControl.contains(name) && labelNames.contains(overrideTreeStatusLabel)) {
@@ -159,15 +152,7 @@ class CiSuccessful extends Validation {
         if (status.state == STATUS_FAILURE && !notInAuthorsControl.contains(name)) {
           failures.add(FailureDetail(name!, status.targetUrl!));
         }
-        if (status.state == STATUS_PENDING && isStale(status.createdAt!) && supportStale(author, slug)) {
-          staleStatuses.add(status);
-        }
       }
-    }
-    if (staleStatuses.isNotEmpty) {
-      log.warning(
-        'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleStatuses.map((e) => e.context).toList()}',
-      );
     }
 
     return allSuccess;
@@ -183,11 +168,9 @@ class CiSuccessful extends Validation {
     List<github.CheckRun> checkRuns,
     Set<FailureDetail> failures,
     bool allSuccess,
-    Author author,
   ) {
     log.info('Validating name: ${slug.name}/$prNumber, checkRuns: $checkRuns');
 
-    final List<github.CheckRun> staleCheckRuns = <github.CheckRun>[];
     for (github.CheckRun checkRun in checkRuns) {
       final String? name = checkRun.name;
 
@@ -201,40 +184,10 @@ class CiSuccessful extends Validation {
         // checkrun has failed.
         log.info('${slug.name}/$prNumber: CheckRun $name failed.');
         failures.add(FailureDetail(name!, checkRun.detailsUrl as String));
-      } else if (checkRun.status == github.CheckRunStatus.queued) {
-        if (isStale(checkRun.startedAt) && supportStale(author, slug)) {
-          staleCheckRuns.add(checkRun);
-        }
       }
       allSuccess = false;
     }
-    if (staleCheckRuns.isNotEmpty) {
-      log.warning(
-        'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleCheckRuns.map((e) => e.name).toList()}',
-      );
-    }
 
     return allSuccess;
-  }
-
-  // Treat any GitHub check run as stale if created over [Config.kGitHubCheckStaleThreshold] hours ago.
-  bool isStale(DateTime dateTime) {
-    return dateTime.compareTo(DateTime.now().subtract(const Duration(hours: Config.kGitHubCheckStaleThreshold))) < 0;
-  }
-
-  /// Perform stale check only on Engine related rolled PRs.
-  ///
-  /// This includes those rolled PRs from upstream to Engine repo and those
-  /// rolled PRs from Engine to Framework.
-  bool supportStale(Author author, github.RepositorySlug slug) {
-    return isToEngineRoller(author, slug) || isEngineToFrameworkRoller(author, slug);
-  }
-
-  bool isToEngineRoller(Author author, github.RepositorySlug slug) {
-    return config.rollerAccounts.contains(author.login!) && slug == Config.engineSlug;
-  }
-
-  bool isEngineToFrameworkRoller(Author author, github.RepositorySlug slug) {
-    return author.login! == 'engine-flutter-autoroll' && slug == Config.flutterSlug;
   }
 }

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:core';
 
 import 'ci_successful_test_data.dart';
 
@@ -68,17 +67,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isTrue,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
         expect(failures, isEmpty);
       });
     });
@@ -89,17 +78,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isTrue,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
         expect(failures, isEmpty);
       });
     });
@@ -110,17 +89,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isTrue,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
         expect(failures, isEmpty);
       });
     });
@@ -131,17 +100,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isFalse,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -153,17 +112,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isTrue,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
         expect(failures, isEmpty);
       });
     });
@@ -174,17 +123,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isFalse,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -198,17 +137,7 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isFalse,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
         expect(failures, isEmpty);
       });
     });
@@ -219,17 +148,7 @@ void main() {
       const bool allSuccess = false;
 
       checkRunFuture.then((checkRuns) {
-        expect(
-          ciSuccessful.validateCheckRuns(
-            slug,
-            prNumber,
-            checkRuns,
-            failures,
-            allSuccess,
-            Author(login: 'testAuthor'),
-          ),
-          isFalse,
-        );
+        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -331,13 +250,13 @@ void main() {
       convertContextNodeStatuses(contextNodeList);
       expect(
         ciSuccessful.validateStatuses(slug, prNumber, author, labelNames, contextNodeList, failures, allSuccess),
-        isTrue,
+        isFalse,
       );
       expect(failures, isEmpty);
       expect(failures.length, 0);
     });
 
-    test('Validate flutter-gold is not checked even if failing for engine auto roller pull requests.', () {
+    test('Validate flutter-gold is checked even if failing for engine auto roller pull requests.', () {
       final List<ContextNode> contextNodeList = getContextNodeListFromJson(repositoryStatusesWithFailedGoldMock);
       const bool allSuccess = true;
       final Author author = Author(login: 'skia-flutter-autoroll');
@@ -350,10 +269,10 @@ void main() {
       convertContextNodeStatuses(contextNodeList);
       expect(
         ciSuccessful.validateStatuses(slug, prNumber, author, labelNames, contextNodeList, failures, allSuccess),
-        isTrue,
+        isFalse,
       );
-      expect(failures, isEmpty);
-      expect(failures.length, 0);
+      expect(failures, isNotEmpty);
+      expect(failures.length, 1);
     });
 
     test('Validate flutter-gold is checked for non engine auto roller pull requests.', () {
@@ -591,80 +510,6 @@ void main() {
         validationResult.message,
         '- The status or check suite [failed_checkrun](https://example.com) has failed. Please fix the issues identified (or deflake) before re-applying this label.\n',
       );
-    });
-  });
-  group('Validate if a datetime is stale', () {
-    setUp(() {
-      githubService = FakeGithubService(client: MockGitHub());
-      config = FakeConfig(githubService: githubService);
-      ciSuccessful = CiSuccessful(config: config);
-    });
-
-    test('when it is stale', () async {
-      final bool isStale = ciSuccessful.isStale(DateTime.now().subtract(const Duration(hours: 3)));
-      expect(isStale, true);
-    });
-    test('when it is not stale', () async {
-      final bool isStale = ciSuccessful.isStale(DateTime.now().subtract(const Duration(hours: 1)));
-      expect(isStale, false);
-    });
-  });
-
-  group('Validate if an engine roller', () {
-    setUp(() {
-      githubService = FakeGithubService(client: MockGitHub());
-      config = FakeConfig(githubService: githubService);
-      ciSuccessful = CiSuccessful(config: config);
-    });
-
-    test('when it is engine roller', () async {
-      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
-        Author(login: 'engine-flutter-autoroll'),
-        github.RepositorySlug('flutter', 'engine'),
-      );
-      expect(isEngineRoller, true);
-    });
-    test('when it is not from roller', () async {
-      final bool isEngineRoller =
-          ciSuccessful.isToEngineRoller(Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'engine'));
-      expect(isEngineRoller, false);
-    });
-    test('when it is not from engine', () async {
-      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
-        Author(login: 'engine-flutter-autoroll'),
-        github.RepositorySlug('flutter', 'flutter'),
-      );
-      expect(isEngineRoller, false);
-    });
-  });
-
-  group('Validate if an engine to framework roller', () {
-    setUp(() {
-      githubService = FakeGithubService(client: MockGitHub());
-      config = FakeConfig(githubService: githubService);
-      ciSuccessful = CiSuccessful(config: config);
-    });
-
-    test('when it is engine roller', () async {
-      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
-        Author(login: 'engine-flutter-autoroll'),
-        github.RepositorySlug('flutter', 'flutter'),
-      );
-      expect(isEngineRoller, true);
-    });
-    test('when it is not from roller', () async {
-      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
-        Author(login: 'testAuthor'),
-        github.RepositorySlug('flutter', 'flutter'),
-      );
-      expect(isEngineRoller, false);
-    });
-    test('when it is not from framework', () async {
-      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
-        Author(login: 'engine-flutter-autoroll'),
-        github.RepositorySlug('flutter', 'engine'),
-      );
-      expect(isEngineRoller, false);
     });
   });
 }

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:core';
 
 import 'ci_successful_test_data.dart';
 
@@ -67,7 +68,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isTrue,
+        );
         expect(failures, isEmpty);
       });
     });
@@ -78,7 +89,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isTrue,
+        );
         expect(failures, isEmpty);
       });
     });
@@ -89,7 +110,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isTrue,
+        );
         expect(failures, isEmpty);
       });
     });
@@ -100,7 +131,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isFalse,
+        );
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -112,7 +153,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isTrue);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isTrue,
+        );
         expect(failures, isEmpty);
       });
     });
@@ -123,7 +174,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isFalse,
+        );
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -137,7 +198,17 @@ void main() {
       const bool allSuccess = true;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isFalse,
+        );
         expect(failures, isEmpty);
       });
     });
@@ -148,7 +219,17 @@ void main() {
       const bool allSuccess = false;
 
       checkRunFuture.then((checkRuns) {
-        expect(ciSuccessful.validateCheckRuns(slug, prNumber, checkRuns, failures, allSuccess), isFalse);
+        expect(
+          ciSuccessful.validateCheckRuns(
+            slug,
+            prNumber,
+            checkRuns,
+            failures,
+            allSuccess,
+            Author(login: 'testAuthor'),
+          ),
+          isFalse,
+        );
         expect(failures, isNotEmpty);
         expect(failures.length, 1);
       });
@@ -237,7 +318,7 @@ void main() {
       expect(failures.length, 2);
     });
 
-    test('Validate flutter-gold is not checked for engine auto roller pull requests.', () {
+    test('Validate flutter-gold is checked for engine auto roller pull requests.', () {
       final List<ContextNode> contextNodeList = getContextNodeListFromJson(repositoryStatusesWithGoldMock);
       const bool allSuccess = true;
       final Author author = Author(login: 'skia-flutter-autoroll');
@@ -510,6 +591,80 @@ void main() {
         validationResult.message,
         '- The status or check suite [failed_checkrun](https://example.com) has failed. Please fix the issues identified (or deflake) before re-applying this label.\n',
       );
+    });
+  });
+  group('Validate if a datetime is stale', () {
+    setUp(() {
+      githubService = FakeGithubService(client: MockGitHub());
+      config = FakeConfig(githubService: githubService);
+      ciSuccessful = CiSuccessful(config: config);
+    });
+
+    test('when it is stale', () async {
+      final bool isStale = ciSuccessful.isStale(DateTime.now().subtract(const Duration(hours: 3)));
+      expect(isStale, true);
+    });
+    test('when it is not stale', () async {
+      final bool isStale = ciSuccessful.isStale(DateTime.now().subtract(const Duration(hours: 1)));
+      expect(isStale, false);
+    });
+  });
+
+  group('Validate if an engine roller', () {
+    setUp(() {
+      githubService = FakeGithubService(client: MockGitHub());
+      config = FakeConfig(githubService: githubService);
+      ciSuccessful = CiSuccessful(config: config);
+    });
+
+    test('when it is engine roller', () async {
+      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'engine'),
+      );
+      expect(isEngineRoller, true);
+    });
+    test('when it is not from roller', () async {
+      final bool isEngineRoller =
+          ciSuccessful.isToEngineRoller(Author(login: 'testAuthor'), github.RepositorySlug('flutter', 'engine'));
+      expect(isEngineRoller, false);
+    });
+    test('when it is not from engine', () async {
+      final bool isEngineRoller = ciSuccessful.isToEngineRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'flutter'),
+      );
+      expect(isEngineRoller, false);
+    });
+  });
+
+  group('Validate if an engine to framework roller', () {
+    setUp(() {
+      githubService = FakeGithubService(client: MockGitHub());
+      config = FakeConfig(githubService: githubService);
+      ciSuccessful = CiSuccessful(config: config);
+    });
+
+    test('when it is engine roller', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'flutter'),
+      );
+      expect(isEngineRoller, true);
+    });
+    test('when it is not from roller', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+        Author(login: 'testAuthor'),
+        github.RepositorySlug('flutter', 'flutter'),
+      );
+      expect(isEngineRoller, false);
+    });
+    test('when it is not from framework', () async {
+      final bool isEngineRoller = ciSuccessful.isEngineToFrameworkRoller(
+        Author(login: 'engine-flutter-autoroll'),
+        github.RepositorySlug('flutter', 'engine'),
+      );
+      expect(isEngineRoller, false);
     });
   });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/143352.

In practice this reverts the functionality in https://github.com/flutter/flutter/issues/123979 (https://github.com/flutter/cocoon/pull/2585). Sorry for the back-and-forth, we tried this model but ended up with (currently) [~170 untriaged failures](https://flutter-engine-gold.skia.org/), so we want to go back to treating these as failures and improve our tools/process if needed instead.

/cc @jonahwilliams and @Piinks 