### PR TITLE
Support multiple records for retries on a same task

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -94,7 +94,10 @@ class Task extends Document {
   ///
   /// This is a human-readable name, typically a test name (e.g.
   /// "hello_world__memory").
-  String? get taskName => fields!['endTimestamp']!.stringValue!;
+  String? get taskName => fields!['name']!.stringValue!;
+
+  /// The sha of the task commit.
+  String? get commitSha => fields!['commitSha']!.stringValue!;
 
   /// The number of attempts that have been made to run this task successfully.
   ///
@@ -156,6 +159,20 @@ class Task extends Document {
     fields!['endTimestamp'] = Value(integerValue: (build.completedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
 
     _setStatusFromLuciStatus(build);
+  }
+
+  void resetAsRetry({int attempt = 1}) {
+    name = '$kDatabase/documents/tasks/${commitSha}_${taskName}_$attempt';
+    fields = <String, Value>{
+      'createTimestamp': Value(integerValue: DateTime.now().millisecondsSinceEpoch.toString()),
+      'endTimestamp': Value(integerValue: '0'),
+      'bringup': Value(booleanValue: bringup),
+      'name': Value(stringValue: taskName),
+      'startTimestamp': Value(integerValue: '0'),
+      'status': Value(stringValue: Task.statusNew),
+      'testFlaky': Value(booleanValue: false),
+      'commitSha': Value(stringValue: commitSha),
+    };
   }
 
   /// Get a [Task] status from a LUCI [Build] status/result.

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
-import '../model/firestore/task.dart' as f;
+import '../model/firestore/task.dart' as firestore;
 import '../model/luci/push_message.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
@@ -84,7 +84,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
     log.fine('Found $task');
 
-    f.Task taskDocument = f.Task();
+    firestore.Task taskDocument = firestore.Task();
 
     if (_shouldUpdateTask(build, task)) {
       final String oldTaskStatus = task.status;
@@ -149,7 +149,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   }
 
   /// Queries the task document and updates based on the latest build data.
-  Future<f.Task> updateFirestore(
+  Future<firestore.Task> updateFirestore(
     Build build,
     String commitKeyId,
     String taskName,
@@ -159,8 +159,8 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final String sha = commitKeyId.split('/').last;
     final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_$currentAttempt';
     log.info('getting firestore document: $documentName');
-    final f.Task firestoreTask =
-        await f.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
+    final firestore.Task firestoreTask =
+        await firestore.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
     log.info('updating firestoreTask based on build');
     firestoreTask.updateFromBuild(build);
     log.info('finished updating firestoreTask based on builds');

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -45,6 +45,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   @override
   Future<Body> post() async {
     final DatastoreService datastore = datastoreProvider(config.db);
+    final FirestoreService firestoreService = await config.createFirestoreService();
 
     final BuildPushMessage buildPushMessage = BuildPushMessage.fromPushMessage(message);
     log.fine('userData=${buildPushMessage.userData}');
@@ -83,12 +84,14 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
     log.fine('Found $task');
 
+    f.Task taskDocument = f.Task();
+
     if (_shouldUpdateTask(build, task)) {
       final String oldTaskStatus = task.status;
       task.updateFromBuild(build);
       await datastore.insert(<Task>[task]);
       try {
-        await updateFirestore(build, rawCommitKey, task.name!);
+        taskDocument = await updateFirestore(build, rawCommitKey, task.name!, firestoreService);
       } catch (error) {
         log.warning('Failed to update task in Firestore: $error');
       }
@@ -114,6 +117,8 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
         target: target,
         task: task,
         datastore: datastore,
+        taskDocument: taskDocument,
+        firestoreService: firestoreService,
       );
       log.info('Retried: $retried');
     }
@@ -144,10 +149,15 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   }
 
   /// Queries the task document and updates based on the latest build data.
-  Future<void> updateFirestore(Build build, String commitKeyId, String taskName) async {
-    final FirestoreService firestoreService = await config.createFirestoreService();
+  Future<f.Task> updateFirestore(
+    Build build,
+    String commitKeyId,
+    String taskName,
+    FirestoreService firestoreService,
+  ) async {
+    final int currentAttempt = githubChecksService.currentAttempt(build);
     final String sha = commitKeyId.split('/').last;
-    final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_1';
+    final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_$currentAttempt';
     log.info('getting firestore document: $documentName');
     final f.Task firestoreTask =
         await f.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
@@ -156,5 +166,6 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     log.info('finished updating firestoreTask based on builds');
     final List<Write> writes = documentsToWrites([firestoreTask], exists: true);
     await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
+    return firestoreTask;
   }
 }

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -72,7 +72,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       );
       bool rescheduled = false;
       if (githubChecksService.taskFailed(buildPushMessage)) {
-        final int currentAttempt = githubChecksService.currentAttempt(buildPushMessage);
+        final int currentAttempt = githubChecksService.currentAttempt(build);
         final int maxAttempt = await _getMaxAttempt(buildPushMessage, slug, builderName);
         if (currentAttempt < maxAttempt) {
           rescheduled = true;

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -144,8 +144,7 @@ class GithubChecksService {
   /// Returns current reschedule attempt.
   ///
   /// It returns 1 if this is the first run, and +1 with each reschedule.
-  int currentAttempt(push_message.BuildPushMessage buildPushMessage) {
-    final push_message.Build build = buildPushMessage.build!;
+  int currentAttempt(push_message.Build build) {
     if (build.tagsByName('current_attempt').isEmpty) {
       return 1;
     } else {

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -7,26 +7,23 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:github/github.dart' as github;
 import 'package:github/hooks.dart';
+import 'package:googleapis/firestore/v1.dart' hide Status;
 import 'package:googleapis/pubsub/v1.dart';
 
 import '../foundation/github_checks_util.dart';
-import '../foundation/utils.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
+import '../model/firestore/task.dart' as f;
 import '../model/ci_yaml/target.dart';
 import '../model/github/checks.dart' as cocoon_checks;
 import '../model/luci/buildbucket.dart';
 import '../model/luci/push_message.dart' as push_message;
-import '../request_handling/pubsub.dart';
 import '../service/datastore.dart';
 import '../service/logging.dart';
-import 'buildbucket.dart';
-import 'cache_service.dart';
-import 'config.dart';
 import 'exceptions.dart';
-import 'gerrit_service.dart';
 import 'github_service.dart';
 
 const Set<String> taskFailStatusSet = <String>{
@@ -619,6 +616,8 @@ class LuciBuildService {
     tags['user_agent'] = <String>['flutter-cocoon'];
     // Tag `scheduler_job_id` is needed when calling buildbucket search build API.
     tags['scheduler_job_id'] = <String>['flutter/${target.value.name}'];
+    // Default attempt is the initial attempt, which is 1.
+    tags['current_attempt'] = tags['current_attempt'] ?? <String>['1'];
     final Map<String, Object> processedProperties = target.getProperties();
     processedProperties.addAll(properties ?? <String, Object>{});
     processedProperties['git_branch'] = commit.branch!;
@@ -682,8 +681,10 @@ class LuciBuildService {
     required Target target,
     required Task task,
     required DatastoreService datastore,
+    FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool ignoreChecks = false,
+    f.Task? taskDocument,
   }) async {
     if (ignoreChecks == false && await _shouldRerunBuilder(task, commit, datastore) == false) {
       return false;
@@ -691,6 +692,19 @@ class LuciBuildService {
     log.info('Rerun builder: ${target.value.name} for commit ${commit.sha}');
     tags ??= <String, List<String>>{};
     tags['trigger_type'] = <String>['retry'];
+
+    // TODO(keyonghan): remove check when [ResetProdTask] supports firestore update.
+    if (taskDocument != null) {
+      try {
+        final int newAttempt = int.parse(taskDocument.name!.split('_').last) + 1;
+        tags['current_attempt'] = <String>[newAttempt.toString()];
+        taskDocument.resetAsRetry(attempt: newAttempt);
+        final List<Write> writes = documentsToWrites([taskDocument]);
+        await firestoreService!.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
+      } catch (error) {
+        log.warning('Failed to insert retried task in Firestore: $error');
+      }
+    }
 
     final BatchRequest request = BatchRequest(
       requests: <Request>[

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -146,4 +146,19 @@ void main() {
       expect(resultedTask.fields, firestoreTask.fields);
     });
   });
+
+  group('resert as retry', () {
+    test('success', () {
+      final Task task = generateFirestoreTask(
+        1,
+        status: Task.statusFailed,
+        testFlaky: true,
+      );
+      task.resetAsRetry(attempt: 2);
+
+      expect(int.parse(task.name!.split('_').last), 2);
+      expect(task.status, Task.statusNew);
+      expect(task.testFlaky, false);
+    });
+  });
 }

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -5,7 +5,7 @@
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
-import 'package:cocoon_service/src/model/firestore/task.dart' as f;
+import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/db.dart';
@@ -92,7 +92,7 @@ void main() {
   });
 
   test('updates task based on message', () async {
-    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,
@@ -303,7 +303,7 @@ void main() {
 
   test('fallback to build parameters if task_key is not present', () async {
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,
@@ -346,7 +346,7 @@ void main() {
     scheduler.ciYaml = nonBringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,
@@ -389,7 +389,7 @@ void main() {
     scheduler.ciYaml = bringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,
@@ -432,7 +432,7 @@ void main() {
     scheduler.ciYaml = unsupportedPostsubmitCheckrunConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -92,7 +92,7 @@ void main() {
   });
 
   test('updates task based on message', () async {
-    final f.Task firestoreTask = generateFirestoreTask(1);
+    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
     when(
       mockFirestoreService.getDocument(
         captureAny,
@@ -110,6 +110,7 @@ void main() {
     ).thenAnswer((Invocation invocation) {
       return Future<BatchWriteResponse>.value(BatchWriteResponse());
     });
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -301,6 +302,25 @@ void main() {
   });
 
   test('fallback to build parameters if task_key is not present', () async {
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
+    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    when(
+      mockFirestoreService.getDocument(
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<Document>.value(
+        firestoreTask,
+      );
+    });
+    when(
+      mockFirestoreService.batchWriteDocuments(
+        captureAny,
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<BatchWriteResponse>.value(BatchWriteResponse());
+    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -325,6 +345,25 @@ void main() {
   test('non-bringup target updates check run', () async {
     scheduler.ciYaml = nonBringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
+    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    when(
+      mockFirestoreService.getDocument(
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<Document>.value(
+        firestoreTask,
+      );
+    });
+    when(
+      mockFirestoreService.batchWriteDocuments(
+        captureAny,
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<BatchWriteResponse>.value(BatchWriteResponse());
+    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822', repo: 'packages');
     final Task task = generateTask(
       4507531199512576,
@@ -349,6 +388,25 @@ void main() {
   test('bringup target does not update check run', () async {
     scheduler.ciYaml = bringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
+    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    when(
+      mockFirestoreService.getDocument(
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<Document>.value(
+        firestoreTask,
+      );
+    });
+    when(
+      mockFirestoreService.batchWriteDocuments(
+        captureAny,
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<BatchWriteResponse>.value(BatchWriteResponse());
+    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -373,6 +431,25 @@ void main() {
   test('unsupported repo target does not update check run', () async {
     scheduler.ciYaml = unsupportedPostsubmitCheckrunConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
+    final f.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
+    when(
+      mockFirestoreService.getDocument(
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<Document>.value(
+        firestoreTask,
+      );
+    });
+    when(
+      mockFirestoreService.batchWriteDocuments(
+        captureAny,
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<BatchWriteResponse>.value(BatchWriteResponse());
+    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -8,13 +8,15 @@ import 'dart:core';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/model/firestore/task.dart' as f;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
+import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_checks;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/service/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:github/github.dart';
-import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_checks;
+import 'package:googleapis/firestore/v1.dart' hide Status;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -911,11 +913,13 @@ void main() {
     late Commit totCommit;
     late DatastoreService datastore;
     late MockGithubChecksUtil mockGithubChecksUtil;
+    late MockFirestoreService mockFirestoreService;
     setUp(() {
       cache = CacheService(inMemory: true);
       config = FakeConfig();
       mockBuildBucketClient = MockBuildBucketClient();
       mockGithubChecksUtil = MockGithubChecksUtil();
+      mockFirestoreService = MockFirestoreService();
       when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
           .thenAnswer((realInvocation) async => generateCheckRun(1));
       pubsub = FakePubSub();
@@ -1063,6 +1067,49 @@ void main() {
         datastore: datastore,
       );
       expect(rerunFlag, isFalse);
+    });
+
+    test('insert retried task document to firestore', () async {
+      // when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
+      final f.Task firestoreTask = generateFirestoreTask(1, attempts: 1);
+      when(
+        mockFirestoreService.batchWriteDocuments(
+          captureAny,
+          captureAny,
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<BatchWriteResponse>.value(BatchWriteResponse());
+      });
+      totCommit = generateCommit(1);
+      config.db.values[totCommit.key] = totCommit;
+      config.maxLuciTaskRetriesValue = 1;
+      final Task task = generateTask(
+        1,
+        status: Task.statusInfraFailure,
+        parent: totCommit,
+        buildNumber: 1,
+      );
+      final Target target = generateTarget(1);
+      expect(firestoreTask.attempts, 1);
+      final bool rerunFlag = await service.checkRerunBuilder(
+        commit: totCommit,
+        task: task,
+        target: target,
+        datastore: datastore,
+        firestoreService: mockFirestoreService,
+        taskDocument: firestoreTask,
+      );
+      expect(rerunFlag, isTrue);
+
+      expect(firestoreTask.attempts, 2);
+      final List<dynamic> captured = verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+      expect(captured.length, 2);
+      final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+      expect(batchWriteRequest.writes!.length, 1);
+      final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
+      expect(insertedTaskDocument, firestoreTask);
+      // expect(firestoreTask.status, Task.statusSucceeded);
+      // expect(firestoreTask.buildNumber, 1698);
     });
   });
 }

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1070,7 +1070,6 @@ void main() {
     });
 
     test('insert retried task document to firestore', () async {
-      // when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
       final f.Task firestoreTask = generateFirestoreTask(1, attempts: 1);
       when(
         mockFirestoreService.batchWriteDocuments(
@@ -1108,8 +1107,6 @@ void main() {
       expect(batchWriteRequest.writes!.length, 1);
       final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
       expect(insertedTaskDocument, firestoreTask);
-      // expect(firestoreTask.status, Task.statusSucceeded);
-      // expect(firestoreTask.buildNumber, 1698);
     });
   });
 }

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -112,7 +112,7 @@ f.Task generateFirestoreTask(
   final String taskName = name ?? 'task$i';
   final String sha = commitSha ?? 'testSha';
   final f.Task task = f.Task()
-    ..name = '${sha}_${taskName}_1'
+    ..name = '${sha}_${taskName}_$attempts'
     ..fields = <String, Value>{
       'createTimestamp': Value(integerValue: (created?.millisecondsSinceEpoch ?? 0).toString()),
       'startTimestamp': Value(integerValue: (started?.millisecondsSinceEpoch ?? 0).toString()),
@@ -121,6 +121,7 @@ f.Task generateFirestoreTask(
       'testFlaky': Value(booleanValue: testFlaky),
       'status': Value(stringValue: status),
       'name': Value(stringValue: taskName),
+      'commitSha': Value(stringValue: sha),
     };
   if (buildNumber != null) {
     task.fields!['buildNumber'] = Value(integerValue: buildNumber.toString());

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -13,12 +13,15 @@ import 'package:cocoon_service/cocoon_service.dart' as _i15;
 import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i22;
 import 'package:cocoon_service/src/model/appengine/branch.dart' as _i31;
 import 'package:cocoon_service/src/model/appengine/commit.dart' as _i32;
-import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
-import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
+import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart'
+    as _i18;
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart'
+    as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i34;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i33;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i38;
+import 'package:cocoon_service/src/model/firestore/task.dart' as _i40;
 import 'package:cocoon_service/src/model/github/checks.dart' as _i39;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart' as _i8;
 import 'package:cocoon_service/src/model/luci/push_message.dart' as _i37;
@@ -41,11 +44,11 @@ import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i28;
 import 'package:neat_cache/neat_cache.dart' as _i25;
-import 'package:process/src/interface/process_manager.dart' as _i40;
+import 'package:process/src/interface/process_manager.dart' as _i41;
 import 'package:retry/retry.dart' as _i27;
 
 import '../../service/cache_service_test.dart' as _i35;
-import 'mocks.dart' as _i41;
+import 'mocks.dart' as _i42;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -90,7 +93,8 @@ class _FakeAccessToken_2 extends _i1.SmartFake implements _i4.AccessToken {
         );
 }
 
-class _FakeAccessClientProvider_3 extends _i1.SmartFake implements _i5.AccessClientProvider {
+class _FakeAccessClientProvider_3 extends _i1.SmartFake
+    implements _i5.AccessClientProvider {
   _FakeAccessClientProvider_3(
     Object parent,
     Invocation parentInvocation,
@@ -100,7 +104,8 @@ class _FakeAccessClientProvider_3 extends _i1.SmartFake implements _i5.AccessCli
         );
 }
 
-class _FakeTabledataResource_4 extends _i1.SmartFake implements _i6.TabledataResource {
+class _FakeTabledataResource_4 extends _i1.SmartFake
+    implements _i6.TabledataResource {
   _FakeTabledataResource_4(
     Object parent,
     Invocation parentInvocation,
@@ -140,7 +145,8 @@ class _FakeBuild_7 extends _i1.SmartFake implements _i8.Build {
         );
 }
 
-class _FakeSearchBuildsResponse_8 extends _i1.SmartFake implements _i8.SearchBuildsResponse {
+class _FakeSearchBuildsResponse_8 extends _i1.SmartFake
+    implements _i8.SearchBuildsResponse {
   _FakeSearchBuildsResponse_8(
     Object parent,
     Invocation parentInvocation,
@@ -160,7 +166,8 @@ class _FakeBatchResponse_9 extends _i1.SmartFake implements _i8.BatchResponse {
         );
 }
 
-class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuildersResponse {
+class _FakeListBuildersResponse_10 extends _i1.SmartFake
+    implements _i8.ListBuildersResponse {
   _FakeListBuildersResponse_10(
     Object parent,
     Invocation parentInvocation,
@@ -170,7 +177,8 @@ class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuil
         );
 }
 
-class _FakeDatastoreService_11 extends _i1.SmartFake implements _i9.DatastoreService {
+class _FakeDatastoreService_11 extends _i1.SmartFake
+    implements _i9.DatastoreService {
   _FakeDatastoreService_11(
     Object parent,
     Invocation parentInvocation,
@@ -230,7 +238,8 @@ class _FakeGitHub_16 extends _i1.SmartFake implements _i13.GitHub {
         );
 }
 
-class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient {
+class _FakeGraphQLClient_17 extends _i1.SmartFake
+    implements _i14.GraphQLClient {
   _FakeGraphQLClient_17(
     Object parent,
     Invocation parentInvocation,
@@ -240,7 +249,8 @@ class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient 
         );
 }
 
-class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreService {
+class _FakeFirestoreService_18 extends _i1.SmartFake
+    implements _i15.FirestoreService {
   _FakeFirestoreService_18(
     Object parent,
     Invocation parentInvocation,
@@ -250,7 +260,8 @@ class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreSe
         );
 }
 
-class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryService {
+class _FakeBigqueryService_19 extends _i1.SmartFake
+    implements _i16.BigqueryService {
   _FakeBigqueryService_19(
     Object parent,
     Invocation parentInvocation,
@@ -260,7 +271,8 @@ class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryServ
         );
 }
 
-class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService {
+class _FakeGithubService_20 extends _i1.SmartFake
+    implements _i17.GithubService {
   _FakeGithubService_20(
     Object parent,
     Invocation parentInvocation,
@@ -270,7 +282,8 @@ class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService 
         );
 }
 
-class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.GithubBuildStatusUpdate {
+class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
+    implements _i18.GithubBuildStatusUpdate {
   _FakeGithubBuildStatusUpdate_21(
     Object parent,
     Invocation parentInvocation,
@@ -280,7 +293,8 @@ class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.Gith
         );
 }
 
-class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake implements _i19.GithubGoldStatusUpdate {
+class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake
+    implements _i19.GithubGoldStatusUpdate {
   _FakeGithubGoldStatusUpdate_22(
     Object parent,
     Invocation parentInvocation,
@@ -321,7 +335,8 @@ class _FakeDocument_25 extends _i1.SmartFake implements _i21.Document {
         );
 }
 
-class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWriteResponse {
+class _FakeBatchWriteResponse_26 extends _i1.SmartFake
+    implements _i21.BatchWriteResponse {
   _FakeBatchWriteResponse_26(
     Object parent,
     Invocation parentInvocation,
@@ -331,7 +346,8 @@ class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWrit
         );
 }
 
-class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitResponse {
+class _FakeCommitResponse_27 extends _i1.SmartFake
+    implements _i21.CommitResponse {
   _FakeCommitResponse_27(
     Object parent,
     Invocation parentInvocation,
@@ -381,7 +397,8 @@ class _FakeMilestone_31 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_32 extends _i1.SmartFake implements _i22.GithubChecksUtil {
+class _FakeGithubChecksUtil_32 extends _i1.SmartFake
+    implements _i22.GithubChecksUtil {
   _FakeGithubChecksUtil_32(
     Object parent,
     Invocation parentInvocation,
@@ -391,7 +408,8 @@ class _FakeGithubChecksUtil_32 extends _i1.SmartFake implements _i22.GithubCheck
         );
 }
 
-class _FakeCheckRunConclusion_33 extends _i1.SmartFake implements _i13.CheckRunConclusion {
+class _FakeCheckRunConclusion_33 extends _i1.SmartFake
+    implements _i13.CheckRunConclusion {
   _FakeCheckRunConclusion_33(
     Object parent,
     Invocation parentInvocation,
@@ -401,7 +419,8 @@ class _FakeCheckRunConclusion_33 extends _i1.SmartFake implements _i13.CheckRunC
         );
 }
 
-class _FakeCheckRunStatus_34 extends _i1.SmartFake implements _i13.CheckRunStatus {
+class _FakeCheckRunStatus_34 extends _i1.SmartFake
+    implements _i13.CheckRunStatus {
   _FakeCheckRunStatus_34(
     Object parent,
     Invocation parentInvocation,
@@ -501,7 +520,8 @@ class _FakeGitTree_43 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_44 extends _i1.SmartFake implements _i14.DefaultPolicies {
+class _FakeDefaultPolicies_44 extends _i1.SmartFake
+    implements _i14.DefaultPolicies {
   _FakeDefaultPolicies_44(
     Object parent,
     Invocation parentInvocation,
@@ -541,7 +561,8 @@ class _FakeQueryManager_47 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
+class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake
+    implements _i14.ObservableQuery<TParsed1> {
   _FakeObservableQuery_48(
     Object parent,
     Invocation parentInvocation,
@@ -551,7 +572,8 @@ class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake implements _i14.Ob
         );
 }
 
-class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
+class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake
+    implements _i14.QueryResult<TParsed1> {
   _FakeQueryResult_49(
     Object parent,
     Invocation parentInvocation,
@@ -561,7 +583,8 @@ class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake implem
         );
 }
 
-class _FakeHttpClientRequest_50 extends _i1.SmartFake implements _i23.HttpClientRequest {
+class _FakeHttpClientRequest_50 extends _i1.SmartFake
+    implements _i23.HttpClientRequest {
   _FakeHttpClientRequest_50(
     Object parent,
     Invocation parentInvocation,
@@ -591,7 +614,8 @@ class _FakeHttpHeaders_52 extends _i1.SmartFake implements _i23.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_53 extends _i1.SmartFake implements _i23.HttpClientResponse {
+class _FakeHttpClientResponse_53 extends _i1.SmartFake
+    implements _i23.HttpClientResponse {
   _FakeHttpClientResponse_53(
     Object parent,
     Invocation parentInvocation,
@@ -621,7 +645,8 @@ class _FakeSocket_55 extends _i1.SmartFake implements _i23.Socket {
         );
 }
 
-class _FakeStreamSubscription_56<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
+class _FakeStreamSubscription_56<T> extends _i1.SmartFake
+    implements _i20.StreamSubscription<T> {
   _FakeStreamSubscription_56(
     Object parent,
     Invocation parentInvocation,
@@ -631,7 +656,8 @@ class _FakeStreamSubscription_56<T> extends _i1.SmartFake implements _i20.Stream
         );
 }
 
-class _FakeJobCancelResponse_57 extends _i1.SmartFake implements _i6.JobCancelResponse {
+class _FakeJobCancelResponse_57 extends _i1.SmartFake
+    implements _i6.JobCancelResponse {
   _FakeJobCancelResponse_57(
     Object parent,
     Invocation parentInvocation,
@@ -651,7 +677,8 @@ class _FakeJob_58 extends _i1.SmartFake implements _i6.Job {
         );
 }
 
-class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
+class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake
+    implements _i6.GetQueryResultsResponse {
   _FakeGetQueryResultsResponse_59(
     Object parent,
     Invocation parentInvocation,
@@ -681,7 +708,8 @@ class _FakeQueryResponse_61 extends _i1.SmartFake implements _i6.QueryResponse {
         );
 }
 
-class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
+class _FakeBuildBucketClient_62 extends _i1.SmartFake
+    implements _i15.BuildBucketClient {
   _FakeBuildBucketClient_62(
     Object parent,
     Invocation parentInvocation,
@@ -721,7 +749,8 @@ class _FakeProcess_65 extends _i1.SmartFake implements _i23.Process {
         );
 }
 
-class _FakePullRequestMerge_66 extends _i1.SmartFake implements _i13.PullRequestMerge {
+class _FakePullRequestMerge_66 extends _i1.SmartFake
+    implements _i13.PullRequestMerge {
   _FakePullRequestMerge_66(
     Object parent,
     Invocation parentInvocation,
@@ -731,7 +760,8 @@ class _FakePullRequestMerge_66 extends _i1.SmartFake implements _i13.PullRequest
         );
 }
 
-class _FakePullRequestComment_67 extends _i1.SmartFake implements _i13.PullRequestComment {
+class _FakePullRequestComment_67 extends _i1.SmartFake
+    implements _i13.PullRequestComment {
   _FakePullRequestComment_67(
     Object parent,
     Invocation parentInvocation,
@@ -741,7 +771,8 @@ class _FakePullRequestComment_67 extends _i1.SmartFake implements _i13.PullReque
         );
 }
 
-class _FakePullRequestReview_68 extends _i1.SmartFake implements _i13.PullRequestReview {
+class _FakePullRequestReview_68 extends _i1.SmartFake
+    implements _i13.PullRequestReview {
   _FakePullRequestReview_68(
     Object parent,
     Invocation parentInvocation,
@@ -761,7 +792,8 @@ class _FakeRepository_69 extends _i1.SmartFake implements _i13.Repository {
         );
 }
 
-class _FakeLicenseDetails_70 extends _i1.SmartFake implements _i13.LicenseDetails {
+class _FakeLicenseDetails_70 extends _i1.SmartFake
+    implements _i13.LicenseDetails {
   _FakeLicenseDetails_70(
     Object parent,
     Invocation parentInvocation,
@@ -771,7 +803,8 @@ class _FakeLicenseDetails_70 extends _i1.SmartFake implements _i13.LicenseDetail
         );
 }
 
-class _FakeLanguageBreakdown_71 extends _i1.SmartFake implements _i13.LanguageBreakdown {
+class _FakeLanguageBreakdown_71 extends _i1.SmartFake
+    implements _i13.LanguageBreakdown {
   _FakeLanguageBreakdown_71(
     Object parent,
     Invocation parentInvocation,
@@ -791,7 +824,8 @@ class _FakeBranch_72 extends _i1.SmartFake implements _i13.Branch {
         );
 }
 
-class _FakeCommitComment_73 extends _i1.SmartFake implements _i13.CommitComment {
+class _FakeCommitComment_73 extends _i1.SmartFake
+    implements _i13.CommitComment {
   _FakeCommitComment_73(
     Object parent,
     Invocation parentInvocation,
@@ -801,7 +835,8 @@ class _FakeCommitComment_73 extends _i1.SmartFake implements _i13.CommitComment 
         );
 }
 
-class _FakeRepositoryCommit_74 extends _i1.SmartFake implements _i13.RepositoryCommit {
+class _FakeRepositoryCommit_74 extends _i1.SmartFake
+    implements _i13.RepositoryCommit {
   _FakeRepositoryCommit_74(
     Object parent,
     Invocation parentInvocation,
@@ -811,7 +846,8 @@ class _FakeRepositoryCommit_74 extends _i1.SmartFake implements _i13.RepositoryC
         );
 }
 
-class _FakeGitHubComparison_75 extends _i1.SmartFake implements _i13.GitHubComparison {
+class _FakeGitHubComparison_75 extends _i1.SmartFake
+    implements _i13.GitHubComparison {
   _FakeGitHubComparison_75(
     Object parent,
     Invocation parentInvocation,
@@ -831,7 +867,8 @@ class _FakeGitHubFile_76 extends _i1.SmartFake implements _i13.GitHubFile {
         );
 }
 
-class _FakeRepositoryContents_77 extends _i1.SmartFake implements _i13.RepositoryContents {
+class _FakeRepositoryContents_77 extends _i1.SmartFake
+    implements _i13.RepositoryContents {
   _FakeRepositoryContents_77(
     Object parent,
     Invocation parentInvocation,
@@ -841,7 +878,8 @@ class _FakeRepositoryContents_77 extends _i1.SmartFake implements _i13.Repositor
         );
 }
 
-class _FakeContentCreation_78 extends _i1.SmartFake implements _i13.ContentCreation {
+class _FakeContentCreation_78 extends _i1.SmartFake
+    implements _i13.ContentCreation {
   _FakeContentCreation_78(
     Object parent,
     Invocation parentInvocation,
@@ -871,7 +909,8 @@ class _FakePublicKey_80 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeRepositoryPages_81 extends _i1.SmartFake implements _i13.RepositoryPages {
+class _FakeRepositoryPages_81 extends _i1.SmartFake
+    implements _i13.RepositoryPages {
   _FakeRepositoryPages_81(
     Object parent,
     Invocation parentInvocation,
@@ -911,7 +950,8 @@ class _FakeReleaseAsset_84 extends _i1.SmartFake implements _i13.ReleaseAsset {
         );
 }
 
-class _FakeContributorParticipation_85 extends _i1.SmartFake implements _i13.ContributorParticipation {
+class _FakeContributorParticipation_85 extends _i1.SmartFake
+    implements _i13.ContributorParticipation {
   _FakeContributorParticipation_85(
     Object parent,
     Invocation parentInvocation,
@@ -921,7 +961,8 @@ class _FakeContributorParticipation_85 extends _i1.SmartFake implements _i13.Con
         );
 }
 
-class _FakeRepositoryStatus_86 extends _i1.SmartFake implements _i13.RepositoryStatus {
+class _FakeRepositoryStatus_86 extends _i1.SmartFake
+    implements _i13.RepositoryStatus {
   _FakeRepositoryStatus_86(
     Object parent,
     Invocation parentInvocation,
@@ -931,7 +972,8 @@ class _FakeRepositoryStatus_86 extends _i1.SmartFake implements _i13.RepositoryS
         );
 }
 
-class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
+class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake
+    implements _i13.CombinedRepositoryStatus {
   _FakeCombinedRepositoryStatus_87(
     Object parent,
     Invocation parentInvocation,
@@ -951,7 +993,8 @@ class _FakeReleaseNotes_88 extends _i1.SmartFake implements _i13.ReleaseNotes {
         );
 }
 
-class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
+class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake
+    implements _i6.TableDataInsertAllResponse {
   _FakeTableDataInsertAllResponse_89(
     Object parent,
     Invocation parentInvocation,
@@ -1011,7 +1054,8 @@ class _FakeCache_94<T> extends _i1.SmartFake implements _i25.Cache<T> {
         );
 }
 
-class _FakeAuthentication_95 extends _i1.SmartFake implements _i13.Authentication {
+class _FakeAuthentication_95 extends _i1.SmartFake
+    implements _i13.Authentication {
   _FakeAuthentication_95(
     Object parent,
     Invocation parentInvocation,
@@ -1021,7 +1065,8 @@ class _FakeAuthentication_95 extends _i1.SmartFake implements _i13.Authenticatio
         );
 }
 
-class _FakeActivityService_96 extends _i1.SmartFake implements _i13.ActivityService {
+class _FakeActivityService_96 extends _i1.SmartFake
+    implements _i13.ActivityService {
   _FakeActivityService_96(
     Object parent,
     Invocation parentInvocation,
@@ -1031,7 +1076,8 @@ class _FakeActivityService_96 extends _i1.SmartFake implements _i13.ActivityServ
         );
 }
 
-class _FakeAuthorizationsService_97 extends _i1.SmartFake implements _i13.AuthorizationsService {
+class _FakeAuthorizationsService_97 extends _i1.SmartFake
+    implements _i13.AuthorizationsService {
   _FakeAuthorizationsService_97(
     Object parent,
     Invocation parentInvocation,
@@ -1061,7 +1107,8 @@ class _FakeGitService_99 extends _i1.SmartFake implements _i13.GitService {
         );
 }
 
-class _FakeIssuesService_100 extends _i1.SmartFake implements _i13.IssuesService {
+class _FakeIssuesService_100 extends _i1.SmartFake
+    implements _i13.IssuesService {
   _FakeIssuesService_100(
     Object parent,
     Invocation parentInvocation,
@@ -1081,7 +1128,8 @@ class _FakeMiscService_101 extends _i1.SmartFake implements _i13.MiscService {
         );
 }
 
-class _FakeOrganizationsService_102 extends _i1.SmartFake implements _i13.OrganizationsService {
+class _FakeOrganizationsService_102 extends _i1.SmartFake
+    implements _i13.OrganizationsService {
   _FakeOrganizationsService_102(
     Object parent,
     Invocation parentInvocation,
@@ -1091,7 +1139,8 @@ class _FakeOrganizationsService_102 extends _i1.SmartFake implements _i13.Organi
         );
 }
 
-class _FakePullRequestsService_103 extends _i1.SmartFake implements _i13.PullRequestsService {
+class _FakePullRequestsService_103 extends _i1.SmartFake
+    implements _i13.PullRequestsService {
   _FakePullRequestsService_103(
     Object parent,
     Invocation parentInvocation,
@@ -1101,7 +1150,8 @@ class _FakePullRequestsService_103 extends _i1.SmartFake implements _i13.PullReq
         );
 }
 
-class _FakeRepositoriesService_104 extends _i1.SmartFake implements _i13.RepositoriesService {
+class _FakeRepositoriesService_104 extends _i1.SmartFake
+    implements _i13.RepositoriesService {
   _FakeRepositoriesService_104(
     Object parent,
     Invocation parentInvocation,
@@ -1111,7 +1161,8 @@ class _FakeRepositoriesService_104 extends _i1.SmartFake implements _i13.Reposit
         );
 }
 
-class _FakeSearchService_105 extends _i1.SmartFake implements _i13.SearchService {
+class _FakeSearchService_105 extends _i1.SmartFake
+    implements _i13.SearchService {
   _FakeSearchService_105(
     Object parent,
     Invocation parentInvocation,
@@ -1121,7 +1172,8 @@ class _FakeSearchService_105 extends _i1.SmartFake implements _i13.SearchService
         );
 }
 
-class _FakeUrlShortenerService_106 extends _i1.SmartFake implements _i13.UrlShortenerService {
+class _FakeUrlShortenerService_106 extends _i1.SmartFake
+    implements _i13.UrlShortenerService {
   _FakeUrlShortenerService_106(
     Object parent,
     Invocation parentInvocation,
@@ -1141,7 +1193,8 @@ class _FakeUsersService_107 extends _i1.SmartFake implements _i13.UsersService {
         );
 }
 
-class _FakeChecksService_108 extends _i1.SmartFake implements _i13.ChecksService {
+class _FakeChecksService_108 extends _i1.SmartFake
+    implements _i13.ChecksService {
   _FakeChecksService_108(
     Object parent,
     Invocation parentInvocation,
@@ -1164,14 +1217,17 @@ class _FakeResponse_109 extends _i1.SmartFake implements _i2.Response {
 /// A class which mocks [AccessClientProvider].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessClientProvider extends _i1.Mock implements _i5.AccessClientProvider {
+class MockAccessClientProvider extends _i1.Mock
+    implements _i5.AccessClientProvider {
   MockAccessClientProvider() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
   _i20.Future<_i2.Client> createAccessClient({
-    List<String>? scopes = const [r'https://www.googleapis.com/auth/cloud-platform'],
+    List<String>? scopes = const [
+      r'https://www.googleapis.com/auth/cloud-platform'
+    ],
     _i2.Client? baseClient,
   }) =>
       (super.noSuchMethod(
@@ -1200,7 +1256,8 @@ class MockAccessClientProvider extends _i1.Mock implements _i5.AccessClientProvi
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock implements _i26.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock
+    implements _i26.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1253,7 +1310,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
           #defaultTabledata,
           [],
         ),
-        returnValue: _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
+        returnValue:
+            _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
           this,
           Invocation.method(
             #defaultTabledata,
@@ -1292,7 +1350,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #bucket: bucket,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(<_i16.BuilderStatistic>[]),
+        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(
+            <_i16.BuilderStatistic>[]),
       ) as _i20.Future<List<_i16.BuilderStatistic>>);
 
   @override
@@ -1310,7 +1369,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #limit: limit,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
+        returnValue:
+            _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
       ) as _i20.Future<List<_i16.BuilderRecord>>);
 }
 
@@ -1380,7 +1440,8 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Future<List<Map<String, String>>>.value(<Map<String, String>>[]),
+        returnValue: _i20.Future<List<Map<String, String>>>.value(
+            <Map<String, String>>[]),
       ) as _i20.Future<List<Map<String, String>>>);
 }
 
@@ -1423,7 +1484,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> scheduleBuild(
     _i8.ScheduleBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1444,7 +1506,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.SearchBuildsResponse> searchBuilds(
     _i8.SearchBuildsRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1452,7 +1515,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(_FakeSearchBuildsResponse_8(
+        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(
+            _FakeSearchBuildsResponse_8(
           this,
           Invocation.method(
             #searchBuilds,
@@ -1465,7 +1529,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.BatchResponse> batch(
     _i8.BatchRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1486,7 +1551,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> cancelBuild(
     _i8.CancelBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1507,7 +1573,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> getBuild(
     _i8.GetBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1528,7 +1595,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.ListBuildersResponse> listBuilders(
     _i8.ListBuildersRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1536,7 +1604,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(_FakeListBuildersResponse_10(
+        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(
+            _FakeListBuildersResponse_10(
           this,
           Invocation.method(
             #listBuilders,
@@ -1583,7 +1652,8 @@ class MockCommitService extends _i1.Mock implements _i29.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i30.CreateEvent? createEvent) => (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i30.CreateEvent? createEvent) =>
+      (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1593,7 +1663,8 @@ class MockCommitService extends _i1.Mock implements _i29.CommitService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) => (super.noSuchMethod(
+  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) =>
+      (super.noSuchMethod(
         Invocation.method(
           #handlePushGithubRequest,
           [pushEvent],
@@ -1678,9 +1749,11 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<Map<String, dynamic>> get githubAppInstallations => (super.noSuchMethod(
+  _i20.Future<Map<String, dynamic>> get githubAppInstallations =>
+      (super.noSuchMethod(
         Invocation.getter(#githubAppInstallations),
-        returnValue: _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+        returnValue:
+            _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i20.Future<Map<String, dynamic>>);
 
   @override
@@ -1930,7 +2003,8 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i31.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i31.Branch>> getBranches(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
@@ -1939,7 +2013,8 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<Iterable<_i31.Branch>>);
 
   @override
-  String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
+  String wrongHeadBranchPullRequestMessage(String? branch) =>
+      (super.noSuchMethod(
         Invocation.method(
           #wrongHeadBranchPullRequestMessage,
           [branch],
@@ -1984,7 +2059,8 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as String);
 
   @override
-  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #flutterGoldAlertConstant,
           [slug],
@@ -2029,7 +2105,8 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #generateGithubToken,
           [slug],
@@ -2086,12 +2163,14 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i13.GitHub);
 
   @override
-  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() => (super.noSuchMethod(
+  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGitHubGraphQLClient,
           [],
         ),
-        returnValue: _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
+        returnValue:
+            _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
           this,
           Invocation.method(
             #createGitHubGraphQLClient,
@@ -2101,12 +2180,14 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i14.GraphQLClient>);
 
   @override
-  _i20.Future<_i15.FirestoreService> createFirestoreService() => (super.noSuchMethod(
+  _i20.Future<_i15.FirestoreService> createFirestoreService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createFirestoreService,
           [],
         ),
-        returnValue: _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
+        returnValue:
+            _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
           this,
           Invocation.method(
             #createFirestoreService,
@@ -2116,12 +2197,14 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i15.FirestoreService>);
 
   @override
-  _i20.Future<_i16.BigqueryService> createBigQueryService() => (super.noSuchMethod(
+  _i20.Future<_i16.BigqueryService> createBigQueryService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createBigQueryService,
           [],
         ),
-        returnValue: _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
+        returnValue:
+            _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
           this,
           Invocation.method(
             #createBigQueryService,
@@ -2131,12 +2214,14 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i16.BigqueryService>);
 
   @override
-  _i20.Future<_i6.TabledataResource> createTabledataResourceApi() => (super.noSuchMethod(
+  _i20.Future<_i6.TabledataResource> createTabledataResourceApi() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createTabledataResourceApi,
           [],
         ),
-        returnValue: _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
+        returnValue:
+            _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
           this,
           Invocation.method(
             #createTabledataResourceApi,
@@ -2146,12 +2231,14 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i6.TabledataResource>);
 
   @override
-  _i20.Future<_i17.GithubService> createDefaultGitHubService() => (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createDefaultGitHubService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createDefaultGitHubService,
           [],
         ),
-        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue:
+            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createDefaultGitHubService,
@@ -2161,12 +2248,15 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i20.Future<_i17.GithubService> createGithubService(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createGithubService(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGithubService,
           [slug],
         ),
-        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue:
+            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createGithubService,
@@ -2176,7 +2266,8 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i17.GithubService createGithubServiceWithToken(String? token) => (super.noSuchMethod(
+  _i17.GithubService createGithubServiceWithToken(String? token) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGithubServiceWithToken,
           [token],
@@ -2293,7 +2384,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Stream<_i33.FullTask>);
 
   @override
-  _i20.Future<List<_i34.Stage>> queryTasksGroupedByStage(_i32.Commit? commit) => (super.noSuchMethod(
+  _i20.Future<List<_i34.Stage>> queryTasksGroupedByStage(_i32.Commit? commit) =>
+      (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
@@ -2314,7 +2406,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(_FakeGithubBuildStatusUpdate_21(
+        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(
+            _FakeGithubBuildStatusUpdate_21(
           this,
           Invocation.method(
             #queryLastStatusUpdate,
@@ -2339,7 +2432,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(_FakeGithubGoldStatusUpdate_22(
+        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(
+            _FakeGithubGoldStatusUpdate_22(
           this,
           Invocation.method(
             #queryLastGoldUpdate,
@@ -2352,16 +2446,20 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<_i19.GithubGoldStatusUpdate>);
 
   @override
-  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
+  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(
+          List<_i11.Model<dynamic>>? rows) =>
+      (super.noSuchMethod(
         Invocation.method(
           #shard,
           [rows],
         ),
-        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(<List<_i11.Model<dynamic>>>[]),
+        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(
+            <List<_i11.Model<dynamic>>>[]),
       ) as _i20.Future<List<List<_i11.Model<dynamic>>>>);
 
   @override
-  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
+  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) =>
+      (super.noSuchMethod(
         Invocation.method(
           #insert,
           [rows],
@@ -2371,7 +2469,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(List<_i11.Key<dynamic>>? keys) =>
+  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(
+          List<_i11.Key<dynamic>>? keys) =>
       (super.noSuchMethod(
         Invocation.method(
           #lookupByKey,
@@ -2413,7 +2512,9 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T>);
 
   @override
-  _i20.Future<T?> withTransaction<T>(_i20.Future<T> Function(_i11.Transaction)? handler) => (super.noSuchMethod(
+  _i20.Future<T?> withTransaction<T>(
+          _i20.Future<T> Function(_i11.Transaction)? handler) =>
+      (super.noSuchMethod(
         Invocation.method(
           #withTransaction,
           [handler],
@@ -2521,13 +2622,14 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i5.AccessClientProvider);
 
   @override
-  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() => (super.noSuchMethod(
+  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() =>
+      (super.noSuchMethod(
         Invocation.method(
           #documentResource,
           [],
         ),
-        returnValue:
-            _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(_FakeProjectsDatabasesDocumentsResource_24(
+        returnValue: _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(
+            _FakeProjectsDatabasesDocumentsResource_24(
           this,
           Invocation.method(
             #documentResource,
@@ -2564,7 +2666,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             database,
           ],
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
+            _FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWriteDocuments,
@@ -2577,12 +2680,15 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.BatchWriteResponse>);
 
   @override
-  _i20.Future<_i21.CommitResponse> writeViaTransaction(List<_i21.Write>? writes) => (super.noSuchMethod(
+  _i20.Future<_i21.CommitResponse> writeViaTransaction(
+          List<_i21.Write>? writes) =>
+      (super.noSuchMethod(
         Invocation.method(
           #writeViaTransaction,
           [writes],
         ),
-        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue:
+            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #writeViaTransaction,
@@ -2816,7 +2922,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<_i13.Issue>);
 
   @override
-  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listAssignees,
           [slug],
@@ -2857,7 +2964,9 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Stream<_i13.IssueComment>);
 
   @override
-  _i20.Stream<_i13.IssueComment> listCommentsByRepo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.IssueComment> listCommentsByRepo(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCommentsByRepo,
           [slug],
@@ -2963,7 +3072,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listLabels,
           [slug],
@@ -3144,7 +3254,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3162,7 +3273,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3200,7 +3312,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listMilestones,
           [slug],
@@ -3305,7 +3418,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
 /// A class which mocks [GithubChecksService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksService {
+class MockGithubChecksService extends _i1.Mock
+    implements _i15.GithubChecksService {
   MockGithubChecksService() {
     _i1.throwOnMissingStub(this);
   }
@@ -3338,7 +3452,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i22.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) =>
+      super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3386,7 +3501,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i20.Future<bool>);
 
   @override
-  bool taskFailed(_i37.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  bool taskFailed(_i37.BuildPushMessage? buildPushMessage) =>
+      (super.noSuchMethod(
         Invocation.method(
           #taskFailed,
           [buildPushMessage],
@@ -3395,10 +3511,10 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as bool);
 
   @override
-  int currentAttempt(_i37.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  int currentAttempt(_i37.Build? build) => (super.noSuchMethod(
         Invocation.method(
           #currentAttempt,
-          [buildPushMessage],
+          [build],
         ),
         returnValue: 0,
       ) as int);
@@ -3419,7 +3535,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i37.Result? result) => (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i37.Result? result) =>
+      (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [result],
@@ -3434,7 +3551,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i37.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i37.Status? status) =>
+      (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
@@ -3488,7 +3606,8 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             checkSuiteEvent,
           ],
         ),
-        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(<String, _i13.CheckRun>{}),
+        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(
+            <String, _i13.CheckRun>{}),
       ) as _i20.Future<Map<String, _i13.CheckRun>>);
 
   @override
@@ -3540,7 +3659,8 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             #checkName: checkName,
           },
         ),
-        returnValue: _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
+        returnValue:
+            _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
       ) as _i20.Future<List<_i13.CheckSuite>>);
 
   @override
@@ -3667,7 +3787,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             lastCommitTimestampMills,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(<_i13.RepositoryCommit>[]),
+        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(
+            <_i13.RepositoryCommit>[]),
       ) as _i20.Future<List<_i13.RepositoryCommit>>);
 
   @override
@@ -3683,7 +3804,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             branch,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
+        returnValue:
+            _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
       ) as _i20.Future<List<_i13.PullRequest>>);
 
   @override
@@ -3755,7 +3877,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             issueNumber,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3773,7 +3896,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3891,11 +4015,13 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #labels: labels,
           },
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
-  _i20.Future<List<String>> listFiles(_i13.PullRequest? pullRequest) => (super.noSuchMethod(
+  _i20.Future<List<String>> listFiles(_i13.PullRequest? pullRequest) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listFiles,
           [pullRequest],
@@ -4372,7 +4498,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.DefaultPolicies);
 
   @override
-  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) => super.noSuchMethod(
+  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) =>
+      super.noSuchMethod(
         Invocation.setter(
           #defaultPolicies,
           _defaultPolicies,
@@ -4450,7 +4577,9 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.GraphQLClient);
 
   @override
-  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(
+          _i14.WatchQueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #watchQuery,
           [options],
@@ -4465,7 +4594,9 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(
+          _i14.WatchQueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #watchMutation,
           [options],
@@ -4480,12 +4611,15 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(_i14.QueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(
+          _i14.QueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4495,12 +4629,15 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(_i14.MutationOptions<TParsed>? options) => (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(
+          _i14.MutationOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4510,7 +4647,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(_i14.SubscriptionOptions<TParsed>? options) =>
+  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(
+          _i14.SubscriptionOptions<TParsed>? options) =>
       (super.noSuchMethod(
         Invocation.method(
           #subscribe,
@@ -4534,7 +4672,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4606,7 +4745,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       );
 
   @override
-  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore({bool? refetchQueries = true}) =>
+  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore(
+          {bool? refetchQueries = true}) =>
       (super.noSuchMethod(Invocation.method(
         #resetStore,
         [],
@@ -4778,7 +4918,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #open,
@@ -4805,7 +4946,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             url,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #openUrl,
@@ -4832,7 +4974,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #get,
@@ -4851,7 +4994,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #getUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #getUrl,
@@ -4875,7 +5019,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #post,
@@ -4894,7 +5039,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #postUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #postUrl,
@@ -4918,7 +5064,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #put,
@@ -4937,7 +5084,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #putUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #putUrl,
@@ -4961,7 +5109,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #delete,
@@ -4975,12 +5124,14 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
       ) as _i20.Future<_i23.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i23.HttpClientRequest> deleteUrl(Uri? url) =>
+      (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #deleteUrl,
@@ -5004,7 +5155,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #patch,
@@ -5023,7 +5175,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #patchUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #patchUrl,
@@ -5047,7 +5200,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #head,
@@ -5066,7 +5220,8 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #headUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue:
+            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #headUrl,
@@ -5243,7 +5398,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   _i20.Future<_i23.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
+            _FakeHttpClientResponse_53(
           this,
           Invocation.getter(#done),
         )),
@@ -5273,7 +5429,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
+            _FakeHttpClientResponse_53(
           this,
           Invocation.method(
             #close,
@@ -5367,7 +5524,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
       );
 
   @override
-  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) => (super.noSuchMethod(
+  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addStream,
           [stream],
@@ -5388,7 +5546,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock
+    implements _i23.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5415,7 +5574,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as int);
 
   @override
-  _i23.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
+  _i23.HttpClientResponseCompressionState get compressionState =>
+      (super.noSuchMethod(
         Invocation.getter(#compressionState),
         returnValue: _i23.HttpClientResponseCompressionState.notCompressed,
       ) as _i23.HttpClientResponseCompressionState);
@@ -5504,7 +5664,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
+            _FakeHttpClientResponse_53(
           this,
           Invocation.method(
             #redirect,
@@ -5581,7 +5742,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.StreamSubscription<List<int>>);
 
   @override
-  _i20.Stream<List<int>> where(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> where(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #where,
           [test],
@@ -5599,7 +5761,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #asyncMap,
           [convert],
@@ -5608,7 +5771,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<E>);
 
   @override
-  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #asyncExpand,
           [convert],
@@ -5631,7 +5795,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #expand,
           [convert],
@@ -5640,7 +5805,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) => (super.noSuchMethod(
+  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) =>
+      (super.noSuchMethod(
         Invocation.method(
           #pipe,
           [streamConsumer],
@@ -5649,7 +5815,9 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Future<dynamic>);
 
   @override
-  _i20.Stream<S> transform<S>(_i20.StreamTransformer<List<int>, S>? streamTransformer) => (super.noSuchMethod(
+  _i20.Stream<S> transform<S>(
+          _i20.StreamTransformer<List<int>, S>? streamTransformer) =>
+      (super.noSuchMethod(
         Invocation.method(
           #transform,
           [streamTransformer],
@@ -5737,7 +5905,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Future<void> forEach(void Function(List<int>)? action) => (super.noSuchMethod(
+  _i20.Future<void> forEach(void Function(List<int>)? action) =>
+      (super.noSuchMethod(
         Invocation.method(
           #forEach,
           [action],
@@ -5747,7 +5916,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Future<bool> every(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #every,
           [test],
@@ -5826,7 +5996,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #takeWhile,
           [test],
@@ -5844,7 +6015,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #skipWhile,
           [test],
@@ -5959,7 +6131,8 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_57(
+        returnValue:
+            _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_57(
           this,
           Invocation.method(
             #cancel,
@@ -6060,7 +6233,8 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_59(
+        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(
+            _FakeGetQueryResultsResponse_59(
           this,
           Invocation.method(
             #getQueryResults,
@@ -6214,7 +6388,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i15.BuildBucketClient);
 
   @override
-  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) => super.noSuchMethod(
+  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) =>
+      super.noSuchMethod(
         Invocation.setter(
           #buildBucketClient,
           _buildBucketClient,
@@ -6259,7 +6434,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i22.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) =>
+      super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -6307,7 +6483,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             max,
           ],
         ),
-        returnValue: _i20.Future<List<List<_i8.Request>>>.value(<List<_i8.Request>>[]),
+        returnValue:
+            _i20.Future<List<List<_i8.Request>>>.value(<List<_i8.Request>>[]),
       ) as _i20.Future<List<List<_i8.Request>>>);
 
   @override
@@ -6329,7 +6506,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(_i13.PullRequest? pullRequest) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(
+          _i13.PullRequest? pullRequest) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getTryBuildsByPullRequest,
           [pullRequest],
@@ -6460,7 +6639,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i39.CheckRunEvent? checkRunEvent) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(
+          _i39.CheckRunEvent? checkRunEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6558,7 +6738,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<
+      List<_i15.Tuple<_i38.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
     required _i32.Commit? commit,
     required List<_i15.Tuple<_i38.Target, _i33.Task, int>>? toBeScheduled,
   }) =>
@@ -6571,8 +6752,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>.value(
-            <_i15.Tuple<_i38.Target, _i33.Task, int>>[]),
+        returnValue:
+            _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>.value(
+                <_i15.Tuple<_i38.Target, _i33.Task, int>>[]),
       ) as _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>);
 
   @override
@@ -6600,8 +6782,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
     required _i38.Target? target,
     required _i33.Task? task,
     required _i9.DatastoreService? datastore,
+    _i15.FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool? ignoreChecks = false,
+    _i40.Task? taskDocument,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6612,8 +6796,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #target: target,
             #task: task,
             #datastore: datastore,
+            #firestoreService: firestoreService,
             #tags: tags,
             #ignoreChecks: ignoreChecks,
+            #taskDocument: taskDocument,
           },
         ),
         returnValue: _i20.Future<bool>.value(false),
@@ -6623,7 +6809,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 /// A class which mocks [ProcessManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessManager extends _i1.Mock implements _i40.ProcessManager {
+class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
   MockProcessManager() {
     _i1.throwOnMissingStub(this);
   }
@@ -6688,7 +6874,8 @@ class MockProcessManager extends _i1.Mock implements _i40.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i23.ProcessResult>.value(_i28.dummyValue<_i23.ProcessResult>(
+        returnValue: _i20.Future<_i23.ProcessResult>.value(
+            _i28.dummyValue<_i23.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6779,7 +6966,8 @@ class MockProcessManager extends _i1.Mock implements _i40.ProcessManager {
 /// A class which mocks [PullRequestsService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsService {
+class MockPullRequestsService extends _i1.Mock
+    implements _i13.PullRequestsService {
   MockPullRequestsService() {
     _i1.throwOnMissingStub(this);
   }
@@ -6995,7 +7183,8 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #requestSha: requestSha,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_66(
+        returnValue:
+            _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_66(
           this,
           Invocation.method(
             #merge,
@@ -7029,7 +7218,9 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
       ) as _i20.Stream<_i13.PullRequestComment>);
 
   @override
-  _i20.Stream<_i13.PullRequestComment> listComments(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.PullRequestComment> listComments(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listComments,
           [slug],
@@ -7052,7 +7243,8 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             comment,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_67(
+        returnValue: _i20.Future<_i13.PullRequestComment>.value(
+            _FakePullRequestComment_67(
           this,
           Invocation.method(
             #createComment,
@@ -7078,7 +7270,8 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             review,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_68(
+        returnValue:
+            _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_68(
           this,
           Invocation.method(
             #createReview,
@@ -7094,7 +7287,8 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
 /// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesService {
+class MockRepositoriesService extends _i1.Mock
+    implements _i13.RepositoriesService {
   MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
@@ -7200,12 +7394,14 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Future<_i13.LicenseDetails> getLicense(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.LicenseDetails> getLicense(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getLicense,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_70(
+        returnValue:
+            _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_70(
           this,
           Invocation.method(
             #getLicense,
@@ -7215,7 +7411,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.LicenseDetails>);
 
   @override
-  _i20.Future<_i13.Repository> getRepository(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.Repository> getRepository(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getRepository,
           [slug],
@@ -7230,7 +7427,9 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Stream<_i13.Repository> getRepositories(List<_i13.RepositorySlug>? slugs) => (super.noSuchMethod(
+  _i20.Stream<_i13.Repository> getRepositories(
+          List<_i13.RepositorySlug>? slugs) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getRepositories,
           [slugs],
@@ -7282,7 +7481,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Future<bool> deleteRepository(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<bool> deleteRepository(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #deleteRepository,
           [slug],
@@ -7305,7 +7505,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.Contributor>);
 
   @override
-  _i20.Stream<_i13.Team> listTeams(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Team> listTeams(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listTeams,
           [slug],
@@ -7314,12 +7515,15 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.Team>);
 
   @override
-  _i20.Future<_i13.LanguageBreakdown> listLanguages(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.LanguageBreakdown> listLanguages(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listLanguages,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_71(
+        returnValue:
+            _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_71(
           this,
           Invocation.method(
             #listLanguages,
@@ -7349,7 +7553,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.Tag>);
 
   @override
-  _i20.Stream<_i13.Branch> listBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Branch> listBranches(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listBranches,
           [slug],
@@ -7383,7 +7588,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.Branch>);
 
   @override
-  _i20.Stream<_i13.Collaborator> listCollaborators(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Collaborator> listCollaborators(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCollaborators,
           [slug],
@@ -7456,7 +7662,9 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.CommitComment>);
 
   @override
-  _i20.Stream<_i13.CommitComment> listCommitComments(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.CommitComment> listCommitComments(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCommitComments,
           [slug],
@@ -7487,7 +7695,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #line: line,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue:
+            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #createCommitComment,
@@ -7516,7 +7725,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue:
+            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #getCommitComment,
@@ -7541,7 +7751,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #body: body,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue:
+            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #updateCommitComment,
@@ -7607,7 +7818,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue:
+            _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
           this,
           Invocation.method(
             #getCommit,
@@ -7659,7 +7871,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             refHead,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_75(
+        returnValue:
+            _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_75(
           this,
           Invocation.method(
             #compareCommits,
@@ -7708,7 +7921,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_77(
+        returnValue: _i20.Future<_i13.RepositoryContents>.value(
+            _FakeRepositoryContents_77(
           this,
           Invocation.method(
             #getContents,
@@ -7734,7 +7948,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             file,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue:
+            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #createFile,
@@ -7767,7 +7982,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#branch: branch},
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue:
+            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #updateFile,
@@ -7802,7 +8018,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue:
+            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #deleteFile,
@@ -7836,7 +8053,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<String?>);
 
   @override
-  _i20.Stream<_i13.Repository> listForks(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Repository> listForks(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listForks,
           [slug],
@@ -7870,7 +8088,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Stream<_i13.Hook> listHooks(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Hook> listHooks(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listHooks,
           [slug],
@@ -8030,7 +8249,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listDeployKeys(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listDeployKeys(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listDeployKeys,
           [slug],
@@ -8114,7 +8334,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             merge,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue:
+            _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
           this,
           Invocation.method(
             #merge,
@@ -8127,12 +8348,14 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.RepositoryCommit>);
 
   @override
-  _i20.Future<_i13.RepositoryPages> getPagesInfo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.RepositoryPages> getPagesInfo(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getPagesInfo,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_81(
+        returnValue:
+            _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_81(
           this,
           Invocation.method(
             #getPagesInfo,
@@ -8142,7 +8365,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.RepositoryPages>);
 
   @override
-  _i20.Stream<_i13.PageBuild> listPagesBuilds(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.PageBuild> listPagesBuilds(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listPagesBuilds,
           [slug],
@@ -8151,7 +8375,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.PageBuild>);
 
   @override
-  _i20.Future<_i13.PageBuild> getLatestPagesBuild(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.PageBuild> getLatestPagesBuild(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getLatestPagesBuild,
           [slug],
@@ -8166,7 +8391,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.PageBuild>);
 
   @override
-  _i20.Stream<_i13.Release> listReleases(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Release> listReleases(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listReleases,
           [slug],
@@ -8175,7 +8401,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.Release>);
 
   @override
-  _i20.Future<_i13.Release> getLatestRelease(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.Release> getLatestRelease(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getLatestRelease,
           [slug],
@@ -8438,20 +8665,26 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             createReleaseAssets,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.ReleaseAsset>>.value(<_i13.ReleaseAsset>[]),
+        returnValue:
+            _i20.Future<List<_i13.ReleaseAsset>>.value(<_i13.ReleaseAsset>[]),
       ) as _i20.Future<List<_i13.ReleaseAsset>>);
 
   @override
-  _i20.Future<List<_i13.ContributorStatistics>> listContributorStats(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<List<_i13.ContributorStatistics>> listContributorStats(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listContributorStats,
           [slug],
         ),
-        returnValue: _i20.Future<List<_i13.ContributorStatistics>>.value(<_i13.ContributorStatistics>[]),
+        returnValue: _i20.Future<List<_i13.ContributorStatistics>>.value(
+            <_i13.ContributorStatistics>[]),
       ) as _i20.Future<List<_i13.ContributorStatistics>>);
 
   @override
-  _i20.Stream<_i13.YearCommitCountWeek> listCommitActivity(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.YearCommitCountWeek> listCommitActivity(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCommitActivity,
           [slug],
@@ -8460,7 +8693,9 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.YearCommitCountWeek>);
 
   @override
-  _i20.Stream<_i13.WeeklyChangesCount> listCodeFrequency(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.WeeklyChangesCount> listCodeFrequency(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCodeFrequency,
           [slug],
@@ -8469,12 +8704,15 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Stream<_i13.WeeklyChangesCount>);
 
   @override
-  _i20.Future<_i13.ContributorParticipation> getParticipation(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i13.ContributorParticipation> getParticipation(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getParticipation,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_85(
+        returnValue: _i20.Future<_i13.ContributorParticipation>.value(
+            _FakeContributorParticipation_85(
           this,
           Invocation.method(
             #getParticipation,
@@ -8484,7 +8722,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.ContributorParticipation>);
 
   @override
-  _i20.Stream<_i13.PunchcardEntry> listPunchcard(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.PunchcardEntry> listPunchcard(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listPunchcard,
           [slug],
@@ -8523,7 +8762,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_86(
+        returnValue:
+            _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_86(
           this,
           Invocation.method(
             #createStatus,
@@ -8549,7 +8789,8 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_87(
+        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(
+            _FakeCombinedRepositoryStatus_87(
           this,
           Invocation.method(
             #getCombinedStatus,
@@ -8562,7 +8803,9 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
       ) as _i20.Future<_i13.CombinedRepositoryStatus>);
 
   @override
-  _i20.Future<_i13.ReleaseNotes> generateReleaseNotes(_i13.CreateReleaseNotes? crn) => (super.noSuchMethod(
+  _i20.Future<_i13.ReleaseNotes> generateReleaseNotes(
+          _i13.CreateReleaseNotes? crn) =>
+      (super.noSuchMethod(
         Invocation.method(
           #generateReleaseNotes,
           [crn],
@@ -8718,7 +8961,8 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_89(
+        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(
+            _FakeTableDataInsertAllResponse_89(
           this,
           Invocation.method(
             #insertAll,
@@ -8920,7 +9164,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.UserEmail>);
 
   @override
-  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) => (super.noSuchMethod(
+  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addEmails,
           [emails],
@@ -9008,7 +9253,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.User>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) => (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listPublicKeys,
           [userLogin],
@@ -9017,7 +9263,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.PublicKey>);
 
   @override
-  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) => (super.noSuchMethod(
+  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createPublicKey,
           [key],
@@ -9071,7 +9318,8 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
       ) as _i25.Cache<_i36.Uint8List>);
 
   @override
-  _i25.Cache<S> withCodec<S>(_i24.Codec<S, _i36.Uint8List>? codec) => (super.noSuchMethod(
+  _i25.Cache<S> withCodec<S>(_i24.Codec<S, _i36.Uint8List>? codec) =>
+      (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],
@@ -9354,7 +9602,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i41.postJsonShim<S, T>(
+        returnValue: _i42.postJsonShim<S, T>(
           path,
           statusCode: statusCode,
           fail: fail,

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -13,10 +13,8 @@ import 'package:cocoon_service/cocoon_service.dart' as _i15;
 import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i22;
 import 'package:cocoon_service/src/model/appengine/branch.dart' as _i31;
 import 'package:cocoon_service/src/model/appengine/commit.dart' as _i32;
-import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart'
-    as _i18;
-import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart'
-    as _i19;
+import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i34;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i33;
@@ -93,8 +91,7 @@ class _FakeAccessToken_2 extends _i1.SmartFake implements _i4.AccessToken {
         );
 }
 
-class _FakeAccessClientProvider_3 extends _i1.SmartFake
-    implements _i5.AccessClientProvider {
+class _FakeAccessClientProvider_3 extends _i1.SmartFake implements _i5.AccessClientProvider {
   _FakeAccessClientProvider_3(
     Object parent,
     Invocation parentInvocation,
@@ -104,8 +101,7 @@ class _FakeAccessClientProvider_3 extends _i1.SmartFake
         );
 }
 
-class _FakeTabledataResource_4 extends _i1.SmartFake
-    implements _i6.TabledataResource {
+class _FakeTabledataResource_4 extends _i1.SmartFake implements _i6.TabledataResource {
   _FakeTabledataResource_4(
     Object parent,
     Invocation parentInvocation,
@@ -145,8 +141,7 @@ class _FakeBuild_7 extends _i1.SmartFake implements _i8.Build {
         );
 }
 
-class _FakeSearchBuildsResponse_8 extends _i1.SmartFake
-    implements _i8.SearchBuildsResponse {
+class _FakeSearchBuildsResponse_8 extends _i1.SmartFake implements _i8.SearchBuildsResponse {
   _FakeSearchBuildsResponse_8(
     Object parent,
     Invocation parentInvocation,
@@ -166,8 +161,7 @@ class _FakeBatchResponse_9 extends _i1.SmartFake implements _i8.BatchResponse {
         );
 }
 
-class _FakeListBuildersResponse_10 extends _i1.SmartFake
-    implements _i8.ListBuildersResponse {
+class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuildersResponse {
   _FakeListBuildersResponse_10(
     Object parent,
     Invocation parentInvocation,
@@ -177,8 +171,7 @@ class _FakeListBuildersResponse_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDatastoreService_11 extends _i1.SmartFake
-    implements _i9.DatastoreService {
+class _FakeDatastoreService_11 extends _i1.SmartFake implements _i9.DatastoreService {
   _FakeDatastoreService_11(
     Object parent,
     Invocation parentInvocation,
@@ -238,8 +231,7 @@ class _FakeGitHub_16 extends _i1.SmartFake implements _i13.GitHub {
         );
 }
 
-class _FakeGraphQLClient_17 extends _i1.SmartFake
-    implements _i14.GraphQLClient {
+class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient {
   _FakeGraphQLClient_17(
     Object parent,
     Invocation parentInvocation,
@@ -249,8 +241,7 @@ class _FakeGraphQLClient_17 extends _i1.SmartFake
         );
 }
 
-class _FakeFirestoreService_18 extends _i1.SmartFake
-    implements _i15.FirestoreService {
+class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreService {
   _FakeFirestoreService_18(
     Object parent,
     Invocation parentInvocation,
@@ -260,8 +251,7 @@ class _FakeFirestoreService_18 extends _i1.SmartFake
         );
 }
 
-class _FakeBigqueryService_19 extends _i1.SmartFake
-    implements _i16.BigqueryService {
+class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryService {
   _FakeBigqueryService_19(
     Object parent,
     Invocation parentInvocation,
@@ -271,8 +261,7 @@ class _FakeBigqueryService_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubService_20 extends _i1.SmartFake
-    implements _i17.GithubService {
+class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService {
   _FakeGithubService_20(
     Object parent,
     Invocation parentInvocation,
@@ -282,8 +271,7 @@ class _FakeGithubService_20 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
-    implements _i18.GithubBuildStatusUpdate {
+class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.GithubBuildStatusUpdate {
   _FakeGithubBuildStatusUpdate_21(
     Object parent,
     Invocation parentInvocation,
@@ -293,8 +281,7 @@ class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake
-    implements _i19.GithubGoldStatusUpdate {
+class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake implements _i19.GithubGoldStatusUpdate {
   _FakeGithubGoldStatusUpdate_22(
     Object parent,
     Invocation parentInvocation,
@@ -335,8 +322,7 @@ class _FakeDocument_25 extends _i1.SmartFake implements _i21.Document {
         );
 }
 
-class _FakeBatchWriteResponse_26 extends _i1.SmartFake
-    implements _i21.BatchWriteResponse {
+class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWriteResponse {
   _FakeBatchWriteResponse_26(
     Object parent,
     Invocation parentInvocation,
@@ -346,8 +332,7 @@ class _FakeBatchWriteResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeCommitResponse_27 extends _i1.SmartFake
-    implements _i21.CommitResponse {
+class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitResponse {
   _FakeCommitResponse_27(
     Object parent,
     Invocation parentInvocation,
@@ -397,8 +382,7 @@ class _FakeMilestone_31 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_32 extends _i1.SmartFake
-    implements _i22.GithubChecksUtil {
+class _FakeGithubChecksUtil_32 extends _i1.SmartFake implements _i22.GithubChecksUtil {
   _FakeGithubChecksUtil_32(
     Object parent,
     Invocation parentInvocation,
@@ -408,8 +392,7 @@ class _FakeGithubChecksUtil_32 extends _i1.SmartFake
         );
 }
 
-class _FakeCheckRunConclusion_33 extends _i1.SmartFake
-    implements _i13.CheckRunConclusion {
+class _FakeCheckRunConclusion_33 extends _i1.SmartFake implements _i13.CheckRunConclusion {
   _FakeCheckRunConclusion_33(
     Object parent,
     Invocation parentInvocation,
@@ -419,8 +402,7 @@ class _FakeCheckRunConclusion_33 extends _i1.SmartFake
         );
 }
 
-class _FakeCheckRunStatus_34 extends _i1.SmartFake
-    implements _i13.CheckRunStatus {
+class _FakeCheckRunStatus_34 extends _i1.SmartFake implements _i13.CheckRunStatus {
   _FakeCheckRunStatus_34(
     Object parent,
     Invocation parentInvocation,
@@ -520,8 +502,7 @@ class _FakeGitTree_43 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_44 extends _i1.SmartFake
-    implements _i14.DefaultPolicies {
+class _FakeDefaultPolicies_44 extends _i1.SmartFake implements _i14.DefaultPolicies {
   _FakeDefaultPolicies_44(
     Object parent,
     Invocation parentInvocation,
@@ -561,8 +542,7 @@ class _FakeQueryManager_47 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake
-    implements _i14.ObservableQuery<TParsed1> {
+class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
   _FakeObservableQuery_48(
     Object parent,
     Invocation parentInvocation,
@@ -572,8 +552,7 @@ class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake
         );
 }
 
-class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake
-    implements _i14.QueryResult<TParsed1> {
+class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
   _FakeQueryResult_49(
     Object parent,
     Invocation parentInvocation,
@@ -583,8 +562,7 @@ class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake
         );
 }
 
-class _FakeHttpClientRequest_50 extends _i1.SmartFake
-    implements _i23.HttpClientRequest {
+class _FakeHttpClientRequest_50 extends _i1.SmartFake implements _i23.HttpClientRequest {
   _FakeHttpClientRequest_50(
     Object parent,
     Invocation parentInvocation,
@@ -614,8 +592,7 @@ class _FakeHttpHeaders_52 extends _i1.SmartFake implements _i23.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_53 extends _i1.SmartFake
-    implements _i23.HttpClientResponse {
+class _FakeHttpClientResponse_53 extends _i1.SmartFake implements _i23.HttpClientResponse {
   _FakeHttpClientResponse_53(
     Object parent,
     Invocation parentInvocation,
@@ -645,8 +622,7 @@ class _FakeSocket_55 extends _i1.SmartFake implements _i23.Socket {
         );
 }
 
-class _FakeStreamSubscription_56<T> extends _i1.SmartFake
-    implements _i20.StreamSubscription<T> {
+class _FakeStreamSubscription_56<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
   _FakeStreamSubscription_56(
     Object parent,
     Invocation parentInvocation,
@@ -656,8 +632,7 @@ class _FakeStreamSubscription_56<T> extends _i1.SmartFake
         );
 }
 
-class _FakeJobCancelResponse_57 extends _i1.SmartFake
-    implements _i6.JobCancelResponse {
+class _FakeJobCancelResponse_57 extends _i1.SmartFake implements _i6.JobCancelResponse {
   _FakeJobCancelResponse_57(
     Object parent,
     Invocation parentInvocation,
@@ -677,8 +652,7 @@ class _FakeJob_58 extends _i1.SmartFake implements _i6.Job {
         );
 }
 
-class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake
-    implements _i6.GetQueryResultsResponse {
+class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
   _FakeGetQueryResultsResponse_59(
     Object parent,
     Invocation parentInvocation,
@@ -708,8 +682,7 @@ class _FakeQueryResponse_61 extends _i1.SmartFake implements _i6.QueryResponse {
         );
 }
 
-class _FakeBuildBucketClient_62 extends _i1.SmartFake
-    implements _i15.BuildBucketClient {
+class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
   _FakeBuildBucketClient_62(
     Object parent,
     Invocation parentInvocation,
@@ -749,8 +722,7 @@ class _FakeProcess_65 extends _i1.SmartFake implements _i23.Process {
         );
 }
 
-class _FakePullRequestMerge_66 extends _i1.SmartFake
-    implements _i13.PullRequestMerge {
+class _FakePullRequestMerge_66 extends _i1.SmartFake implements _i13.PullRequestMerge {
   _FakePullRequestMerge_66(
     Object parent,
     Invocation parentInvocation,
@@ -760,8 +732,7 @@ class _FakePullRequestMerge_66 extends _i1.SmartFake
         );
 }
 
-class _FakePullRequestComment_67 extends _i1.SmartFake
-    implements _i13.PullRequestComment {
+class _FakePullRequestComment_67 extends _i1.SmartFake implements _i13.PullRequestComment {
   _FakePullRequestComment_67(
     Object parent,
     Invocation parentInvocation,
@@ -771,8 +742,7 @@ class _FakePullRequestComment_67 extends _i1.SmartFake
         );
 }
 
-class _FakePullRequestReview_68 extends _i1.SmartFake
-    implements _i13.PullRequestReview {
+class _FakePullRequestReview_68 extends _i1.SmartFake implements _i13.PullRequestReview {
   _FakePullRequestReview_68(
     Object parent,
     Invocation parentInvocation,
@@ -792,8 +762,7 @@ class _FakeRepository_69 extends _i1.SmartFake implements _i13.Repository {
         );
 }
 
-class _FakeLicenseDetails_70 extends _i1.SmartFake
-    implements _i13.LicenseDetails {
+class _FakeLicenseDetails_70 extends _i1.SmartFake implements _i13.LicenseDetails {
   _FakeLicenseDetails_70(
     Object parent,
     Invocation parentInvocation,
@@ -803,8 +772,7 @@ class _FakeLicenseDetails_70 extends _i1.SmartFake
         );
 }
 
-class _FakeLanguageBreakdown_71 extends _i1.SmartFake
-    implements _i13.LanguageBreakdown {
+class _FakeLanguageBreakdown_71 extends _i1.SmartFake implements _i13.LanguageBreakdown {
   _FakeLanguageBreakdown_71(
     Object parent,
     Invocation parentInvocation,
@@ -824,8 +792,7 @@ class _FakeBranch_72 extends _i1.SmartFake implements _i13.Branch {
         );
 }
 
-class _FakeCommitComment_73 extends _i1.SmartFake
-    implements _i13.CommitComment {
+class _FakeCommitComment_73 extends _i1.SmartFake implements _i13.CommitComment {
   _FakeCommitComment_73(
     Object parent,
     Invocation parentInvocation,
@@ -835,8 +802,7 @@ class _FakeCommitComment_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRepositoryCommit_74 extends _i1.SmartFake
-    implements _i13.RepositoryCommit {
+class _FakeRepositoryCommit_74 extends _i1.SmartFake implements _i13.RepositoryCommit {
   _FakeRepositoryCommit_74(
     Object parent,
     Invocation parentInvocation,
@@ -846,8 +812,7 @@ class _FakeRepositoryCommit_74 extends _i1.SmartFake
         );
 }
 
-class _FakeGitHubComparison_75 extends _i1.SmartFake
-    implements _i13.GitHubComparison {
+class _FakeGitHubComparison_75 extends _i1.SmartFake implements _i13.GitHubComparison {
   _FakeGitHubComparison_75(
     Object parent,
     Invocation parentInvocation,
@@ -867,8 +832,7 @@ class _FakeGitHubFile_76 extends _i1.SmartFake implements _i13.GitHubFile {
         );
 }
 
-class _FakeRepositoryContents_77 extends _i1.SmartFake
-    implements _i13.RepositoryContents {
+class _FakeRepositoryContents_77 extends _i1.SmartFake implements _i13.RepositoryContents {
   _FakeRepositoryContents_77(
     Object parent,
     Invocation parentInvocation,
@@ -878,8 +842,7 @@ class _FakeRepositoryContents_77 extends _i1.SmartFake
         );
 }
 
-class _FakeContentCreation_78 extends _i1.SmartFake
-    implements _i13.ContentCreation {
+class _FakeContentCreation_78 extends _i1.SmartFake implements _i13.ContentCreation {
   _FakeContentCreation_78(
     Object parent,
     Invocation parentInvocation,
@@ -909,8 +872,7 @@ class _FakePublicKey_80 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeRepositoryPages_81 extends _i1.SmartFake
-    implements _i13.RepositoryPages {
+class _FakeRepositoryPages_81 extends _i1.SmartFake implements _i13.RepositoryPages {
   _FakeRepositoryPages_81(
     Object parent,
     Invocation parentInvocation,
@@ -950,8 +912,7 @@ class _FakeReleaseAsset_84 extends _i1.SmartFake implements _i13.ReleaseAsset {
         );
 }
 
-class _FakeContributorParticipation_85 extends _i1.SmartFake
-    implements _i13.ContributorParticipation {
+class _FakeContributorParticipation_85 extends _i1.SmartFake implements _i13.ContributorParticipation {
   _FakeContributorParticipation_85(
     Object parent,
     Invocation parentInvocation,
@@ -961,8 +922,7 @@ class _FakeContributorParticipation_85 extends _i1.SmartFake
         );
 }
 
-class _FakeRepositoryStatus_86 extends _i1.SmartFake
-    implements _i13.RepositoryStatus {
+class _FakeRepositoryStatus_86 extends _i1.SmartFake implements _i13.RepositoryStatus {
   _FakeRepositoryStatus_86(
     Object parent,
     Invocation parentInvocation,
@@ -972,8 +932,7 @@ class _FakeRepositoryStatus_86 extends _i1.SmartFake
         );
 }
 
-class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake
-    implements _i13.CombinedRepositoryStatus {
+class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
   _FakeCombinedRepositoryStatus_87(
     Object parent,
     Invocation parentInvocation,
@@ -993,8 +952,7 @@ class _FakeReleaseNotes_88 extends _i1.SmartFake implements _i13.ReleaseNotes {
         );
 }
 
-class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake
-    implements _i6.TableDataInsertAllResponse {
+class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
   _FakeTableDataInsertAllResponse_89(
     Object parent,
     Invocation parentInvocation,
@@ -1054,8 +1012,7 @@ class _FakeCache_94<T> extends _i1.SmartFake implements _i25.Cache<T> {
         );
 }
 
-class _FakeAuthentication_95 extends _i1.SmartFake
-    implements _i13.Authentication {
+class _FakeAuthentication_95 extends _i1.SmartFake implements _i13.Authentication {
   _FakeAuthentication_95(
     Object parent,
     Invocation parentInvocation,
@@ -1065,8 +1022,7 @@ class _FakeAuthentication_95 extends _i1.SmartFake
         );
 }
 
-class _FakeActivityService_96 extends _i1.SmartFake
-    implements _i13.ActivityService {
+class _FakeActivityService_96 extends _i1.SmartFake implements _i13.ActivityService {
   _FakeActivityService_96(
     Object parent,
     Invocation parentInvocation,
@@ -1076,8 +1032,7 @@ class _FakeActivityService_96 extends _i1.SmartFake
         );
 }
 
-class _FakeAuthorizationsService_97 extends _i1.SmartFake
-    implements _i13.AuthorizationsService {
+class _FakeAuthorizationsService_97 extends _i1.SmartFake implements _i13.AuthorizationsService {
   _FakeAuthorizationsService_97(
     Object parent,
     Invocation parentInvocation,
@@ -1107,8 +1062,7 @@ class _FakeGitService_99 extends _i1.SmartFake implements _i13.GitService {
         );
 }
 
-class _FakeIssuesService_100 extends _i1.SmartFake
-    implements _i13.IssuesService {
+class _FakeIssuesService_100 extends _i1.SmartFake implements _i13.IssuesService {
   _FakeIssuesService_100(
     Object parent,
     Invocation parentInvocation,
@@ -1128,8 +1082,7 @@ class _FakeMiscService_101 extends _i1.SmartFake implements _i13.MiscService {
         );
 }
 
-class _FakeOrganizationsService_102 extends _i1.SmartFake
-    implements _i13.OrganizationsService {
+class _FakeOrganizationsService_102 extends _i1.SmartFake implements _i13.OrganizationsService {
   _FakeOrganizationsService_102(
     Object parent,
     Invocation parentInvocation,
@@ -1139,8 +1092,7 @@ class _FakeOrganizationsService_102 extends _i1.SmartFake
         );
 }
 
-class _FakePullRequestsService_103 extends _i1.SmartFake
-    implements _i13.PullRequestsService {
+class _FakePullRequestsService_103 extends _i1.SmartFake implements _i13.PullRequestsService {
   _FakePullRequestsService_103(
     Object parent,
     Invocation parentInvocation,
@@ -1150,8 +1102,7 @@ class _FakePullRequestsService_103 extends _i1.SmartFake
         );
 }
 
-class _FakeRepositoriesService_104 extends _i1.SmartFake
-    implements _i13.RepositoriesService {
+class _FakeRepositoriesService_104 extends _i1.SmartFake implements _i13.RepositoriesService {
   _FakeRepositoriesService_104(
     Object parent,
     Invocation parentInvocation,
@@ -1161,8 +1112,7 @@ class _FakeRepositoriesService_104 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchService_105 extends _i1.SmartFake
-    implements _i13.SearchService {
+class _FakeSearchService_105 extends _i1.SmartFake implements _i13.SearchService {
   _FakeSearchService_105(
     Object parent,
     Invocation parentInvocation,
@@ -1172,8 +1122,7 @@ class _FakeSearchService_105 extends _i1.SmartFake
         );
 }
 
-class _FakeUrlShortenerService_106 extends _i1.SmartFake
-    implements _i13.UrlShortenerService {
+class _FakeUrlShortenerService_106 extends _i1.SmartFake implements _i13.UrlShortenerService {
   _FakeUrlShortenerService_106(
     Object parent,
     Invocation parentInvocation,
@@ -1193,8 +1142,7 @@ class _FakeUsersService_107 extends _i1.SmartFake implements _i13.UsersService {
         );
 }
 
-class _FakeChecksService_108 extends _i1.SmartFake
-    implements _i13.ChecksService {
+class _FakeChecksService_108 extends _i1.SmartFake implements _i13.ChecksService {
   _FakeChecksService_108(
     Object parent,
     Invocation parentInvocation,
@@ -1217,17 +1165,14 @@ class _FakeResponse_109 extends _i1.SmartFake implements _i2.Response {
 /// A class which mocks [AccessClientProvider].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessClientProvider extends _i1.Mock
-    implements _i5.AccessClientProvider {
+class MockAccessClientProvider extends _i1.Mock implements _i5.AccessClientProvider {
   MockAccessClientProvider() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
   _i20.Future<_i2.Client> createAccessClient({
-    List<String>? scopes = const [
-      r'https://www.googleapis.com/auth/cloud-platform'
-    ],
+    List<String>? scopes = const [r'https://www.googleapis.com/auth/cloud-platform'],
     _i2.Client? baseClient,
   }) =>
       (super.noSuchMethod(
@@ -1256,8 +1201,7 @@ class MockAccessClientProvider extends _i1.Mock
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock
-    implements _i26.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock implements _i26.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1310,8 +1254,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
           #defaultTabledata,
           [],
         ),
-        returnValue:
-            _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
+        returnValue: _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
           this,
           Invocation.method(
             #defaultTabledata,
@@ -1350,8 +1293,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #bucket: bucket,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(
-            <_i16.BuilderStatistic>[]),
+        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(<_i16.BuilderStatistic>[]),
       ) as _i20.Future<List<_i16.BuilderStatistic>>);
 
   @override
@@ -1369,8 +1311,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #limit: limit,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
+        returnValue: _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
       ) as _i20.Future<List<_i16.BuilderRecord>>);
 }
 
@@ -1440,8 +1381,7 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Future<List<Map<String, String>>>.value(
-            <Map<String, String>>[]),
+        returnValue: _i20.Future<List<Map<String, String>>>.value(<Map<String, String>>[]),
       ) as _i20.Future<List<Map<String, String>>>);
 }
 
@@ -1484,8 +1424,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> scheduleBuild(
     _i8.ScheduleBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1506,8 +1445,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.SearchBuildsResponse> searchBuilds(
     _i8.SearchBuildsRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1515,8 +1453,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(
-            _FakeSearchBuildsResponse_8(
+        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(_FakeSearchBuildsResponse_8(
           this,
           Invocation.method(
             #searchBuilds,
@@ -1529,8 +1466,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.BatchResponse> batch(
     _i8.BatchRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1551,8 +1487,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> cancelBuild(
     _i8.CancelBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1573,8 +1508,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> getBuild(
     _i8.GetBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1595,8 +1529,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.ListBuildersResponse> listBuilders(
     _i8.ListBuildersRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1604,8 +1537,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(
-            _FakeListBuildersResponse_10(
+        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(_FakeListBuildersResponse_10(
           this,
           Invocation.method(
             #listBuilders,
@@ -1652,8 +1584,7 @@ class MockCommitService extends _i1.Mock implements _i29.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i30.CreateEvent? createEvent) =>
-      (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i30.CreateEvent? createEvent) => (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1663,8 +1594,7 @@ class MockCommitService extends _i1.Mock implements _i29.CommitService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) =>
-      (super.noSuchMethod(
+  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) => (super.noSuchMethod(
         Invocation.method(
           #handlePushGithubRequest,
           [pushEvent],
@@ -1749,11 +1679,9 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<Map<String, dynamic>> get githubAppInstallations =>
-      (super.noSuchMethod(
+  _i20.Future<Map<String, dynamic>> get githubAppInstallations => (super.noSuchMethod(
         Invocation.getter(#githubAppInstallations),
-        returnValue:
-            _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+        returnValue: _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i20.Future<Map<String, dynamic>>);
 
   @override
@@ -2003,8 +1931,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i31.Branch>> getBranches(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<Iterable<_i31.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
@@ -2013,8 +1940,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<Iterable<_i31.Branch>>);
 
   @override
-  String wrongHeadBranchPullRequestMessage(String? branch) =>
-      (super.noSuchMethod(
+  String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
         Invocation.method(
           #wrongHeadBranchPullRequestMessage,
           [branch],
@@ -2059,8 +1985,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as String);
 
   @override
-  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #flutterGoldAlertConstant,
           [slug],
@@ -2105,8 +2030,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #generateGithubToken,
           [slug],
@@ -2163,14 +2087,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i13.GitHub);
 
   @override
-  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() => (super.noSuchMethod(
         Invocation.method(
           #createGitHubGraphQLClient,
           [],
         ),
-        returnValue:
-            _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
+        returnValue: _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
           this,
           Invocation.method(
             #createGitHubGraphQLClient,
@@ -2180,14 +2102,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i14.GraphQLClient>);
 
   @override
-  _i20.Future<_i15.FirestoreService> createFirestoreService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i15.FirestoreService> createFirestoreService() => (super.noSuchMethod(
         Invocation.method(
           #createFirestoreService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
+        returnValue: _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
           this,
           Invocation.method(
             #createFirestoreService,
@@ -2197,14 +2117,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i15.FirestoreService>);
 
   @override
-  _i20.Future<_i16.BigqueryService> createBigQueryService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i16.BigqueryService> createBigQueryService() => (super.noSuchMethod(
         Invocation.method(
           #createBigQueryService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
+        returnValue: _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
           this,
           Invocation.method(
             #createBigQueryService,
@@ -2214,14 +2132,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i16.BigqueryService>);
 
   @override
-  _i20.Future<_i6.TabledataResource> createTabledataResourceApi() =>
-      (super.noSuchMethod(
+  _i20.Future<_i6.TabledataResource> createTabledataResourceApi() => (super.noSuchMethod(
         Invocation.method(
           #createTabledataResourceApi,
           [],
         ),
-        returnValue:
-            _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
+        returnValue: _i20.Future<_i6.TabledataResource>.value(_FakeTabledataResource_4(
           this,
           Invocation.method(
             #createTabledataResourceApi,
@@ -2231,14 +2147,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i6.TabledataResource>);
 
   @override
-  _i20.Future<_i17.GithubService> createDefaultGitHubService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createDefaultGitHubService() => (super.noSuchMethod(
         Invocation.method(
           #createDefaultGitHubService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createDefaultGitHubService,
@@ -2248,15 +2162,12 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i20.Future<_i17.GithubService> createGithubService(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createGithubService(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #createGithubService,
           [slug],
         ),
-        returnValue:
-            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createGithubService,
@@ -2266,8 +2177,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i17.GithubService createGithubServiceWithToken(String? token) =>
-      (super.noSuchMethod(
+  _i17.GithubService createGithubServiceWithToken(String? token) => (super.noSuchMethod(
         Invocation.method(
           #createGithubServiceWithToken,
           [token],
@@ -2384,8 +2294,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Stream<_i33.FullTask>);
 
   @override
-  _i20.Future<List<_i34.Stage>> queryTasksGroupedByStage(_i32.Commit? commit) =>
-      (super.noSuchMethod(
+  _i20.Future<List<_i34.Stage>> queryTasksGroupedByStage(_i32.Commit? commit) => (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
@@ -2406,8 +2315,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(
-            _FakeGithubBuildStatusUpdate_21(
+        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(_FakeGithubBuildStatusUpdate_21(
           this,
           Invocation.method(
             #queryLastStatusUpdate,
@@ -2432,8 +2340,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(
-            _FakeGithubGoldStatusUpdate_22(
+        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(_FakeGithubGoldStatusUpdate_22(
           this,
           Invocation.method(
             #queryLastGoldUpdate,
@@ -2446,20 +2353,16 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<_i19.GithubGoldStatusUpdate>);
 
   @override
-  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(
-          List<_i11.Model<dynamic>>? rows) =>
-      (super.noSuchMethod(
+  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
         Invocation.method(
           #shard,
           [rows],
         ),
-        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(
-            <List<_i11.Model<dynamic>>>[]),
+        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(<List<_i11.Model<dynamic>>>[]),
       ) as _i20.Future<List<List<_i11.Model<dynamic>>>>);
 
   @override
-  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) =>
-      (super.noSuchMethod(
+  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
         Invocation.method(
           #insert,
           [rows],
@@ -2469,8 +2372,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(
-          List<_i11.Key<dynamic>>? keys) =>
+  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(List<_i11.Key<dynamic>>? keys) =>
       (super.noSuchMethod(
         Invocation.method(
           #lookupByKey,
@@ -2512,9 +2414,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T>);
 
   @override
-  _i20.Future<T?> withTransaction<T>(
-          _i20.Future<T> Function(_i11.Transaction)? handler) =>
-      (super.noSuchMethod(
+  _i20.Future<T?> withTransaction<T>(_i20.Future<T> Function(_i11.Transaction)? handler) => (super.noSuchMethod(
         Invocation.method(
           #withTransaction,
           [handler],
@@ -2622,14 +2522,13 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i5.AccessClientProvider);
 
   @override
-  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() =>
-      (super.noSuchMethod(
+  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() => (super.noSuchMethod(
         Invocation.method(
           #documentResource,
           [],
         ),
-        returnValue: _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(
-            _FakeProjectsDatabasesDocumentsResource_24(
+        returnValue:
+            _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(_FakeProjectsDatabasesDocumentsResource_24(
           this,
           Invocation.method(
             #documentResource,
@@ -2666,8 +2565,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             database,
           ],
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
-            _FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWriteDocuments,
@@ -2680,15 +2578,12 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.BatchWriteResponse>);
 
   @override
-  _i20.Future<_i21.CommitResponse> writeViaTransaction(
-          List<_i21.Write>? writes) =>
-      (super.noSuchMethod(
+  _i20.Future<_i21.CommitResponse> writeViaTransaction(List<_i21.Write>? writes) => (super.noSuchMethod(
         Invocation.method(
           #writeViaTransaction,
           [writes],
         ),
-        returnValue:
-            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #writeViaTransaction,
@@ -2922,8 +2817,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<_i13.Issue>);
 
   @override
-  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listAssignees,
           [slug],
@@ -2964,9 +2858,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Stream<_i13.IssueComment>);
 
   @override
-  _i20.Stream<_i13.IssueComment> listCommentsByRepo(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.IssueComment> listCommentsByRepo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCommentsByRepo,
           [slug],
@@ -3072,8 +2964,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listLabels,
           [slug],
@@ -3254,8 +3145,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3273,8 +3163,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3312,8 +3201,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listMilestones,
           [slug],
@@ -3418,8 +3306,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
 /// A class which mocks [GithubChecksService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksService extends _i1.Mock
-    implements _i15.GithubChecksService {
+class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksService {
   MockGithubChecksService() {
     _i1.throwOnMissingStub(this);
   }
@@ -3452,8 +3339,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as _i22.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) =>
-      super.noSuchMethod(
+  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3501,8 +3387,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as _i20.Future<bool>);
 
   @override
-  bool taskFailed(_i37.BuildPushMessage? buildPushMessage) =>
-      (super.noSuchMethod(
+  bool taskFailed(_i37.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
         Invocation.method(
           #taskFailed,
           [buildPushMessage],
@@ -3535,8 +3420,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i37.Result? result) =>
-      (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i37.Result? result) => (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [result],
@@ -3551,8 +3435,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i37.Status? status) =>
-      (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i37.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
@@ -3606,8 +3489,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             checkSuiteEvent,
           ],
         ),
-        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(
-            <String, _i13.CheckRun>{}),
+        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(<String, _i13.CheckRun>{}),
       ) as _i20.Future<Map<String, _i13.CheckRun>>);
 
   @override
@@ -3659,8 +3541,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             #checkName: checkName,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
+        returnValue: _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
       ) as _i20.Future<List<_i13.CheckSuite>>);
 
   @override
@@ -3787,8 +3668,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             lastCommitTimestampMills,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(
-            <_i13.RepositoryCommit>[]),
+        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(<_i13.RepositoryCommit>[]),
       ) as _i20.Future<List<_i13.RepositoryCommit>>);
 
   @override
@@ -3804,8 +3684,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             branch,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
+        returnValue: _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
       ) as _i20.Future<List<_i13.PullRequest>>);
 
   @override
@@ -3877,8 +3756,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             issueNumber,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3896,8 +3774,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -4015,13 +3892,11 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #labels: labels,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
-  _i20.Future<List<String>> listFiles(_i13.PullRequest? pullRequest) =>
-      (super.noSuchMethod(
+  _i20.Future<List<String>> listFiles(_i13.PullRequest? pullRequest) => (super.noSuchMethod(
         Invocation.method(
           #listFiles,
           [pullRequest],
@@ -4498,8 +4373,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.DefaultPolicies);
 
   @override
-  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) =>
-      super.noSuchMethod(
+  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) => super.noSuchMethod(
         Invocation.setter(
           #defaultPolicies,
           _defaultPolicies,
@@ -4577,9 +4451,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.GraphQLClient);
 
   @override
-  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(
-          _i14.WatchQueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #watchQuery,
           [options],
@@ -4594,9 +4466,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(
-          _i14.WatchQueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #watchMutation,
           [options],
@@ -4611,15 +4481,12 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(
-          _i14.QueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(_i14.QueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4629,15 +4496,12 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(
-          _i14.MutationOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(_i14.MutationOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4647,8 +4511,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(
-          _i14.SubscriptionOptions<TParsed>? options) =>
+  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(_i14.SubscriptionOptions<TParsed>? options) =>
       (super.noSuchMethod(
         Invocation.method(
           #subscribe,
@@ -4672,8 +4535,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4745,8 +4607,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       );
 
   @override
-  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore(
-          {bool? refetchQueries = true}) =>
+  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore({bool? refetchQueries = true}) =>
       (super.noSuchMethod(Invocation.method(
         #resetStore,
         [],
@@ -4918,8 +4779,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #open,
@@ -4946,8 +4806,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             url,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #openUrl,
@@ -4974,8 +4833,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #get,
@@ -4994,8 +4852,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #getUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #getUrl,
@@ -5019,8 +4876,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #post,
@@ -5039,8 +4895,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #postUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #postUrl,
@@ -5064,8 +4919,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #put,
@@ -5084,8 +4938,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #putUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #putUrl,
@@ -5109,8 +4962,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #delete,
@@ -5124,14 +4976,12 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
       ) as _i20.Future<_i23.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> deleteUrl(Uri? url) =>
-      (super.noSuchMethod(
+  _i20.Future<_i23.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #deleteUrl,
@@ -5155,8 +5005,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #patch,
@@ -5175,8 +5024,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #patchUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #patchUrl,
@@ -5200,8 +5048,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #head,
@@ -5220,8 +5067,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #headUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
           this,
           Invocation.method(
             #headUrl,
@@ -5398,8 +5244,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   _i20.Future<_i23.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
-            _FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
           this,
           Invocation.getter(#done),
         )),
@@ -5429,8 +5274,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
-            _FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
           this,
           Invocation.method(
             #close,
@@ -5524,8 +5368,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
       );
 
   @override
-  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) =>
-      (super.noSuchMethod(
+  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) => (super.noSuchMethod(
         Invocation.method(
           #addStream,
           [stream],
@@ -5546,8 +5389,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock
-    implements _i23.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5574,8 +5416,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as int);
 
   @override
-  _i23.HttpClientResponseCompressionState get compressionState =>
-      (super.noSuchMethod(
+  _i23.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
         Invocation.getter(#compressionState),
         returnValue: _i23.HttpClientResponseCompressionState.notCompressed,
       ) as _i23.HttpClientResponseCompressionState);
@@ -5664,8 +5505,7 @@ class MockHttpClientResponse extends _i1.Mock
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(
-            _FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
           this,
           Invocation.method(
             #redirect,
@@ -5742,8 +5582,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.StreamSubscription<List<int>>);
 
   @override
-  _i20.Stream<List<int>> where(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> where(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #where,
           [test],
@@ -5761,8 +5600,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #asyncMap,
           [convert],
@@ -5771,8 +5609,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<E>);
 
   @override
-  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #asyncExpand,
           [convert],
@@ -5795,8 +5632,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #expand,
           [convert],
@@ -5805,8 +5641,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) =>
-      (super.noSuchMethod(
+  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) => (super.noSuchMethod(
         Invocation.method(
           #pipe,
           [streamConsumer],
@@ -5815,9 +5650,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<dynamic>);
 
   @override
-  _i20.Stream<S> transform<S>(
-          _i20.StreamTransformer<List<int>, S>? streamTransformer) =>
-      (super.noSuchMethod(
+  _i20.Stream<S> transform<S>(_i20.StreamTransformer<List<int>, S>? streamTransformer) => (super.noSuchMethod(
         Invocation.method(
           #transform,
           [streamTransformer],
@@ -5905,8 +5738,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Future<void> forEach(void Function(List<int>)? action) =>
-      (super.noSuchMethod(
+  _i20.Future<void> forEach(void Function(List<int>)? action) => (super.noSuchMethod(
         Invocation.method(
           #forEach,
           [action],
@@ -5916,8 +5748,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<bool> every(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #every,
           [test],
@@ -5996,8 +5827,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #takeWhile,
           [test],
@@ -6015,8 +5845,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #skipWhile,
           [test],
@@ -6131,8 +5960,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue:
-            _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_57(
+        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_57(
           this,
           Invocation.method(
             #cancel,
@@ -6233,8 +6061,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(
-            _FakeGetQueryResultsResponse_59(
+        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_59(
           this,
           Invocation.method(
             #getQueryResults,
@@ -6388,8 +6215,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i15.BuildBucketClient);
 
   @override
-  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) =>
-      super.noSuchMethod(
+  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) => super.noSuchMethod(
         Invocation.setter(
           #buildBucketClient,
           _buildBucketClient,
@@ -6434,8 +6260,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i22.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) =>
-      super.noSuchMethod(
+  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -6483,8 +6308,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             max,
           ],
         ),
-        returnValue:
-            _i20.Future<List<List<_i8.Request>>>.value(<List<_i8.Request>>[]),
+        returnValue: _i20.Future<List<List<_i8.Request>>>.value(<List<_i8.Request>>[]),
       ) as _i20.Future<List<List<_i8.Request>>>);
 
   @override
@@ -6506,9 +6330,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(
-          _i13.PullRequest? pullRequest) =>
-      (super.noSuchMethod(
+  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(_i13.PullRequest? pullRequest) => (super.noSuchMethod(
         Invocation.method(
           #getTryBuildsByPullRequest,
           [pullRequest],
@@ -6639,8 +6461,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(
-          _i39.CheckRunEvent? checkRunEvent) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i39.CheckRunEvent? checkRunEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6738,8 +6559,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<
-      List<_i15.Tuple<_i38.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
     required _i32.Commit? commit,
     required List<_i15.Tuple<_i38.Target, _i33.Task, int>>? toBeScheduled,
   }) =>
@@ -6752,9 +6572,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>.value(
-                <_i15.Tuple<_i38.Target, _i33.Task, int>>[]),
+        returnValue: _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>.value(
+            <_i15.Tuple<_i38.Target, _i33.Task, int>>[]),
       ) as _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>);
 
   @override
@@ -6874,8 +6693,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i23.ProcessResult>.value(
-            _i28.dummyValue<_i23.ProcessResult>(
+        returnValue: _i20.Future<_i23.ProcessResult>.value(_i28.dummyValue<_i23.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6966,8 +6784,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
 /// A class which mocks [PullRequestsService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPullRequestsService extends _i1.Mock
-    implements _i13.PullRequestsService {
+class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsService {
   MockPullRequestsService() {
     _i1.throwOnMissingStub(this);
   }
@@ -7183,8 +7000,7 @@ class MockPullRequestsService extends _i1.Mock
             #requestSha: requestSha,
           },
         ),
-        returnValue:
-            _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_66(
+        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_66(
           this,
           Invocation.method(
             #merge,
@@ -7218,9 +7034,7 @@ class MockPullRequestsService extends _i1.Mock
       ) as _i20.Stream<_i13.PullRequestComment>);
 
   @override
-  _i20.Stream<_i13.PullRequestComment> listComments(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PullRequestComment> listComments(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listComments,
           [slug],
@@ -7243,8 +7057,7 @@ class MockPullRequestsService extends _i1.Mock
             comment,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestComment>.value(
-            _FakePullRequestComment_67(
+        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_67(
           this,
           Invocation.method(
             #createComment,
@@ -7270,8 +7083,7 @@ class MockPullRequestsService extends _i1.Mock
             review,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_68(
+        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_68(
           this,
           Invocation.method(
             #createReview,
@@ -7287,8 +7099,7 @@ class MockPullRequestsService extends _i1.Mock
 /// A class which mocks [RepositoriesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRepositoriesService extends _i1.Mock
-    implements _i13.RepositoriesService {
+class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesService {
   MockRepositoriesService() {
     _i1.throwOnMissingStub(this);
   }
@@ -7394,14 +7205,12 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Future<_i13.LicenseDetails> getLicense(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.LicenseDetails> getLicense(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getLicense,
           [slug],
         ),
-        returnValue:
-            _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_70(
+        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_70(
           this,
           Invocation.method(
             #getLicense,
@@ -7411,8 +7220,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.LicenseDetails>);
 
   @override
-  _i20.Future<_i13.Repository> getRepository(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.Repository> getRepository(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getRepository,
           [slug],
@@ -7427,9 +7235,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Stream<_i13.Repository> getRepositories(
-          List<_i13.RepositorySlug>? slugs) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Repository> getRepositories(List<_i13.RepositorySlug>? slugs) => (super.noSuchMethod(
         Invocation.method(
           #getRepositories,
           [slugs],
@@ -7481,8 +7287,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Future<bool> deleteRepository(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<bool> deleteRepository(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #deleteRepository,
           [slug],
@@ -7505,8 +7310,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.Contributor>);
 
   @override
-  _i20.Stream<_i13.Team> listTeams(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Team> listTeams(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listTeams,
           [slug],
@@ -7515,15 +7319,12 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.Team>);
 
   @override
-  _i20.Future<_i13.LanguageBreakdown> listLanguages(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.LanguageBreakdown> listLanguages(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listLanguages,
           [slug],
         ),
-        returnValue:
-            _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_71(
+        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_71(
           this,
           Invocation.method(
             #listLanguages,
@@ -7553,8 +7354,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.Tag>);
 
   @override
-  _i20.Stream<_i13.Branch> listBranches(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Branch> listBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listBranches,
           [slug],
@@ -7588,8 +7388,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.Branch>);
 
   @override
-  _i20.Stream<_i13.Collaborator> listCollaborators(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Collaborator> listCollaborators(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCollaborators,
           [slug],
@@ -7662,9 +7461,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.CommitComment>);
 
   @override
-  _i20.Stream<_i13.CommitComment> listCommitComments(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.CommitComment> listCommitComments(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCommitComments,
           [slug],
@@ -7695,8 +7492,7 @@ class MockRepositoriesService extends _i1.Mock
             #line: line,
           },
         ),
-        returnValue:
-            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #createCommitComment,
@@ -7725,8 +7521,7 @@ class MockRepositoriesService extends _i1.Mock
           [slug],
           {#id: id},
         ),
-        returnValue:
-            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #getCommitComment,
@@ -7751,8 +7546,7 @@ class MockRepositoriesService extends _i1.Mock
             #body: body,
           },
         ),
-        returnValue:
-            _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
           this,
           Invocation.method(
             #updateCommitComment,
@@ -7818,8 +7612,7 @@ class MockRepositoriesService extends _i1.Mock
             sha,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
           this,
           Invocation.method(
             #getCommit,
@@ -7871,8 +7664,7 @@ class MockRepositoriesService extends _i1.Mock
             refHead,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_75(
+        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_75(
           this,
           Invocation.method(
             #compareCommits,
@@ -7921,8 +7713,7 @@ class MockRepositoriesService extends _i1.Mock
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.RepositoryContents>.value(
-            _FakeRepositoryContents_77(
+        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_77(
           this,
           Invocation.method(
             #getContents,
@@ -7948,8 +7739,7 @@ class MockRepositoriesService extends _i1.Mock
             file,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #createFile,
@@ -7982,8 +7772,7 @@ class MockRepositoriesService extends _i1.Mock
           ],
           {#branch: branch},
         ),
-        returnValue:
-            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #updateFile,
@@ -8018,8 +7807,7 @@ class MockRepositoriesService extends _i1.Mock
             branch,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
           this,
           Invocation.method(
             #deleteFile,
@@ -8053,8 +7841,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<String?>);
 
   @override
-  _i20.Stream<_i13.Repository> listForks(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Repository> listForks(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listForks,
           [slug],
@@ -8088,8 +7875,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.Repository>);
 
   @override
-  _i20.Stream<_i13.Hook> listHooks(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Hook> listHooks(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listHooks,
           [slug],
@@ -8249,8 +8035,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listDeployKeys(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listDeployKeys(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listDeployKeys,
           [slug],
@@ -8334,8 +8119,7 @@ class MockRepositoriesService extends _i1.Mock
             merge,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
           this,
           Invocation.method(
             #merge,
@@ -8348,14 +8132,12 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.RepositoryCommit>);
 
   @override
-  _i20.Future<_i13.RepositoryPages> getPagesInfo(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.RepositoryPages> getPagesInfo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getPagesInfo,
           [slug],
         ),
-        returnValue:
-            _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_81(
+        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_81(
           this,
           Invocation.method(
             #getPagesInfo,
@@ -8365,8 +8147,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.RepositoryPages>);
 
   @override
-  _i20.Stream<_i13.PageBuild> listPagesBuilds(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PageBuild> listPagesBuilds(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listPagesBuilds,
           [slug],
@@ -8375,8 +8156,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.PageBuild>);
 
   @override
-  _i20.Future<_i13.PageBuild> getLatestPagesBuild(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.PageBuild> getLatestPagesBuild(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getLatestPagesBuild,
           [slug],
@@ -8391,8 +8171,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.PageBuild>);
 
   @override
-  _i20.Stream<_i13.Release> listReleases(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Release> listReleases(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listReleases,
           [slug],
@@ -8401,8 +8180,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.Release>);
 
   @override
-  _i20.Future<_i13.Release> getLatestRelease(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.Release> getLatestRelease(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getLatestRelease,
           [slug],
@@ -8665,26 +8443,20 @@ class MockRepositoriesService extends _i1.Mock
             createReleaseAssets,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.ReleaseAsset>>.value(<_i13.ReleaseAsset>[]),
+        returnValue: _i20.Future<List<_i13.ReleaseAsset>>.value(<_i13.ReleaseAsset>[]),
       ) as _i20.Future<List<_i13.ReleaseAsset>>);
 
   @override
-  _i20.Future<List<_i13.ContributorStatistics>> listContributorStats(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<List<_i13.ContributorStatistics>> listContributorStats(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listContributorStats,
           [slug],
         ),
-        returnValue: _i20.Future<List<_i13.ContributorStatistics>>.value(
-            <_i13.ContributorStatistics>[]),
+        returnValue: _i20.Future<List<_i13.ContributorStatistics>>.value(<_i13.ContributorStatistics>[]),
       ) as _i20.Future<List<_i13.ContributorStatistics>>);
 
   @override
-  _i20.Stream<_i13.YearCommitCountWeek> listCommitActivity(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.YearCommitCountWeek> listCommitActivity(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCommitActivity,
           [slug],
@@ -8693,9 +8465,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.YearCommitCountWeek>);
 
   @override
-  _i20.Stream<_i13.WeeklyChangesCount> listCodeFrequency(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.WeeklyChangesCount> listCodeFrequency(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCodeFrequency,
           [slug],
@@ -8704,15 +8474,12 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Stream<_i13.WeeklyChangesCount>);
 
   @override
-  _i20.Future<_i13.ContributorParticipation> getParticipation(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.ContributorParticipation> getParticipation(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getParticipation,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.ContributorParticipation>.value(
-            _FakeContributorParticipation_85(
+        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_85(
           this,
           Invocation.method(
             #getParticipation,
@@ -8722,8 +8489,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.ContributorParticipation>);
 
   @override
-  _i20.Stream<_i13.PunchcardEntry> listPunchcard(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PunchcardEntry> listPunchcard(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listPunchcard,
           [slug],
@@ -8762,8 +8528,7 @@ class MockRepositoriesService extends _i1.Mock
             request,
           ],
         ),
-        returnValue:
-            _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_86(
+        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_86(
           this,
           Invocation.method(
             #createStatus,
@@ -8789,8 +8554,7 @@ class MockRepositoriesService extends _i1.Mock
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(
-            _FakeCombinedRepositoryStatus_87(
+        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_87(
           this,
           Invocation.method(
             #getCombinedStatus,
@@ -8803,9 +8567,7 @@ class MockRepositoriesService extends _i1.Mock
       ) as _i20.Future<_i13.CombinedRepositoryStatus>);
 
   @override
-  _i20.Future<_i13.ReleaseNotes> generateReleaseNotes(
-          _i13.CreateReleaseNotes? crn) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.ReleaseNotes> generateReleaseNotes(_i13.CreateReleaseNotes? crn) => (super.noSuchMethod(
         Invocation.method(
           #generateReleaseNotes,
           [crn],
@@ -8961,8 +8723,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(
-            _FakeTableDataInsertAllResponse_89(
+        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_89(
           this,
           Invocation.method(
             #insertAll,
@@ -9164,8 +8925,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.UserEmail>);
 
   @override
-  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) => (super.noSuchMethod(
         Invocation.method(
           #addEmails,
           [emails],
@@ -9253,8 +9013,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.User>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) => (super.noSuchMethod(
         Invocation.method(
           #listPublicKeys,
           [userLogin],
@@ -9263,8 +9022,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.PublicKey>);
 
   @override
-  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) => (super.noSuchMethod(
         Invocation.method(
           #createPublicKey,
           [key],
@@ -9318,8 +9076,7 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
       ) as _i25.Cache<_i36.Uint8List>);
 
   @override
-  _i25.Cache<S> withCodec<S>(_i24.Codec<S, _i36.Uint8List>? codec) =>
-      (super.noSuchMethod(
+  _i25.Cache<S> withCodec<S>(_i24.Codec<S, _i36.Uint8List>? codec) => (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],

--- a/cloud_build/verify_provenance.sh
+++ b/cloud_build/verify_provenance.sh
@@ -10,7 +10,7 @@ set -e
 # legitimate, then the script will exit with a non-zero exit code.
 PROVENANCE_PATH=$1
 BUILDER_ID=https://cloudbuild.googleapis.com/GoogleHostedWorker
-SOURCE_URI=github.com/flutter/cocoon
+SOURCE_URI=github.com/keyonghan/cocoon
 
 # Download the jq binary in order to obtain the artifact registry url from the
 # docker image provenance.


### PR DESCRIPTION
This PR adds support to save multiple entries for a task retry. Old logic overrides task statuses on a single task, which fails to track statuses.

This PR:
1) makes it customizable to collect `attempts` info
2) adds `current_attempt` tag to make it easy to track `attempts` info.
3) handles `attempt` increase when retry is triggered.

Part of https://github.com/flutter/flutter/issues/142951.