### PR TITLE
Update Firestore when reseting a prod task

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -144,7 +144,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
 
     firestore.Task? taskDocument;
     final int currentAttempt = task.attempts!;
-    final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_$currentAttempt';
+    final String documentName = '$kDatabase/documents/$kTaskCollectionId/${sha}_${taskName}_$currentAttempt';
     try {
       taskDocument = await firestore.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
     } catch (error) {

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -691,7 +691,7 @@ class LuciBuildService {
     }
     log.info('Rerun builder: ${target.value.name} for commit ${commit.sha}');
     tags ??= <String, List<String>>{};
-    tags['trigger_type'] = <String>['retry'];
+    tags['trigger_type'] ??= <String>['auto_retry'];
 
     // TODO(keyonghan): remove check when [ResetProdTask] supports firestore update.
     if (taskDocument != null) {

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -961,6 +961,7 @@ void main() {
       }
       expect(scheduleBuildRequest.priority, LuciBuildService.kRerunPriority);
       expect(scheduleBuildRequest.gitilesCommit?.project, 'mirrors/engine');
+      expect(scheduleBuildRequest.tags?['trigger_type'], <String>['auto_retry']);
       expect(rerunFlag, isTrue);
       expect(task.attempts, 2);
       expect(task.status, Task.statusInProgress);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

This PR:
1) inserts new task document to Firestore when retried manually
2) fixes `trigger_type` tag: instead of overriding manual case as `trigger_type: auto`, we now distinguish them with
2.1) `trigger_type: manual_retry` for manual retry
2.2) `trigger_type: auto_retry` for auto retry