### PR TITLE
Update Firestore task when mulitple reruns exist

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -164,12 +164,15 @@ class Task extends Document {
       throw const BadRequestException('build_address does not contain build number');
     }
     fields![kTaskBuildNumberField] = Value(integerValue: buildAddress.split('/').last);
-    fields![kTaskCreateTimestampField] =
-        Value(integerValue: (build.createdTimestamp?.millisecondsSinceEpoch ?? 0).toString());
-    fields![kTaskStartTimestampField] =
-        Value(integerValue: (build.startedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
-    fields![kTaskEndTimestampField] =
-        Value(integerValue: (build.completedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
+    fields![kTaskCreateTimestampField] = Value(
+      integerValue: (build.createdTimestamp?.millisecondsSinceEpoch ?? kTaskDefaultTimestampValue).toString(),
+    );
+    fields![kTaskStartTimestampField] = Value(
+      integerValue: (build.startedTimestamp?.millisecondsSinceEpoch ?? kTaskDefaultTimestampValue).toString(),
+    );
+    fields![kTaskEndTimestampField] = Value(
+      integerValue: (build.completedTimestamp?.millisecondsSinceEpoch ?? kTaskDefaultTimestampValue).toString(),
+    );
 
     _setStatusFromLuciStatus(build);
   }
@@ -178,10 +181,10 @@ class Task extends Document {
     name = '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${taskName}_$attempt';
     fields = <String, Value>{
       kTaskCreateTimestampField: Value(integerValue: DateTime.now().millisecondsSinceEpoch.toString()),
-      kTaskEndTimestampField: Value(integerValue: '0'),
+      kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
       kTaskBringupField: Value(booleanValue: bringup),
       kTaskNameField: Value(stringValue: taskName),
-      kTaskStartTimestampField: Value(integerValue: '0'),
+      kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
       kTaskStatusField: Value(stringValue: Task.statusNew),
       kTaskTestFlakyField: Value(booleanValue: false),
       kTaskCommitShaField: Value(stringValue: commitSha),

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
 
 import '../../request_handling/exceptions.dart';
@@ -77,27 +78,27 @@ class Task extends Document {
   ///
   /// This is _not_ when the task first started running, as tasks start out in
   /// the 'New' state until they've been picked up by an [Agent].
-  int? get createTimestamp => int.parse(fields!['createTimestamp']!.integerValue!);
+  int? get createTimestamp => int.parse(fields![kTaskCreateTimestampField]!.integerValue!);
 
   /// The timestamp (in milliseconds since the Epoch) that this task started
   /// running.
   ///
   /// Tasks may be run more than once. If this task has been run more than
   /// once, this timestamp represents when the task was most recently started.
-  int? get startTimestamp => int.parse(fields!['startTimestamp']!.integerValue!);
+  int? get startTimestamp => int.parse(fields![kTaskStartTimestampField]!.integerValue!);
 
   /// The timestamp (in milliseconds since the Epoch) that this task last
   /// finished running.
-  int? get endTimestamp => int.parse(fields!['endTimestamp']!.integerValue!);
+  int? get endTimestamp => int.parse(fields![kTaskEndTimestampField]!.integerValue!);
 
   /// The name of the task.
   ///
   /// This is a human-readable name, typically a test name (e.g.
   /// "hello_world__memory").
-  String? get taskName => fields!['name']!.stringValue!;
+  String? get taskName => fields![kTaskNameField]!.stringValue!;
 
   /// The sha of the task commit.
-  String? get commitSha => fields!['commitSha']!.stringValue!;
+  String? get commitSha => fields![kTaskCommitShaField]!.stringValue!;
 
   /// The number of attempts that have been made to run this task successfully.
   ///
@@ -112,7 +113,7 @@ class Task extends Document {
   ///  * <https://github.com/flutter/flutter/blob/master/.ci.yaml>
   ///
   /// A flaky (`bringup: true`) task will not block the tree.
-  bool? get bringup => fields!['bringup']!.booleanValue!;
+  bool? get bringup => fields![kTaskBringupField]!.booleanValue!;
 
   /// Whether the test execution of this task shows flake.
   ///
@@ -120,16 +121,17 @@ class Task extends Document {
   ///
   /// See also:
   ///  * <https://github.com/flutter/flutter/blob/master/dev/devicelab/lib/framework/runner.dart>
-  bool? get testFlaky => fields!['testFlaky']!.booleanValue!;
+  bool? get testFlaky => fields![kTaskTestFlakyField]!.booleanValue!;
 
   /// The build number of luci build: https://chromium.googlesource.com/infra/luci/luci-go/+/master/buildbucket/proto/build.proto#146
-  int? get buildNumber => fields!.containsKey('buildNumber') ? int.parse(fields!['buildNumber']!.integerValue!) : null;
+  int? get buildNumber =>
+      fields!.containsKey(kTaskBuildNumberField) ? int.parse(fields![kTaskBuildNumberField]!.integerValue!) : null;
 
   /// The status of the task.
   ///
   /// Legal values and their meanings are defined in [legalStatusValues].
   String get status {
-    final String taskStatus = fields!['status']!.stringValue!;
+    final String taskStatus = fields![kTaskStatusField]!.stringValue!;
     if (!legalStatusValues.contains(taskStatus)) {
       throw ArgumentError('Invalid state: "$taskStatus"');
     }
@@ -140,16 +142,16 @@ class Task extends Document {
     if (!legalStatusValues.contains(value)) {
       throw ArgumentError('Invalid state: "$value"');
     }
-    fields!['status'] = Value(stringValue: value);
+    fields![kTaskStatusField] = Value(stringValue: value);
     return value;
   }
 
   void setEndTimestamp(int endTimestamp) {
-    fields!['endTimestamp'] = Value(integerValue: endTimestamp.toString());
+    fields![kTaskEndTimestampField] = Value(integerValue: endTimestamp.toString());
   }
 
   void setTestFlaky(bool testFlaky) {
-    fields!['testFlaky'] = Value(booleanValue: testFlaky);
+    fields![kTaskTestFlakyField] = Value(booleanValue: testFlaky);
   }
 
   /// Update [Task] fields based on a LUCI [Build].
@@ -161,25 +163,28 @@ class Task extends Document {
       log.warning('Tags: $tags');
       throw const BadRequestException('build_address does not contain build number');
     }
-    fields!['buildNumber'] = Value(integerValue: buildAddress.split('/').last);
-    fields!['createTimestamp'] = Value(integerValue: (build.createdTimestamp?.millisecondsSinceEpoch ?? 0).toString());
-    fields!['startTimestamp'] = Value(integerValue: (build.startedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
-    fields!['endTimestamp'] = Value(integerValue: (build.completedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
+    fields![kTaskBuildNumberField] = Value(integerValue: buildAddress.split('/').last);
+    fields![kTaskCreateTimestampField] =
+        Value(integerValue: (build.createdTimestamp?.millisecondsSinceEpoch ?? 0).toString());
+    fields![kTaskStartTimestampField] =
+        Value(integerValue: (build.startedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
+    fields![kTaskEndTimestampField] =
+        Value(integerValue: (build.completedTimestamp?.millisecondsSinceEpoch ?? 0).toString());
 
     _setStatusFromLuciStatus(build);
   }
 
   void resetAsRetry({int attempt = 1}) {
-    name = '$kDatabase/documents/tasks/${commitSha}_${taskName}_$attempt';
+    name = '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${taskName}_$attempt';
     fields = <String, Value>{
-      'createTimestamp': Value(integerValue: DateTime.now().millisecondsSinceEpoch.toString()),
-      'endTimestamp': Value(integerValue: '0'),
-      'bringup': Value(booleanValue: bringup),
-      'name': Value(stringValue: taskName),
-      'startTimestamp': Value(integerValue: '0'),
-      'status': Value(stringValue: Task.statusNew),
-      'testFlaky': Value(booleanValue: false),
-      'commitSha': Value(stringValue: commitSha),
+      kTaskCreateTimestampField: Value(integerValue: DateTime.now().millisecondsSinceEpoch.toString()),
+      kTaskEndTimestampField: Value(integerValue: '0'),
+      kTaskBringupField: Value(booleanValue: bringup),
+      kTaskNameField: Value(stringValue: taskName),
+      kTaskStartTimestampField: Value(integerValue: '0'),
+      kTaskStatusField: Value(stringValue: Task.statusNew),
+      kTaskTestFlakyField: Value(booleanValue: false),
+      kTaskCommitShaField: Value(stringValue: commitSha),
     };
   }
 
@@ -226,13 +231,13 @@ class Task extends Document {
   String toString() {
     final StringBuffer buf = StringBuffer()
       ..write('$runtimeType(')
-      ..write(', createTimestamp: $createTimestamp')
-      ..write(', startTimestamp: $startTimestamp')
-      ..write(', endTimestamp: $endTimestamp')
-      ..write(', name: $name')
-      ..write(', bringup: $bringup')
-      ..write(', testRunFlaky: $testFlaky')
-      ..write(', status: $status')
+      ..write(', $kTaskCreateTimestampField: $createTimestamp')
+      ..write(', $kTaskStartTimestampField: $startTimestamp')
+      ..write(', $kTaskEndTimestampField: $endTimestamp')
+      ..write(', $kTaskNameField: $name')
+      ..write(', $kTaskBringupField: $bringup')
+      ..write(', $kTaskTestFlakyField: $testFlaky')
+      ..write(', $kTaskStatusField: $status')
       ..write(')');
     return buf.toString();
   }

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -79,6 +79,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_1';
     log.info('getting firestore document: $documentName');
     final List<firestore.Task> initialTasks = await firestoreService.queryCommitTasks(sha);
+    // Targets the latest task. This assumes only one task is running at any time.
     final firestore.Task firestoreTask = initialTasks.where((firestore.Task task) => task.taskName == taskName).reduce(
           (firestore.Task current, firestore.Task next) => current.name!.compareTo(next.name!) > 0 ? current : next,
         );

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -78,8 +78,10 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final String? taskName = requestData![builderNameParam] as String?;
     final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_1';
     log.info('getting firestore document: $documentName');
-    final firestore.Task firestoreTask =
-        await firestore.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
+    final List<firestore.Task> initialTasks = await firestoreService.queryCommitTasks(sha);
+    final firestore.Task firestoreTask = initialTasks.where((firestore.Task task) => task.taskName == taskName).reduce(
+          (firestore.Task current, firestore.Task next) => current.name!.compareTo(next.name!) > 0 ? current : next,
+        );
     firestoreTask.setStatus(status);
     firestoreTask.setEndTimestamp(endTimestamp);
     firestoreTask.setTestFlaky(isTestFlaky);

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -20,6 +20,7 @@ const String kDocumentParent = '$kDatabase/documents';
 const String kFieldFilterOpEqual = 'EQUAL';
 
 const String kTaskCollectionId = 'tasks';
+const int kTaskDefaultTimestampValue = 0;
 const String kTaskBringupField = 'bringup';
 const String kTaskBuildNumberField = 'buildNumber';
 const String kTaskCommitShaField = 'commitSha';
@@ -116,10 +117,10 @@ List<Document> targetsToTaskDocuments(Commit commit, List<Target> targets) {
       name: '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${target.value.name}_1',
       fields: <String, Value>{
         kTaskCreateTimestampField: Value(integerValue: commit.timestamp!.toString()),
-        kTaskEndTimestampField: Value(integerValue: '0'),
+        kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
         kTaskBringupField: Value(booleanValue: target.value.bringup),
         kTaskNameField: Value(stringValue: target.value.name.toString()),
-        kTaskStartTimestampField: Value(integerValue: '0'),
+        kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
         kTaskStatusField: Value(stringValue: Task.statusNew),
         kTaskTestFlakyField: Value(booleanValue: false),
         kTaskCommitShaField: Value(stringValue: commit.sha),

--- a/app_dart/test/request_handlers/update_task_status_test.dart
+++ b/app_dart/test/request_handlers/update_task_status_test.dart
@@ -56,14 +56,15 @@ void main() {
     });
 
     test('TestFlaky is false when not injected', () async {
-      final firestore.Task firestoreTask = generateFirestoreTask(1);
+      final firestore.Task firestoreTask1 = generateFirestoreTask(1, name: 'linux_integration_ui_ios', attempts: 1);
+      final firestore.Task firestoreTask2 = generateFirestoreTask(2, name: 'linux_integration_ui_ios', attempts: 2);
       when(
-        mockFirestoreService.getDocument(
+        mockFirestoreService.queryCommitTasks(
           captureAny,
         ),
       ).thenAnswer((Invocation invocation) {
-        return Future<Document>.value(
-          firestoreTask,
+        return Future<List<firestore.Task>>.value(
+          <firestore.Task>[firestoreTask1, firestoreTask2],
         );
       });
       when(
@@ -95,18 +96,19 @@ void main() {
       await tester.post(handler);
 
       expect(task.isTestFlaky, false);
-      expect(firestoreTask.testFlaky, false);
+      expect(firestoreTask2.testFlaky, false);
     });
 
     test('TestFlaky is true when injected', () async {
-      final firestore.Task firestoreTask = generateFirestoreTask(1);
+      final firestore.Task firestoreTask1 = generateFirestoreTask(1, name: 'linux_integration_ui_ios', attempts: 1);
+      final firestore.Task firestoreTask2 = generateFirestoreTask(2, name: 'linux_integration_ui_ios', attempts: 2);
       when(
-        mockFirestoreService.getDocument(
+        mockFirestoreService.queryCommitTasks(
           captureAny,
         ),
       ).thenAnswer((Invocation invocation) {
-        return Future<Document>.value(
-          firestoreTask,
+        return Future<List<firestore.Task>>.value(
+          <firestore.Task>[firestoreTask1, firestoreTask2],
         );
       });
       when(
@@ -139,18 +141,18 @@ void main() {
       await tester.post(handler);
 
       expect(task.isTestFlaky, true);
-      expect(firestoreTask.testFlaky, true);
     });
 
     test('task name requests can update tasks', () async {
-      final firestore.Task firestoreTask = generateFirestoreTask(1);
+      final firestore.Task firestoreTask1 = generateFirestoreTask(1, name: 'linux_integration_ui_ios', attempts: 1);
+      final firestore.Task firestoreTask2 = generateFirestoreTask(2, name: 'linux_integration_ui_ios', attempts: 2);
       when(
-        mockFirestoreService.getDocument(
+        mockFirestoreService.queryCommitTasks(
           captureAny,
         ),
       ).thenAnswer((Invocation invocation) {
-        return Future<Document>.value(
-          firestoreTask,
+        return Future<List<firestore.Task>>.value(
+          <firestore.Task>[firestoreTask1, firestoreTask2],
         );
       });
       when(
@@ -183,8 +185,8 @@ void main() {
 
       expect(task.status, 'Failed');
       expect(task.attempts, 1);
-      expect(firestoreTask.status, 'Failed');
-      expect(firestoreTask.attempts, 1);
+      expect(firestoreTask2.status, 'Failed');
+      expect(firestoreTask2.attempts, 2);
     });
 
     test('task name requests when task does not exists returns exception', () async {
@@ -198,14 +200,15 @@ void main() {
     });
 
     test('task name request updates when input has whitespace', () async {
-      final firestore.Task firestoreTask = generateFirestoreTask(1);
+      final firestore.Task firestoreTask1 = generateFirestoreTask(1, name: 'linux_integration_ui_ios', attempts: 1);
+      final firestore.Task firestoreTask2 = generateFirestoreTask(2, name: 'linux_integration_ui_ios', attempts: 2);
       when(
-        mockFirestoreService.getDocument(
+        mockFirestoreService.queryCommitTasks(
           captureAny,
         ),
       ).thenAnswer((Invocation invocation) {
-        return Future<Document>.value(
-          firestoreTask,
+        return Future<List<firestore.Task>>.value(
+          <firestore.Task>[firestoreTask1, firestoreTask2],
         );
       });
       when(

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -21,28 +21,28 @@ void main() {
     ];
     final List<Document> taskDocuments = targetsToTaskDocuments(commit, targets);
     expect(taskDocuments.length, 2);
-    expect(taskDocuments[0].name, '$kDatabase/documents/tasks/${commit.sha}_${targets[0].value.name}_1');
-    expect(taskDocuments[0].fields!['createTimestamp']!.integerValue, commit.timestamp.toString());
-    expect(taskDocuments[0].fields!['endTimestamp']!.integerValue, '0');
-    expect(taskDocuments[0].fields!['bringup']!.booleanValue, false);
-    expect(taskDocuments[0].fields!['name']!.stringValue, targets[0].value.name);
-    expect(taskDocuments[0].fields!['startTimestamp']!.integerValue, '0');
-    expect(taskDocuments[0].fields!['status']!.stringValue, Task.statusNew);
-    expect(taskDocuments[0].fields!['testFlaky']!.booleanValue, false);
-    expect(taskDocuments[0].fields!['commitSha']!.stringValue, commit.sha);
+    expect(taskDocuments[0].name, '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${targets[0].value.name}_1');
+    expect(taskDocuments[0].fields![kTaskCreateTimestampField]!.integerValue, commit.timestamp.toString());
+    expect(taskDocuments[0].fields![kTaskEndTimestampField]!.integerValue, '0');
+    expect(taskDocuments[0].fields![kTaskBringupField]!.booleanValue, false);
+    expect(taskDocuments[0].fields![kTaskNameField]!.stringValue, targets[0].value.name);
+    expect(taskDocuments[0].fields![kTaskStartTimestampField]!.integerValue, '0');
+    expect(taskDocuments[0].fields![kTaskStatusField]!.stringValue, Task.statusNew);
+    expect(taskDocuments[0].fields![kTaskTestFlakyField]!.booleanValue, false);
+    expect(taskDocuments[0].fields![kTaskCommitShaField]!.stringValue, commit.sha);
   });
 
   test('creates commit document correctly from commit data model', () async {
     final Commit commit = generateCommit(1);
     final Document commitDocument = commitToCommitDocument(commit);
-    expect(commitDocument.name, '$kDatabase/documents/commits/${commit.sha}');
-    expect(commitDocument.fields!['avatar']!.stringValue, commit.authorAvatarUrl);
-    expect(commitDocument.fields!['branch']!.stringValue, commit.branch);
-    expect(commitDocument.fields!['createTimestamp']!.integerValue, commit.timestamp.toString());
-    expect(commitDocument.fields!['author']!.stringValue, commit.author);
-    expect(commitDocument.fields!['message']!.stringValue, commit.message);
-    expect(commitDocument.fields!['repositoryPath']!.stringValue, commit.repository);
-    expect(commitDocument.fields!['sha']!.stringValue, commit.sha);
+    expect(commitDocument.name, '$kDatabase/documents/$kCommitCollectionId/${commit.sha}');
+    expect(commitDocument.fields![kCommitAvatarField]!.stringValue, commit.authorAvatarUrl);
+    expect(commitDocument.fields![kCommitBranchField]!.stringValue, commit.branch);
+    expect(commitDocument.fields![kCommitCreateTimestampField]!.integerValue, commit.timestamp.toString());
+    expect(commitDocument.fields![kCommitAuthorField]!.stringValue, commit.author);
+    expect(commitDocument.fields![kCommitMessageField]!.stringValue, commit.message);
+    expect(commitDocument.fields![kCommitRepositoryPathField]!.stringValue, commit.repository);
+    expect(commitDocument.fields![kCommitShaField]!.stringValue, commit.sha);
   });
 
   test('creates writes correctly from documents', () async {

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -18,11 +18,11 @@ import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dar
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i34;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i33;
-import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i38;
-import 'package:cocoon_service/src/model/firestore/task.dart' as _i40;
-import 'package:cocoon_service/src/model/github/checks.dart' as _i39;
+import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i39;
+import 'package:cocoon_service/src/model/firestore/task.dart' as _i37;
+import 'package:cocoon_service/src/model/github/checks.dart' as _i40;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart' as _i8;
-import 'package:cocoon_service/src/model/luci/push_message.dart' as _i37;
+import 'package:cocoon_service/src/model/luci/push_message.dart' as _i38;
 import 'package:cocoon_service/src/service/access_client_provider.dart' as _i5;
 import 'package:cocoon_service/src/service/access_token_provider.dart' as _i26;
 import 'package:cocoon_service/src/service/bigquery.dart' as _i16;
@@ -2591,6 +2591,15 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
           ),
         )),
       ) as _i20.Future<_i21.CommitResponse>);
+
+  @override
+  _i20.Future<List<_i37.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
+        Invocation.method(
+          #queryCommitTasks,
+          [commitSha],
+        ),
+        returnValue: _i20.Future<List<_i37.Task>>.value(<_i37.Task>[]),
+      ) as _i20.Future<List<_i37.Task>>);
 }
 
 /// A class which mocks [IssuesService].
@@ -3368,7 +3377,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
 
   @override
   _i20.Future<bool> updateCheckStatus(
-    _i37.BuildPushMessage? buildPushMessage,
+    _i38.BuildPushMessage? buildPushMessage,
     _i15.LuciBuildService? luciBuildService,
     _i13.RepositorySlug? slug, {
     bool? rescheduled = false,
@@ -3387,7 +3396,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i20.Future<bool>);
 
   @override
-  bool taskFailed(_i37.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  bool taskFailed(_i38.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
         Invocation.method(
           #taskFailed,
           [buildPushMessage],
@@ -3396,7 +3405,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as bool);
 
   @override
-  int currentAttempt(_i37.Build? build) => (super.noSuchMethod(
+  int currentAttempt(_i38.Build? build) => (super.noSuchMethod(
         Invocation.method(
           #currentAttempt,
           [build],
@@ -3420,7 +3429,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i37.Result? result) => (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i38.Result? result) => (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [result],
@@ -3435,7 +3444,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i37.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i38.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
@@ -6379,8 +6388,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<List<_i38.Target>> scheduleTryBuilds({
-    required List<_i38.Target>? targets,
+  _i20.Future<List<_i39.Target>> scheduleTryBuilds({
+    required List<_i39.Target>? targets,
     required _i13.PullRequest? pullRequest,
     _i30.CheckSuiteEvent? checkSuiteEvent,
   }) =>
@@ -6394,8 +6403,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #checkSuiteEvent: checkSuiteEvent,
           },
         ),
-        returnValue: _i20.Future<List<_i38.Target>>.value(<_i38.Target>[]),
-      ) as _i20.Future<List<_i38.Target>>);
+        returnValue: _i20.Future<List<_i39.Target>>.value(<_i39.Target>[]),
+      ) as _i20.Future<List<_i39.Target>>);
 
   @override
   _i20.Future<void> cancelBuilds(
@@ -6417,7 +6426,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<List<_i8.Build?>> failedBuilds(
     _i13.PullRequest? pullRequest,
-    List<_i38.Target>? targets,
+    List<_i39.Target>? targets,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6433,7 +6442,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<_i8.Build> rescheduleBuild({
     required String? builderName,
-    required _i37.BuildPushMessage? buildPushMessage,
+    required _i38.BuildPushMessage? buildPushMessage,
     required int? rescheduleAttempt,
   }) =>
       (super.noSuchMethod(
@@ -6461,7 +6470,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i39.CheckRunEvent? checkRunEvent) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i40.CheckRunEvent? checkRunEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6491,10 +6500,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 
   @override
   _i20.Future<_i8.Build> reschedulePostsubmitBuildUsingCheckRunEvent(
-    _i39.CheckRunEvent? checkRunEvent, {
+    _i40.CheckRunEvent? checkRunEvent, {
     required _i32.Commit? commit,
     required _i33.Task? task,
-    required _i38.Target? target,
+    required _i39.Target? target,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6559,9 +6568,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
     required _i32.Commit? commit,
-    required List<_i15.Tuple<_i38.Target, _i33.Task, int>>? toBeScheduled,
+    required List<_i15.Tuple<_i39.Target, _i33.Task, int>>? toBeScheduled,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6572,14 +6581,14 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>.value(
-            <_i15.Tuple<_i38.Target, _i33.Task, int>>[]),
-      ) as _i20.Future<List<_i15.Tuple<_i38.Target, _i33.Task, int>>>);
+        returnValue: _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>>.value(
+            <_i15.Tuple<_i39.Target, _i33.Task, int>>[]),
+      ) as _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>>);
 
   @override
   _i20.Future<void> createPostsubmitCheckRun(
     _i32.Commit? commit,
-    _i38.Target? target,
+    _i39.Target? target,
     Map<String, dynamic>? rawUserData,
   ) =>
       (super.noSuchMethod(
@@ -6598,13 +6607,13 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<bool> checkRerunBuilder({
     required _i32.Commit? commit,
-    required _i38.Target? target,
+    required _i39.Target? target,
     required _i33.Task? task,
     required _i9.DatastoreService? datastore,
     _i15.FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool? ignoreChecks = false,
-    _i40.Task? taskDocument,
+    _i37.Task? taskDocument,
   }) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/cocoon/pull/3495.

This PR:
1) updates the latest task status correctly when multiple records exist
2) uses const variables to avoid potential typos

Part of https://github.com/flutter/flutter/issues/142951