### PR TITLE
Update Firestore task documents when back filling

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -115,11 +115,11 @@ class BatchBackfiller extends RequestHandler {
     }
   }
 
+  /// Updates task documents in Firestore.
   Future<void> updateTaskDocuments(List<Task> tasks) async {
     if (tasks.isEmpty) {
       return;
     }
-    // Updates task documents in Firestore.
     final List<firestore.Task> taskDocuments = tasks.map((e) => taskToTaskDocument(e)).toList();
     final List<Write> writes = documentsToWrites(taskDocuments, exists: true);
     final FirestoreService firestoreService = await config.createFirestoreService();

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -119,7 +119,7 @@ List<Document> targetsToTaskDocuments(Commit commit, List<Target> targets) {
         kTaskCreateTimestampField: Value(integerValue: commit.timestamp!.toString()),
         kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
         kTaskBringupField: Value(booleanValue: target.value.bringup),
-        kTaskNameField: Value(stringValue: target.value.name.toString()),
+        kTaskNameField: Value(stringValue: target.value.name),
         kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
         kTaskStatusField: Value(stringValue: Task.statusNew),
         kTaskTestFlakyField: Value(booleanValue: false),
@@ -143,6 +143,26 @@ Document commitToCommitDocument(Commit commit) {
       kCommitRepositoryPathField: Value(stringValue: commit.repository),
       kCommitShaField: Value(stringValue: commit.sha),
     },
+  );
+}
+
+/// Generates task document based on datastore task data model.
+firestore.Task taskToTaskDocument(Task task) {
+  final String commitSha = task.commitKey!.id!.split('/').last;
+  return firestore.Task.fromDocument(
+    taskDocument: Document(
+      name: '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}',
+      fields: <String, Value>{
+        kTaskCreateTimestampField: Value(integerValue: task.createTimestamp.toString()),
+        kTaskEndTimestampField: Value(integerValue: task.endTimestamp.toString()),
+        kTaskBringupField: Value(booleanValue: task.isFlaky),
+        kTaskNameField: Value(stringValue: task.name),
+        kTaskStartTimestampField: Value(integerValue: task.startTimestamp.toString()),
+        kTaskStatusField: Value(stringValue: task.status),
+        kTaskTestFlakyField: Value(booleanValue: task.isTestFlaky),
+        kTaskCommitShaField: Value(stringValue: commitSha),
+      },
+    ),
   );
 }
 

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 
@@ -43,6 +44,21 @@ void main() {
     expect(commitDocument.fields![kCommitMessageField]!.stringValue, commit.message);
     expect(commitDocument.fields![kCommitRepositoryPathField]!.stringValue, commit.repository);
     expect(commitDocument.fields![kCommitShaField]!.stringValue, commit.sha);
+  });
+
+  test('creates task document correctly from task data model', () async {
+    final Task task = generateTask(1);
+    final String commitSha = task.commitKey!.id!.split('/').last;
+    final firestore.Task taskDocument = taskToTaskDocument(task);
+    expect(taskDocument.name, '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}');
+    expect(taskDocument.createTimestamp, task.createTimestamp);
+    expect(taskDocument.endTimestamp, task.endTimestamp);
+    expect(taskDocument.bringup, task.isFlaky);
+    expect(taskDocument.taskName, task.name);
+    expect(taskDocument.startTimestamp, task.startTimestamp);
+    expect(taskDocument.status, task.status);
+    expect(taskDocument.testFlaky, task.isTestFlaky);
+    expect(taskDocument.commitSha, commitSha);
   });
 
   test('creates writes correctly from documents', () async {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

This PR starts updating task documents in Firestore when batch back filling tasks.