### PR TITLE
Updates github gold status to Firestore

### DIFF
--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -9,7 +9,7 @@ import 'package:googleapis/firestore/v1.dart' hide Status;
 import '../../service/firestore.dart';
 
 class Commit extends Document {
-  /// Lookup [Task] from Firestore.
+  /// Lookup [Commit] from Firestore.
   ///
   /// `documentName` follows `/projects/{project}/databases/{database}/documents/{document_path}`
   static Future<Commit> fromFirestore({

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -1,0 +1,73 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:github/github.dart';
+import 'package:googleapis/firestore/v1.dart' hide Status;
+
+import '../../service/firestore.dart';
+
+class GithubGoldStatus extends Document {
+  /// Lookup [GithubGoldStatus] from Firestore.
+  ///
+  /// `documentName` follows `/projects/{project}/databases/{database}/documents/{document_path}`
+  static Future<GithubGoldStatus> fromFirestore({
+    required FirestoreService firestoreService,
+    required String documentName,
+  }) async {
+    final Document document = await firestoreService.getDocument(documentName);
+    return GithubGoldStatus.fromDocument(githubGoldStatus: document);
+  }
+
+  /// Create [Commit] from a Commit Document.
+  static GithubGoldStatus fromDocument({
+    required Document githubGoldStatus,
+  }) {
+    return GithubGoldStatus()
+      ..fields = githubGoldStatus.fields!
+      ..name = githubGoldStatus.name!;
+  }
+
+  // The flutter-gold status cannot report a `failure` status
+  // due to auto-rollers. This is why we hold a `pending` status
+  // when there are image changes. This provides the opportunity
+  // for images to be triaged, and the auto-roller to proceed.
+  // For more context, see: https://github.com/flutter/flutter/issues/48744
+
+  static const String statusCompleted = 'success';
+
+  static const String statusRunning = 'pending';
+
+  int? get prNumber => int.parse(fields![kGithubGoldStatusPrNumberField]!.integerValue!);
+
+  String? get head => fields![kGithubGoldStatusHeadField]!.stringValue!;
+
+  String? get status => fields![kGithubGoldStatusStatusField]!.stringValue!;
+
+  String? get description => fields![kGithubGoldStatusDescriptionField]!.stringValue!;
+
+  int? get updates => int.parse(fields![kGithubGoldStatusUpdatesField]!.integerValue!);
+
+  /// A serializable form of [slug].
+  ///
+  /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
+  String? get repository => fields![kGithubGoldStatusRepositoryField]!.stringValue!;
+
+  /// [RepositorySlug] of where this commit exists.
+  RepositorySlug get slug => RepositorySlug.full(repository!);
+
+  @override
+  String toString() {
+    final StringBuffer buf = StringBuffer()
+      ..write('$runtimeType(')
+      ..write(', $kGithubGoldStatusPrNumberField: $prNumber')
+      ..write(', $kGithubGoldStatusHeadField: $head')
+      ..write(', $kGithubGoldStatusStatusField: $status')
+      ..write(', $kGithubGoldStatusDescriptionField $description')
+      ..write(', $kGithubGoldStatusUpdatesField: $updates')
+      ..write(', $kGithubGoldStatusRepositoryField: $repository')
+      ..write(')');
+    return buf.toString();
+  }
+}

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -6,13 +6,16 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:github/github.dart';
+import 'package:googleapis/firestore/v1.dart';
 import 'package:gql/language.dart' as lang;
 import 'package:graphql/client.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import '../model/appengine/github_gold_status_update.dart';
+import '../model/firestore/github_gold_status.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
@@ -205,6 +208,25 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     }
     await datastore.insert(statusUpdates);
     log.fine('Committed all updates for $slug');
+
+    // TODO(keyonghan): remove try block after fully migrated to firestore
+    // https://github.com/flutter/flutter/issues/142951
+    try {
+      await updateGithubGoldStatusDocuments(statusUpdates);
+    } catch (error) {
+      log.warning('Failed to update github gold status in Firestore: $error');
+    }
+  }
+
+  Future<void> updateGithubGoldStatusDocuments(List<GithubGoldStatusUpdate> statusUpdates) async {
+    if (statusUpdates.isEmpty) {
+      return;
+    }
+    final List<GithubGoldStatus> githubGoldStatusDocuments =
+        statusUpdates.map((e) => githubGoldStatusToDocument(e)).toList();
+    final List<Write> writes = documentsToWrites(githubGoldStatusDocuments);
+    final FirestoreService firestoreService = await config.createFirestoreService();
+    await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
   }
 
   /// Returns a GitHub Status for the given state and description.

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -699,7 +699,7 @@ class LuciBuildService {
         final int newAttempt = int.parse(taskDocument.name!.split('_').last) + 1;
         tags['current_attempt'] = <String>[newAttempt.toString()];
         taskDocument.resetAsRetry(attempt: newAttempt);
-        final List<Write> writes = documentsToWrites([taskDocument]);
+        final List<Write> writes = documentsToWrites([taskDocument], exists: false);
         await firestoreService!.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
       } catch (error) {
         log.warning('Failed to insert retried task in Firestore: $error');

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -169,7 +169,7 @@ class Scheduler {
     await _uploadToBigQuery(commit);
     final firestore_commmit.Commit commitDocument = commitToCommitDocument(commit);
     final List<firestore.Task> taskDocuments = targetsToTaskDocuments(commit, initialTargets);
-    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument]);
+    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
     final FirestoreService firestoreService = await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.
     try {

--- a/app_dart/test/model/firestore/github_gold_status_test.dart
+++ b/app_dart/test/model/firestore/github_gold_status_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../src/utilities/entity_generators.dart';
+import '../../src/utilities/mocks.dart';
+
+void main() {
+  group('GithubGoldStatus.fromFirestore', () {
+    late MockFirestoreService mockFirestoreService;
+
+    setUp(() {
+      mockFirestoreService = MockFirestoreService();
+    });
+
+    test('generates githubGoldStatus correctly', () async {
+      final GithubGoldStatus githubGoldStatus = generateFirestoreGithubGoldStatus(1);
+      when(
+        mockFirestoreService.getDocument(
+          captureAny,
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<GithubGoldStatus>.value(
+          githubGoldStatus,
+        );
+      });
+      final GithubGoldStatus resultedGithubGoldStatus = await GithubGoldStatus.fromFirestore(
+        firestoreService: mockFirestoreService,
+        documentName: 'test',
+      );
+      expect(resultedGithubGoldStatus.name, githubGoldStatus.name);
+      expect(resultedGithubGoldStatus.fields, githubGoldStatus.fields);
+    });
+  });
+}

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -70,7 +70,7 @@ void main() {
       Document(name: 'd1', fields: <String, Value>{'key1': Value(stringValue: 'value1')}),
       Document(name: 'd2', fields: <String, Value>{'key1': Value(stringValue: 'value2')}),
     ];
-    final List<Write> writes = documentsToWrites(documents);
+    final List<Write> writes = documentsToWrites(documents, exists: false);
     expect(writes.length, documents.length);
     expect(writes[0].update, documents[0]);
     expect(writes[0].currentDocument!.exists, false);

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -7,6 +7,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commit;
+import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/gerrit/commit.dart';
@@ -147,6 +148,27 @@ firestore_commit.Commit generateFirestoreCommit(
       kCommitRepositoryPathField: Value(stringValue: '$owner/$repo'),
       kCommitBranchField: Value(stringValue: branch),
       kCommitShaField: Value(stringValue: sha ?? '$i'),
+    };
+  return commit;
+}
+
+GithubGoldStatus generateFirestoreGithubGoldStatus(
+  int i, {
+  String? head,
+  int? pr,
+  String owner = 'flutter',
+  String repo = 'flutter',
+  int? updates,
+}) {
+  pr ??= i;
+  head ??= 'sha$i';
+  final GithubGoldStatus commit = GithubGoldStatus()
+    ..name = '{$pr}_$head'
+    ..fields = <String, Value>{
+      kGithubGoldStatusHeadField: Value(stringValue: head),
+      kGithubGoldStatusPrNumberField: Value(integerValue: pr.toString()),
+      kGithubGoldStatusRepositoryField: Value(stringValue: '$owner/$repo'),
+      kGithubGoldStatusUpdatesField: Value(integerValue: updates.toString()),
     };
   return commit;
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

This PR:
1) starts updating Github Gold Status to Firestore
2) updates status in a try block to avoid breaking prod workflow
3) creates a corresponding Firestore model
4) updates `documentsToWrites` to have default `exists=null` to support generic document writes.