### PR TITLE
Write github build status to Firestore

### DIFF
--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -1,0 +1,96 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:github/github.dart';
+import 'package:googleapis/firestore/v1.dart' hide Status;
+
+import '../../service/firestore.dart';
+import '../appengine/github_build_status_update.dart';
+
+const String kGithubBuildStatusCollectionId = 'githubBuildStatuses';
+const String kGithubBuildStatusPrNumberField = 'prNumber';
+const String kGithubBuildStatusRepositoryField = 'repository';
+const String kGithubBuildStatusHeadField = 'head';
+const String kGithubBuildStatusStatusField = 'status';
+const String kGithubBuildStatusUpdateTimeMillisField = 'updateTimeMillis';
+const String kGithubBuildStatusUpdatesField = 'updates';
+
+/// Class that represents an update having been posted to a GitHub PR on the
+/// status of the Flutter build.
+class GithubBuildStatus extends Document {
+  /// Lookup [GithubBuildStatus] from Firestore.
+  ///
+  /// `documentName` follows `/projects/{project}/databases/{database}/documents/{document_path}`
+  static Future<GithubBuildStatus> fromFirestore({
+    required FirestoreService firestoreService,
+    required String documentName,
+  }) async {
+    final Document document = await firestoreService.getDocument(documentName);
+    return GithubBuildStatus.fromDocument(githubBuildStatus: document);
+  }
+
+  /// Create [GithubBuildStatus] from a GithubBuildStatus Document.
+  static GithubBuildStatus fromDocument({
+    required Document githubBuildStatus,
+  }) {
+    return GithubBuildStatus()
+      ..fields = githubBuildStatus.fields!
+      ..name = githubBuildStatus.name!;
+  }
+
+  static const String statusSuccess = 'success';
+
+  static const String statusFailure = 'failure';
+
+  int? get prNumber => int.parse(fields![kGithubBuildStatusPrNumberField]!.integerValue!);
+
+  /// A serializable form of [slug].
+  ///
+  /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
+  String? get repository => fields![kGithubBuildStatusRepositoryField]!.stringValue!;
+
+  /// [RepositorySlug] of where this commit exists.
+  RepositorySlug get slug => RepositorySlug.full(repository!);
+
+  String? get head => fields![kGithubBuildStatusHeadField]!.stringValue!;
+
+  String? get status => fields![kGithubBuildStatusStatusField]!.stringValue!;
+
+  /// The last time when the status is updated for the PR.
+  int? get updateTimeMillis => int.parse(fields![kGithubBuildStatusUpdateTimeMillisField]!.integerValue!);
+
+  int? get updates => int.parse(fields![kGithubBuildStatusUpdatesField]!.integerValue!);
+
+  @override
+  String toString() {
+    final StringBuffer buf = StringBuffer()
+      ..write('$runtimeType(')
+      ..write(', $kGithubBuildStatusRepositoryField: $repository')
+      ..write(', $kGithubBuildStatusPrNumberField: $prNumber')
+      ..write(', $kGithubBuildStatusHeadField: $head')
+      ..write(', $kGithubBuildStatusStatusField: $status')
+      ..write(', $kGithubBuildStatusUpdatesField: $updates')
+      ..write(', $kGithubBuildStatusUpdateTimeMillisField: $updateTimeMillis')
+      ..write(')');
+    return buf.toString();
+  }
+}
+
+/// Generates GithubGoldStatus document based on datastore GithubGoldStatusUpdate data model.
+GithubBuildStatus githubBuildStatusToDocument(GithubBuildStatusUpdate githubBuildStatus) {
+  return GithubBuildStatus.fromDocument(
+    githubBuildStatus: Document(
+      name: '$kDatabase/documents/$kGithubBuildStatusCollectionId/${githubBuildStatus.head}_${githubBuildStatus.pr}',
+      fields: <String, Value>{
+        kGithubBuildStatusUpdateTimeMillisField: Value(stringValue: githubBuildStatus.updateTimeMillis.toString()),
+        kGithubBuildStatusHeadField: Value(stringValue: githubBuildStatus.head),
+        kGithubBuildStatusPrNumberField: Value(integerValue: githubBuildStatus.pr.toString()),
+        kGithubBuildStatusRepositoryField: Value(stringValue: githubBuildStatus.repository),
+        kGithubBuildStatusStatusField: Value(stringValue: githubBuildStatus.status),
+        kGithubBuildStatusUpdatesField: Value(integerValue: githubBuildStatus.updates.toString()),
+      },
+    ),
+  );
+}

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -20,7 +20,7 @@ class GithubGoldStatus extends Document {
     return GithubGoldStatus.fromDocument(githubGoldStatus: document);
   }
 
-  /// Create [Commit] from a Commit Document.
+  /// Create [GithubGoldStatus] from a GithubGoldStatus Document.
   static GithubGoldStatus fromDocument({
     required Document githubGoldStatus,
   }) {

--- a/app_dart/test/model/firestore/github_build_status_test.dart
+++ b/app_dart/test/model/firestore/github_build_status_test.dart
@@ -58,8 +58,10 @@ void main() {
         githubBuildStatusDocument.fields![kGithubBuildStatusPrNumberField]!.integerValue,
         githubBuildStatusUpdate.pr.toString(),
       );
-      expect(githubBuildStatusDocument.fields![kGithubBuildStatusStatusField]!.stringValue,
-          githubBuildStatusUpdate.status);
+      expect(
+        githubBuildStatusDocument.fields![kGithubBuildStatusStatusField]!.stringValue,
+        githubBuildStatusUpdate.status,
+      );
       expect(
         githubBuildStatusDocument.fields![kGithubBuildStatusUpdatesField]!.integerValue,
         githubBuildStatusUpdate.updates.toString(),

--- a/app_dart/test/model/firestore/github_build_status_test.dart
+++ b/app_dart/test/model/firestore/github_build_status_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart';
+import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../src/utilities/entity_generators.dart';
+import '../../src/utilities/mocks.dart';
+
+void main() {
+  group('GithubBuildStatus.fromFirestore', () {
+    late MockFirestoreService mockFirestoreService;
+
+    setUp(() {
+      mockFirestoreService = MockFirestoreService();
+    });
+
+    test('generates githubBuildStatus correctly', () async {
+      final GithubBuildStatus githubBuildStatus = generateFirestoreGithubBuildStatus(1);
+      when(
+        mockFirestoreService.getDocument(
+          captureAny,
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<GithubBuildStatus>.value(
+          githubBuildStatus,
+        );
+      });
+      final GithubBuildStatus resultedGithubBuildStatus = await GithubBuildStatus.fromFirestore(
+        firestoreService: mockFirestoreService,
+        documentName: 'test',
+      );
+      expect(resultedGithubBuildStatus.name, githubBuildStatus.name);
+      expect(resultedGithubBuildStatus.fields, githubBuildStatus.fields);
+    });
+  });
+
+  group('Creates github gold status document', () {
+    test('from data model', () async {
+      final GithubBuildStatusUpdate githubBuildStatusUpdate = GithubBuildStatusUpdate(
+        head: 'sha',
+        pr: 1,
+        status: GithubBuildStatusUpdate.statusSuccess,
+        updates: 2,
+        repository: '',
+      );
+      final GithubBuildStatus githubBuildStatusDocument = githubBuildStatusToDocument(githubBuildStatusUpdate);
+      expect(
+        githubBuildStatusDocument.name,
+        '$kDatabase/documents/$kGithubBuildStatusCollectionId/${githubBuildStatusUpdate.head}_${githubBuildStatusUpdate.pr}',
+      );
+      expect(githubBuildStatusDocument.fields![kGithubBuildStatusHeadField]!.stringValue, githubBuildStatusUpdate.head);
+      expect(
+        githubBuildStatusDocument.fields![kGithubBuildStatusPrNumberField]!.integerValue,
+        githubBuildStatusUpdate.pr.toString(),
+      );
+      expect(githubBuildStatusDocument.fields![kGithubBuildStatusStatusField]!.stringValue,
+          githubBuildStatusUpdate.status);
+      expect(
+        githubBuildStatusDocument.fields![kGithubBuildStatusUpdatesField]!.integerValue,
+        githubBuildStatusUpdate.updates.toString(),
+      );
+      expect(githubBuildStatusDocument.fields![kGithubBuildStatusRepositoryField]!.stringValue, '');
+    });
+  });
+}

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -7,6 +7,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commit;
+import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
@@ -162,7 +163,7 @@ GithubGoldStatus generateFirestoreGithubGoldStatus(
 }) {
   pr ??= i;
   head ??= 'sha$i';
-  final GithubGoldStatus commit = GithubGoldStatus()
+  final GithubGoldStatus githubGoldStatus = GithubGoldStatus()
     ..name = '{$pr}_$head'
     ..fields = <String, Value>{
       kGithubGoldStatusHeadField: Value(stringValue: head),
@@ -170,7 +171,28 @@ GithubGoldStatus generateFirestoreGithubGoldStatus(
       kGithubGoldStatusRepositoryField: Value(stringValue: '$owner/$repo'),
       kGithubGoldStatusUpdatesField: Value(integerValue: updates.toString()),
     };
-  return commit;
+  return githubGoldStatus;
+}
+
+GithubBuildStatus generateFirestoreGithubBuildStatus(
+  int i, {
+  String? head,
+  int? pr,
+  String owner = 'flutter',
+  String repo = 'flutter',
+  int? updates,
+}) {
+  pr ??= i;
+  head ??= 'sha$i';
+  final GithubBuildStatus githubBuildStatus = GithubBuildStatus()
+    ..name = '{$pr}_$head'
+    ..fields = <String, Value>{
+      kGithubBuildStatusHeadField: Value(stringValue: head),
+      kGithubBuildStatusPrNumberField: Value(integerValue: pr.toString()),
+      kGithubBuildStatusRepositoryField: Value(stringValue: '$owner/$repo'),
+      kGithubBuildStatusUpdatesField: Value(integerValue: updates.toString()),
+    };
+  return githubBuildStatus;
 }
 
 Target generateTarget(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

This PR:

- starts updating Github Build Status to Firestore
- updates status in a try block to avoid breaking prod workflow
- creates a corresponding Firestore model