### PR TITLE
Fix the outpit directory for ktlint

### DIFF
--- a/cipd_packages/ktlint/tools/build.sh
+++ b/cipd_packages/ktlint/tools/build.sh
@@ -17,6 +17,5 @@ KTLINT_FILE_NAME=$(cat $DIR/../ktlint_metadata.txt | cut -d ',' -f 2)
 
 # Create the package structure.
 rm -rf $DIR/../build && mkdir -p $DIR/../build
-mkdir -p $DIR/../build/ktlint
 
-curl https://github.com/pinterest/ktlint/releases/download/"$KTLINT_MAJOR_VERSION"/"$KTLINT_FILE_NAME" -o $DIR/../build/ktlint/ktlint
+curl https://github.com/pinterest/ktlint/releases/download/"$KTLINT_MAJOR_VERSION"/"$KTLINT_FILE_NAME" -o $DIR/../build/ktlint

--- a/cipd_packages/ktlint/tools/build.sh
+++ b/cipd_packages/ktlint/tools/build.sh
@@ -19,4 +19,4 @@ KTLINT_FILE_NAME=$(cat $DIR/../ktlint_metadata.txt | cut -d ',' -f 2)
 rm -rf $DIR/../build && mkdir -p $DIR/../build
 mkdir -p $DIR/../build/ktlint
 
-curl https://github.com/pinterest/ktlint/releases/download/"$KTLINT_MAJOR_VERSION"/"$KTLINT_FILE_NAME" -o $DIR/../build/ktlint
+curl https://github.com/pinterest/ktlint/releases/download/"$KTLINT_MAJOR_VERSION"/"$KTLINT_FILE_NAME" -o $DIR/../build/ktlint/ktlint


### PR DESCRIPTION
In https://github.com/flutter/cocoon/pull/3522 I landed a `build.sh` which uses `curl` with the output
```
 -o $DIR/../build/ktlint/
```
I didn't know `-o` is intended to target the output file, not directory (both the file and the directory in this case are named ktlint). Hence the warning:
```
Warning: Failed to create the file 
Warning: /b/s/w/ir/x/w/cocoon/cipd_packages/ktlint/tools/../build/ktlint: Is a 
Warning: directory
```

Changes to `-o $DIR/../build/ktlint/ktlint`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
