### PR TITLE
Refactor to move logics closer to data models

### DIFF
--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -7,6 +7,16 @@ import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
 
 import '../../service/firestore.dart';
+import '../appengine/commit.dart' as datastore;
+
+const String kCommitCollectionId = 'commits';
+const String kCommitAvatarField = 'avatar';
+const String kCommitBranchField = 'branch';
+const String kCommitCreateTimestampField = 'createTimestamp';
+const String kCommitAuthorField = 'author';
+const String kCommitMessageField = 'message';
+const String kCommitRepositoryPathField = 'repositoryPath';
+const String kCommitShaField = 'sha';
 
 class Commit extends Document {
   /// Lookup [Commit] from Firestore.
@@ -75,4 +85,22 @@ class Commit extends Document {
       ..write(')');
     return buf.toString();
   }
+}
+
+/// Generates commit document based on datastore commit data model.
+Commit commitToCommitDocument(datastore.Commit commit) {
+  return Commit.fromDocument(
+    commitDocument: Document(
+      name: '$kDatabase/documents/$kCommitCollectionId/${commit.sha}',
+      fields: <String, Value>{
+        kCommitAvatarField: Value(stringValue: commit.authorAvatarUrl),
+        kCommitBranchField: Value(stringValue: commit.branch),
+        kCommitCreateTimestampField: Value(integerValue: commit.timestamp.toString()),
+        kCommitAuthorField: Value(stringValue: commit.author),
+        kCommitMessageField: Value(stringValue: commit.message),
+        kCommitRepositoryPathField: Value(stringValue: commit.repository),
+        kCommitShaField: Value(stringValue: commit.sha),
+      },
+    ),
+  );
 }

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -7,6 +7,15 @@ import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
 
 import '../../service/firestore.dart';
+import '../appengine/github_gold_status_update.dart';
+
+const String kGithubGoldStatusCollectionId = 'githubGoldStatuses';
+const String kGithubGoldStatusPrNumberField = 'prNumber';
+const String kGithubGoldStatusHeadField = 'head';
+const String kGithubGoldStatusStatusField = 'status';
+const String kGithubGoldStatusDescriptionField = 'description';
+const String kGithubGoldStatusUpdatesField = 'updates';
+const String kGithubGoldStatusRepositoryField = 'repository';
 
 class GithubGoldStatus extends Document {
   /// Lookup [GithubGoldStatus] from Firestore.
@@ -70,4 +79,21 @@ class GithubGoldStatus extends Document {
       ..write(')');
     return buf.toString();
   }
+}
+
+/// Generates GithubGoldStatus document based on datastore GithubGoldStatusUpdate data model.
+GithubGoldStatus githubGoldStatusToDocument(GithubGoldStatusUpdate githubGoldStatus) {
+  return GithubGoldStatus.fromDocument(
+    githubGoldStatus: Document(
+      name: '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatus.head}_${githubGoldStatus.pr}',
+      fields: <String, Value>{
+        kGithubGoldStatusDescriptionField: Value(stringValue: githubGoldStatus.description),
+        kGithubGoldStatusHeadField: Value(stringValue: githubGoldStatus.head),
+        kGithubGoldStatusPrNumberField: Value(integerValue: githubGoldStatus.pr.toString()),
+        kGithubGoldStatusRepositoryField: Value(stringValue: githubGoldStatus.repository),
+        kGithubGoldStatusStatusField: Value(stringValue: githubGoldStatus.status),
+        kGithubGoldStatusUpdatesField: Value(integerValue: githubGoldStatus.updates.toString()),
+      },
+    ),
+  );
 }

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -285,7 +285,7 @@ List<Task> targetsToTaskDocuments(Commit commit, List<Target> targets) {
 }
 
 /// Generates task document based on datastore task data model.
-Task taskToTaskDocument(datastore.Task task) {
+Task taskToDocument(datastore.Task task) {
   final String commitSha = task.commitKey!.id!.split('/').last;
   return Task.fromDocument(
     taskDocument: Document(

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -8,7 +8,23 @@ import 'package:googleapis/firestore/v1.dart' hide Status;
 import '../../request_handling/exceptions.dart';
 import '../../service/firestore.dart';
 import '../../service/logging.dart';
+import '../appengine/commit.dart';
+import '../appengine/task.dart' as datastore;
+import '../ci_yaml/target.dart';
 import '../luci/push_message.dart';
+
+const String kTaskCollectionId = 'tasks';
+const int kTaskDefaultTimestampValue = 0;
+const int kTaskInitialAttempt = 1;
+const String kTaskBringupField = 'bringup';
+const String kTaskBuildNumberField = 'buildNumber';
+const String kTaskCommitShaField = 'commitSha';
+const String kTaskCreateTimestampField = 'createTimestamp';
+const String kTaskEndTimestampField = 'endTimestamp';
+const String kTaskNameField = 'name';
+const String kTaskStartTimestampField = 'startTimestamp';
+const String kTaskStatusField = 'status';
+const String kTaskTestFlakyField = 'testFlaky';
 
 class Task extends Document {
   /// Lookup [Task] from Firestore.
@@ -244,4 +260,46 @@ class Task extends Document {
       ..write(')');
     return buf.toString();
   }
+}
+
+/// Generates task documents based on targets.
+List<Task> targetsToTaskDocuments(Commit commit, List<Target> targets) {
+  final Iterable<Task> iterableDocuments = targets.map(
+    (Target target) => Task.fromDocument(
+      taskDocument: Document(
+        name: '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${target.value.name}_$kTaskInitialAttempt',
+        fields: <String, Value>{
+          kTaskCreateTimestampField: Value(integerValue: commit.timestamp!.toString()),
+          kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
+          kTaskBringupField: Value(booleanValue: target.value.bringup),
+          kTaskNameField: Value(stringValue: target.value.name),
+          kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
+          kTaskStatusField: Value(stringValue: Task.statusNew),
+          kTaskTestFlakyField: Value(booleanValue: false),
+          kTaskCommitShaField: Value(stringValue: commit.sha),
+        },
+      ),
+    ),
+  );
+  return iterableDocuments.toList();
+}
+
+/// Generates task document based on datastore task data model.
+Task taskToTaskDocument(datastore.Task task) {
+  final String commitSha = task.commitKey!.id!.split('/').last;
+  return Task.fromDocument(
+    taskDocument: Document(
+      name: '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}',
+      fields: <String, Value>{
+        kTaskCreateTimestampField: Value(integerValue: task.createTimestamp.toString()),
+        kTaskEndTimestampField: Value(integerValue: task.endTimestamp.toString()),
+        kTaskBringupField: Value(booleanValue: task.isFlaky),
+        kTaskNameField: Value(stringValue: task.name),
+        kTaskStartTimestampField: Value(integerValue: task.startTimestamp.toString()),
+        kTaskStatusField: Value(stringValue: task.status),
+        kTaskTestFlakyField: Value(booleanValue: task.isTestFlaky),
+        kTaskCommitShaField: Value(stringValue: commitSha),
+      },
+    ),
+  );
 }

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -104,7 +104,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     await datastore.insert(<Task>[taskToInsert]);
     try {
       final FirestoreService firestoreService = await config.createFirestoreService();
-      final firestore.Task taskDocument = firestore.taskToTaskDocument(taskToInsert);
+      final firestore.Task taskDocument = firestore.taskToDocument(taskToInsert);
       final List<Write> writes = documentsToWrites([taskDocument]);
       await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
     } catch (error) {

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -104,7 +104,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     await datastore.insert(<Task>[taskToInsert]);
     try {
       final FirestoreService firestoreService = await config.createFirestoreService();
-      final firestore.Task taskDocument = taskToTaskDocument(taskToInsert);
+      final firestore.Task taskDocument = firestore.taskToTaskDocument(taskToInsert);
       final List<Write> writes = documentsToWrites([taskDocument]);
       await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
     } catch (error) {

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -146,7 +146,8 @@ class ResetProdTask extends ApiRequestHandler<Body> {
 
     firestore.Task? taskDocument;
     final int currentAttempt = task.attempts!;
-    final String documentName = '$kDatabase/documents/$kTaskCollectionId/${sha}_${taskName}_$currentAttempt';
+    final String documentName =
+        '$kDatabase/documents/${firestore.kTaskCollectionId}/${sha}_${taskName}_$currentAttempt';
     try {
       taskDocument = await firestore.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
     } catch (error) {

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -120,7 +120,7 @@ class BatchBackfiller extends RequestHandler {
     if (tasks.isEmpty) {
       return;
     }
-    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToTaskDocument(e)).toList();
+    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToDocument(e)).toList();
     final List<Write> writes = documentsToWrites(taskDocuments, exists: true);
     final FirestoreService firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -120,7 +120,7 @@ class BatchBackfiller extends RequestHandler {
     if (tasks.isEmpty) {
       return;
     }
-    final List<firestore.Task> taskDocuments = tasks.map((e) => taskToTaskDocument(e)).toList();
+    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToTaskDocument(e)).toList();
     final List<Write> writes = documentsToWrites(taskDocuments, exists: true);
     final FirestoreService firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -74,7 +74,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
     if (tasks.isEmpty) {
       return;
     }
-    final List<firestore.Task> taskDocuments = tasks.map((e) => taskToTaskDocument(e)).toList();
+    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToTaskDocument(e)).toList();
     final List<Write> writes = documentsToWrites(taskDocuments, exists: true);
     final FirestoreService firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -74,7 +74,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
     if (tasks.isEmpty) {
       return;
     }
-    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToTaskDocument(e)).toList();
+    final List<firestore.Task> taskDocuments = tasks.map((e) => firestore.taskToDocument(e)).toList();
     final List<Write> writes = documentsToWrites(taskDocuments, exists: true);
     final FirestoreService firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -94,7 +94,7 @@ class CommitService {
       log.info('Commit does not exist in datastore, inserting into datastore');
       await datastore.insert(<Commit>[commit]);
       try {
-        final firestore.Commit commitDocument = commitToCommitDocument(commit);
+        final firestore.Commit commitDocument = firestore.commitToCommitDocument(commit);
         final List<Write> writes = documentsToWrites([commitDocument], exists: false);
         await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
       } catch (error) {

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -70,7 +70,7 @@ class FirestoreService {
   Future<List<firestore.Task>> queryCommitTasks(String commitSha) async {
     final ProjectsDatabasesDocumentsResource databasesDocumentsResource = await documentResource();
     final List<CollectionSelector> from = <CollectionSelector>[
-      CollectionSelector(collectionId: firestore.kTaskCollectionId)
+      CollectionSelector(collectionId: firestore.kTaskCollectionId),
     ];
     final Filter filter = Filter(
       fieldFilter: FieldFilter(

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -8,49 +8,13 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:http/http.dart';
 
-import '../model/appengine/commit.dart';
-import '../model/appengine/github_gold_status_update.dart';
-import '../model/appengine/task.dart';
-import '../model/firestore/commit.dart' as firestore_comit;
-import '../model/firestore/github_gold_status.dart';
 import '../model/firestore/task.dart' as firestore;
-import '../model/ci_yaml/target.dart';
 import 'access_client_provider.dart';
 import 'config.dart';
 
 const String kDatabase = 'projects/${Config.flutterGcpProjectId}/databases/${Config.flutterGcpFirestoreDatabase}';
 const String kDocumentParent = '$kDatabase/documents';
 const String kFieldFilterOpEqual = 'EQUAL';
-
-const String kTaskCollectionId = 'tasks';
-const int kTaskDefaultTimestampValue = 0;
-const int kTaskInitialAttempt = 1;
-const String kTaskBringupField = 'bringup';
-const String kTaskBuildNumberField = 'buildNumber';
-const String kTaskCommitShaField = 'commitSha';
-const String kTaskCreateTimestampField = 'createTimestamp';
-const String kTaskEndTimestampField = 'endTimestamp';
-const String kTaskNameField = 'name';
-const String kTaskStartTimestampField = 'startTimestamp';
-const String kTaskStatusField = 'status';
-const String kTaskTestFlakyField = 'testFlaky';
-
-const String kCommitCollectionId = 'commits';
-const String kCommitAvatarField = 'avatar';
-const String kCommitBranchField = 'branch';
-const String kCommitCreateTimestampField = 'createTimestamp';
-const String kCommitAuthorField = 'author';
-const String kCommitMessageField = 'message';
-const String kCommitRepositoryPathField = 'repositoryPath';
-const String kCommitShaField = 'sha';
-
-const String kGithubGoldStatusCollectionId = 'githubGoldStatuses';
-const String kGithubGoldStatusPrNumberField = 'prNumber';
-const String kGithubGoldStatusHeadField = 'head';
-const String kGithubGoldStatusStatusField = 'status';
-const String kGithubGoldStatusDescriptionField = 'description';
-const String kGithubGoldStatusUpdatesField = 'updates';
-const String kGithubGoldStatusRepositoryField = 'repository';
 
 class FirestoreService {
   const FirestoreService(this.accessClientProvider);
@@ -105,10 +69,12 @@ class FirestoreService {
 
   Future<List<firestore.Task>> queryCommitTasks(String commitSha) async {
     final ProjectsDatabasesDocumentsResource databasesDocumentsResource = await documentResource();
-    final List<CollectionSelector> from = <CollectionSelector>[CollectionSelector(collectionId: kTaskCollectionId)];
+    final List<CollectionSelector> from = <CollectionSelector>[
+      CollectionSelector(collectionId: firestore.kTaskCollectionId)
+    ];
     final Filter filter = Filter(
       fieldFilter: FieldFilter(
-        field: FieldReference(fieldPath: kTaskCommitShaField),
+        field: FieldReference(fieldPath: firestore.kTaskCommitShaField),
         op: kFieldFilterOpEqual,
         value: Value(stringValue: commitSha),
       ),
@@ -120,83 +86,6 @@ class FirestoreService {
     final List<Document> documents = runQueryResponseElements.map((e) => e.document!).toList();
     return documents.map((Document document) => firestore.Task.fromDocument(taskDocument: document)).toList();
   }
-}
-
-/// Generates task documents based on targets.
-List<firestore.Task> targetsToTaskDocuments(Commit commit, List<Target> targets) {
-  final Iterable<firestore.Task> iterableDocuments = targets.map(
-    (Target target) => firestore.Task.fromDocument(
-      taskDocument: Document(
-        name: '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${target.value.name}_$kTaskInitialAttempt',
-        fields: <String, Value>{
-          kTaskCreateTimestampField: Value(integerValue: commit.timestamp!.toString()),
-          kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
-          kTaskBringupField: Value(booleanValue: target.value.bringup),
-          kTaskNameField: Value(stringValue: target.value.name),
-          kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
-          kTaskStatusField: Value(stringValue: Task.statusNew),
-          kTaskTestFlakyField: Value(booleanValue: false),
-          kTaskCommitShaField: Value(stringValue: commit.sha),
-        },
-      ),
-    ),
-  );
-  return iterableDocuments.toList();
-}
-
-/// Generates commit document based on datastore commit data model.
-firestore_comit.Commit commitToCommitDocument(Commit commit) {
-  return firestore_comit.Commit.fromDocument(
-    commitDocument: Document(
-      name: '$kDatabase/documents/$kCommitCollectionId/${commit.sha}',
-      fields: <String, Value>{
-        kCommitAvatarField: Value(stringValue: commit.authorAvatarUrl),
-        kCommitBranchField: Value(stringValue: commit.branch),
-        kCommitCreateTimestampField: Value(integerValue: commit.timestamp.toString()),
-        kCommitAuthorField: Value(stringValue: commit.author),
-        kCommitMessageField: Value(stringValue: commit.message),
-        kCommitRepositoryPathField: Value(stringValue: commit.repository),
-        kCommitShaField: Value(stringValue: commit.sha),
-      },
-    ),
-  );
-}
-
-/// Generates task document based on datastore task data model.
-firestore.Task taskToTaskDocument(Task task) {
-  final String commitSha = task.commitKey!.id!.split('/').last;
-  return firestore.Task.fromDocument(
-    taskDocument: Document(
-      name: '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}',
-      fields: <String, Value>{
-        kTaskCreateTimestampField: Value(integerValue: task.createTimestamp.toString()),
-        kTaskEndTimestampField: Value(integerValue: task.endTimestamp.toString()),
-        kTaskBringupField: Value(booleanValue: task.isFlaky),
-        kTaskNameField: Value(stringValue: task.name),
-        kTaskStartTimestampField: Value(integerValue: task.startTimestamp.toString()),
-        kTaskStatusField: Value(stringValue: task.status),
-        kTaskTestFlakyField: Value(booleanValue: task.isTestFlaky),
-        kTaskCommitShaField: Value(stringValue: commitSha),
-      },
-    ),
-  );
-}
-
-/// Generates GithubGoldStatus document based on datastore GithubGoldStatusUpdate data model.
-GithubGoldStatus githubGoldStatusToDocument(GithubGoldStatusUpdate githubGoldStatus) {
-  return GithubGoldStatus.fromDocument(
-    githubGoldStatus: Document(
-      name: '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatus.head}_${githubGoldStatus.pr}',
-      fields: <String, Value>{
-        kGithubGoldStatusDescriptionField: Value(stringValue: githubGoldStatus.description),
-        kGithubGoldStatusHeadField: Value(stringValue: githubGoldStatus.head),
-        kGithubGoldStatusPrNumberField: Value(integerValue: githubGoldStatus.pr.toString()),
-        kGithubGoldStatusRepositoryField: Value(stringValue: githubGoldStatus.repository),
-        kGithubGoldStatusStatusField: Value(stringValue: githubGoldStatus.status),
-        kGithubGoldStatusUpdatesField: Value(integerValue: githubGoldStatus.updates.toString()),
-      },
-    ),
-  );
 }
 
 /// Creates a list of [Write] based on documents.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -167,8 +167,8 @@ class Scheduler {
 
     await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
-    final firestore_commmit.Commit commitDocument = commitToCommitDocument(commit);
-    final List<firestore.Task> taskDocuments = targetsToTaskDocuments(commit, initialTargets);
+    final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
+    final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
     final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
     final FirestoreService firestoreService = await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.

--- a/app_dart/test/model/firestore/commit_test.dart
+++ b/app_dart/test/model/firestore/commit_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/model/appengine/commit.dart' as datastore;
 import 'package:cocoon_service/src/model/firestore/commit.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -35,5 +37,18 @@ void main() {
       expect(resultedCommit.name, commit.name);
       expect(resultedCommit.fields, commit.fields);
     });
+  });
+
+  test('creates commit document correctly from commit data model', () async {
+    final datastore.Commit commit = generateCommit(1);
+    final Commit commitDocument = commitToCommitDocument(commit);
+    expect(commitDocument.name, '$kDatabase/documents/$kCommitCollectionId/${commit.sha}');
+    expect(commitDocument.fields![kCommitAvatarField]!.stringValue, commit.authorAvatarUrl);
+    expect(commitDocument.fields![kCommitBranchField]!.stringValue, commit.branch);
+    expect(commitDocument.fields![kCommitCreateTimestampField]!.integerValue, commit.timestamp.toString());
+    expect(commitDocument.fields![kCommitAuthorField]!.stringValue, commit.author);
+    expect(commitDocument.fields![kCommitMessageField]!.stringValue, commit.message);
+    expect(commitDocument.fields![kCommitRepositoryPathField]!.stringValue, commit.repository);
+    expect(commitDocument.fields![kCommitShaField]!.stringValue, commit.sha);
   });
 }

--- a/app_dart/test/model/firestore/github_gold_status_test.dart
+++ b/app_dart/test/model/firestore/github_gold_status_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart';
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -35,5 +37,30 @@ void main() {
       expect(resultedGithubGoldStatus.name, githubGoldStatus.name);
       expect(resultedGithubGoldStatus.fields, githubGoldStatus.fields);
     });
+  });
+
+  test('creates github gold status document correctly from data model', () async {
+    final GithubGoldStatusUpdate githubGoldStatusUpdate = GithubGoldStatusUpdate(
+      head: 'sha',
+      pr: 1,
+      status: GithubGoldStatusUpdate.statusCompleted,
+      updates: 2,
+      description: '',
+      repository: '',
+    );
+    final GithubGoldStatus commitDocument = githubGoldStatusToDocument(githubGoldStatusUpdate);
+    expect(
+      commitDocument.name,
+      '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatusUpdate.head}_${githubGoldStatusUpdate.pr}',
+    );
+    expect(commitDocument.fields![kGithubGoldStatusHeadField]!.stringValue, githubGoldStatusUpdate.head);
+    expect(commitDocument.fields![kGithubGoldStatusPrNumberField]!.integerValue, githubGoldStatusUpdate.pr.toString());
+    expect(commitDocument.fields![kGithubGoldStatusStatusField]!.stringValue, githubGoldStatusUpdate.status);
+    expect(
+      commitDocument.fields![kGithubGoldStatusUpdatesField]!.integerValue,
+      githubGoldStatusUpdate.updates.toString(),
+    );
+    expect(commitDocument.fields![kGithubGoldStatusDescriptionField]!.stringValue, '');
+    expect(commitDocument.fields![kGithubGoldStatusRepositoryField]!.stringValue, '');
   });
 }

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/appengine/task.dart' as datastore;
+import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as pm;
+import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -16,6 +20,43 @@ void main() {
     test('disallows illegal status', () {
       final Task task = Task();
       expect(() => task.setStatus('unknown'), throwsArgumentError);
+    });
+
+    test('creates task document correctly from task data model', () async {
+      final datastore.Task task = generateTask(1);
+      final String commitSha = task.commitKey!.id!.split('/').last;
+      final Task taskDocument = taskToTaskDocument(task);
+      expect(taskDocument.name, '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}');
+      expect(taskDocument.createTimestamp, task.createTimestamp);
+      expect(taskDocument.endTimestamp, task.endTimestamp);
+      expect(taskDocument.bringup, task.isFlaky);
+      expect(taskDocument.taskName, task.name);
+      expect(taskDocument.startTimestamp, task.startTimestamp);
+      expect(taskDocument.status, task.status);
+      expect(taskDocument.testFlaky, task.isTestFlaky);
+      expect(taskDocument.commitSha, commitSha);
+    });
+
+    test('creates task documents correctly from targets', () async {
+      final Commit commit = generateCommit(1);
+      final List<Target> targets = <Target>[
+        generateTarget(1, platform: 'Mac'),
+        generateTarget(2, platform: 'Linux'),
+      ];
+      final List<Task> taskDocuments = targetsToTaskDocuments(commit, targets);
+      expect(taskDocuments.length, 2);
+      expect(
+        taskDocuments[0].name,
+        '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${targets[0].value.name}_$kTaskInitialAttempt',
+      );
+      expect(taskDocuments[0].fields![kTaskCreateTimestampField]!.integerValue, commit.timestamp.toString());
+      expect(taskDocuments[0].fields![kTaskEndTimestampField]!.integerValue, '0');
+      expect(taskDocuments[0].fields![kTaskBringupField]!.booleanValue, false);
+      expect(taskDocuments[0].fields![kTaskNameField]!.stringValue, targets[0].value.name);
+      expect(taskDocuments[0].fields![kTaskStartTimestampField]!.integerValue, '0');
+      expect(taskDocuments[0].fields![kTaskStatusField]!.stringValue, Task.statusNew);
+      expect(taskDocuments[0].fields![kTaskTestFlakyField]!.booleanValue, false);
+      expect(taskDocuments[0].fields![kTaskCommitShaField]!.stringValue, commit.sha);
     });
 
     group('updateFromBuild', () {

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('creates task document correctly from task data model', () async {
       final datastore.Task task = generateTask(1);
       final String commitSha = task.commitKey!.id!.split('/').last;
-      final Task taskDocument = taskToTaskDocument(task);
+      final Task taskDocument = taskToDocument(task);
       expect(taskDocument.name, '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}');
       expect(taskDocument.createTimestamp, task.createTimestamp);
       expect(taskDocument.endTimestamp, task.endTimestamp);

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -100,7 +100,8 @@ void main() {
       final List<dynamic> captured = verify(mockFirestoreService.getDocument(captureAny)).captured;
       expect(captured.length, 1);
       final String documentName = captured[0] as String;
-      expect(documentName, '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${task.name}_${task.attempts}');
+      expect(documentName,
+          '$kDatabase/documents/${firestore.kTaskCollectionId}/${commit.sha}_${task.name}_${task.attempts}');
     });
 
     test('Re-schedule existing task', () async {

--- a/app_dart/test/request_handlers/reset_prod_task_test.dart
+++ b/app_dart/test/request_handlers/reset_prod_task_test.dart
@@ -100,8 +100,10 @@ void main() {
       final List<dynamic> captured = verify(mockFirestoreService.getDocument(captureAny)).captured;
       expect(captured.length, 1);
       final String documentName = captured[0] as String;
-      expect(documentName,
-          '$kDatabase/documents/${firestore.kTaskCollectionId}/${commit.sha}_${task.name}_${task.attempts}');
+      expect(
+        documentName,
+        '$kDatabase/documents/${firestore.kTaskCollectionId}/${commit.sha}_${task.name}_${task.attempts}',
+      );
     });
 
     test('Re-schedule existing task', () async {

--- a/app_dart/test/service/commit_service_test.dart
+++ b/app_dart/test/service/commit_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore;
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
@@ -99,7 +100,7 @@ void main() {
       final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
       expect(batchWriteRequest.writes!.length, 1);
       final Document insertedCommitDocument = batchWriteRequest.writes![0].update!;
-      expect(insertedCommitDocument.name, '$kDatabase/documents/$kCommitCollectionId/$sha');
+      expect(insertedCommitDocument.name, '$kDatabase/documents/${firestore.kCommitCollectionId}/$sha');
     });
 
     test('does not add commit to db if it exists in the datastore', () async {

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -2,96 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/model/appengine/commit.dart';
-import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart';
-import 'package:cocoon_service/src/model/appengine/task.dart';
-import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commmit;
-import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
-import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
-import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 
 import 'package:googleapis/firestore/v1.dart';
 import 'package:test/test.dart';
 
-import '../src/utilities/entity_generators.dart';
-
 void main() {
-  test('creates task documents correctly from targets', () async {
-    final Commit commit = generateCommit(1);
-    final List<Target> targets = <Target>[
-      generateTarget(1, platform: 'Mac'),
-      generateTarget(2, platform: 'Linux'),
-    ];
-    final List<firestore.Task> taskDocuments = targetsToTaskDocuments(commit, targets);
-    expect(taskDocuments.length, 2);
-    expect(
-      taskDocuments[0].name,
-      '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${targets[0].value.name}_$kTaskInitialAttempt',
-    );
-    expect(taskDocuments[0].fields![kTaskCreateTimestampField]!.integerValue, commit.timestamp.toString());
-    expect(taskDocuments[0].fields![kTaskEndTimestampField]!.integerValue, '0');
-    expect(taskDocuments[0].fields![kTaskBringupField]!.booleanValue, false);
-    expect(taskDocuments[0].fields![kTaskNameField]!.stringValue, targets[0].value.name);
-    expect(taskDocuments[0].fields![kTaskStartTimestampField]!.integerValue, '0');
-    expect(taskDocuments[0].fields![kTaskStatusField]!.stringValue, Task.statusNew);
-    expect(taskDocuments[0].fields![kTaskTestFlakyField]!.booleanValue, false);
-    expect(taskDocuments[0].fields![kTaskCommitShaField]!.stringValue, commit.sha);
-  });
-
-  test('creates commit document correctly from commit data model', () async {
-    final Commit commit = generateCommit(1);
-    final firestore_commmit.Commit commitDocument = commitToCommitDocument(commit);
-    expect(commitDocument.name, '$kDatabase/documents/$kCommitCollectionId/${commit.sha}');
-    expect(commitDocument.fields![kCommitAvatarField]!.stringValue, commit.authorAvatarUrl);
-    expect(commitDocument.fields![kCommitBranchField]!.stringValue, commit.branch);
-    expect(commitDocument.fields![kCommitCreateTimestampField]!.integerValue, commit.timestamp.toString());
-    expect(commitDocument.fields![kCommitAuthorField]!.stringValue, commit.author);
-    expect(commitDocument.fields![kCommitMessageField]!.stringValue, commit.message);
-    expect(commitDocument.fields![kCommitRepositoryPathField]!.stringValue, commit.repository);
-    expect(commitDocument.fields![kCommitShaField]!.stringValue, commit.sha);
-  });
-
-  test('creates github gold status document correctly from data model', () async {
-    final GithubGoldStatusUpdate githubGoldStatusUpdate = GithubGoldStatusUpdate(
-      head: 'sha',
-      pr: 1,
-      status: GithubGoldStatusUpdate.statusCompleted,
-      updates: 2,
-      description: '',
-      repository: '',
-    );
-    final GithubGoldStatus commitDocument = githubGoldStatusToDocument(githubGoldStatusUpdate);
-    expect(
-      commitDocument.name,
-      '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatusUpdate.head}_${githubGoldStatusUpdate.pr}',
-    );
-    expect(commitDocument.fields![kGithubGoldStatusHeadField]!.stringValue, githubGoldStatusUpdate.head);
-    expect(commitDocument.fields![kGithubGoldStatusPrNumberField]!.integerValue, githubGoldStatusUpdate.pr.toString());
-    expect(commitDocument.fields![kGithubGoldStatusStatusField]!.stringValue, githubGoldStatusUpdate.status);
-    expect(
-      commitDocument.fields![kGithubGoldStatusUpdatesField]!.integerValue,
-      githubGoldStatusUpdate.updates.toString(),
-    );
-    expect(commitDocument.fields![kGithubGoldStatusDescriptionField]!.stringValue, '');
-    expect(commitDocument.fields![kGithubGoldStatusRepositoryField]!.stringValue, '');
-  });
-
-  test('creates task document correctly from task data model', () async {
-    final Task task = generateTask(1);
-    final String commitSha = task.commitKey!.id!.split('/').last;
-    final firestore.Task taskDocument = taskToTaskDocument(task);
-    expect(taskDocument.name, '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}');
-    expect(taskDocument.createTimestamp, task.createTimestamp);
-    expect(taskDocument.endTimestamp, task.endTimestamp);
-    expect(taskDocument.bringup, task.isFlaky);
-    expect(taskDocument.taskName, task.name);
-    expect(taskDocument.startTimestamp, task.startTimestamp);
-    expect(taskDocument.status, task.status);
-    expect(taskDocument.testFlaky, task.isTestFlaky);
-    expect(taskDocument.commitSha, commitSha);
-  });
-
   test('creates writes correctly from documents', () async {
     final List<Document> documents = <Document>[
       Document(name: 'd1', fields: <String, Value>{'key1': Value(stringValue: 'value1')}),

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/ci_yaml.dart';
-import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commit;
@@ -15,7 +14,6 @@ import 'package:cocoon_service/src/model/gerrit/commit.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/luci/push_message.dart' as push_message;
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
-import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:gcloud/db.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
 import 'package:github/github.dart' as github;
@@ -119,17 +117,17 @@ firestore.Task generateFirestoreTask(
   final firestore.Task task = firestore.Task()
     ..name = '${sha}_${taskName}_$attempts'
     ..fields = <String, Value>{
-      kTaskCreateTimestampField: Value(integerValue: (created?.millisecondsSinceEpoch ?? 0).toString()),
-      kTaskStartTimestampField: Value(integerValue: (started?.millisecondsSinceEpoch ?? 0).toString()),
-      kTaskEndTimestampField: Value(integerValue: (ended?.millisecondsSinceEpoch ?? 0).toString()),
-      kTaskBringupField: Value(booleanValue: bringup),
-      kTaskTestFlakyField: Value(booleanValue: testFlaky),
-      kTaskStatusField: Value(stringValue: status),
-      kTaskNameField: Value(stringValue: taskName),
-      kTaskCommitShaField: Value(stringValue: sha),
+      firestore.kTaskCreateTimestampField: Value(integerValue: (created?.millisecondsSinceEpoch ?? 0).toString()),
+      firestore.kTaskStartTimestampField: Value(integerValue: (started?.millisecondsSinceEpoch ?? 0).toString()),
+      firestore.kTaskEndTimestampField: Value(integerValue: (ended?.millisecondsSinceEpoch ?? 0).toString()),
+      firestore.kTaskBringupField: Value(booleanValue: bringup),
+      firestore.kTaskTestFlakyField: Value(booleanValue: testFlaky),
+      firestore.kTaskStatusField: Value(stringValue: status),
+      firestore.kTaskNameField: Value(stringValue: taskName),
+      firestore.kTaskCommitShaField: Value(stringValue: sha),
     };
   if (buildNumber != null) {
-    task.fields![kTaskBuildNumberField] = Value(integerValue: buildNumber.toString());
+    task.fields![firestore.kTaskBuildNumberField] = Value(integerValue: buildNumber.toString());
   }
   return task;
 }
@@ -145,10 +143,10 @@ firestore_commit.Commit generateFirestoreCommit(
   final firestore_commit.Commit commit = firestore_commit.Commit()
     ..name = sha ?? '$i'
     ..fields = <String, Value>{
-      kCommitCreateTimestampField: Value(integerValue: (createTimestamp ?? i).toString()),
-      kCommitRepositoryPathField: Value(stringValue: '$owner/$repo'),
-      kCommitBranchField: Value(stringValue: branch),
-      kCommitShaField: Value(stringValue: sha ?? '$i'),
+      firestore_commit.kCommitCreateTimestampField: Value(integerValue: (createTimestamp ?? i).toString()),
+      firestore_commit.kCommitRepositoryPathField: Value(stringValue: '$owner/$repo'),
+      firestore_commit.kCommitBranchField: Value(stringValue: branch),
+      firestore_commit.kCommitShaField: Value(stringValue: sha ?? '$i'),
     };
   return commit;
 }


### PR DESCRIPTION
This PR doesn't add new functionalities, but refactor logics to closer to data models.

1) moves task `variables` and `functions` from `firestore.dart` to `firestore/task.dart`.
2) moves commit `variables` and `functions` from `firestore.dart` to `firestore/commit.dart`.
3) moves github gold status `variables` and `functions` from `firestore.dart` to `firestore/github_gold_status.dart`.
4) updates related reference points from other places.