### PR TITLE
Use repository and prNumber as goldstatusstatus document name

### DIFF
--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -83,6 +83,7 @@ class GithubGoldStatus extends Document {
 
 /// Generates GithubGoldStatus document based on datastore GithubGoldStatusUpdate data model.
 GithubGoldStatus githubGoldStatusToDocument(GithubGoldStatusUpdate githubGoldStatus) {
+  // Prefers `_` instead of `/` in Firestore document names.
   final String repo = githubGoldStatus.repository!.replaceAll('/', '_');
   return GithubGoldStatus.fromDocument(
     githubGoldStatus: Document(

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -83,9 +83,10 @@ class GithubGoldStatus extends Document {
 
 /// Generates GithubGoldStatus document based on datastore GithubGoldStatusUpdate data model.
 GithubGoldStatus githubGoldStatusToDocument(GithubGoldStatusUpdate githubGoldStatus) {
+  final String repo = githubGoldStatus.repository!.replaceAll('/', '_');
   return GithubGoldStatus.fromDocument(
     githubGoldStatus: Document(
-      name: '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatus.head}_${githubGoldStatus.pr}',
+      name: '$kDatabase/documents/$kGithubGoldStatusCollectionId/${repo}_${githubGoldStatus.pr}',
       fields: <String, Value>{
         kGithubGoldStatusDescriptionField: Value(stringValue: githubGoldStatus.description),
         kGithubGoldStatusHeadField: Value(stringValue: githubGoldStatus.head),

--- a/app_dart/test/model/firestore/github_gold_status_test.dart
+++ b/app_dart/test/model/firestore/github_gold_status_test.dart
@@ -46,12 +46,12 @@ void main() {
       status: GithubGoldStatusUpdate.statusCompleted,
       updates: 2,
       description: '',
-      repository: '',
+      repository: 'flutter/flutter',
     );
     final GithubGoldStatus commitDocument = githubGoldStatusToDocument(githubGoldStatusUpdate);
     expect(
       commitDocument.name,
-      '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatusUpdate.head}_${githubGoldStatusUpdate.pr}',
+      '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatusUpdate.repository!.replaceAll('/', '_')}_${githubGoldStatusUpdate.pr}',
     );
     expect(commitDocument.fields![kGithubGoldStatusHeadField]!.stringValue, githubGoldStatusUpdate.head);
     expect(commitDocument.fields![kGithubGoldStatusPrNumberField]!.integerValue, githubGoldStatusUpdate.pr.toString());
@@ -60,7 +60,7 @@ void main() {
       commitDocument.fields![kGithubGoldStatusUpdatesField]!.integerValue,
       githubGoldStatusUpdate.updates.toString(),
     );
-    expect(commitDocument.fields![kGithubGoldStatusDescriptionField]!.stringValue, '');
-    expect(commitDocument.fields![kGithubGoldStatusRepositoryField]!.stringValue, '');
+    expect(commitDocument.fields![kGithubGoldStatusDescriptionField]!.stringValue, githubGoldStatusUpdate.description);
+    expect(commitDocument.fields![kGithubGoldStatusRepositoryField]!.stringValue, githubGoldStatusUpdate.repository);
   });
 }


### PR DESCRIPTION
This is to make it consistent with old datastore logic: for each pr of a repo, we keep a single record.

Namely, this PR replaces the following entries into a single one.
![Screenshot 2024-03-06 at 10 30 36 AM](https://github.com/flutter/cocoon/assets/54558023/ab5c0d13-b5e7-407d-a66f-77e7cc27f7f2)
