### PR TITLE
Add a wrapper for Firestore query to simplify logics

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -8,13 +8,18 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:http/http.dart';
 
-import '../model/firestore/task.dart' as firestore;
+import '../model/firestore/task.dart';
 import 'access_client_provider.dart';
 import 'config.dart';
 
 const String kDatabase = 'projects/${Config.flutterGcpProjectId}/databases/${Config.flutterGcpFirestoreDatabase}';
 const String kDocumentParent = '$kDatabase/documents';
 const String kFieldFilterOpEqual = 'EQUAL';
+const String kCompositeFilterOpAnd = 'AND';
+
+const Map<String, String> kRelationMapping = <String, String>{
+  '=': 'EQUAL',
+};
 
 class FirestoreService {
   const FirestoreService(this.accessClientProvider);
@@ -67,24 +72,88 @@ class FirestoreService {
     return databasesDocumentsResource.commit(commitRequest, kDatabase);
   }
 
-  Future<List<firestore.Task>> queryCommitTasks(String commitSha) async {
+  /// Returns all tasks running against the speificed [commitSha].
+  Future<List<Task>> queryCommitTasks(String commitSha) async {
+    final Map<String, Object> filterMap = <String, Object>{
+      '$kTaskCommitShaField = ': commitSha,
+    };
+    final List<Document> documents = await query(kTaskCollectionId, filterMap);
+    return documents.map((Document document) => Task.fromDocument(taskDocument: document)).toList();
+  }
+
+  /// Returns Firestore [Value] based on corresponding object type.
+  Value getValueFromFilter(Object comparisonOject) {
+    if (comparisonOject is int) {
+      return Value(integerValue: comparisonOject.toString());
+    } else if (comparisonOject is bool) {
+      return Value(booleanValue: comparisonOject);
+    }
+    return Value(stringValue: comparisonOject as String);
+  }
+
+  /// Generates Firestore query filter based on "human" read conditions.
+  Filter generateFilter(Map<String, Object> filterMap, String compositeFilterOp) {
+    final List<Filter> filters = <Filter>[];
+    filterMap.forEach((filterString, comparisonOject) {
+      final List<String> parts = filterString.split(' ');
+      if (parts.length != 2 || !kRelationMapping.containsKey(parts[1])) {
+        throw ArgumentError("Invalid filter string '$filterString'.");
+      }
+      final String name = parts[0];
+      final String comparison = kRelationMapping[parts[1]]!;
+      final Value value = getValueFromFilter(comparisonOject);
+
+      filters.add(
+        Filter(
+          fieldFilter: FieldFilter(
+            field: FieldReference(fieldPath: name),
+            op: comparison,
+            value: value,
+          ),
+        ),
+      );
+    });
+    Filter? finalFilter;
+    if (filters.length == 1) {
+      finalFilter = filters.single;
+    } else {
+      finalFilter = Filter(
+        compositeFilter: CompositeFilter(
+          filters: filters,
+          op: compositeFilterOp,
+        ),
+      );
+    }
+    return finalFilter;
+  }
+
+  /// Wrapper to simplify Firestore query.
+  ///
+  /// The [filterMap] follows format:
+  ///   {
+  ///     'fieldInt =': 1,
+  ///     'fieldString =': 'string',
+  ///     'fieldBool =': true,
+  ///   }
+  /// Note
+  ///   1. the space in the key, which will be used to retrieve the field name and operator.
+  ///   2. the value could be any type, like int, string, bool, etc.
+  Future<List<Document>> query(
+    String collectionId,
+    Map<String, Object> filterMap, {
+    String compositeFilterOp = kCompositeFilterOpAnd,
+  }) async {
     final ProjectsDatabasesDocumentsResource databasesDocumentsResource = await documentResource();
     final List<CollectionSelector> from = <CollectionSelector>[
-      CollectionSelector(collectionId: firestore.kTaskCollectionId),
+      CollectionSelector(collectionId: collectionId),
     ];
-    final Filter filter = Filter(
-      fieldFilter: FieldFilter(
-        field: FieldReference(fieldPath: firestore.kTaskCommitShaField),
-        op: kFieldFilterOpEqual,
-        value: Value(stringValue: commitSha),
-      ),
-    );
+    final Filter filter = generateFilter(filterMap, compositeFilterOp);
     final RunQueryRequest runQueryRequest =
         RunQueryRequest(structuredQuery: StructuredQuery(from: from, where: filter));
     final List<RunQueryResponseElement> runQueryResponseElements =
         await databasesDocumentsResource.runQuery(runQueryRequest, kDocumentParent);
     final List<Document> documents = runQueryResponseElements.map((e) => e.document!).toList();
-    return documents.map((Document document) => firestore.Task.fromDocument(taskDocument: document)).toList();
+    return documents;
   }
 }
 

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/service/access_client_provider.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 
 import 'package:googleapis/firestore/v1.dart';
@@ -17,5 +18,58 @@ void main() {
     expect(writes.length, documents.length);
     expect(writes[0].update, documents[0]);
     expect(writes[0].currentDocument!.exists, false);
+  });
+
+  group('getValueFromFilter', () {
+    final FirestoreService firestoreService = FirestoreService(AccessClientProvider());
+    test('int object', () async {
+      const Object intValue = 1;
+      expect(firestoreService.getValueFromFilter(intValue).integerValue, '1');
+    });
+
+    test('string object', () async {
+      const Object stringValue = 'string';
+      expect(firestoreService.getValueFromFilter(stringValue).stringValue, 'string');
+    });
+
+    test('bool object', () async {
+      const Object boolValue = true;
+      expect(firestoreService.getValueFromFilter(boolValue).booleanValue, true);
+    });
+  });
+
+  group('generateFilter', () {
+    final FirestoreService firestoreService = FirestoreService(AccessClientProvider());
+    test('a field filter', () async {
+      final Map<String, Object> filterMap = <String, Object>{
+        'intField =': 1,
+      };
+      const String compositeFilterOp = kCompositeFilterOpAnd;
+      final Filter filter = firestoreService.generateFilter(filterMap, compositeFilterOp);
+      expect(filter.fieldFilter, isNotNull);
+      expect(filter.compositeFilter, isNull);
+      expect(filter.fieldFilter!.field!.fieldPath, 'intField');
+      expect(filter.fieldFilter!.value!.integerValue, '1');
+      expect(filter.fieldFilter!.op, kFieldFilterOpEqual);
+    });
+
+    test('a composite filter', () async {
+      final Map<String, Object> filterMap = <String, Object>{
+        'intField =': 1,
+        'stringField =': 'string',
+      };
+      const String compositeFilterOp = kCompositeFilterOpAnd;
+      final Filter filter = firestoreService.generateFilter(filterMap, compositeFilterOp);
+      expect(filter.fieldFilter, isNull);
+      expect(filter.compositeFilter, isNotNull);
+      final List<Filter> filters = filter.compositeFilter!.filters!;
+      expect(filters.length, 2);
+      expect(filters[0].fieldFilter!.field!.fieldPath, 'intField');
+      expect(filters[0].fieldFilter!.value!.integerValue, '1');
+      expect(filters[0].fieldFilter!.op, kFieldFilterOpEqual);
+      expect(filters[1].fieldFilter!.field!.fieldPath, 'stringField');
+      expect(filters[1].fieldFilter!.value!.stringValue, 'string');
+      expect(filters[1].fieldFilter!.op, kFieldFilterOpEqual);
+    });
   });
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -342,8 +342,8 @@ class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitRespons
         );
 }
 
-class _FakeIssue_28 extends _i1.SmartFake implements _i13.Issue {
-  _FakeIssue_28(
+class _FakeValue_28 extends _i1.SmartFake implements _i21.Value {
+  _FakeValue_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -352,8 +352,8 @@ class _FakeIssue_28 extends _i1.SmartFake implements _i13.Issue {
         );
 }
 
-class _FakeIssueComment_29 extends _i1.SmartFake implements _i13.IssueComment {
-  _FakeIssueComment_29(
+class _FakeFilter_29 extends _i1.SmartFake implements _i21.Filter {
+  _FakeFilter_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +362,8 @@ class _FakeIssueComment_29 extends _i1.SmartFake implements _i13.IssueComment {
         );
 }
 
-class _FakeIssueLabel_30 extends _i1.SmartFake implements _i13.IssueLabel {
-  _FakeIssueLabel_30(
+class _FakeIssue_30 extends _i1.SmartFake implements _i13.Issue {
+  _FakeIssue_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,8 +372,8 @@ class _FakeIssueLabel_30 extends _i1.SmartFake implements _i13.IssueLabel {
         );
 }
 
-class _FakeMilestone_31 extends _i1.SmartFake implements _i13.Milestone {
-  _FakeMilestone_31(
+class _FakeIssueComment_31 extends _i1.SmartFake implements _i13.IssueComment {
+  _FakeIssueComment_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -382,8 +382,8 @@ class _FakeMilestone_31 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_32 extends _i1.SmartFake implements _i22.GithubChecksUtil {
-  _FakeGithubChecksUtil_32(
+class _FakeIssueLabel_32 extends _i1.SmartFake implements _i13.IssueLabel {
+  _FakeIssueLabel_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -392,8 +392,8 @@ class _FakeGithubChecksUtil_32 extends _i1.SmartFake implements _i22.GithubCheck
         );
 }
 
-class _FakeCheckRunConclusion_33 extends _i1.SmartFake implements _i13.CheckRunConclusion {
-  _FakeCheckRunConclusion_33(
+class _FakeMilestone_33 extends _i1.SmartFake implements _i13.Milestone {
+  _FakeMilestone_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,8 +402,8 @@ class _FakeCheckRunConclusion_33 extends _i1.SmartFake implements _i13.CheckRunC
         );
 }
 
-class _FakeCheckRunStatus_34 extends _i1.SmartFake implements _i13.CheckRunStatus {
-  _FakeCheckRunStatus_34(
+class _FakeGithubChecksUtil_34 extends _i1.SmartFake implements _i22.GithubChecksUtil {
+  _FakeGithubChecksUtil_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,8 +412,8 @@ class _FakeCheckRunStatus_34 extends _i1.SmartFake implements _i13.CheckRunStatu
         );
 }
 
-class _FakeCheckSuite_35 extends _i1.SmartFake implements _i13.CheckSuite {
-  _FakeCheckSuite_35(
+class _FakeCheckRunConclusion_35 extends _i1.SmartFake implements _i13.CheckRunConclusion {
+  _FakeCheckRunConclusion_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +422,8 @@ class _FakeCheckSuite_35 extends _i1.SmartFake implements _i13.CheckSuite {
         );
 }
 
-class _FakeCheckRun_36 extends _i1.SmartFake implements _i13.CheckRun {
-  _FakeCheckRun_36(
+class _FakeCheckRunStatus_36 extends _i1.SmartFake implements _i13.CheckRunStatus {
+  _FakeCheckRunStatus_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,8 +432,8 @@ class _FakeCheckRun_36 extends _i1.SmartFake implements _i13.CheckRun {
         );
 }
 
-class _FakePullRequest_37 extends _i1.SmartFake implements _i13.PullRequest {
-  _FakePullRequest_37(
+class _FakeCheckSuite_37 extends _i1.SmartFake implements _i13.CheckSuite {
+  _FakeCheckSuite_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -442,8 +442,8 @@ class _FakePullRequest_37 extends _i1.SmartFake implements _i13.PullRequest {
         );
 }
 
-class _FakeGitReference_38 extends _i1.SmartFake implements _i13.GitReference {
-  _FakeGitReference_38(
+class _FakeCheckRun_38 extends _i1.SmartFake implements _i13.CheckRun {
+  _FakeCheckRun_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,8 +452,8 @@ class _FakeGitReference_38 extends _i1.SmartFake implements _i13.GitReference {
         );
 }
 
-class _FakeRateLimit_39 extends _i1.SmartFake implements _i13.RateLimit {
-  _FakeRateLimit_39(
+class _FakePullRequest_39 extends _i1.SmartFake implements _i13.PullRequest {
+  _FakePullRequest_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,8 +462,8 @@ class _FakeRateLimit_39 extends _i1.SmartFake implements _i13.RateLimit {
         );
 }
 
-class _FakeGitBlob_40 extends _i1.SmartFake implements _i13.GitBlob {
-  _FakeGitBlob_40(
+class _FakeGitReference_40 extends _i1.SmartFake implements _i13.GitReference {
+  _FakeGitReference_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -472,8 +472,8 @@ class _FakeGitBlob_40 extends _i1.SmartFake implements _i13.GitBlob {
         );
 }
 
-class _FakeGitCommit_41 extends _i1.SmartFake implements _i13.GitCommit {
-  _FakeGitCommit_41(
+class _FakeRateLimit_41 extends _i1.SmartFake implements _i13.RateLimit {
+  _FakeRateLimit_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -482,8 +482,8 @@ class _FakeGitCommit_41 extends _i1.SmartFake implements _i13.GitCommit {
         );
 }
 
-class _FakeGitTag_42 extends _i1.SmartFake implements _i13.GitTag {
-  _FakeGitTag_42(
+class _FakeGitBlob_42 extends _i1.SmartFake implements _i13.GitBlob {
+  _FakeGitBlob_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,8 +492,8 @@ class _FakeGitTag_42 extends _i1.SmartFake implements _i13.GitTag {
         );
 }
 
-class _FakeGitTree_43 extends _i1.SmartFake implements _i13.GitTree {
-  _FakeGitTree_43(
+class _FakeGitCommit_43 extends _i1.SmartFake implements _i13.GitCommit {
+  _FakeGitCommit_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,8 +502,8 @@ class _FakeGitTree_43 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_44 extends _i1.SmartFake implements _i14.DefaultPolicies {
-  _FakeDefaultPolicies_44(
+class _FakeGitTag_44 extends _i1.SmartFake implements _i13.GitTag {
+  _FakeGitTag_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -512,8 +512,8 @@ class _FakeDefaultPolicies_44 extends _i1.SmartFake implements _i14.DefaultPolic
         );
 }
 
-class _FakeLink_45 extends _i1.SmartFake implements _i14.Link {
-  _FakeLink_45(
+class _FakeGitTree_45 extends _i1.SmartFake implements _i13.GitTree {
+  _FakeGitTree_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,8 +522,8 @@ class _FakeLink_45 extends _i1.SmartFake implements _i14.Link {
         );
 }
 
-class _FakeGraphQLCache_46 extends _i1.SmartFake implements _i14.GraphQLCache {
-  _FakeGraphQLCache_46(
+class _FakeDefaultPolicies_46 extends _i1.SmartFake implements _i14.DefaultPolicies {
+  _FakeDefaultPolicies_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -532,8 +532,8 @@ class _FakeGraphQLCache_46 extends _i1.SmartFake implements _i14.GraphQLCache {
         );
 }
 
-class _FakeQueryManager_47 extends _i1.SmartFake implements _i14.QueryManager {
-  _FakeQueryManager_47(
+class _FakeLink_47 extends _i1.SmartFake implements _i14.Link {
+  _FakeLink_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,8 +542,8 @@ class _FakeQueryManager_47 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
-  _FakeObservableQuery_48(
+class _FakeGraphQLCache_48 extends _i1.SmartFake implements _i14.GraphQLCache {
+  _FakeGraphQLCache_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,8 +552,8 @@ class _FakeObservableQuery_48<TParsed1> extends _i1.SmartFake implements _i14.Ob
         );
 }
 
-class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
-  _FakeQueryResult_49(
+class _FakeQueryManager_49 extends _i1.SmartFake implements _i14.QueryManager {
+  _FakeQueryManager_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -562,8 +562,8 @@ class _FakeQueryResult_49<TParsed1 extends Object?> extends _i1.SmartFake implem
         );
 }
 
-class _FakeHttpClientRequest_50 extends _i1.SmartFake implements _i23.HttpClientRequest {
-  _FakeHttpClientRequest_50(
+class _FakeObservableQuery_50<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
+  _FakeObservableQuery_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +572,8 @@ class _FakeHttpClientRequest_50 extends _i1.SmartFake implements _i23.HttpClient
         );
 }
 
-class _FakeUri_51 extends _i1.SmartFake implements Uri {
-  _FakeUri_51(
+class _FakeQueryResult_51<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
+  _FakeQueryResult_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,8 +582,8 @@ class _FakeUri_51 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeHttpHeaders_52 extends _i1.SmartFake implements _i23.HttpHeaders {
-  _FakeHttpHeaders_52(
+class _FakeHttpClientRequest_52 extends _i1.SmartFake implements _i23.HttpClientRequest {
+  _FakeHttpClientRequest_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,8 +592,8 @@ class _FakeHttpHeaders_52 extends _i1.SmartFake implements _i23.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_53 extends _i1.SmartFake implements _i23.HttpClientResponse {
-  _FakeHttpClientResponse_53(
+class _FakeUri_53 extends _i1.SmartFake implements Uri {
+  _FakeUri_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +602,8 @@ class _FakeHttpClientResponse_53 extends _i1.SmartFake implements _i23.HttpClien
         );
 }
 
-class _FakeEncoding_54 extends _i1.SmartFake implements _i24.Encoding {
-  _FakeEncoding_54(
+class _FakeHttpHeaders_54 extends _i1.SmartFake implements _i23.HttpHeaders {
+  _FakeHttpHeaders_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +612,8 @@ class _FakeEncoding_54 extends _i1.SmartFake implements _i24.Encoding {
         );
 }
 
-class _FakeSocket_55 extends _i1.SmartFake implements _i23.Socket {
-  _FakeSocket_55(
+class _FakeHttpClientResponse_55 extends _i1.SmartFake implements _i23.HttpClientResponse {
+  _FakeHttpClientResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +622,8 @@ class _FakeSocket_55 extends _i1.SmartFake implements _i23.Socket {
         );
 }
 
-class _FakeStreamSubscription_56<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
-  _FakeStreamSubscription_56(
+class _FakeEncoding_56 extends _i1.SmartFake implements _i24.Encoding {
+  _FakeEncoding_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,8 +632,8 @@ class _FakeStreamSubscription_56<T> extends _i1.SmartFake implements _i20.Stream
         );
 }
 
-class _FakeJobCancelResponse_57 extends _i1.SmartFake implements _i6.JobCancelResponse {
-  _FakeJobCancelResponse_57(
+class _FakeSocket_57 extends _i1.SmartFake implements _i23.Socket {
+  _FakeSocket_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -642,8 +642,8 @@ class _FakeJobCancelResponse_57 extends _i1.SmartFake implements _i6.JobCancelRe
         );
 }
 
-class _FakeJob_58 extends _i1.SmartFake implements _i6.Job {
-  _FakeJob_58(
+class _FakeStreamSubscription_58<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
+  _FakeStreamSubscription_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,8 +652,8 @@ class _FakeJob_58 extends _i1.SmartFake implements _i6.Job {
         );
 }
 
-class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
-  _FakeGetQueryResultsResponse_59(
+class _FakeJobCancelResponse_59 extends _i1.SmartFake implements _i6.JobCancelResponse {
+  _FakeJobCancelResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -662,8 +662,8 @@ class _FakeGetQueryResultsResponse_59 extends _i1.SmartFake implements _i6.GetQu
         );
 }
 
-class _FakeJobList_60 extends _i1.SmartFake implements _i6.JobList {
-  _FakeJobList_60(
+class _FakeJob_60 extends _i1.SmartFake implements _i6.Job {
+  _FakeJob_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,8 +672,8 @@ class _FakeJobList_60 extends _i1.SmartFake implements _i6.JobList {
         );
 }
 
-class _FakeQueryResponse_61 extends _i1.SmartFake implements _i6.QueryResponse {
-  _FakeQueryResponse_61(
+class _FakeGetQueryResultsResponse_61 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
+  _FakeGetQueryResultsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -682,8 +682,8 @@ class _FakeQueryResponse_61 extends _i1.SmartFake implements _i6.QueryResponse {
         );
 }
 
-class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
-  _FakeBuildBucketClient_62(
+class _FakeJobList_62 extends _i1.SmartFake implements _i6.JobList {
+  _FakeJobList_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,8 +692,8 @@ class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucke
         );
 }
 
-class _FakeCacheService_63 extends _i1.SmartFake implements _i15.CacheService {
-  _FakeCacheService_63(
+class _FakeQueryResponse_63 extends _i1.SmartFake implements _i6.QueryResponse {
+  _FakeQueryResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -702,8 +702,8 @@ class _FakeCacheService_63 extends _i1.SmartFake implements _i15.CacheService {
         );
 }
 
-class _FakePubSub_64 extends _i1.SmartFake implements _i15.PubSub {
-  _FakePubSub_64(
+class _FakeBuildBucketClient_64 extends _i1.SmartFake implements _i15.BuildBucketClient {
+  _FakeBuildBucketClient_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -712,8 +712,8 @@ class _FakePubSub_64 extends _i1.SmartFake implements _i15.PubSub {
         );
 }
 
-class _FakeProcess_65 extends _i1.SmartFake implements _i23.Process {
-  _FakeProcess_65(
+class _FakeCacheService_65 extends _i1.SmartFake implements _i15.CacheService {
+  _FakeCacheService_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,8 +722,8 @@ class _FakeProcess_65 extends _i1.SmartFake implements _i23.Process {
         );
 }
 
-class _FakePullRequestMerge_66 extends _i1.SmartFake implements _i13.PullRequestMerge {
-  _FakePullRequestMerge_66(
+class _FakePubSub_66 extends _i1.SmartFake implements _i15.PubSub {
+  _FakePubSub_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +732,8 @@ class _FakePullRequestMerge_66 extends _i1.SmartFake implements _i13.PullRequest
         );
 }
 
-class _FakePullRequestComment_67 extends _i1.SmartFake implements _i13.PullRequestComment {
-  _FakePullRequestComment_67(
+class _FakeProcess_67 extends _i1.SmartFake implements _i23.Process {
+  _FakeProcess_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +742,8 @@ class _FakePullRequestComment_67 extends _i1.SmartFake implements _i13.PullReque
         );
 }
 
-class _FakePullRequestReview_68 extends _i1.SmartFake implements _i13.PullRequestReview {
-  _FakePullRequestReview_68(
+class _FakePullRequestMerge_68 extends _i1.SmartFake implements _i13.PullRequestMerge {
+  _FakePullRequestMerge_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +752,8 @@ class _FakePullRequestReview_68 extends _i1.SmartFake implements _i13.PullReques
         );
 }
 
-class _FakeRepository_69 extends _i1.SmartFake implements _i13.Repository {
-  _FakeRepository_69(
+class _FakePullRequestComment_69 extends _i1.SmartFake implements _i13.PullRequestComment {
+  _FakePullRequestComment_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,8 +762,8 @@ class _FakeRepository_69 extends _i1.SmartFake implements _i13.Repository {
         );
 }
 
-class _FakeLicenseDetails_70 extends _i1.SmartFake implements _i13.LicenseDetails {
-  _FakeLicenseDetails_70(
+class _FakePullRequestReview_70 extends _i1.SmartFake implements _i13.PullRequestReview {
+  _FakePullRequestReview_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -772,8 +772,8 @@ class _FakeLicenseDetails_70 extends _i1.SmartFake implements _i13.LicenseDetail
         );
 }
 
-class _FakeLanguageBreakdown_71 extends _i1.SmartFake implements _i13.LanguageBreakdown {
-  _FakeLanguageBreakdown_71(
+class _FakeRepository_71 extends _i1.SmartFake implements _i13.Repository {
+  _FakeRepository_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -782,8 +782,8 @@ class _FakeLanguageBreakdown_71 extends _i1.SmartFake implements _i13.LanguageBr
         );
 }
 
-class _FakeBranch_72 extends _i1.SmartFake implements _i13.Branch {
-  _FakeBranch_72(
+class _FakeLicenseDetails_72 extends _i1.SmartFake implements _i13.LicenseDetails {
+  _FakeLicenseDetails_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -792,8 +792,8 @@ class _FakeBranch_72 extends _i1.SmartFake implements _i13.Branch {
         );
 }
 
-class _FakeCommitComment_73 extends _i1.SmartFake implements _i13.CommitComment {
-  _FakeCommitComment_73(
+class _FakeLanguageBreakdown_73 extends _i1.SmartFake implements _i13.LanguageBreakdown {
+  _FakeLanguageBreakdown_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +802,8 @@ class _FakeCommitComment_73 extends _i1.SmartFake implements _i13.CommitComment 
         );
 }
 
-class _FakeRepositoryCommit_74 extends _i1.SmartFake implements _i13.RepositoryCommit {
-  _FakeRepositoryCommit_74(
+class _FakeBranch_74 extends _i1.SmartFake implements _i13.Branch {
+  _FakeBranch_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +812,8 @@ class _FakeRepositoryCommit_74 extends _i1.SmartFake implements _i13.RepositoryC
         );
 }
 
-class _FakeGitHubComparison_75 extends _i1.SmartFake implements _i13.GitHubComparison {
-  _FakeGitHubComparison_75(
+class _FakeCommitComment_75 extends _i1.SmartFake implements _i13.CommitComment {
+  _FakeCommitComment_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,8 +822,8 @@ class _FakeGitHubComparison_75 extends _i1.SmartFake implements _i13.GitHubCompa
         );
 }
 
-class _FakeGitHubFile_76 extends _i1.SmartFake implements _i13.GitHubFile {
-  _FakeGitHubFile_76(
+class _FakeRepositoryCommit_76 extends _i1.SmartFake implements _i13.RepositoryCommit {
+  _FakeRepositoryCommit_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +832,8 @@ class _FakeGitHubFile_76 extends _i1.SmartFake implements _i13.GitHubFile {
         );
 }
 
-class _FakeRepositoryContents_77 extends _i1.SmartFake implements _i13.RepositoryContents {
-  _FakeRepositoryContents_77(
+class _FakeGitHubComparison_77 extends _i1.SmartFake implements _i13.GitHubComparison {
+  _FakeGitHubComparison_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +842,8 @@ class _FakeRepositoryContents_77 extends _i1.SmartFake implements _i13.Repositor
         );
 }
 
-class _FakeContentCreation_78 extends _i1.SmartFake implements _i13.ContentCreation {
-  _FakeContentCreation_78(
+class _FakeGitHubFile_78 extends _i1.SmartFake implements _i13.GitHubFile {
+  _FakeGitHubFile_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +852,8 @@ class _FakeContentCreation_78 extends _i1.SmartFake implements _i13.ContentCreat
         );
 }
 
-class _FakeHook_79 extends _i1.SmartFake implements _i13.Hook {
-  _FakeHook_79(
+class _FakeRepositoryContents_79 extends _i1.SmartFake implements _i13.RepositoryContents {
+  _FakeRepositoryContents_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +862,8 @@ class _FakeHook_79 extends _i1.SmartFake implements _i13.Hook {
         );
 }
 
-class _FakePublicKey_80 extends _i1.SmartFake implements _i13.PublicKey {
-  _FakePublicKey_80(
+class _FakeContentCreation_80 extends _i1.SmartFake implements _i13.ContentCreation {
+  _FakeContentCreation_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +872,8 @@ class _FakePublicKey_80 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeRepositoryPages_81 extends _i1.SmartFake implements _i13.RepositoryPages {
-  _FakeRepositoryPages_81(
+class _FakeHook_81 extends _i1.SmartFake implements _i13.Hook {
+  _FakeHook_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +882,8 @@ class _FakeRepositoryPages_81 extends _i1.SmartFake implements _i13.RepositoryPa
         );
 }
 
-class _FakePageBuild_82 extends _i1.SmartFake implements _i13.PageBuild {
-  _FakePageBuild_82(
+class _FakePublicKey_82 extends _i1.SmartFake implements _i13.PublicKey {
+  _FakePublicKey_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +892,8 @@ class _FakePageBuild_82 extends _i1.SmartFake implements _i13.PageBuild {
         );
 }
 
-class _FakeRelease_83 extends _i1.SmartFake implements _i13.Release {
-  _FakeRelease_83(
+class _FakeRepositoryPages_83 extends _i1.SmartFake implements _i13.RepositoryPages {
+  _FakeRepositoryPages_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +902,8 @@ class _FakeRelease_83 extends _i1.SmartFake implements _i13.Release {
         );
 }
 
-class _FakeReleaseAsset_84 extends _i1.SmartFake implements _i13.ReleaseAsset {
-  _FakeReleaseAsset_84(
+class _FakePageBuild_84 extends _i1.SmartFake implements _i13.PageBuild {
+  _FakePageBuild_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +912,8 @@ class _FakeReleaseAsset_84 extends _i1.SmartFake implements _i13.ReleaseAsset {
         );
 }
 
-class _FakeContributorParticipation_85 extends _i1.SmartFake implements _i13.ContributorParticipation {
-  _FakeContributorParticipation_85(
+class _FakeRelease_85 extends _i1.SmartFake implements _i13.Release {
+  _FakeRelease_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,8 +922,8 @@ class _FakeContributorParticipation_85 extends _i1.SmartFake implements _i13.Con
         );
 }
 
-class _FakeRepositoryStatus_86 extends _i1.SmartFake implements _i13.RepositoryStatus {
-  _FakeRepositoryStatus_86(
+class _FakeReleaseAsset_86 extends _i1.SmartFake implements _i13.ReleaseAsset {
+  _FakeReleaseAsset_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -932,8 +932,8 @@ class _FakeRepositoryStatus_86 extends _i1.SmartFake implements _i13.RepositoryS
         );
 }
 
-class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
-  _FakeCombinedRepositoryStatus_87(
+class _FakeContributorParticipation_87 extends _i1.SmartFake implements _i13.ContributorParticipation {
+  _FakeContributorParticipation_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -942,8 +942,8 @@ class _FakeCombinedRepositoryStatus_87 extends _i1.SmartFake implements _i13.Com
         );
 }
 
-class _FakeReleaseNotes_88 extends _i1.SmartFake implements _i13.ReleaseNotes {
-  _FakeReleaseNotes_88(
+class _FakeRepositoryStatus_88 extends _i1.SmartFake implements _i13.RepositoryStatus {
+  _FakeRepositoryStatus_88(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -952,8 +952,8 @@ class _FakeReleaseNotes_88 extends _i1.SmartFake implements _i13.ReleaseNotes {
         );
 }
 
-class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
-  _FakeTableDataInsertAllResponse_89(
+class _FakeCombinedRepositoryStatus_89 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
+  _FakeCombinedRepositoryStatus_89(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -962,8 +962,8 @@ class _FakeTableDataInsertAllResponse_89 extends _i1.SmartFake implements _i6.Ta
         );
 }
 
-class _FakeTableDataList_90 extends _i1.SmartFake implements _i6.TableDataList {
-  _FakeTableDataList_90(
+class _FakeReleaseNotes_90 extends _i1.SmartFake implements _i13.ReleaseNotes {
+  _FakeReleaseNotes_90(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -972,8 +972,8 @@ class _FakeTableDataList_90 extends _i1.SmartFake implements _i6.TableDataList {
         );
 }
 
-class _FakeUser_91 extends _i1.SmartFake implements _i13.User {
-  _FakeUser_91(
+class _FakeTableDataInsertAllResponse_91 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
+  _FakeTableDataInsertAllResponse_91(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -982,8 +982,8 @@ class _FakeUser_91 extends _i1.SmartFake implements _i13.User {
         );
 }
 
-class _FakeCurrentUser_92 extends _i1.SmartFake implements _i13.CurrentUser {
-  _FakeCurrentUser_92(
+class _FakeTableDataList_92 extends _i1.SmartFake implements _i6.TableDataList {
+  _FakeTableDataList_92(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -992,8 +992,8 @@ class _FakeCurrentUser_92 extends _i1.SmartFake implements _i13.CurrentUser {
         );
 }
 
-class _FakeEntry_93<T> extends _i1.SmartFake implements _i25.Entry<T> {
-  _FakeEntry_93(
+class _FakeUser_93 extends _i1.SmartFake implements _i13.User {
+  _FakeUser_93(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1002,8 +1002,8 @@ class _FakeEntry_93<T> extends _i1.SmartFake implements _i25.Entry<T> {
         );
 }
 
-class _FakeCache_94<T> extends _i1.SmartFake implements _i25.Cache<T> {
-  _FakeCache_94(
+class _FakeCurrentUser_94 extends _i1.SmartFake implements _i13.CurrentUser {
+  _FakeCurrentUser_94(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1012,8 +1012,8 @@ class _FakeCache_94<T> extends _i1.SmartFake implements _i25.Cache<T> {
         );
 }
 
-class _FakeAuthentication_95 extends _i1.SmartFake implements _i13.Authentication {
-  _FakeAuthentication_95(
+class _FakeEntry_95<T> extends _i1.SmartFake implements _i25.Entry<T> {
+  _FakeEntry_95(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1022,8 +1022,8 @@ class _FakeAuthentication_95 extends _i1.SmartFake implements _i13.Authenticatio
         );
 }
 
-class _FakeActivityService_96 extends _i1.SmartFake implements _i13.ActivityService {
-  _FakeActivityService_96(
+class _FakeCache_96<T> extends _i1.SmartFake implements _i25.Cache<T> {
+  _FakeCache_96(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1032,8 +1032,8 @@ class _FakeActivityService_96 extends _i1.SmartFake implements _i13.ActivityServ
         );
 }
 
-class _FakeAuthorizationsService_97 extends _i1.SmartFake implements _i13.AuthorizationsService {
-  _FakeAuthorizationsService_97(
+class _FakeAuthentication_97 extends _i1.SmartFake implements _i13.Authentication {
+  _FakeAuthentication_97(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1042,8 +1042,8 @@ class _FakeAuthorizationsService_97 extends _i1.SmartFake implements _i13.Author
         );
 }
 
-class _FakeGistsService_98 extends _i1.SmartFake implements _i13.GistsService {
-  _FakeGistsService_98(
+class _FakeActivityService_98 extends _i1.SmartFake implements _i13.ActivityService {
+  _FakeActivityService_98(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1052,8 +1052,8 @@ class _FakeGistsService_98 extends _i1.SmartFake implements _i13.GistsService {
         );
 }
 
-class _FakeGitService_99 extends _i1.SmartFake implements _i13.GitService {
-  _FakeGitService_99(
+class _FakeAuthorizationsService_99 extends _i1.SmartFake implements _i13.AuthorizationsService {
+  _FakeAuthorizationsService_99(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1062,8 +1062,8 @@ class _FakeGitService_99 extends _i1.SmartFake implements _i13.GitService {
         );
 }
 
-class _FakeIssuesService_100 extends _i1.SmartFake implements _i13.IssuesService {
-  _FakeIssuesService_100(
+class _FakeGistsService_100 extends _i1.SmartFake implements _i13.GistsService {
+  _FakeGistsService_100(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1072,8 +1072,8 @@ class _FakeIssuesService_100 extends _i1.SmartFake implements _i13.IssuesService
         );
 }
 
-class _FakeMiscService_101 extends _i1.SmartFake implements _i13.MiscService {
-  _FakeMiscService_101(
+class _FakeGitService_101 extends _i1.SmartFake implements _i13.GitService {
+  _FakeGitService_101(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1082,8 +1082,8 @@ class _FakeMiscService_101 extends _i1.SmartFake implements _i13.MiscService {
         );
 }
 
-class _FakeOrganizationsService_102 extends _i1.SmartFake implements _i13.OrganizationsService {
-  _FakeOrganizationsService_102(
+class _FakeIssuesService_102 extends _i1.SmartFake implements _i13.IssuesService {
+  _FakeIssuesService_102(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1092,8 +1092,8 @@ class _FakeOrganizationsService_102 extends _i1.SmartFake implements _i13.Organi
         );
 }
 
-class _FakePullRequestsService_103 extends _i1.SmartFake implements _i13.PullRequestsService {
-  _FakePullRequestsService_103(
+class _FakeMiscService_103 extends _i1.SmartFake implements _i13.MiscService {
+  _FakeMiscService_103(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1102,8 +1102,8 @@ class _FakePullRequestsService_103 extends _i1.SmartFake implements _i13.PullReq
         );
 }
 
-class _FakeRepositoriesService_104 extends _i1.SmartFake implements _i13.RepositoriesService {
-  _FakeRepositoriesService_104(
+class _FakeOrganizationsService_104 extends _i1.SmartFake implements _i13.OrganizationsService {
+  _FakeOrganizationsService_104(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1112,8 +1112,8 @@ class _FakeRepositoriesService_104 extends _i1.SmartFake implements _i13.Reposit
         );
 }
 
-class _FakeSearchService_105 extends _i1.SmartFake implements _i13.SearchService {
-  _FakeSearchService_105(
+class _FakePullRequestsService_105 extends _i1.SmartFake implements _i13.PullRequestsService {
+  _FakePullRequestsService_105(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1122,8 +1122,8 @@ class _FakeSearchService_105 extends _i1.SmartFake implements _i13.SearchService
         );
 }
 
-class _FakeUrlShortenerService_106 extends _i1.SmartFake implements _i13.UrlShortenerService {
-  _FakeUrlShortenerService_106(
+class _FakeRepositoriesService_106 extends _i1.SmartFake implements _i13.RepositoriesService {
+  _FakeRepositoriesService_106(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1132,8 +1132,8 @@ class _FakeUrlShortenerService_106 extends _i1.SmartFake implements _i13.UrlShor
         );
 }
 
-class _FakeUsersService_107 extends _i1.SmartFake implements _i13.UsersService {
-  _FakeUsersService_107(
+class _FakeSearchService_107 extends _i1.SmartFake implements _i13.SearchService {
+  _FakeSearchService_107(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1142,8 +1142,8 @@ class _FakeUsersService_107 extends _i1.SmartFake implements _i13.UsersService {
         );
 }
 
-class _FakeChecksService_108 extends _i1.SmartFake implements _i13.ChecksService {
-  _FakeChecksService_108(
+class _FakeUrlShortenerService_108 extends _i1.SmartFake implements _i13.UrlShortenerService {
+  _FakeUrlShortenerService_108(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1152,8 +1152,28 @@ class _FakeChecksService_108 extends _i1.SmartFake implements _i13.ChecksService
         );
 }
 
-class _FakeResponse_109 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_109(
+class _FakeUsersService_109 extends _i1.SmartFake implements _i13.UsersService {
+  _FakeUsersService_109(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeChecksService_110 extends _i1.SmartFake implements _i13.ChecksService {
+  _FakeChecksService_110(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeResponse_111 extends _i1.SmartFake implements _i2.Response {
+  _FakeResponse_111(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -2600,6 +2620,64 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
         ),
         returnValue: _i20.Future<List<_i37.Task>>.value(<_i37.Task>[]),
       ) as _i20.Future<List<_i37.Task>>);
+
+  @override
+  _i21.Value getValueFromFilter(Object? comparisonOject) => (super.noSuchMethod(
+        Invocation.method(
+          #getValueFromFilter,
+          [comparisonOject],
+        ),
+        returnValue: _FakeValue_28(
+          this,
+          Invocation.method(
+            #getValueFromFilter,
+            [comparisonOject],
+          ),
+        ),
+      ) as _i21.Value);
+
+  @override
+  _i21.Filter generateFilter(
+    Map<String, Object>? filterMap,
+    String? compositeFilterOp,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #generateFilter,
+          [
+            filterMap,
+            compositeFilterOp,
+          ],
+        ),
+        returnValue: _FakeFilter_29(
+          this,
+          Invocation.method(
+            #generateFilter,
+            [
+              filterMap,
+              compositeFilterOp,
+            ],
+          ),
+        ),
+      ) as _i21.Filter);
+
+  @override
+  _i20.Future<List<_i21.Document>> query(
+    String? collectionId,
+    Map<String, Object>? filterMap, {
+    String? compositeFilterOp = r'AND',
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #query,
+          [
+            collectionId,
+            filterMap,
+          ],
+          {#compositeFilterOp: compositeFilterOp},
+        ),
+        returnValue: _i20.Future<List<_i21.Document>>.value(<_i21.Document>[]),
+      ) as _i20.Future<List<_i21.Document>>);
 }
 
 /// A class which mocks [IssuesService].
@@ -2762,7 +2840,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_28(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
           this,
           Invocation.method(
             #edit,
@@ -2788,7 +2866,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issueNumber,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_28(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
           this,
           Invocation.method(
             #get,
@@ -2813,7 +2891,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_28(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
           this,
           Invocation.method(
             #create,
@@ -2888,7 +2966,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_29(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
           this,
           Invocation.method(
             #getComment,
@@ -2915,7 +2993,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_29(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
           this,
           Invocation.method(
             #createComment,
@@ -2943,7 +3021,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_29(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
           this,
           Invocation.method(
             #updateComment,
@@ -2994,7 +3072,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             name,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_30(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
           this,
           Invocation.method(
             #getLabel,
@@ -3025,7 +3103,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_30(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
           this,
           Invocation.method(
             #createLabel,
@@ -3056,7 +3134,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             color,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_30(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
           this,
           Invocation.method(
             #editLabel,
@@ -3090,7 +3168,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_30(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
           this,
           Invocation.method(
             #updateLabel,
@@ -3231,7 +3309,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_31(
+        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_33(
           this,
           Invocation.method(
             #createMilestone,
@@ -3341,7 +3419,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
   @override
   _i22.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_32(
+        returnValue: _FakeGithubChecksUtil_34(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
@@ -3434,7 +3512,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
           #conclusionForResult,
           [result],
         ),
-        returnValue: _FakeCheckRunConclusion_33(
+        returnValue: _FakeCheckRunConclusion_35(
           this,
           Invocation.method(
             #conclusionForResult,
@@ -3449,7 +3527,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
           #statusForResult,
           [status],
         ),
-        returnValue: _FakeCheckRunStatus_34(
+        returnValue: _FakeCheckRunStatus_36(
           this,
           Invocation.method(
             #statusForResult,
@@ -3516,7 +3594,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             checkSuiteId,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_35(
+        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_37(
           this,
           Invocation.method(
             #getCheckSuite,
@@ -3597,7 +3675,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_36(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_38(
           this,
           Invocation.method(
             #getCheckRun,
@@ -3629,7 +3707,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
           ],
           {#output: output},
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_36(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_38(
           this,
           Invocation.method(
             #createCheckRun,
@@ -3717,7 +3795,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #entries: entries,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_37(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
           this,
           Invocation.method(
             #createPullRequest,
@@ -3853,7 +3931,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #assignee: assignee,
           },
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_28(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
           this,
           Invocation.method(
             #createIssue,
@@ -3954,7 +4032,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_38(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
           this,
           Invocation.method(
             #getReference,
@@ -3972,7 +4050,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
           #getRateLimit,
           [],
         ),
-        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_39(
+        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_41(
           this,
           Invocation.method(
             #getRateLimit,
@@ -4016,7 +4094,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_37(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
           this,
           Invocation.method(
             #getPullRequest,
@@ -4059,7 +4137,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_40(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_42(
           this,
           Invocation.method(
             #getBlob,
@@ -4084,7 +4162,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             blob,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_40(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_42(
           this,
           Invocation.method(
             #createBlob,
@@ -4109,7 +4187,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_41(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_43(
           this,
           Invocation.method(
             #getCommit,
@@ -4134,7 +4212,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             commit,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_41(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_43(
           this,
           Invocation.method(
             #createCommit,
@@ -4159,7 +4237,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_38(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
           this,
           Invocation.method(
             #getReference,
@@ -4200,7 +4278,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_38(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
           this,
           Invocation.method(
             #createReference,
@@ -4230,7 +4308,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#force: force},
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_38(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
           this,
           Invocation.method(
             #editReference,
@@ -4273,7 +4351,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_42(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_44(
           this,
           Invocation.method(
             #getTag,
@@ -4298,7 +4376,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tag,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_42(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_44(
           this,
           Invocation.method(
             #createTag,
@@ -4325,7 +4403,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#recursive: recursive},
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_43(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_45(
           this,
           Invocation.method(
             #getTree,
@@ -4351,7 +4429,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tree,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_43(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_45(
           this,
           Invocation.method(
             #createTree,
@@ -4375,7 +4453,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.DefaultPolicies get defaultPolicies => (super.noSuchMethod(
         Invocation.getter(#defaultPolicies),
-        returnValue: _FakeDefaultPolicies_44(
+        returnValue: _FakeDefaultPolicies_46(
           this,
           Invocation.getter(#defaultPolicies),
         ),
@@ -4393,7 +4471,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.Link get link => (super.noSuchMethod(
         Invocation.getter(#link),
-        returnValue: _FakeLink_45(
+        returnValue: _FakeLink_47(
           this,
           Invocation.getter(#link),
         ),
@@ -4402,7 +4480,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.GraphQLCache get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeGraphQLCache_46(
+        returnValue: _FakeGraphQLCache_48(
           this,
           Invocation.getter(#cache),
         ),
@@ -4411,7 +4489,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.QueryManager get queryManager => (super.noSuchMethod(
         Invocation.getter(#queryManager),
-        returnValue: _FakeQueryManager_47(
+        returnValue: _FakeQueryManager_49(
           this,
           Invocation.getter(#queryManager),
         ),
@@ -4465,7 +4543,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchQuery,
           [options],
         ),
-        returnValue: _FakeObservableQuery_48<TParsed>(
+        returnValue: _FakeObservableQuery_50<TParsed>(
           this,
           Invocation.method(
             #watchQuery,
@@ -4480,7 +4558,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchMutation,
           [options],
         ),
-        returnValue: _FakeObservableQuery_48<TParsed>(
+        returnValue: _FakeObservableQuery_50<TParsed>(
           this,
           Invocation.method(
             #watchMutation,
@@ -4495,7 +4573,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4510,7 +4588,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4544,7 +4622,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_49<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4788,7 +4866,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #open,
@@ -4815,7 +4893,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             url,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #openUrl,
@@ -4842,7 +4920,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #get,
@@ -4861,7 +4939,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #getUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #getUrl,
@@ -4885,7 +4963,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #post,
@@ -4904,7 +4982,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #postUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #postUrl,
@@ -4928,7 +5006,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #put,
@@ -4947,7 +5025,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #putUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #putUrl,
@@ -4971,7 +5049,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #delete,
@@ -4990,7 +5068,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #deleteUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #deleteUrl,
@@ -5014,7 +5092,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #patch,
@@ -5033,7 +5111,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #patchUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #patchUrl,
@@ -5057,7 +5135,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #head,
@@ -5076,7 +5154,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
           #headUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_50(
+        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
           this,
           Invocation.method(
             #headUrl,
@@ -5229,7 +5307,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   Uri get uri => (super.noSuchMethod(
         Invocation.getter(#uri),
-        returnValue: _FakeUri_51(
+        returnValue: _FakeUri_53(
           this,
           Invocation.getter(#uri),
         ),
@@ -5238,7 +5316,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   _i23.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_52(
+        returnValue: _FakeHttpHeaders_54(
           this,
           Invocation.getter(#headers),
         ),
@@ -5253,7 +5331,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   _i20.Future<_i23.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
           this,
           Invocation.getter(#done),
         )),
@@ -5262,7 +5340,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   _i24.Encoding get encoding => (super.noSuchMethod(
         Invocation.getter(#encoding),
-        returnValue: _FakeEncoding_54(
+        returnValue: _FakeEncoding_56(
           this,
           Invocation.getter(#encoding),
         ),
@@ -5283,7 +5361,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
           this,
           Invocation.method(
             #close,
@@ -5451,7 +5529,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
   @override
   _i23.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_52(
+        returnValue: _FakeHttpHeaders_54(
           this,
           Invocation.getter(#headers),
         ),
@@ -5514,7 +5592,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_53(
+        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
           this,
           Invocation.method(
             #redirect,
@@ -5533,7 +5611,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
           #detachSocket,
           [],
         ),
-        returnValue: _i20.Future<_i23.Socket>.value(_FakeSocket_55(
+        returnValue: _i20.Future<_i23.Socket>.value(_FakeSocket_57(
           this,
           Invocation.method(
             #detachSocket,
@@ -5576,7 +5654,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             #cancelOnError: cancelOnError,
           },
         ),
-        returnValue: _FakeStreamSubscription_56<List<int>>(
+        returnValue: _FakeStreamSubscription_58<List<int>>(
           this,
           Invocation.method(
             #listen,
@@ -5969,7 +6047,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_57(
+        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_59(
           this,
           Invocation.method(
             #cancel,
@@ -6027,7 +6105,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_58(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_60(
           this,
           Invocation.method(
             #get,
@@ -6070,7 +6148,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_59(
+        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_61(
           this,
           Invocation.method(
             #getQueryResults,
@@ -6111,7 +6189,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #uploadMedia: uploadMedia,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_58(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_60(
           this,
           Invocation.method(
             #insert,
@@ -6157,7 +6235,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_60(
+        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_62(
           this,
           Invocation.method(
             #list,
@@ -6192,7 +6270,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_61(
+        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_63(
           this,
           Invocation.method(
             #query,
@@ -6217,7 +6295,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.BuildBucketClient get buildBucketClient => (super.noSuchMethod(
         Invocation.getter(#buildBucketClient),
-        returnValue: _FakeBuildBucketClient_62(
+        returnValue: _FakeBuildBucketClient_64(
           this,
           Invocation.getter(#buildBucketClient),
         ),
@@ -6235,7 +6313,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.CacheService get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeCacheService_63(
+        returnValue: _FakeCacheService_65(
           this,
           Invocation.getter(#cache),
         ),
@@ -6262,7 +6340,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i22.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_32(
+        returnValue: _FakeGithubChecksUtil_34(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
@@ -6298,7 +6376,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.PubSub get pubsub => (super.noSuchMethod(
         Invocation.getter(#pubsub),
-        returnValue: _FakePubSub_64(
+        returnValue: _FakePubSub_66(
           this,
           Invocation.getter(#pubsub),
         ),
@@ -6663,7 +6741,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             #mode: mode,
           },
         ),
-        returnValue: _i20.Future<_i23.Process>.value(_FakeProcess_65(
+        returnValue: _i20.Future<_i23.Process>.value(_FakeProcess_67(
           this,
           Invocation.method(
             #start,
@@ -6846,7 +6924,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_37(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
           this,
           Invocation.method(
             #get,
@@ -6871,7 +6949,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_37(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
           this,
           Invocation.method(
             #create,
@@ -6906,7 +6984,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #base: base,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_37(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
           this,
           Invocation.method(
             #edit,
@@ -7009,7 +7087,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #requestSha: requestSha,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_66(
+        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_68(
           this,
           Invocation.method(
             #merge,
@@ -7066,7 +7144,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             comment,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_67(
+        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_69(
           this,
           Invocation.method(
             #createComment,
@@ -7092,7 +7170,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             review,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_68(
+        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_70(
           this,
           Invocation.method(
             #createReview,
@@ -7203,7 +7281,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [repository],
           {#org: org},
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_69(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
           this,
           Invocation.method(
             #createRepository,
@@ -7219,7 +7297,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLicense,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_70(
+        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_72(
           this,
           Invocation.method(
             #getLicense,
@@ -7234,7 +7312,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getRepository,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_69(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
           this,
           Invocation.method(
             #getRepository,
@@ -7277,7 +7355,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #hasDownloads: hasDownloads,
           },
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_69(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
           this,
           Invocation.method(
             #editRepository,
@@ -7333,7 +7411,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #listLanguages,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_71(
+        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_73(
           this,
           Invocation.method(
             #listLanguages,
@@ -7384,7 +7462,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_72(
+        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_74(
           this,
           Invocation.method(
             #getBranch,
@@ -7501,7 +7579,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #line: line,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
           this,
           Invocation.method(
             #createCommitComment,
@@ -7530,7 +7608,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
           this,
           Invocation.method(
             #getCommitComment,
@@ -7555,7 +7633,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #body: body,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_73(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
           this,
           Invocation.method(
             #updateCommitComment,
@@ -7621,7 +7699,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_76(
           this,
           Invocation.method(
             #getCommit,
@@ -7673,7 +7751,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             refHead,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_75(
+        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_77(
           this,
           Invocation.method(
             #compareCommits,
@@ -7697,7 +7775,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_76(
+        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_78(
           this,
           Invocation.method(
             #getReadme,
@@ -7722,7 +7800,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_77(
+        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_79(
           this,
           Invocation.method(
             #getContents,
@@ -7748,7 +7826,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             file,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
           this,
           Invocation.method(
             #createFile,
@@ -7781,7 +7859,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#branch: branch},
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
           this,
           Invocation.method(
             #updateFile,
@@ -7816,7 +7894,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_78(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
           this,
           Invocation.method(
             #deleteFile,
@@ -7871,7 +7949,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             fork,
           ],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_69(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
           this,
           Invocation.method(
             #createFork,
@@ -7905,7 +7983,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_79(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
           this,
           Invocation.method(
             #getHook,
@@ -7930,7 +8008,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             hook,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_79(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
           this,
           Invocation.method(
             #createHook,
@@ -7973,7 +8051,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #active: active,
           },
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_79(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
           this,
           Invocation.method(
             #editHook,
@@ -8063,7 +8141,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_80(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
           this,
           Invocation.method(
             #getDeployKey,
@@ -8086,7 +8164,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             key,
           ],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_80(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
           this,
           Invocation.method(
             #createDeployKey,
@@ -8128,7 +8206,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             merge,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_74(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_76(
           this,
           Invocation.method(
             #merge,
@@ -8146,7 +8224,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getPagesInfo,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_81(
+        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_83(
           this,
           Invocation.method(
             #getPagesInfo,
@@ -8170,7 +8248,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestPagesBuild,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_82(
+        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_84(
           this,
           Invocation.method(
             #getLatestPagesBuild,
@@ -8194,7 +8272,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestRelease,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_83(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
           this,
           Invocation.method(
             #getLatestRelease,
@@ -8216,7 +8294,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_83(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
           this,
           Invocation.method(
             #getReleaseById,
@@ -8241,7 +8319,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             tagName,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_83(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
           this,
           Invocation.method(
             #getReleaseByTagName,
@@ -8268,7 +8346,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#getIfExists: getIfExists},
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_83(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
           this,
           Invocation.method(
             #createRelease,
@@ -8308,7 +8386,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #preRelease: preRelease,
           },
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_83(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
           this,
           Invocation.method(
             #editRelease,
@@ -8375,7 +8453,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#assetId: assetId},
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_84(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_86(
           this,
           Invocation.method(
             #getReleaseAsset,
@@ -8407,7 +8485,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #label: label,
           },
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_84(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_86(
           this,
           Invocation.method(
             #editReleaseAsset,
@@ -8488,7 +8566,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getParticipation,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_85(
+        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_87(
           this,
           Invocation.method(
             #getParticipation,
@@ -8537,7 +8615,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_86(
+        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_88(
           this,
           Invocation.method(
             #createStatus,
@@ -8563,7 +8641,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_87(
+        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_89(
           this,
           Invocation.method(
             #getCombinedStatus,
@@ -8581,7 +8659,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #generateReleaseNotes,
           [crn],
         ),
-        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_88(
+        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_90(
           this,
           Invocation.method(
             #generateReleaseNotes,
@@ -8732,7 +8810,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_89(
+        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_91(
           this,
           Invocation.method(
             #insertAll,
@@ -8774,7 +8852,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_90(
+        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_92(
           this,
           Invocation.method(
             #list,
@@ -8818,7 +8896,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getUser,
           [name],
         ),
-        returnValue: _i20.Future<_i13.User>.value(_FakeUser_91(
+        returnValue: _i20.Future<_i13.User>.value(_FakeUser_93(
           this,
           Invocation.method(
             #getUser,
@@ -8851,7 +8929,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
             #bio: bio,
           },
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_92(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_94(
           this,
           Invocation.method(
             #editCurrentUser,
@@ -8889,7 +8967,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getCurrentUser,
           [],
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_92(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_94(
           this,
           Invocation.method(
             #getCurrentUser,
@@ -9036,7 +9114,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #createPublicKey,
           [key],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_80(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
           this,
           Invocation.method(
             #createPublicKey,
@@ -9060,7 +9138,7 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
           #[],
           [key],
         ),
-        returnValue: _FakeEntry_93<_i36.Uint8List>(
+        returnValue: _FakeEntry_95<_i36.Uint8List>(
           this,
           Invocation.method(
             #[],
@@ -9075,7 +9153,7 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
           #withPrefix,
           [prefix],
         ),
-        returnValue: _FakeCache_94<_i36.Uint8List>(
+        returnValue: _FakeCache_96<_i36.Uint8List>(
           this,
           Invocation.method(
             #withPrefix,
@@ -9090,7 +9168,7 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
           #withCodec,
           [codec],
         ),
-        returnValue: _FakeCache_94<S>(
+        returnValue: _FakeCache_96<S>(
           this,
           Invocation.method(
             #withCodec,
@@ -9105,7 +9183,7 @@ class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
           #withTTL,
           [ttl],
         ),
-        returnValue: _FakeCache_94<_i36.Uint8List>(
+        returnValue: _FakeCache_96<_i36.Uint8List>(
           this,
           Invocation.method(
             #withTTL,
@@ -9126,7 +9204,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.Authentication get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthentication_95(
+        returnValue: _FakeAuthentication_97(
           this,
           Invocation.getter(#auth),
         ),
@@ -9171,7 +9249,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ActivityService get activity => (super.noSuchMethod(
         Invocation.getter(#activity),
-        returnValue: _FakeActivityService_96(
+        returnValue: _FakeActivityService_98(
           this,
           Invocation.getter(#activity),
         ),
@@ -9180,7 +9258,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.AuthorizationsService get authorizations => (super.noSuchMethod(
         Invocation.getter(#authorizations),
-        returnValue: _FakeAuthorizationsService_97(
+        returnValue: _FakeAuthorizationsService_99(
           this,
           Invocation.getter(#authorizations),
         ),
@@ -9189,7 +9267,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GistsService get gists => (super.noSuchMethod(
         Invocation.getter(#gists),
-        returnValue: _FakeGistsService_98(
+        returnValue: _FakeGistsService_100(
           this,
           Invocation.getter(#gists),
         ),
@@ -9198,7 +9276,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GitService get git => (super.noSuchMethod(
         Invocation.getter(#git),
-        returnValue: _FakeGitService_99(
+        returnValue: _FakeGitService_101(
           this,
           Invocation.getter(#git),
         ),
@@ -9207,7 +9285,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.IssuesService get issues => (super.noSuchMethod(
         Invocation.getter(#issues),
-        returnValue: _FakeIssuesService_100(
+        returnValue: _FakeIssuesService_102(
           this,
           Invocation.getter(#issues),
         ),
@@ -9216,7 +9294,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.MiscService get misc => (super.noSuchMethod(
         Invocation.getter(#misc),
-        returnValue: _FakeMiscService_101(
+        returnValue: _FakeMiscService_103(
           this,
           Invocation.getter(#misc),
         ),
@@ -9225,7 +9303,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.OrganizationsService get organizations => (super.noSuchMethod(
         Invocation.getter(#organizations),
-        returnValue: _FakeOrganizationsService_102(
+        returnValue: _FakeOrganizationsService_104(
           this,
           Invocation.getter(#organizations),
         ),
@@ -9234,7 +9312,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.PullRequestsService get pullRequests => (super.noSuchMethod(
         Invocation.getter(#pullRequests),
-        returnValue: _FakePullRequestsService_103(
+        returnValue: _FakePullRequestsService_105(
           this,
           Invocation.getter(#pullRequests),
         ),
@@ -9243,7 +9321,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.RepositoriesService get repositories => (super.noSuchMethod(
         Invocation.getter(#repositories),
-        returnValue: _FakeRepositoriesService_104(
+        returnValue: _FakeRepositoriesService_106(
           this,
           Invocation.getter(#repositories),
         ),
@@ -9252,7 +9330,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.SearchService get search => (super.noSuchMethod(
         Invocation.getter(#search),
-        returnValue: _FakeSearchService_105(
+        returnValue: _FakeSearchService_107(
           this,
           Invocation.getter(#search),
         ),
@@ -9261,7 +9339,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UrlShortenerService get urlShortener => (super.noSuchMethod(
         Invocation.getter(#urlShortener),
-        returnValue: _FakeUrlShortenerService_106(
+        returnValue: _FakeUrlShortenerService_108(
           this,
           Invocation.getter(#urlShortener),
         ),
@@ -9270,7 +9348,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UsersService get users => (super.noSuchMethod(
         Invocation.getter(#users),
-        returnValue: _FakeUsersService_107(
+        returnValue: _FakeUsersService_109(
           this,
           Invocation.getter(#users),
         ),
@@ -9279,7 +9357,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ChecksService get checks => (super.noSuchMethod(
         Invocation.getter(#checks),
-        returnValue: _FakeChecksService_108(
+        returnValue: _FakeChecksService_110(
           this,
           Invocation.getter(#checks),
         ),
@@ -9603,7 +9681,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_109(
+        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_111(
           this,
           Invocation.method(
             #request,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951.

This PR:
1) adds a query wrapper to simplify logics
2)switch existing commitTask query to use the new wrapper