### PR TITLE
Switch github gold status API toFirestore

### DIFF
--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -58,6 +58,26 @@ class GithubGoldStatus extends Document {
 
   int? get updates => int.parse(fields![kGithubGoldStatusUpdatesField]!.integerValue!);
 
+  String setStatus(String status) {
+    fields![kGithubGoldStatusStatusField] = Value(stringValue: status);
+    return status;
+  }
+
+  String setHead(String head) {
+    fields![kGithubGoldStatusHeadField] = Value(stringValue: head);
+    return head;
+  }
+
+  int setUpdates(int updates) {
+    fields![kGithubGoldStatusUpdatesField] = Value(integerValue: updates.toString());
+    return updates;
+  }
+
+  String setDescription(String description) {
+    fields![kGithubGoldStatusDescriptionField] = Value(stringValue: description);
+    return description;
+  }
+
   /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -39,35 +39,39 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   @override
   Future<Body> get() async {
     final DatastoreService datastore = datastoreProvider(config.db);
+    final FirestoreService firestoreService = await config.createFirestoreService();
 
     if (authContext!.clientContext.isDevelopmentEnvironment) {
       // Don't push gold status from the local dev server.
       return Body.empty;
     }
 
-    await _sendStatusUpdates(datastore, Config.flutterSlug);
-    await _sendStatusUpdates(datastore, Config.engineSlug);
+    await _sendStatusUpdates(datastore, firestoreService, Config.flutterSlug);
+    await _sendStatusUpdates(datastore, firestoreService, Config.engineSlug);
 
     return Body.empty;
   }
 
   Future<void> _sendStatusUpdates(
     DatastoreService datastore,
+    FirestoreService firestoreService,
     RepositorySlug slug,
   ) async {
     final GitHub gitHubClient = await config.createGitHubClient(slug: slug);
     final List<GithubGoldStatusUpdate> statusUpdates = <GithubGoldStatusUpdate>[];
+    final List<GithubGoldStatus> githubGoldStatuses= <GithubGoldStatus>[];
     log.fine('Beginning Gold checks...');
     await for (PullRequest pr in gitHubClient.pullRequests.list(slug)) {
       assert(pr.number != null);
-      // Get last known Gold status from datastore.
+      // Get last known Gold status from firestore.
       final GithubGoldStatusUpdate lastUpdate = await datastore.queryLastGoldUpdate(slug, pr);
+      final GithubGoldStatus githubGoldStatus = await firestoreService.queryLastGoldStatus(slug, pr.number!);
       CreateStatus statusRequest;
 
       log.fine('Last known Gold status for $slug#${pr.number} was with sha: '
-          '${lastUpdate.head}, status: ${lastUpdate.status}, description: ${lastUpdate.description}');
+          '${githubGoldStatus.head}, status: ${githubGoldStatus.status}, description: ${githubGoldStatus.description}');
 
-      if (lastUpdate.status == GithubGoldStatusUpdate.statusCompleted && lastUpdate.head == pr.head!.sha) {
+      if (githubGoldStatus.status == GithubGoldStatus.statusCompleted && githubGoldStatus.head == pr.head!.sha) {
         log.fine('Completed status already reported for this commit.');
         // We have already seen this commit and it is completed or, this is not
         // a change staged to land on master, which we should ignore.
@@ -90,8 +94,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         // been a new commit, we cannot rescind a previously posted status, so
         // if it is already pending, we should make the contributor aware of
         // that fact.
-        if (lastUpdate.status == GithubGoldStatusUpdate.statusRunning &&
-            lastUpdate.head == pr.head!.sha &&
+        if (githubGoldStatus.status == GithubGoldStatus.statusRunning &&
+            githubGoldStatus.head == pr.head!.sha &&
             !await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldDraftChange)) {
           await gitHubClient.issues
               .createComment(slug, pr.number!, config.flutterGoldDraftChange + config.flutterGoldAlertConstant(slug));
@@ -99,7 +103,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         continue;
       }
 
-      log.fine('Querying builds for pull request #${pr.number} with sha: ${lastUpdate.head}...');
+      log.fine('Querying builds for pull request #${pr.number} with sha: ${githubGoldStatus.head}...');
       final GraphQLClient gitHubGraphQLClient = await config.createGitHubGraphQLClient();
       final List<String> incompleteChecks = <String>[];
       bool runsGoldenFileTests = false;
@@ -165,7 +169,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           // until marked ready for review.
           log.fine('Waiting for checks to be completed.');
           statusRequest =
-              _createStatus(GithubGoldStatusUpdate.statusRunning, config.flutterGoldPending, slug, pr.number!);
+              _createStatus(GithubGoldStatus.statusRunning, config.flutterGoldPending, slug, pr.number!);
         } else {
           // We do not want to query Gold on a draft PR.
           assert(!pr.draft!);
@@ -173,12 +177,12 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           final String goldStatus = await _getGoldStatus(slug, pr);
           statusRequest = _createStatus(
             goldStatus,
-            goldStatus == GithubGoldStatusUpdate.statusRunning ? config.flutterGoldChanges : config.flutterGoldSuccess,
+            goldStatus == GithubGoldStatus.statusRunning ? config.flutterGoldChanges : config.flutterGoldSuccess,
             slug,
             pr.number!,
           );
           log.fine('New status for potential update: ${statusRequest.state}, ${statusRequest.description}');
-          if (goldStatus == GithubGoldStatusUpdate.statusRunning &&
+          if (goldStatus == GithubGoldStatus.statusRunning &&
               !await _alreadyCommented(gitHubClient, pr, slug, config.flutterGoldCommentID(pr))) {
             log.fine('Notifying for triage.');
             await _commentAndApplyGoldLabels(gitHubClient, pr, slug);
@@ -187,7 +191,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
 
         // Push updates if there is a status change (detected by unique description)
         // or this is a new commit.
-        if (lastUpdate.description != statusRequest.description || lastUpdate.head != pr.head!.sha) {
+        if (githubGoldStatus.description != statusRequest.description || githubGoldStatus.head != pr.head!.sha) {
           try {
             log.fine('Pushing status to GitHub: ${statusRequest.state}, ${statusRequest.description}');
             await gitHubClient.repositories.createStatus(slug, pr.head!.sha!, statusRequest);
@@ -196,6 +200,13 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             lastUpdate.updates = (lastUpdate.updates ?? 0) + 1;
             lastUpdate.description = statusRequest.description!;
             statusUpdates.add(lastUpdate);
+
+            githubGoldStatus.setStatus(statusRequest.state!);
+            githubGoldStatus.setHead(pr.head!.sha!);
+            githubGoldStatus.setUpdates((lastUpdate.updates ?? 0) + 1);
+            githubGoldStatus.setDescription(statusRequest.description!);
+            githubGoldStatus.name = '$kDatabase/documents/$kGithubGoldStatusCollectionId/${githubGoldStatus.head}_${githubGoldStatus.prNumber}';
+            githubGoldStatuses.add(githubGoldStatus);
           } catch (error) {
             log.severe('Failed to post status update to ${slug.fullName}#${pr.number}: $error');
           }
@@ -210,20 +221,22 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
     // TODO(keyonghan): remove try block after fully migrated to firestore
     // https://github.com/flutter/flutter/issues/142951
     try {
-      await updateGithubGoldStatusDocuments(statusUpdates);
+      await updateGithubGoldStatusDocuments(statusUpdates, firestoreService);
     } catch (error) {
       log.warning('Failed to update github gold status in Firestore: $error');
     }
   }
 
-  Future<void> updateGithubGoldStatusDocuments(List<GithubGoldStatusUpdate> statusUpdates) async {
+  Future<void> updateGithubGoldStatusDocuments(
+    List<GithubGoldStatusUpdate> statusUpdates,
+    FirestoreService firestoreService,
+  ) async {
     if (statusUpdates.isEmpty) {
       return;
     }
     final List<GithubGoldStatus> githubGoldStatusDocuments =
         statusUpdates.map((e) => githubGoldStatusToDocument(e)).toList();
     final List<Write> writes = documentsToWrites(githubGoldStatusDocuments);
-    final FirestoreService firestoreService = await config.createFirestoreService();
     await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
   }
 

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -87,7 +87,7 @@ class FirestoreService {
   }
 
   /// Queries the last updated Gold status for the [slug] and [prNumber].
-  /// 
+  ///
   /// If not existing, returns a fresh new Gold status.
   Future<GithubGoldStatus> queryLastGoldStatus(RepositorySlug slug, int prNumber) async {
     final Map<String, Object> filterMap = <String, Object>{
@@ -100,6 +100,7 @@ class FirestoreService {
     if (githubGoldStatuses.isEmpty) {
       return GithubGoldStatus.fromDocument(
         githubGoldStatus: Document(
+          name: '$kDatabase/documents/$kGithubGoldStatusCollectionId/${slug.owner}_${slug.name}_$prNumber',
           fields: <String, Value>{
             kGithubGoldStatusPrNumberField: Value(integerValue: prNumber.toString()),
             kGithubGoldStatusHeadField: Value(stringValue: ''),

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -80,7 +80,7 @@ class FirestoreService {
   /// Returns all tasks running against the speificed [commitSha].
   Future<List<Task>> queryCommitTasks(String commitSha) async {
     final Map<String, Object> filterMap = <String, Object>{
-      '$kTaskCommitShaField = ': commitSha,
+      '$kTaskCommitShaField =': commitSha,
     };
     final List<Document> documents = await query(kTaskCollectionId, filterMap);
     return documents.map((Document document) => Task.fromDocument(taskDocument: document)).toList();
@@ -91,8 +91,8 @@ class FirestoreService {
   /// If not existing, returns a fresh new Gold status.
   Future<GithubGoldStatus> queryLastGoldStatus(RepositorySlug slug, int prNumber) async {
     final Map<String, Object> filterMap = <String, Object>{
-      '$kGithubGoldStatusPrNumberField = ': prNumber,
-      '$kGithubGoldStatusRepositoryField = ': slug.fullName,
+      '$kGithubGoldStatusPrNumberField =': prNumber,
+      '$kGithubGoldStatusRepositoryField =': slug.fullName,
     };
     final List<Document> documents = await query(kGithubGoldStatusCollectionId, filterMap);
     final List<GithubGoldStatus> githubGoldStatuses =

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -5,9 +5,11 @@
 import 'dart:async';
 
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:http/http.dart';
 
+import '../model/firestore/github_gold_status.dart';
 import '../model/firestore/task.dart';
 import 'access_client_provider.dart';
 import 'config.dart';
@@ -82,6 +84,39 @@ class FirestoreService {
     };
     final List<Document> documents = await query(kTaskCollectionId, filterMap);
     return documents.map((Document document) => Task.fromDocument(taskDocument: document)).toList();
+  }
+
+  /// Queries the last updated Gold status for the [slug] and [prNumber].
+  /// 
+  /// If not existing, returns a fresh new Gold status.
+  Future<GithubGoldStatus> queryLastGoldStatus(RepositorySlug slug, int prNumber) async {
+    final Map<String, Object> filterMap = <String, Object>{
+      '$kGithubGoldStatusPrNumberField = ': prNumber,
+      '$kGithubGoldStatusRepositoryField = ': slug.fullName,
+    };
+    final List<Document> documents = await query(kGithubGoldStatusCollectionId, filterMap);
+    final List<GithubGoldStatus> githubGoldStatuses =
+        documents.map((Document document) => GithubGoldStatus.fromDocument(githubGoldStatus: document)).toList();
+    if (githubGoldStatuses.isEmpty) {
+      return GithubGoldStatus.fromDocument(
+        githubGoldStatus: Document(
+          fields: <String, Value>{
+            kGithubGoldStatusPrNumberField: Value(integerValue: prNumber.toString()),
+            kGithubGoldStatusHeadField: Value(stringValue: ''),
+            kGithubGoldStatusStatusField: Value(stringValue: ''),
+            kGithubGoldStatusUpdatesField: Value(integerValue: '0'),
+            kGithubGoldStatusDescriptionField: Value(stringValue: ''),
+            kGithubGoldStatusRepositoryField: Value(stringValue: slug.fullName),
+          },
+        ),
+      );
+    } else {
+      if (githubGoldStatuses.length > 1) {
+        throw StateError('GithubGoldStatusUpdate should have no more than one entry on '
+            'repository ${slug.fullName}, pr $prNumber.');
+      }
+      return githubGoldStatuses.single;
+    }
   }
 
   /// Returns Firestore [Value] based on corresponding object type.

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -142,6 +142,10 @@ void main() {
         pullRequestsService = MockPullRequestsService();
         issuesService = MockIssuesService();
         repositoriesService = MockRepositoriesService();
+        githubGoldStatus = null;
+        githubGoldStatusNext = null;
+        githubGoldStatusEngine = null;
+
         when(github.pullRequests).thenReturn(pullRequestsService);
         when(github.issues).thenReturn(issuesService);
         when(github.repositories).thenReturn(repositoriesService);
@@ -1427,6 +1431,13 @@ void main() {
           final GithubGoldStatusUpdate status =
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(
+            slug,
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldPendingValue!,
+          );
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -1443,6 +1454,7 @@ void main() {
           expect(status.updates, 0);
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
 
           // Should not apply labels or make comments
           verifyNever(
@@ -1604,6 +1616,13 @@ void main() {
           config.flutterGoldPendingValue!,
         );
         db.values[status.key] = status;
+        githubGoldStatus = newGithubGoldStatus(
+          slug,
+          pr,
+          GithubGoldStatusUpdate.statusRunning,
+          'abc',
+          config.flutterGoldPendingValue!,
+        );
 
         // null status for luci build
         checkRuns = <dynamic>[
@@ -1619,6 +1638,7 @@ void main() {
         expect(status.updates, 0);
         expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
         expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+        verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
 
         // Should not apply labels or make comments
         verifyNever(

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -28,6 +28,7 @@ import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
 import '../src/request_handling/fake_authentication.dart';
 import '../src/service/fake_graphql_client.dart';
+import '../src/utilities/entity_generators.dart';
 import '../src/utilities/mocks.dart';
 
 void main() {
@@ -120,11 +121,6 @@ void main() {
 
       test('Does nothing', () async {
         config.githubClient = ThrowingGitHub();
-        db.onCommit =
-            (List<gcloud_db.Model<dynamic>> insert, List<gcloud_db.Key<dynamic>> deletes) => throw AssertionError();
-        db.addOnQuery<GithubGoldStatusUpdate>((Iterable<GithubGoldStatusUpdate> results) {
-          throw AssertionError();
-        });
         final Body body = await tester.get<Body>(handler);
         expect(body, same(Body.empty));
       });
@@ -137,6 +133,9 @@ void main() {
       late MockRepositoriesService repositoriesService;
       List<PullRequest> prsFromGitHub = <PullRequest>[];
       List<PullRequest> enginePrsFromGitHub = <PullRequest>[];
+      GithubGoldStatus? githubGoldStatus;
+      GithubGoldStatus? githubGoldStatusNext;
+      GithubGoldStatus? githubGoldStatusEngine;
 
       setUp(() {
         github = MockGitHub();
@@ -155,6 +154,38 @@ void main() {
         enginePrsFromGitHub.clear();
         when(pullRequestsService.list(engineSlug)).thenAnswer((Invocation _) {
           return Stream<PullRequest>.fromIterable(enginePrsFromGitHub);
+        });
+
+        when(
+          mockFirestoreService.queryLastGoldStatus(slug, 123),
+        ).thenAnswer((Invocation invocation) {
+          return Future<GithubGoldStatus>.value(
+            githubGoldStatus,
+          );
+        });
+        when(
+          mockFirestoreService.queryLastGoldStatus(slug, 456),
+        ).thenAnswer((Invocation invocation) {
+          return Future<GithubGoldStatus>.value(
+            githubGoldStatusNext,
+          );
+        });
+
+        when(
+          mockFirestoreService.queryLastGoldStatus(engineSlug, captureAny),
+        ).thenAnswer((Invocation invocation) {
+          return Future<GithubGoldStatus>.value(
+            githubGoldStatusEngine,
+          );
+        });
+
+        when(
+          mockFirestoreService.batchWriteDocuments(
+            captureAny,
+            captureAny,
+          ),
+        ).thenAnswer((Invocation invocation) {
+          return Future<BatchWriteResponse>.value(BatchWriteResponse());
         });
 
         when(repositoriesService.createStatus(any, any, any)).thenAnswer((_) async => RepositoryStatus());
@@ -179,6 +210,24 @@ void main() {
           updates: 0,
           description: description,
           repository: slug.fullName,
+        );
+      }
+
+      GithubGoldStatus newGithubGoldStatus(
+        RepositorySlug slug,
+        PullRequest pr,
+        String statusUpdate,
+        String sha,
+        String description,
+      ) {
+        return generateFirestoreGithubGoldStatus(
+          1,
+          head: sha,
+          pr: pr.number,
+          status: statusUpdate,
+          updates: 0,
+          description: description,
+          repo: slug.name,
         );
       }
 
@@ -212,16 +261,14 @@ void main() {
           ];
           final PullRequest flutterPr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[flutterPr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, flutterPr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, flutterPr, '', '', '');
 
           engineCheckRuns = <dynamic>[
             <String, String>{'name': 'linux-host1', 'status': 'completed', 'conclusion': 'success'},
           ];
           final PullRequest enginePr = newPullRequest(456, 'def', 'main');
           enginePrsFromGitHub = <PullRequest>[enginePr];
-          final GithubGoldStatusUpdate engineStatus = newStatusUpdate(engineSlug, enginePr, '', '', '');
-          db.values[engineStatus.key] = engineStatus;
+          githubGoldStatusEngine = newGithubGoldStatus(engineSlug, enginePr, '', '', '');
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
@@ -270,8 +317,7 @@ void main() {
           ];
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
@@ -301,14 +347,13 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
+          githubGoldStatus = newGithubGoldStatus(
             slug,
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
             config.flutterGoldPendingValue!,
           );
-          db.values[status.key] = status;
 
           // Checks still running
           checkRuns = <dynamic>[
@@ -318,7 +363,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -346,14 +391,13 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
+          githubGoldStatus = newGithubGoldStatus(
             slug,
             pr,
             GithubGoldStatusUpdate.statusCompleted,
             'abc',
             config.flutterGoldSuccessValue!,
           );
-          db.values[status.key] = status;
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -363,7 +407,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -392,25 +436,23 @@ void main() {
           // Same commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(
+          githubGoldStatus = newGithubGoldStatus(
             slug,
             pr,
             GithubGoldStatusUpdate.statusRunning,
             'abc',
             config.flutterGoldChangesValue!,
           );
-          db.values[status.key] = status;
 
           final PullRequest enginePr = newPullRequest(456, 'def', 'main');
           enginePrsFromGitHub = <PullRequest>[enginePr];
-          final GithubGoldStatusUpdate engineStatus = newStatusUpdate(
+          githubGoldStatusEngine = newGithubGoldStatus(
             engineSlug,
             enginePr,
             GithubGoldStatusUpdate.statusRunning,
             'def',
             config.flutterGoldChangesValue!,
           );
-          db.values[engineStatus.key] = engineStatus;
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -460,7 +502,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -504,8 +546,7 @@ void main() {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'release');
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // All checks completed
           checkRuns = <dynamic>[
@@ -514,7 +555,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -542,8 +583,7 @@ void main() {
           // New commit, draft PR
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -552,7 +592,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -580,8 +620,7 @@ void main() {
           // New commit, draft PR
           final PullRequest pr = newPullRequest(123, 'abc', 'master', draft: true);
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -590,7 +629,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -619,8 +658,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -636,7 +674,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -665,8 +703,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -682,7 +719,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -711,8 +748,7 @@ void main() {
           final PullRequest pr =
               newPullRequest(123, 'abc', 'master', updated: DateTime.now().subtract(const Duration(days: 30)));
           prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -728,7 +764,7 @@ void main() {
 
           final Body body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(status.updates, 0);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
@@ -754,25 +790,18 @@ void main() {
       });
 
       group('updates GitHub and/or Datastore', () {
-        setUp(() {
-          when(
-            mockFirestoreService.batchWriteDocuments(
-              captureAny,
-              captureAny,
-            ),
-          ).thenAnswer((Invocation invocation) {
-            return Future<BatchWriteResponse>.value(BatchWriteResponse());
-          });
-        });
         test('new commit, checks running', () async {
           // New commit
           final PullRequest flutterPr = newPullRequest(123, 'f-abc', 'master');
           prsFromGitHub = <PullRequest>[flutterPr];
           final GithubGoldStatusUpdate status = newStatusUpdate(slug, flutterPr, '', '', '');
+          githubGoldStatus = newGithubGoldStatus(slug, flutterPr, '', '', '');
+          expect(githubGoldStatus!.updates, 0);
 
           final PullRequest enginePr = newPullRequest(567, 'e-abc', 'main');
           enginePrsFromGitHub = <PullRequest>[enginePr];
           final GithubGoldStatusUpdate engineStatus = newStatusUpdate(engineSlug, enginePr, '', '', '');
+          githubGoldStatusEngine = newGithubGoldStatus(engineSlug, enginePr, '', '', '');
 
           db.values[status.key] = status;
           db.values[engineStatus.key] = engineStatus;
@@ -802,13 +831,13 @@ void main() {
           expect(batchWriteRequest.writes!.length, 1);
           final GithubGoldStatus updatedDocument =
               GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocument.updates, status.updates);
+          expect(updatedDocument.updates, 1);
           // The third element corresponds to the `engineStatus`.
           final BatchWriteRequest batchWriteRequestEngine = captured[2] as BatchWriteRequest;
           expect(batchWriteRequestEngine.writes!.length, 1);
           final GithubGoldStatus updatedDocumentEngine =
               GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocumentEngine.updates, engineStatus.updates);
+          expect(updatedDocumentEngine.updates, 1);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -852,6 +881,7 @@ void main() {
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -887,6 +917,16 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
           // Should not label or comment
           verifyNever(
             issuesService.addLabelsToIssue(
@@ -913,6 +953,7 @@ void main() {
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -948,6 +989,16 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
           // Should not label or comment
           verifyNever(
             issuesService.addLabelsToIssue(
@@ -974,6 +1025,7 @@ void main() {
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -1016,6 +1068,16 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
           // Should label and comment
           verify(
             issuesService.addLabelsToIssue(
@@ -1044,6 +1106,8 @@ void main() {
           final GithubGoldStatusUpdate status =
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(
+              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -1085,6 +1149,16 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
           // Should apply labels and make comment
           verify(
             issuesService.addLabelsToIssue(
@@ -1112,6 +1186,8 @@ void main() {
           final GithubGoldStatusUpdate status =
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(
+              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -1152,6 +1228,16 @@ void main() {
           expect(status.updates, 1);
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
 
           // Should apply labels and make comment
           verify(
@@ -1194,6 +1280,8 @@ void main() {
           final GithubGoldStatusUpdate status =
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(
+              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -1235,6 +1323,16 @@ void main() {
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
 
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
           // Should not label or comment
           verifyNever(
             issuesService.addLabelsToIssue(
@@ -1262,6 +1360,8 @@ void main() {
           final GithubGoldStatusUpdate status =
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(
+              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -1278,6 +1378,7 @@ void main() {
           expect(status.updates, 0);
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+          verifyNever(mockFirestoreService.batchWriteDocuments(captureAny, captureAny));
 
           // Should not apply labels or make comments
           verifyNever(
@@ -1349,6 +1450,7 @@ void main() {
           prsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
           db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
           // Checks failed
           checkRuns = <dynamic>[
@@ -1361,6 +1463,16 @@ void main() {
           expect(status.status, GithubGoldStatusUpdate.statusRunning);
           expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
           expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -1384,14 +1496,6 @@ void main() {
       });
 
       test('Completed pull request does not skip follow-up prs with early return', () async {
-        when(
-          mockFirestoreService.batchWriteDocuments(
-            captureAny,
-            captureAny,
-          ),
-        ).thenAnswer((Invocation invocation) {
-          return Future<BatchWriteResponse>.value(BatchWriteResponse());
-        });
         final PullRequest completedPR = newPullRequest(123, 'abc', 'master');
         final PullRequest followUpPR = newPullRequest(456, 'def', 'master');
         prsFromGitHub = <PullRequest>[
@@ -1408,6 +1512,14 @@ void main() {
         final GithubGoldStatusUpdate followUpStatus = newStatusUpdate(slug, followUpPR, '', '', '');
         db.values[completedStatus.key] = completedStatus;
         db.values[followUpStatus.key] = followUpStatus;
+        githubGoldStatus = newGithubGoldStatus(
+          slug,
+          completedPR,
+          GithubGoldStatusUpdate.statusCompleted,
+          'abc',
+          config.flutterGoldSuccessValue!,
+        );
+        githubGoldStatusNext = newGithubGoldStatus(slug, followUpPR, '', '', '');
 
         // Checks completed
         checkRuns = <dynamic>[
@@ -1450,8 +1562,12 @@ void main() {
         expect(body, same(Body.empty));
         expect(completedStatus.updates, 0);
         expect(followUpStatus.updates, 1);
+        expect(githubGoldStatus!.updates, 0);
+        expect(githubGoldStatusNext!.updates, 1);
         expect(completedStatus.status, GithubGoldStatusUpdate.statusCompleted);
         expect(followUpStatus.status, GithubGoldStatusUpdate.statusCompleted);
+        expect(githubGoldStatus!.status, GithubGoldStatusUpdate.statusCompleted);
+        expect(githubGoldStatusNext!.status, GithubGoldStatusUpdate.statusCompleted);
         expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
         expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
       });
@@ -1505,24 +1621,18 @@ void main() {
       });
 
       test('uses the correct Gold endpoint to get status', () async {
-        when(
-          mockFirestoreService.batchWriteDocuments(
-            captureAny,
-            captureAny,
-          ),
-        ).thenAnswer((Invocation invocation) {
-          return Future<BatchWriteResponse>.value(BatchWriteResponse());
-        });
         // New commit
         final PullRequest pr = newPullRequest(123, 'abc', 'master');
         prsFromGitHub = <PullRequest>[pr];
         final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
         db.values[status.key] = status;
+        githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
 
         final PullRequest enginePr = newPullRequest(456, 'def', 'main');
         enginePrsFromGitHub = <PullRequest>[enginePr];
         final GithubGoldStatusUpdate engineStatus = newStatusUpdate(engineSlug, enginePr, '', '', '');
         db.values[engineStatus.key] = engineStatus;
+        githubGoldStatusEngine = newGithubGoldStatus(engineSlug, enginePr, '', '', '');
 
         // Checks completed
         checkRuns = <dynamic>[

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -1107,7 +1107,12 @@ void main() {
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
           githubGoldStatus = newGithubGoldStatus(
-              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+            slug,
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldPendingValue!,
+          );
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -1187,7 +1192,12 @@ void main() {
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
           githubGoldStatus = newGithubGoldStatus(
-              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+            slug,
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldPendingValue!,
+          );
 
           // Checks complete
           checkRuns = <dynamic>[
@@ -1281,7 +1291,12 @@ void main() {
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
           githubGoldStatus = newGithubGoldStatus(
-              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+            slug,
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldPendingValue!,
+          );
 
           // Checks completed
           checkRuns = <dynamic>[
@@ -1361,7 +1376,12 @@ void main() {
               newStatusUpdate(slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
           db.values[status.key] = status;
           githubGoldStatus = newGithubGoldStatus(
-              slug, pr, GithubGoldStatusUpdate.statusRunning, 'abc', config.flutterGoldPendingValue!);
+            slug,
+            pr,
+            GithubGoldStatusUpdate.statusRunning,
+            'abc',
+            config.flutterGoldPendingValue!,
+          );
 
           // Checks completed
           checkRuns = <dynamic>[

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -157,7 +157,9 @@ GithubGoldStatus generateFirestoreGithubGoldStatus(
   int? pr,
   String owner = 'flutter',
   String repo = 'flutter',
+  String? status,
   int? updates,
+  String? description,
 }) {
   pr ??= i;
   head ??= 'sha$i';
@@ -168,6 +170,8 @@ GithubGoldStatus generateFirestoreGithubGoldStatus(
       kGithubGoldStatusPrNumberField: Value(integerValue: pr.toString()),
       kGithubGoldStatusRepositoryField: Value(stringValue: '$owner/$repo'),
       kGithubGoldStatusUpdatesField: Value(integerValue: updates.toString()),
+      kGithubGoldStatusDescriptionField: Value(stringValue: description),
+      kGithubGoldStatusStatusField: Value(stringValue: status),
     };
   return githubGoldStatus;
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4,49 +4,50 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i20;
-import 'dart:convert' as _i24;
-import 'dart:io' as _i23;
-import 'dart:typed_data' as _i36;
+import 'dart:convert' as _i25;
+import 'dart:io' as _i24;
+import 'dart:typed_data' as _i37;
 
 import 'package:appengine/appengine.dart' as _i10;
 import 'package:cocoon_service/cocoon_service.dart' as _i15;
-import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i22;
-import 'package:cocoon_service/src/model/appengine/branch.dart' as _i31;
-import 'package:cocoon_service/src/model/appengine/commit.dart' as _i32;
+import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i23;
+import 'package:cocoon_service/src/model/appengine/branch.dart' as _i32;
+import 'package:cocoon_service/src/model/appengine/commit.dart' as _i33;
 import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
 import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
-import 'package:cocoon_service/src/model/appengine/stage.dart' as _i34;
-import 'package:cocoon_service/src/model/appengine/task.dart' as _i33;
-import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i39;
-import 'package:cocoon_service/src/model/firestore/task.dart' as _i37;
-import 'package:cocoon_service/src/model/github/checks.dart' as _i40;
+import 'package:cocoon_service/src/model/appengine/stage.dart' as _i35;
+import 'package:cocoon_service/src/model/appengine/task.dart' as _i34;
+import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i40;
+import 'package:cocoon_service/src/model/firestore/github_gold_status.dart' as _i22;
+import 'package:cocoon_service/src/model/firestore/task.dart' as _i38;
+import 'package:cocoon_service/src/model/github/checks.dart' as _i41;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart' as _i8;
-import 'package:cocoon_service/src/model/luci/push_message.dart' as _i38;
+import 'package:cocoon_service/src/model/luci/push_message.dart' as _i39;
 import 'package:cocoon_service/src/service/access_client_provider.dart' as _i5;
-import 'package:cocoon_service/src/service/access_token_provider.dart' as _i26;
+import 'package:cocoon_service/src/service/access_token_provider.dart' as _i27;
 import 'package:cocoon_service/src/service/bigquery.dart' as _i16;
-import 'package:cocoon_service/src/service/commit_service.dart' as _i29;
+import 'package:cocoon_service/src/service/commit_service.dart' as _i30;
 import 'package:cocoon_service/src/service/config.dart' as _i3;
 import 'package:cocoon_service/src/service/datastore.dart' as _i9;
 import 'package:cocoon_service/src/service/gerrit_service.dart' as _i7;
 import 'package:cocoon_service/src/service/github_service.dart' as _i17;
 import 'package:gcloud/db.dart' as _i11;
 import 'package:github/github.dart' as _i13;
-import 'package:github/hooks.dart' as _i30;
+import 'package:github/hooks.dart' as _i31;
 import 'package:googleapis/bigquery/v2.dart' as _i6;
 import 'package:googleapis/firestore/v1.dart' as _i21;
 import 'package:googleapis_auth/auth_io.dart' as _i4;
 import 'package:graphql/client.dart' as _i14;
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i28;
-import 'package:neat_cache/neat_cache.dart' as _i25;
-import 'package:process/src/interface/process_manager.dart' as _i41;
-import 'package:retry/retry.dart' as _i27;
+import 'package:mockito/src/dummies.dart' as _i29;
+import 'package:neat_cache/neat_cache.dart' as _i26;
+import 'package:process/src/interface/process_manager.dart' as _i42;
+import 'package:retry/retry.dart' as _i28;
 
-import '../../service/cache_service_test.dart' as _i35;
-import 'mocks.dart' as _i42;
+import '../../service/cache_service_test.dart' as _i36;
+import 'mocks.dart' as _i43;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -342,8 +343,8 @@ class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitRespons
         );
 }
 
-class _FakeValue_28 extends _i1.SmartFake implements _i21.Value {
-  _FakeValue_28(
+class _FakeGithubGoldStatus_28 extends _i1.SmartFake implements _i22.GithubGoldStatus {
+  _FakeGithubGoldStatus_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -352,8 +353,8 @@ class _FakeValue_28 extends _i1.SmartFake implements _i21.Value {
         );
 }
 
-class _FakeFilter_29 extends _i1.SmartFake implements _i21.Filter {
-  _FakeFilter_29(
+class _FakeValue_29 extends _i1.SmartFake implements _i21.Value {
+  _FakeValue_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +363,8 @@ class _FakeFilter_29 extends _i1.SmartFake implements _i21.Filter {
         );
 }
 
-class _FakeIssue_30 extends _i1.SmartFake implements _i13.Issue {
-  _FakeIssue_30(
+class _FakeFilter_30 extends _i1.SmartFake implements _i21.Filter {
+  _FakeFilter_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,8 +373,8 @@ class _FakeIssue_30 extends _i1.SmartFake implements _i13.Issue {
         );
 }
 
-class _FakeIssueComment_31 extends _i1.SmartFake implements _i13.IssueComment {
-  _FakeIssueComment_31(
+class _FakeIssue_31 extends _i1.SmartFake implements _i13.Issue {
+  _FakeIssue_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -382,8 +383,8 @@ class _FakeIssueComment_31 extends _i1.SmartFake implements _i13.IssueComment {
         );
 }
 
-class _FakeIssueLabel_32 extends _i1.SmartFake implements _i13.IssueLabel {
-  _FakeIssueLabel_32(
+class _FakeIssueComment_32 extends _i1.SmartFake implements _i13.IssueComment {
+  _FakeIssueComment_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -392,8 +393,8 @@ class _FakeIssueLabel_32 extends _i1.SmartFake implements _i13.IssueLabel {
         );
 }
 
-class _FakeMilestone_33 extends _i1.SmartFake implements _i13.Milestone {
-  _FakeMilestone_33(
+class _FakeIssueLabel_33 extends _i1.SmartFake implements _i13.IssueLabel {
+  _FakeIssueLabel_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,8 +403,8 @@ class _FakeMilestone_33 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_34 extends _i1.SmartFake implements _i22.GithubChecksUtil {
-  _FakeGithubChecksUtil_34(
+class _FakeMilestone_34 extends _i1.SmartFake implements _i13.Milestone {
+  _FakeMilestone_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,8 +413,8 @@ class _FakeGithubChecksUtil_34 extends _i1.SmartFake implements _i22.GithubCheck
         );
 }
 
-class _FakeCheckRunConclusion_35 extends _i1.SmartFake implements _i13.CheckRunConclusion {
-  _FakeCheckRunConclusion_35(
+class _FakeGithubChecksUtil_35 extends _i1.SmartFake implements _i23.GithubChecksUtil {
+  _FakeGithubChecksUtil_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +423,8 @@ class _FakeCheckRunConclusion_35 extends _i1.SmartFake implements _i13.CheckRunC
         );
 }
 
-class _FakeCheckRunStatus_36 extends _i1.SmartFake implements _i13.CheckRunStatus {
-  _FakeCheckRunStatus_36(
+class _FakeCheckRunConclusion_36 extends _i1.SmartFake implements _i13.CheckRunConclusion {
+  _FakeCheckRunConclusion_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,8 +433,8 @@ class _FakeCheckRunStatus_36 extends _i1.SmartFake implements _i13.CheckRunStatu
         );
 }
 
-class _FakeCheckSuite_37 extends _i1.SmartFake implements _i13.CheckSuite {
-  _FakeCheckSuite_37(
+class _FakeCheckRunStatus_37 extends _i1.SmartFake implements _i13.CheckRunStatus {
+  _FakeCheckRunStatus_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -442,8 +443,8 @@ class _FakeCheckSuite_37 extends _i1.SmartFake implements _i13.CheckSuite {
         );
 }
 
-class _FakeCheckRun_38 extends _i1.SmartFake implements _i13.CheckRun {
-  _FakeCheckRun_38(
+class _FakeCheckSuite_38 extends _i1.SmartFake implements _i13.CheckSuite {
+  _FakeCheckSuite_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,8 +453,8 @@ class _FakeCheckRun_38 extends _i1.SmartFake implements _i13.CheckRun {
         );
 }
 
-class _FakePullRequest_39 extends _i1.SmartFake implements _i13.PullRequest {
-  _FakePullRequest_39(
+class _FakeCheckRun_39 extends _i1.SmartFake implements _i13.CheckRun {
+  _FakeCheckRun_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,8 +463,8 @@ class _FakePullRequest_39 extends _i1.SmartFake implements _i13.PullRequest {
         );
 }
 
-class _FakeGitReference_40 extends _i1.SmartFake implements _i13.GitReference {
-  _FakeGitReference_40(
+class _FakePullRequest_40 extends _i1.SmartFake implements _i13.PullRequest {
+  _FakePullRequest_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -472,8 +473,8 @@ class _FakeGitReference_40 extends _i1.SmartFake implements _i13.GitReference {
         );
 }
 
-class _FakeRateLimit_41 extends _i1.SmartFake implements _i13.RateLimit {
-  _FakeRateLimit_41(
+class _FakeGitReference_41 extends _i1.SmartFake implements _i13.GitReference {
+  _FakeGitReference_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -482,8 +483,8 @@ class _FakeRateLimit_41 extends _i1.SmartFake implements _i13.RateLimit {
         );
 }
 
-class _FakeGitBlob_42 extends _i1.SmartFake implements _i13.GitBlob {
-  _FakeGitBlob_42(
+class _FakeRateLimit_42 extends _i1.SmartFake implements _i13.RateLimit {
+  _FakeRateLimit_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,8 +493,8 @@ class _FakeGitBlob_42 extends _i1.SmartFake implements _i13.GitBlob {
         );
 }
 
-class _FakeGitCommit_43 extends _i1.SmartFake implements _i13.GitCommit {
-  _FakeGitCommit_43(
+class _FakeGitBlob_43 extends _i1.SmartFake implements _i13.GitBlob {
+  _FakeGitBlob_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,8 +503,8 @@ class _FakeGitCommit_43 extends _i1.SmartFake implements _i13.GitCommit {
         );
 }
 
-class _FakeGitTag_44 extends _i1.SmartFake implements _i13.GitTag {
-  _FakeGitTag_44(
+class _FakeGitCommit_44 extends _i1.SmartFake implements _i13.GitCommit {
+  _FakeGitCommit_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -512,8 +513,8 @@ class _FakeGitTag_44 extends _i1.SmartFake implements _i13.GitTag {
         );
 }
 
-class _FakeGitTree_45 extends _i1.SmartFake implements _i13.GitTree {
-  _FakeGitTree_45(
+class _FakeGitTag_45 extends _i1.SmartFake implements _i13.GitTag {
+  _FakeGitTag_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,8 +523,8 @@ class _FakeGitTree_45 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_46 extends _i1.SmartFake implements _i14.DefaultPolicies {
-  _FakeDefaultPolicies_46(
+class _FakeGitTree_46 extends _i1.SmartFake implements _i13.GitTree {
+  _FakeGitTree_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -532,8 +533,8 @@ class _FakeDefaultPolicies_46 extends _i1.SmartFake implements _i14.DefaultPolic
         );
 }
 
-class _FakeLink_47 extends _i1.SmartFake implements _i14.Link {
-  _FakeLink_47(
+class _FakeDefaultPolicies_47 extends _i1.SmartFake implements _i14.DefaultPolicies {
+  _FakeDefaultPolicies_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,8 +543,8 @@ class _FakeLink_47 extends _i1.SmartFake implements _i14.Link {
         );
 }
 
-class _FakeGraphQLCache_48 extends _i1.SmartFake implements _i14.GraphQLCache {
-  _FakeGraphQLCache_48(
+class _FakeLink_48 extends _i1.SmartFake implements _i14.Link {
+  _FakeLink_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,8 +553,8 @@ class _FakeGraphQLCache_48 extends _i1.SmartFake implements _i14.GraphQLCache {
         );
 }
 
-class _FakeQueryManager_49 extends _i1.SmartFake implements _i14.QueryManager {
-  _FakeQueryManager_49(
+class _FakeGraphQLCache_49 extends _i1.SmartFake implements _i14.GraphQLCache {
+  _FakeGraphQLCache_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -562,8 +563,8 @@ class _FakeQueryManager_49 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_50<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
-  _FakeObservableQuery_50(
+class _FakeQueryManager_50 extends _i1.SmartFake implements _i14.QueryManager {
+  _FakeQueryManager_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +573,8 @@ class _FakeObservableQuery_50<TParsed1> extends _i1.SmartFake implements _i14.Ob
         );
 }
 
-class _FakeQueryResult_51<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
-  _FakeQueryResult_51(
+class _FakeObservableQuery_51<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
+  _FakeObservableQuery_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,8 +583,8 @@ class _FakeQueryResult_51<TParsed1 extends Object?> extends _i1.SmartFake implem
         );
 }
 
-class _FakeHttpClientRequest_52 extends _i1.SmartFake implements _i23.HttpClientRequest {
-  _FakeHttpClientRequest_52(
+class _FakeQueryResult_52<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
+  _FakeQueryResult_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,8 +593,8 @@ class _FakeHttpClientRequest_52 extends _i1.SmartFake implements _i23.HttpClient
         );
 }
 
-class _FakeUri_53 extends _i1.SmartFake implements Uri {
-  _FakeUri_53(
+class _FakeHttpClientRequest_53 extends _i1.SmartFake implements _i24.HttpClientRequest {
+  _FakeHttpClientRequest_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,8 +603,8 @@ class _FakeUri_53 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeHttpHeaders_54 extends _i1.SmartFake implements _i23.HttpHeaders {
-  _FakeHttpHeaders_54(
+class _FakeUri_54 extends _i1.SmartFake implements Uri {
+  _FakeUri_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -612,8 +613,8 @@ class _FakeHttpHeaders_54 extends _i1.SmartFake implements _i23.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_55 extends _i1.SmartFake implements _i23.HttpClientResponse {
-  _FakeHttpClientResponse_55(
+class _FakeHttpHeaders_55 extends _i1.SmartFake implements _i24.HttpHeaders {
+  _FakeHttpHeaders_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -622,8 +623,8 @@ class _FakeHttpClientResponse_55 extends _i1.SmartFake implements _i23.HttpClien
         );
 }
 
-class _FakeEncoding_56 extends _i1.SmartFake implements _i24.Encoding {
-  _FakeEncoding_56(
+class _FakeHttpClientResponse_56 extends _i1.SmartFake implements _i24.HttpClientResponse {
+  _FakeHttpClientResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,8 +633,8 @@ class _FakeEncoding_56 extends _i1.SmartFake implements _i24.Encoding {
         );
 }
 
-class _FakeSocket_57 extends _i1.SmartFake implements _i23.Socket {
-  _FakeSocket_57(
+class _FakeEncoding_57 extends _i1.SmartFake implements _i25.Encoding {
+  _FakeEncoding_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -642,8 +643,8 @@ class _FakeSocket_57 extends _i1.SmartFake implements _i23.Socket {
         );
 }
 
-class _FakeStreamSubscription_58<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
-  _FakeStreamSubscription_58(
+class _FakeSocket_58 extends _i1.SmartFake implements _i24.Socket {
+  _FakeSocket_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,8 +653,8 @@ class _FakeStreamSubscription_58<T> extends _i1.SmartFake implements _i20.Stream
         );
 }
 
-class _FakeJobCancelResponse_59 extends _i1.SmartFake implements _i6.JobCancelResponse {
-  _FakeJobCancelResponse_59(
+class _FakeStreamSubscription_59<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
+  _FakeStreamSubscription_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -662,8 +663,8 @@ class _FakeJobCancelResponse_59 extends _i1.SmartFake implements _i6.JobCancelRe
         );
 }
 
-class _FakeJob_60 extends _i1.SmartFake implements _i6.Job {
-  _FakeJob_60(
+class _FakeJobCancelResponse_60 extends _i1.SmartFake implements _i6.JobCancelResponse {
+  _FakeJobCancelResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,8 +673,8 @@ class _FakeJob_60 extends _i1.SmartFake implements _i6.Job {
         );
 }
 
-class _FakeGetQueryResultsResponse_61 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
-  _FakeGetQueryResultsResponse_61(
+class _FakeJob_61 extends _i1.SmartFake implements _i6.Job {
+  _FakeJob_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -682,8 +683,8 @@ class _FakeGetQueryResultsResponse_61 extends _i1.SmartFake implements _i6.GetQu
         );
 }
 
-class _FakeJobList_62 extends _i1.SmartFake implements _i6.JobList {
-  _FakeJobList_62(
+class _FakeGetQueryResultsResponse_62 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
+  _FakeGetQueryResultsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,8 +693,8 @@ class _FakeJobList_62 extends _i1.SmartFake implements _i6.JobList {
         );
 }
 
-class _FakeQueryResponse_63 extends _i1.SmartFake implements _i6.QueryResponse {
-  _FakeQueryResponse_63(
+class _FakeJobList_63 extends _i1.SmartFake implements _i6.JobList {
+  _FakeJobList_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -702,8 +703,8 @@ class _FakeQueryResponse_63 extends _i1.SmartFake implements _i6.QueryResponse {
         );
 }
 
-class _FakeBuildBucketClient_64 extends _i1.SmartFake implements _i15.BuildBucketClient {
-  _FakeBuildBucketClient_64(
+class _FakeQueryResponse_64 extends _i1.SmartFake implements _i6.QueryResponse {
+  _FakeQueryResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -712,8 +713,8 @@ class _FakeBuildBucketClient_64 extends _i1.SmartFake implements _i15.BuildBucke
         );
 }
 
-class _FakeCacheService_65 extends _i1.SmartFake implements _i15.CacheService {
-  _FakeCacheService_65(
+class _FakeBuildBucketClient_65 extends _i1.SmartFake implements _i15.BuildBucketClient {
+  _FakeBuildBucketClient_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,8 +723,8 @@ class _FakeCacheService_65 extends _i1.SmartFake implements _i15.CacheService {
         );
 }
 
-class _FakePubSub_66 extends _i1.SmartFake implements _i15.PubSub {
-  _FakePubSub_66(
+class _FakeCacheService_66 extends _i1.SmartFake implements _i15.CacheService {
+  _FakeCacheService_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +733,8 @@ class _FakePubSub_66 extends _i1.SmartFake implements _i15.PubSub {
         );
 }
 
-class _FakeProcess_67 extends _i1.SmartFake implements _i23.Process {
-  _FakeProcess_67(
+class _FakePubSub_67 extends _i1.SmartFake implements _i15.PubSub {
+  _FakePubSub_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +743,8 @@ class _FakeProcess_67 extends _i1.SmartFake implements _i23.Process {
         );
 }
 
-class _FakePullRequestMerge_68 extends _i1.SmartFake implements _i13.PullRequestMerge {
-  _FakePullRequestMerge_68(
+class _FakeProcess_68 extends _i1.SmartFake implements _i24.Process {
+  _FakeProcess_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,8 +753,8 @@ class _FakePullRequestMerge_68 extends _i1.SmartFake implements _i13.PullRequest
         );
 }
 
-class _FakePullRequestComment_69 extends _i1.SmartFake implements _i13.PullRequestComment {
-  _FakePullRequestComment_69(
+class _FakePullRequestMerge_69 extends _i1.SmartFake implements _i13.PullRequestMerge {
+  _FakePullRequestMerge_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -762,8 +763,8 @@ class _FakePullRequestComment_69 extends _i1.SmartFake implements _i13.PullReque
         );
 }
 
-class _FakePullRequestReview_70 extends _i1.SmartFake implements _i13.PullRequestReview {
-  _FakePullRequestReview_70(
+class _FakePullRequestComment_70 extends _i1.SmartFake implements _i13.PullRequestComment {
+  _FakePullRequestComment_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -772,8 +773,8 @@ class _FakePullRequestReview_70 extends _i1.SmartFake implements _i13.PullReques
         );
 }
 
-class _FakeRepository_71 extends _i1.SmartFake implements _i13.Repository {
-  _FakeRepository_71(
+class _FakePullRequestReview_71 extends _i1.SmartFake implements _i13.PullRequestReview {
+  _FakePullRequestReview_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -782,8 +783,8 @@ class _FakeRepository_71 extends _i1.SmartFake implements _i13.Repository {
         );
 }
 
-class _FakeLicenseDetails_72 extends _i1.SmartFake implements _i13.LicenseDetails {
-  _FakeLicenseDetails_72(
+class _FakeRepository_72 extends _i1.SmartFake implements _i13.Repository {
+  _FakeRepository_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -792,8 +793,8 @@ class _FakeLicenseDetails_72 extends _i1.SmartFake implements _i13.LicenseDetail
         );
 }
 
-class _FakeLanguageBreakdown_73 extends _i1.SmartFake implements _i13.LanguageBreakdown {
-  _FakeLanguageBreakdown_73(
+class _FakeLicenseDetails_73 extends _i1.SmartFake implements _i13.LicenseDetails {
+  _FakeLicenseDetails_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +803,8 @@ class _FakeLanguageBreakdown_73 extends _i1.SmartFake implements _i13.LanguageBr
         );
 }
 
-class _FakeBranch_74 extends _i1.SmartFake implements _i13.Branch {
-  _FakeBranch_74(
+class _FakeLanguageBreakdown_74 extends _i1.SmartFake implements _i13.LanguageBreakdown {
+  _FakeLanguageBreakdown_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +813,8 @@ class _FakeBranch_74 extends _i1.SmartFake implements _i13.Branch {
         );
 }
 
-class _FakeCommitComment_75 extends _i1.SmartFake implements _i13.CommitComment {
-  _FakeCommitComment_75(
+class _FakeBranch_75 extends _i1.SmartFake implements _i13.Branch {
+  _FakeBranch_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,8 +823,8 @@ class _FakeCommitComment_75 extends _i1.SmartFake implements _i13.CommitComment 
         );
 }
 
-class _FakeRepositoryCommit_76 extends _i1.SmartFake implements _i13.RepositoryCommit {
-  _FakeRepositoryCommit_76(
+class _FakeCommitComment_76 extends _i1.SmartFake implements _i13.CommitComment {
+  _FakeCommitComment_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +833,8 @@ class _FakeRepositoryCommit_76 extends _i1.SmartFake implements _i13.RepositoryC
         );
 }
 
-class _FakeGitHubComparison_77 extends _i1.SmartFake implements _i13.GitHubComparison {
-  _FakeGitHubComparison_77(
+class _FakeRepositoryCommit_77 extends _i1.SmartFake implements _i13.RepositoryCommit {
+  _FakeRepositoryCommit_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +843,8 @@ class _FakeGitHubComparison_77 extends _i1.SmartFake implements _i13.GitHubCompa
         );
 }
 
-class _FakeGitHubFile_78 extends _i1.SmartFake implements _i13.GitHubFile {
-  _FakeGitHubFile_78(
+class _FakeGitHubComparison_78 extends _i1.SmartFake implements _i13.GitHubComparison {
+  _FakeGitHubComparison_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +853,8 @@ class _FakeGitHubFile_78 extends _i1.SmartFake implements _i13.GitHubFile {
         );
 }
 
-class _FakeRepositoryContents_79 extends _i1.SmartFake implements _i13.RepositoryContents {
-  _FakeRepositoryContents_79(
+class _FakeGitHubFile_79 extends _i1.SmartFake implements _i13.GitHubFile {
+  _FakeGitHubFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +863,8 @@ class _FakeRepositoryContents_79 extends _i1.SmartFake implements _i13.Repositor
         );
 }
 
-class _FakeContentCreation_80 extends _i1.SmartFake implements _i13.ContentCreation {
-  _FakeContentCreation_80(
+class _FakeRepositoryContents_80 extends _i1.SmartFake implements _i13.RepositoryContents {
+  _FakeRepositoryContents_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +873,8 @@ class _FakeContentCreation_80 extends _i1.SmartFake implements _i13.ContentCreat
         );
 }
 
-class _FakeHook_81 extends _i1.SmartFake implements _i13.Hook {
-  _FakeHook_81(
+class _FakeContentCreation_81 extends _i1.SmartFake implements _i13.ContentCreation {
+  _FakeContentCreation_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +883,8 @@ class _FakeHook_81 extends _i1.SmartFake implements _i13.Hook {
         );
 }
 
-class _FakePublicKey_82 extends _i1.SmartFake implements _i13.PublicKey {
-  _FakePublicKey_82(
+class _FakeHook_82 extends _i1.SmartFake implements _i13.Hook {
+  _FakeHook_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,8 +893,8 @@ class _FakePublicKey_82 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeRepositoryPages_83 extends _i1.SmartFake implements _i13.RepositoryPages {
-  _FakeRepositoryPages_83(
+class _FakePublicKey_83 extends _i1.SmartFake implements _i13.PublicKey {
+  _FakePublicKey_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,8 +903,8 @@ class _FakeRepositoryPages_83 extends _i1.SmartFake implements _i13.RepositoryPa
         );
 }
 
-class _FakePageBuild_84 extends _i1.SmartFake implements _i13.PageBuild {
-  _FakePageBuild_84(
+class _FakeRepositoryPages_84 extends _i1.SmartFake implements _i13.RepositoryPages {
+  _FakeRepositoryPages_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -912,8 +913,8 @@ class _FakePageBuild_84 extends _i1.SmartFake implements _i13.PageBuild {
         );
 }
 
-class _FakeRelease_85 extends _i1.SmartFake implements _i13.Release {
-  _FakeRelease_85(
+class _FakePageBuild_85 extends _i1.SmartFake implements _i13.PageBuild {
+  _FakePageBuild_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,8 +923,8 @@ class _FakeRelease_85 extends _i1.SmartFake implements _i13.Release {
         );
 }
 
-class _FakeReleaseAsset_86 extends _i1.SmartFake implements _i13.ReleaseAsset {
-  _FakeReleaseAsset_86(
+class _FakeRelease_86 extends _i1.SmartFake implements _i13.Release {
+  _FakeRelease_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -932,8 +933,8 @@ class _FakeReleaseAsset_86 extends _i1.SmartFake implements _i13.ReleaseAsset {
         );
 }
 
-class _FakeContributorParticipation_87 extends _i1.SmartFake implements _i13.ContributorParticipation {
-  _FakeContributorParticipation_87(
+class _FakeReleaseAsset_87 extends _i1.SmartFake implements _i13.ReleaseAsset {
+  _FakeReleaseAsset_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -942,8 +943,8 @@ class _FakeContributorParticipation_87 extends _i1.SmartFake implements _i13.Con
         );
 }
 
-class _FakeRepositoryStatus_88 extends _i1.SmartFake implements _i13.RepositoryStatus {
-  _FakeRepositoryStatus_88(
+class _FakeContributorParticipation_88 extends _i1.SmartFake implements _i13.ContributorParticipation {
+  _FakeContributorParticipation_88(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -952,8 +953,8 @@ class _FakeRepositoryStatus_88 extends _i1.SmartFake implements _i13.RepositoryS
         );
 }
 
-class _FakeCombinedRepositoryStatus_89 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
-  _FakeCombinedRepositoryStatus_89(
+class _FakeRepositoryStatus_89 extends _i1.SmartFake implements _i13.RepositoryStatus {
+  _FakeRepositoryStatus_89(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -962,8 +963,8 @@ class _FakeCombinedRepositoryStatus_89 extends _i1.SmartFake implements _i13.Com
         );
 }
 
-class _FakeReleaseNotes_90 extends _i1.SmartFake implements _i13.ReleaseNotes {
-  _FakeReleaseNotes_90(
+class _FakeCombinedRepositoryStatus_90 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
+  _FakeCombinedRepositoryStatus_90(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -972,8 +973,8 @@ class _FakeReleaseNotes_90 extends _i1.SmartFake implements _i13.ReleaseNotes {
         );
 }
 
-class _FakeTableDataInsertAllResponse_91 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
-  _FakeTableDataInsertAllResponse_91(
+class _FakeReleaseNotes_91 extends _i1.SmartFake implements _i13.ReleaseNotes {
+  _FakeReleaseNotes_91(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -982,8 +983,8 @@ class _FakeTableDataInsertAllResponse_91 extends _i1.SmartFake implements _i6.Ta
         );
 }
 
-class _FakeTableDataList_92 extends _i1.SmartFake implements _i6.TableDataList {
-  _FakeTableDataList_92(
+class _FakeTableDataInsertAllResponse_92 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
+  _FakeTableDataInsertAllResponse_92(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -992,8 +993,8 @@ class _FakeTableDataList_92 extends _i1.SmartFake implements _i6.TableDataList {
         );
 }
 
-class _FakeUser_93 extends _i1.SmartFake implements _i13.User {
-  _FakeUser_93(
+class _FakeTableDataList_93 extends _i1.SmartFake implements _i6.TableDataList {
+  _FakeTableDataList_93(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1002,8 +1003,8 @@ class _FakeUser_93 extends _i1.SmartFake implements _i13.User {
         );
 }
 
-class _FakeCurrentUser_94 extends _i1.SmartFake implements _i13.CurrentUser {
-  _FakeCurrentUser_94(
+class _FakeUser_94 extends _i1.SmartFake implements _i13.User {
+  _FakeUser_94(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1012,8 +1013,8 @@ class _FakeCurrentUser_94 extends _i1.SmartFake implements _i13.CurrentUser {
         );
 }
 
-class _FakeEntry_95<T> extends _i1.SmartFake implements _i25.Entry<T> {
-  _FakeEntry_95(
+class _FakeCurrentUser_95 extends _i1.SmartFake implements _i13.CurrentUser {
+  _FakeCurrentUser_95(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1022,8 +1023,8 @@ class _FakeEntry_95<T> extends _i1.SmartFake implements _i25.Entry<T> {
         );
 }
 
-class _FakeCache_96<T> extends _i1.SmartFake implements _i25.Cache<T> {
-  _FakeCache_96(
+class _FakeEntry_96<T> extends _i1.SmartFake implements _i26.Entry<T> {
+  _FakeEntry_96(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1032,8 +1033,8 @@ class _FakeCache_96<T> extends _i1.SmartFake implements _i25.Cache<T> {
         );
 }
 
-class _FakeAuthentication_97 extends _i1.SmartFake implements _i13.Authentication {
-  _FakeAuthentication_97(
+class _FakeCache_97<T> extends _i1.SmartFake implements _i26.Cache<T> {
+  _FakeCache_97(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1042,8 +1043,8 @@ class _FakeAuthentication_97 extends _i1.SmartFake implements _i13.Authenticatio
         );
 }
 
-class _FakeActivityService_98 extends _i1.SmartFake implements _i13.ActivityService {
-  _FakeActivityService_98(
+class _FakeAuthentication_98 extends _i1.SmartFake implements _i13.Authentication {
+  _FakeAuthentication_98(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1052,8 +1053,8 @@ class _FakeActivityService_98 extends _i1.SmartFake implements _i13.ActivityServ
         );
 }
 
-class _FakeAuthorizationsService_99 extends _i1.SmartFake implements _i13.AuthorizationsService {
-  _FakeAuthorizationsService_99(
+class _FakeActivityService_99 extends _i1.SmartFake implements _i13.ActivityService {
+  _FakeActivityService_99(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1062,8 +1063,8 @@ class _FakeAuthorizationsService_99 extends _i1.SmartFake implements _i13.Author
         );
 }
 
-class _FakeGistsService_100 extends _i1.SmartFake implements _i13.GistsService {
-  _FakeGistsService_100(
+class _FakeAuthorizationsService_100 extends _i1.SmartFake implements _i13.AuthorizationsService {
+  _FakeAuthorizationsService_100(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1072,8 +1073,8 @@ class _FakeGistsService_100 extends _i1.SmartFake implements _i13.GistsService {
         );
 }
 
-class _FakeGitService_101 extends _i1.SmartFake implements _i13.GitService {
-  _FakeGitService_101(
+class _FakeGistsService_101 extends _i1.SmartFake implements _i13.GistsService {
+  _FakeGistsService_101(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1082,8 +1083,8 @@ class _FakeGitService_101 extends _i1.SmartFake implements _i13.GitService {
         );
 }
 
-class _FakeIssuesService_102 extends _i1.SmartFake implements _i13.IssuesService {
-  _FakeIssuesService_102(
+class _FakeGitService_102 extends _i1.SmartFake implements _i13.GitService {
+  _FakeGitService_102(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1092,8 +1093,8 @@ class _FakeIssuesService_102 extends _i1.SmartFake implements _i13.IssuesService
         );
 }
 
-class _FakeMiscService_103 extends _i1.SmartFake implements _i13.MiscService {
-  _FakeMiscService_103(
+class _FakeIssuesService_103 extends _i1.SmartFake implements _i13.IssuesService {
+  _FakeIssuesService_103(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1102,8 +1103,8 @@ class _FakeMiscService_103 extends _i1.SmartFake implements _i13.MiscService {
         );
 }
 
-class _FakeOrganizationsService_104 extends _i1.SmartFake implements _i13.OrganizationsService {
-  _FakeOrganizationsService_104(
+class _FakeMiscService_104 extends _i1.SmartFake implements _i13.MiscService {
+  _FakeMiscService_104(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1112,8 +1113,8 @@ class _FakeOrganizationsService_104 extends _i1.SmartFake implements _i13.Organi
         );
 }
 
-class _FakePullRequestsService_105 extends _i1.SmartFake implements _i13.PullRequestsService {
-  _FakePullRequestsService_105(
+class _FakeOrganizationsService_105 extends _i1.SmartFake implements _i13.OrganizationsService {
+  _FakeOrganizationsService_105(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1122,8 +1123,8 @@ class _FakePullRequestsService_105 extends _i1.SmartFake implements _i13.PullReq
         );
 }
 
-class _FakeRepositoriesService_106 extends _i1.SmartFake implements _i13.RepositoriesService {
-  _FakeRepositoriesService_106(
+class _FakePullRequestsService_106 extends _i1.SmartFake implements _i13.PullRequestsService {
+  _FakePullRequestsService_106(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1132,8 +1133,8 @@ class _FakeRepositoriesService_106 extends _i1.SmartFake implements _i13.Reposit
         );
 }
 
-class _FakeSearchService_107 extends _i1.SmartFake implements _i13.SearchService {
-  _FakeSearchService_107(
+class _FakeRepositoriesService_107 extends _i1.SmartFake implements _i13.RepositoriesService {
+  _FakeRepositoriesService_107(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1142,8 +1143,8 @@ class _FakeSearchService_107 extends _i1.SmartFake implements _i13.SearchService
         );
 }
 
-class _FakeUrlShortenerService_108 extends _i1.SmartFake implements _i13.UrlShortenerService {
-  _FakeUrlShortenerService_108(
+class _FakeSearchService_108 extends _i1.SmartFake implements _i13.SearchService {
+  _FakeSearchService_108(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1152,8 +1153,8 @@ class _FakeUrlShortenerService_108 extends _i1.SmartFake implements _i13.UrlShor
         );
 }
 
-class _FakeUsersService_109 extends _i1.SmartFake implements _i13.UsersService {
-  _FakeUsersService_109(
+class _FakeUrlShortenerService_109 extends _i1.SmartFake implements _i13.UrlShortenerService {
+  _FakeUrlShortenerService_109(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1162,8 +1163,8 @@ class _FakeUsersService_109 extends _i1.SmartFake implements _i13.UsersService {
         );
 }
 
-class _FakeChecksService_110 extends _i1.SmartFake implements _i13.ChecksService {
-  _FakeChecksService_110(
+class _FakeUsersService_110 extends _i1.SmartFake implements _i13.UsersService {
+  _FakeUsersService_110(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1172,8 +1173,18 @@ class _FakeChecksService_110 extends _i1.SmartFake implements _i13.ChecksService
         );
 }
 
-class _FakeResponse_111 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_111(
+class _FakeChecksService_111 extends _i1.SmartFake implements _i13.ChecksService {
+  _FakeChecksService_111(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeResponse_112 extends _i1.SmartFake implements _i2.Response {
+  _FakeResponse_112(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1221,7 +1232,7 @@ class MockAccessClientProvider extends _i1.Mock implements _i5.AccessClientProvi
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock implements _i26.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock implements _i27.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1362,13 +1373,13 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
       ) as _i7.GerritService);
 
   @override
-  _i27.RetryOptions get retryOptions => (super.noSuchMethod(
+  _i28.RetryOptions get retryOptions => (super.noSuchMethod(
         Invocation.getter(#retryOptions),
-        returnValue: _i28.dummyValue<_i27.RetryOptions>(
+        returnValue: _i29.dummyValue<_i28.RetryOptions>(
           this,
           Invocation.getter(#retryOptions),
         ),
-      ) as _i27.RetryOptions);
+      ) as _i28.RetryOptions);
 
   @override
   _i20.Future<void> branchFlutterRecipes(
@@ -1417,7 +1428,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   String get buildBucketBuildUri => (super.noSuchMethod(
         Invocation.getter(#buildBucketBuildUri),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#buildBucketBuildUri),
         ),
@@ -1426,7 +1437,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   String get buildBucketBuilderUri => (super.noSuchMethod(
         Invocation.getter(#buildBucketBuilderUri),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#buildBucketBuilderUri),
         ),
@@ -1580,7 +1591,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
 /// A class which mocks [CommitService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCommitService extends _i1.Mock implements _i29.CommitService {
+class MockCommitService extends _i1.Mock implements _i30.CommitService {
   MockCommitService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1604,7 +1615,7 @@ class MockCommitService extends _i1.Mock implements _i29.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i30.CreateEvent? createEvent) => (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i31.CreateEvent? createEvent) => (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1647,7 +1658,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get autosubmitBot => (super.noSuchMethod(
         Invocation.getter(#autosubmitBot),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#autosubmitBot),
         ),
@@ -1665,7 +1676,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubPrivateKey => (super.noSuchMethod(
         Invocation.getter(#githubPrivateKey),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#githubPrivateKey),
         )),
@@ -1674,7 +1685,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get overrideTreeStatusLabel => (super.noSuchMethod(
         Invocation.getter(#overrideTreeStatusLabel),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#overrideTreeStatusLabel),
         )),
@@ -1683,7 +1694,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubPublicKey => (super.noSuchMethod(
         Invocation.getter(#githubPublicKey),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#githubPublicKey),
         )),
@@ -1692,7 +1703,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubAppId => (super.noSuchMethod(
         Invocation.getter(#githubAppId),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#githubAppId),
         )),
@@ -1707,7 +1718,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get defaultRecipeBundleRef => (super.noSuchMethod(
         Invocation.getter(#defaultRecipeBundleRef),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#defaultRecipeBundleRef),
         ),
@@ -1761,7 +1772,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get oauthClientId => (super.noSuchMethod(
         Invocation.getter(#oauthClientId),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#oauthClientId),
         )),
@@ -1770,7 +1781,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get frobWebhookKey => (super.noSuchMethod(
         Invocation.getter(#frobWebhookKey),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#frobWebhookKey),
         )),
@@ -1779,7 +1790,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubOAuthToken => (super.noSuchMethod(
         Invocation.getter(#githubOAuthToken),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#githubOAuthToken),
         )),
@@ -1788,7 +1799,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get wrongBaseBranchPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#wrongBaseBranchPullRequestMessage),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#wrongBaseBranchPullRequestMessage),
         ),
@@ -1797,7 +1808,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get releaseBranchPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#releaseBranchPullRequestMessage),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#releaseBranchPullRequestMessage),
         ),
@@ -1806,7 +1817,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get webhookKey => (super.noSuchMethod(
         Invocation.getter(#webhookKey),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.getter(#webhookKey),
         )),
@@ -1815,7 +1826,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get mergeConflictPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#mergeConflictPullRequestMessage),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#mergeConflictPullRequestMessage),
         ),
@@ -1824,7 +1835,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get missingTestsPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#missingTestsPullRequestMessage),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#missingTestsPullRequestMessage),
         ),
@@ -1833,7 +1844,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldPending => (super.noSuchMethod(
         Invocation.getter(#flutterGoldPending),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldPending),
         ),
@@ -1842,7 +1853,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldSuccess => (super.noSuchMethod(
         Invocation.getter(#flutterGoldSuccess),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldSuccess),
         ),
@@ -1851,7 +1862,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldChanges => (super.noSuchMethod(
         Invocation.getter(#flutterGoldChanges),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldChanges),
         ),
@@ -1860,7 +1871,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldStalePR => (super.noSuchMethod(
         Invocation.getter(#flutterGoldStalePR),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldStalePR),
         ),
@@ -1869,7 +1880,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldDraftChange => (super.noSuchMethod(
         Invocation.getter(#flutterGoldDraftChange),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldDraftChange),
         ),
@@ -1920,7 +1931,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterBuild => (super.noSuchMethod(
         Invocation.getter(#flutterBuild),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterBuild),
         ),
@@ -1929,7 +1940,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterBuildDescription => (super.noSuchMethod(
         Invocation.getter(#flutterBuildDescription),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#flutterBuildDescription),
         ),
@@ -1938,7 +1949,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get waitingForTreeToGoGreenLabelName => (super.noSuchMethod(
         Invocation.getter(#waitingForTreeToGoGreenLabelName),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#waitingForTreeToGoGreenLabelName),
         ),
@@ -1951,13 +1962,13 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i31.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i32.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
         ),
-        returnValue: _i20.Future<Iterable<_i31.Branch>>.value(<_i31.Branch>[]),
-      ) as _i20.Future<Iterable<_i31.Branch>>);
+        returnValue: _i20.Future<Iterable<_i32.Branch>>.value(<_i32.Branch>[]),
+      ) as _i20.Future<Iterable<_i32.Branch>>);
 
   @override
   String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
@@ -1965,7 +1976,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #wrongHeadBranchPullRequestMessage,
           [branch],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #wrongHeadBranchPullRequestMessage,
@@ -1980,7 +1991,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldInitialAlert,
           [url],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldInitialAlert,
@@ -1995,7 +2006,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldFollowUpAlert,
           [url],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldFollowUpAlert,
@@ -2010,7 +2021,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldAlertConstant,
           [slug],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldAlertConstant,
@@ -2025,7 +2036,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldCommentID,
           [pr],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldCommentID,
@@ -2040,7 +2051,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #generateJsonWebToken,
           [],
         ),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.method(
             #generateJsonWebToken,
@@ -2055,7 +2066,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #generateGithubToken,
           [slug],
         ),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.method(
             #generateGithubToken,
@@ -2237,16 +2248,16 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i11.DatastoreDB);
 
   @override
-  _i27.RetryOptions get retryOptions => (super.noSuchMethod(
+  _i28.RetryOptions get retryOptions => (super.noSuchMethod(
         Invocation.getter(#retryOptions),
-        returnValue: _i28.dummyValue<_i27.RetryOptions>(
+        returnValue: _i29.dummyValue<_i28.RetryOptions>(
           this,
           Invocation.getter(#retryOptions),
         ),
-      ) as _i27.RetryOptions);
+      ) as _i28.RetryOptions);
 
   @override
-  _i20.Stream<_i32.Commit> queryRecentCommits({
+  _i20.Stream<_i33.Commit> queryRecentCommits({
     int? limit = 100,
     int? timestamp,
     String? branch,
@@ -2263,20 +2274,20 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Stream<_i32.Commit>.empty(),
-      ) as _i20.Stream<_i32.Commit>);
+        returnValue: _i20.Stream<_i33.Commit>.empty(),
+      ) as _i20.Stream<_i33.Commit>);
 
   @override
-  _i20.Stream<_i31.Branch> queryBranches() => (super.noSuchMethod(
+  _i20.Stream<_i32.Branch> queryBranches() => (super.noSuchMethod(
         Invocation.method(
           #queryBranches,
           [],
         ),
-        returnValue: _i20.Stream<_i31.Branch>.empty(),
-      ) as _i20.Stream<_i31.Branch>);
+        returnValue: _i20.Stream<_i32.Branch>.empty(),
+      ) as _i20.Stream<_i32.Branch>);
 
   @override
-  _i20.Stream<_i33.Task> queryRecentTasksByName({
+  _i20.Stream<_i34.Task> queryRecentTasksByName({
     int? limit = 100,
     required String? name,
   }) =>
@@ -2289,11 +2300,11 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #name: name,
           },
         ),
-        returnValue: _i20.Stream<_i33.Task>.empty(),
-      ) as _i20.Stream<_i33.Task>);
+        returnValue: _i20.Stream<_i34.Task>.empty(),
+      ) as _i20.Stream<_i34.Task>);
 
   @override
-  _i20.Stream<_i33.FullTask> queryRecentTasks({
+  _i20.Stream<_i34.FullTask> queryRecentTasks({
     String? taskName,
     int? commitLimit = 20,
     String? branch,
@@ -2310,17 +2321,17 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Stream<_i33.FullTask>.empty(),
-      ) as _i20.Stream<_i33.FullTask>);
+        returnValue: _i20.Stream<_i34.FullTask>.empty(),
+      ) as _i20.Stream<_i34.FullTask>);
 
   @override
-  _i20.Future<List<_i34.Stage>> queryTasksGroupedByStage(_i32.Commit? commit) => (super.noSuchMethod(
+  _i20.Future<List<_i35.Stage>> queryTasksGroupedByStage(_i33.Commit? commit) => (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
         ),
-        returnValue: _i20.Future<List<_i34.Stage>>.value(<_i34.Stage>[]),
-      ) as _i20.Future<List<_i34.Stage>>);
+        returnValue: _i20.Future<List<_i35.Stage>>.value(<_i35.Stage>[]),
+      ) as _i20.Future<List<_i35.Stage>>);
 
   @override
   _i20.Future<_i18.GithubBuildStatusUpdate> queryLastStatusUpdate(
@@ -2412,8 +2423,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
           [key],
           {#orElse: orElse},
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<T>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #lookupByValue,
@@ -2443,7 +2454,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T?>);
 
   @override
-  _i20.Future<_i33.Task?> getTaskFromBuildbucketBuild(
+  _i20.Future<_i34.Task?> getTaskFromBuildbucketBuild(
     _i8.Build? build, {
     String? customName,
   }) =>
@@ -2453,26 +2464,26 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
           [build],
           {#customName: customName},
         ),
-        returnValue: _i20.Future<_i33.Task?>.value(),
-      ) as _i20.Future<_i33.Task?>);
+        returnValue: _i20.Future<_i34.Task?>.value(),
+      ) as _i20.Future<_i34.Task?>);
 }
 
 /// A class which mocks [FakeEntry].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockFakeEntry extends _i1.Mock implements _i35.FakeEntry {
+class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
   MockFakeEntry() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i36.Uint8List get value => (super.noSuchMethod(
+  _i37.Uint8List get value => (super.noSuchMethod(
         Invocation.getter(#value),
-        returnValue: _i36.Uint8List(0),
-      ) as _i36.Uint8List);
+        returnValue: _i37.Uint8List(0),
+      ) as _i37.Uint8List);
 
   @override
-  set value(_i36.Uint8List? _value) => super.noSuchMethod(
+  set value(_i37.Uint8List? _value) => super.noSuchMethod(
         Invocation.setter(
           #value,
           _value,
@@ -2481,8 +2492,8 @@ class MockFakeEntry extends _i1.Mock implements _i35.FakeEntry {
       );
 
   @override
-  _i20.Future<_i36.Uint8List> get([
-    _i20.Future<_i36.Uint8List?> Function()? create,
+  _i20.Future<_i37.Uint8List> get([
+    _i20.Future<_i37.Uint8List?> Function()? create,
     Duration? ttl,
   ]) =>
       (super.noSuchMethod(
@@ -2493,8 +2504,8 @@ class MockFakeEntry extends _i1.Mock implements _i35.FakeEntry {
             ttl,
           ],
         ),
-        returnValue: _i20.Future<_i36.Uint8List>.value(_i36.Uint8List(0)),
-      ) as _i20.Future<_i36.Uint8List>);
+        returnValue: _i20.Future<_i37.Uint8List>.value(_i37.Uint8List(0)),
+      ) as _i20.Future<_i37.Uint8List>);
 
   @override
   _i20.Future<void> purge({int? retries = 0}) => (super.noSuchMethod(
@@ -2508,8 +2519,8 @@ class MockFakeEntry extends _i1.Mock implements _i35.FakeEntry {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<_i36.Uint8List?> set(
-    _i36.Uint8List? value, [
+  _i20.Future<_i37.Uint8List?> set(
+    _i37.Uint8List? value, [
     Duration? ttl,
   ]) =>
       (super.noSuchMethod(
@@ -2520,8 +2531,8 @@ class MockFakeEntry extends _i1.Mock implements _i35.FakeEntry {
             ttl,
           ],
         ),
-        returnValue: _i20.Future<_i36.Uint8List?>.value(),
-      ) as _i20.Future<_i36.Uint8List?>);
+        returnValue: _i20.Future<_i37.Uint8List?>.value(),
+      ) as _i20.Future<_i37.Uint8List?>);
 }
 
 /// A class which mocks [FirestoreService].
@@ -2613,13 +2624,38 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.CommitResponse>);
 
   @override
-  _i20.Future<List<_i37.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
+  _i20.Future<List<_i38.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
         Invocation.method(
           #queryCommitTasks,
           [commitSha],
         ),
-        returnValue: _i20.Future<List<_i37.Task>>.value(<_i37.Task>[]),
-      ) as _i20.Future<List<_i37.Task>>);
+        returnValue: _i20.Future<List<_i38.Task>>.value(<_i38.Task>[]),
+      ) as _i20.Future<List<_i38.Task>>);
+
+  @override
+  _i20.Future<_i22.GithubGoldStatus> queryLastGoldStatus(
+    _i13.RepositorySlug? slug,
+    int? prNumber,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryLastGoldStatus,
+          [
+            slug,
+            prNumber,
+          ],
+        ),
+        returnValue: _i20.Future<_i22.GithubGoldStatus>.value(_FakeGithubGoldStatus_28(
+          this,
+          Invocation.method(
+            #queryLastGoldStatus,
+            [
+              slug,
+              prNumber,
+            ],
+          ),
+        )),
+      ) as _i20.Future<_i22.GithubGoldStatus>);
 
   @override
   _i21.Value getValueFromFilter(Object? comparisonOject) => (super.noSuchMethod(
@@ -2627,7 +2663,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
           #getValueFromFilter,
           [comparisonOject],
         ),
-        returnValue: _FakeValue_28(
+        returnValue: _FakeValue_29(
           this,
           Invocation.method(
             #getValueFromFilter,
@@ -2649,7 +2685,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             compositeFilterOp,
           ],
         ),
-        returnValue: _FakeFilter_29(
+        returnValue: _FakeFilter_30(
           this,
           Invocation.method(
             #generateFilter,
@@ -2840,7 +2876,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
           this,
           Invocation.method(
             #edit,
@@ -2866,7 +2902,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issueNumber,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
           this,
           Invocation.method(
             #get,
@@ -2891,7 +2927,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
           this,
           Invocation.method(
             #create,
@@ -2966,7 +3002,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
           this,
           Invocation.method(
             #getComment,
@@ -2993,7 +3029,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
           this,
           Invocation.method(
             #createComment,
@@ -3021,7 +3057,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_31(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
           this,
           Invocation.method(
             #updateComment,
@@ -3072,7 +3108,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             name,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
           this,
           Invocation.method(
             #getLabel,
@@ -3103,7 +3139,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
           this,
           Invocation.method(
             #createLabel,
@@ -3134,7 +3170,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             color,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
           this,
           Invocation.method(
             #editLabel,
@@ -3168,7 +3204,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_32(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
           this,
           Invocation.method(
             #updateLabel,
@@ -3309,7 +3345,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_33(
+        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_34(
           this,
           Invocation.method(
             #createMilestone,
@@ -3417,16 +3453,16 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       );
 
   @override
-  _i22.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
+  _i23.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_34(
+        returnValue: _FakeGithubChecksUtil_35(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
-      ) as _i22.GithubChecksUtil);
+      ) as _i23.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i23.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3437,7 +3473,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
   @override
   _i20.Future<void> handleCheckSuite(
     _i13.PullRequest? pullRequest,
-    _i30.CheckSuiteEvent? checkSuiteEvent,
+    _i31.CheckSuiteEvent? checkSuiteEvent,
     _i15.Scheduler? scheduler,
   ) =>
       (super.noSuchMethod(
@@ -3455,7 +3491,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
 
   @override
   _i20.Future<bool> updateCheckStatus(
-    _i38.BuildPushMessage? buildPushMessage,
+    _i39.BuildPushMessage? buildPushMessage,
     _i15.LuciBuildService? luciBuildService,
     _i13.RepositorySlug? slug, {
     bool? rescheduled = false,
@@ -3474,7 +3510,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i20.Future<bool>);
 
   @override
-  bool taskFailed(_i38.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  bool taskFailed(_i39.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
         Invocation.method(
           #taskFailed,
           [buildPushMessage],
@@ -3483,7 +3519,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as bool);
 
   @override
-  int currentAttempt(_i38.Build? build) => (super.noSuchMethod(
+  int currentAttempt(_i39.Build? build) => (super.noSuchMethod(
         Invocation.method(
           #currentAttempt,
           [build],
@@ -3497,7 +3533,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
           #getGithubSummary,
           [summary],
         ),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.method(
             #getGithubSummary,
@@ -3507,12 +3543,12 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i38.Result? result) => (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i39.Result? result) => (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [result],
         ),
-        returnValue: _FakeCheckRunConclusion_35(
+        returnValue: _FakeCheckRunConclusion_36(
           this,
           Invocation.method(
             #conclusionForResult,
@@ -3522,12 +3558,12 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i38.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i39.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
         ),
-        returnValue: _FakeCheckRunStatus_36(
+        returnValue: _FakeCheckRunStatus_37(
           this,
           Invocation.method(
             #statusForResult,
@@ -3558,7 +3594,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
 /// A class which mocks [GithubChecksUtil].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
+class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
   MockGithubChecksUtil() {
     _i1.throwOnMissingStub(this);
   }
@@ -3566,7 +3602,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
   @override
   _i20.Future<Map<String, _i13.CheckRun>> allCheckRuns(
     _i13.GitHub? gitHubClient,
-    _i30.CheckSuiteEvent? checkSuiteEvent,
+    _i31.CheckSuiteEvent? checkSuiteEvent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3594,7 +3630,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             checkSuiteId,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_37(
+        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_38(
           this,
           Invocation.method(
             #getCheckSuite,
@@ -3675,7 +3711,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_38(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_39(
           this,
           Invocation.method(
             #getCheckRun,
@@ -3707,7 +3743,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i22.GithubChecksUtil {
           ],
           {#output: output},
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_38(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_39(
           this,
           Invocation.method(
             #createCheckRun,
@@ -3795,7 +3831,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #entries: entries,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
           this,
           Invocation.method(
             #createPullRequest,
@@ -3931,7 +3967,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #assignee: assignee,
           },
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_30(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
           this,
           Invocation.method(
             #createIssue,
@@ -4006,7 +4042,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.method(
             #getFileContent,
@@ -4032,7 +4068,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
           this,
           Invocation.method(
             #getReference,
@@ -4050,7 +4086,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
           #getRateLimit,
           [],
         ),
-        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_41(
+        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_42(
           this,
           Invocation.method(
             #getRateLimit,
@@ -4094,7 +4130,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
           this,
           Invocation.method(
             #getPullRequest,
@@ -4137,7 +4173,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_42(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_43(
           this,
           Invocation.method(
             #getBlob,
@@ -4162,7 +4198,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             blob,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_42(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_43(
           this,
           Invocation.method(
             #createBlob,
@@ -4187,7 +4223,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_43(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_44(
           this,
           Invocation.method(
             #getCommit,
@@ -4212,7 +4248,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             commit,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_43(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_44(
           this,
           Invocation.method(
             #createCommit,
@@ -4237,7 +4273,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
           this,
           Invocation.method(
             #getReference,
@@ -4278,7 +4314,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
           this,
           Invocation.method(
             #createReference,
@@ -4308,7 +4344,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#force: force},
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_40(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
           this,
           Invocation.method(
             #editReference,
@@ -4351,7 +4387,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_44(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_45(
           this,
           Invocation.method(
             #getTag,
@@ -4376,7 +4412,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tag,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_44(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_45(
           this,
           Invocation.method(
             #createTag,
@@ -4403,7 +4439,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#recursive: recursive},
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_45(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_46(
           this,
           Invocation.method(
             #getTree,
@@ -4429,7 +4465,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tree,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_45(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_46(
           this,
           Invocation.method(
             #createTree,
@@ -4453,7 +4489,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.DefaultPolicies get defaultPolicies => (super.noSuchMethod(
         Invocation.getter(#defaultPolicies),
-        returnValue: _FakeDefaultPolicies_46(
+        returnValue: _FakeDefaultPolicies_47(
           this,
           Invocation.getter(#defaultPolicies),
         ),
@@ -4471,7 +4507,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.Link get link => (super.noSuchMethod(
         Invocation.getter(#link),
-        returnValue: _FakeLink_47(
+        returnValue: _FakeLink_48(
           this,
           Invocation.getter(#link),
         ),
@@ -4480,7 +4516,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.GraphQLCache get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeGraphQLCache_48(
+        returnValue: _FakeGraphQLCache_49(
           this,
           Invocation.getter(#cache),
         ),
@@ -4489,7 +4525,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.QueryManager get queryManager => (super.noSuchMethod(
         Invocation.getter(#queryManager),
-        returnValue: _FakeQueryManager_49(
+        returnValue: _FakeQueryManager_50(
           this,
           Invocation.getter(#queryManager),
         ),
@@ -4543,7 +4579,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchQuery,
           [options],
         ),
-        returnValue: _FakeObservableQuery_50<TParsed>(
+        returnValue: _FakeObservableQuery_51<TParsed>(
           this,
           Invocation.method(
             #watchQuery,
@@ -4558,7 +4594,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchMutation,
           [options],
         ),
-        returnValue: _FakeObservableQuery_50<TParsed>(
+        returnValue: _FakeObservableQuery_51<TParsed>(
           this,
           Invocation.method(
             #watchMutation,
@@ -4573,7 +4609,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4588,7 +4624,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4622,7 +4658,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_51<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4705,7 +4741,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
 /// A class which mocks [HttpClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
+class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
   MockHttpClient() {
     _i1.throwOnMissingStub(this);
   }
@@ -4787,7 +4823,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
 
   @override
   set connectionFactory(
-          _i20.Future<_i23.ConnectionTask<_i23.Socket>> Function(
+          _i20.Future<_i24.ConnectionTask<_i24.Socket>> Function(
             Uri,
             String?,
             int?,
@@ -4828,7 +4864,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
   @override
   set badCertificateCallback(
           bool Function(
-            _i23.X509Certificate,
+            _i24.X509Certificate,
             String,
             int,
           )? callback) =>
@@ -4850,7 +4886,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
       );
 
   @override
-  _i20.Future<_i23.HttpClientRequest> open(
+  _i20.Future<_i24.HttpClientRequest> open(
     String? method,
     String? host,
     int? port,
@@ -4866,7 +4902,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #open,
@@ -4878,10 +4914,10 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> openUrl(
+  _i20.Future<_i24.HttpClientRequest> openUrl(
     String? method,
     Uri? url,
   ) =>
@@ -4893,7 +4929,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             url,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #openUrl,
@@ -4903,10 +4939,10 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> get(
+  _i20.Future<_i24.HttpClientRequest> get(
     String? host,
     int? port,
     String? path,
@@ -4920,7 +4956,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #get,
@@ -4931,25 +4967,25 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #getUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #getUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> post(
+  _i20.Future<_i24.HttpClientRequest> post(
     String? host,
     int? port,
     String? path,
@@ -4963,7 +4999,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #post,
@@ -4974,25 +5010,25 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #postUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #postUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> put(
+  _i20.Future<_i24.HttpClientRequest> put(
     String? host,
     int? port,
     String? path,
@@ -5006,7 +5042,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #put,
@@ -5017,25 +5053,25 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #putUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #putUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> delete(
+  _i20.Future<_i24.HttpClientRequest> delete(
     String? host,
     int? port,
     String? path,
@@ -5049,7 +5085,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #delete,
@@ -5060,25 +5096,25 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #deleteUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> patch(
+  _i20.Future<_i24.HttpClientRequest> patch(
     String? host,
     int? port,
     String? path,
@@ -5092,7 +5128,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #patch,
@@ -5103,25 +5139,25 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #patchUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #patchUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> head(
+  _i20.Future<_i24.HttpClientRequest> head(
     String? host,
     int? port,
     String? path,
@@ -5135,7 +5171,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #head,
@@ -5146,28 +5182,28 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
-  _i20.Future<_i23.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #headUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i23.HttpClientRequest>.value(_FakeHttpClientRequest_52(
+        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
           this,
           Invocation.method(
             #headUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientRequest>);
+      ) as _i20.Future<_i24.HttpClientRequest>);
 
   @override
   void addCredentials(
     Uri? url,
     String? realm,
-    _i23.HttpClientCredentials? credentials,
+    _i24.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -5186,7 +5222,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
     String? host,
     int? port,
     String? realm,
-    _i23.HttpClientCredentials? credentials,
+    _i24.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -5215,7 +5251,7 @@ class MockHttpClient extends _i1.Mock implements _i23.HttpClient {
 /// A class which mocks [HttpClientRequest].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
+class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
   MockHttpClientRequest() {
     _i1.throwOnMissingStub(this);
   }
@@ -5298,7 +5334,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   String get method => (super.noSuchMethod(
         Invocation.getter(#method),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#method),
         ),
@@ -5307,47 +5343,47 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
   @override
   Uri get uri => (super.noSuchMethod(
         Invocation.getter(#uri),
-        returnValue: _FakeUri_53(
+        returnValue: _FakeUri_54(
           this,
           Invocation.getter(#uri),
         ),
       ) as Uri);
 
   @override
-  _i23.HttpHeaders get headers => (super.noSuchMethod(
+  _i24.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_54(
+        returnValue: _FakeHttpHeaders_55(
           this,
           Invocation.getter(#headers),
         ),
-      ) as _i23.HttpHeaders);
+      ) as _i24.HttpHeaders);
 
   @override
-  List<_i23.Cookie> get cookies => (super.noSuchMethod(
+  List<_i24.Cookie> get cookies => (super.noSuchMethod(
         Invocation.getter(#cookies),
-        returnValue: <_i23.Cookie>[],
-      ) as List<_i23.Cookie>);
+        returnValue: <_i24.Cookie>[],
+      ) as List<_i24.Cookie>);
 
   @override
-  _i20.Future<_i23.HttpClientResponse> get done => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
+        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
           this,
           Invocation.getter(#done),
         )),
-      ) as _i20.Future<_i23.HttpClientResponse>);
+      ) as _i20.Future<_i24.HttpClientResponse>);
 
   @override
-  _i24.Encoding get encoding => (super.noSuchMethod(
+  _i25.Encoding get encoding => (super.noSuchMethod(
         Invocation.getter(#encoding),
-        returnValue: _FakeEncoding_56(
+        returnValue: _FakeEncoding_57(
           this,
           Invocation.getter(#encoding),
         ),
-      ) as _i24.Encoding);
+      ) as _i25.Encoding);
 
   @override
-  set encoding(_i24.Encoding? _encoding) => super.noSuchMethod(
+  set encoding(_i25.Encoding? _encoding) => super.noSuchMethod(
         Invocation.setter(
           #encoding,
           _encoding,
@@ -5356,19 +5392,19 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
       );
 
   @override
-  _i20.Future<_i23.HttpClientResponse> close() => (super.noSuchMethod(
+  _i20.Future<_i24.HttpClientResponse> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
+        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
           this,
           Invocation.method(
             #close,
             [],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientResponse>);
+      ) as _i20.Future<_i24.HttpClientResponse>);
 
   @override
   void abort([
@@ -5476,7 +5512,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i23.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5490,7 +5526,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
   @override
   String get reasonPhrase => (super.noSuchMethod(
         Invocation.getter(#reasonPhrase),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#reasonPhrase),
         ),
@@ -5503,10 +5539,10 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as int);
 
   @override
-  _i23.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
+  _i24.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
         Invocation.getter(#compressionState),
-        returnValue: _i23.HttpClientResponseCompressionState.notCompressed,
-      ) as _i23.HttpClientResponseCompressionState);
+        returnValue: _i24.HttpClientResponseCompressionState.notCompressed,
+      ) as _i24.HttpClientResponseCompressionState);
 
   @override
   bool get persistentConnection => (super.noSuchMethod(
@@ -5521,25 +5557,25 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as bool);
 
   @override
-  List<_i23.RedirectInfo> get redirects => (super.noSuchMethod(
+  List<_i24.RedirectInfo> get redirects => (super.noSuchMethod(
         Invocation.getter(#redirects),
-        returnValue: <_i23.RedirectInfo>[],
-      ) as List<_i23.RedirectInfo>);
+        returnValue: <_i24.RedirectInfo>[],
+      ) as List<_i24.RedirectInfo>);
 
   @override
-  _i23.HttpHeaders get headers => (super.noSuchMethod(
+  _i24.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_54(
+        returnValue: _FakeHttpHeaders_55(
           this,
           Invocation.getter(#headers),
         ),
-      ) as _i23.HttpHeaders);
+      ) as _i24.HttpHeaders);
 
   @override
-  List<_i23.Cookie> get cookies => (super.noSuchMethod(
+  List<_i24.Cookie> get cookies => (super.noSuchMethod(
         Invocation.getter(#cookies),
-        returnValue: <_i23.Cookie>[],
-      ) as List<_i23.Cookie>);
+        returnValue: <_i24.Cookie>[],
+      ) as List<_i24.Cookie>);
 
   @override
   bool get isBroadcast => (super.noSuchMethod(
@@ -5578,7 +5614,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
       ) as _i20.Future<List<int>>);
 
   @override
-  _i20.Future<_i23.HttpClientResponse> redirect([
+  _i20.Future<_i24.HttpClientResponse> redirect([
     String? method,
     Uri? url,
     bool? followLoops,
@@ -5592,7 +5628,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i23.HttpClientResponse>.value(_FakeHttpClientResponse_55(
+        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
           this,
           Invocation.method(
             #redirect,
@@ -5603,22 +5639,22 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             ],
           ),
         )),
-      ) as _i20.Future<_i23.HttpClientResponse>);
+      ) as _i20.Future<_i24.HttpClientResponse>);
 
   @override
-  _i20.Future<_i23.Socket> detachSocket() => (super.noSuchMethod(
+  _i20.Future<_i24.Socket> detachSocket() => (super.noSuchMethod(
         Invocation.method(
           #detachSocket,
           [],
         ),
-        returnValue: _i20.Future<_i23.Socket>.value(_FakeSocket_57(
+        returnValue: _i20.Future<_i24.Socket>.value(_FakeSocket_58(
           this,
           Invocation.method(
             #detachSocket,
             [],
           ),
         )),
-      ) as _i20.Future<_i23.Socket>);
+      ) as _i20.Future<_i24.Socket>);
 
   @override
   _i20.Stream<List<int>> asBroadcastStream({
@@ -5654,7 +5690,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             #cancelOnError: cancelOnError,
           },
         ),
-        returnValue: _FakeStreamSubscription_58<List<int>>(
+        returnValue: _FakeStreamSubscription_59<List<int>>(
           this,
           Invocation.method(
             #listen,
@@ -5775,8 +5811,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
             combine,
           ],
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<S>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<S>(
                 this,
                 Invocation.method(
                   #fold,
@@ -5806,7 +5842,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
           #join,
           [separator],
         ),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.method(
             #join,
@@ -5885,8 +5921,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i23.HttpClientResponse
           #drain,
           [futureValue],
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<E>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<E>(
                 this,
                 Invocation.method(
                   #drain,
@@ -6047,7 +6083,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_59(
+        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_60(
           this,
           Invocation.method(
             #cancel,
@@ -6105,7 +6141,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_60(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_61(
           this,
           Invocation.method(
             #get,
@@ -6148,7 +6184,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_61(
+        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_62(
           this,
           Invocation.method(
             #getQueryResults,
@@ -6189,7 +6225,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #uploadMedia: uploadMedia,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_60(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_61(
           this,
           Invocation.method(
             #insert,
@@ -6235,7 +6271,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_62(
+        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_63(
           this,
           Invocation.method(
             #list,
@@ -6270,7 +6306,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_63(
+        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_64(
           this,
           Invocation.method(
             #query,
@@ -6295,7 +6331,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.BuildBucketClient get buildBucketClient => (super.noSuchMethod(
         Invocation.getter(#buildBucketClient),
-        returnValue: _FakeBuildBucketClient_64(
+        returnValue: _FakeBuildBucketClient_65(
           this,
           Invocation.getter(#buildBucketClient),
         ),
@@ -6313,7 +6349,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.CacheService get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeCacheService_65(
+        returnValue: _FakeCacheService_66(
           this,
           Invocation.getter(#cache),
         ),
@@ -6338,16 +6374,16 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       );
 
   @override
-  _i22.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
+  _i23.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_34(
+        returnValue: _FakeGithubChecksUtil_35(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
-      ) as _i22.GithubChecksUtil);
+      ) as _i23.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i22.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i23.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -6376,7 +6412,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.PubSub get pubsub => (super.noSuchMethod(
         Invocation.getter(#pubsub),
-        returnValue: _FakePubSub_66(
+        returnValue: _FakePubSub_67(
           this,
           Invocation.getter(#pubsub),
         ),
@@ -6466,10 +6502,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<List<_i39.Target>> scheduleTryBuilds({
-    required List<_i39.Target>? targets,
+  _i20.Future<List<_i40.Target>> scheduleTryBuilds({
+    required List<_i40.Target>? targets,
     required _i13.PullRequest? pullRequest,
-    _i30.CheckSuiteEvent? checkSuiteEvent,
+    _i31.CheckSuiteEvent? checkSuiteEvent,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6481,8 +6517,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #checkSuiteEvent: checkSuiteEvent,
           },
         ),
-        returnValue: _i20.Future<List<_i39.Target>>.value(<_i39.Target>[]),
-      ) as _i20.Future<List<_i39.Target>>);
+        returnValue: _i20.Future<List<_i40.Target>>.value(<_i40.Target>[]),
+      ) as _i20.Future<List<_i40.Target>>);
 
   @override
   _i20.Future<void> cancelBuilds(
@@ -6504,7 +6540,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<List<_i8.Build?>> failedBuilds(
     _i13.PullRequest? pullRequest,
-    List<_i39.Target>? targets,
+    List<_i40.Target>? targets,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6520,7 +6556,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<_i8.Build> rescheduleBuild({
     required String? builderName,
-    required _i38.BuildPushMessage? buildPushMessage,
+    required _i39.BuildPushMessage? buildPushMessage,
     required int? rescheduleAttempt,
   }) =>
       (super.noSuchMethod(
@@ -6548,7 +6584,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i40.CheckRunEvent? checkRunEvent) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i41.CheckRunEvent? checkRunEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6578,10 +6614,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 
   @override
   _i20.Future<_i8.Build> reschedulePostsubmitBuildUsingCheckRunEvent(
-    _i40.CheckRunEvent? checkRunEvent, {
-    required _i32.Commit? commit,
-    required _i33.Task? task,
-    required _i39.Target? target,
+    _i41.CheckRunEvent? checkRunEvent, {
+    required _i33.Commit? commit,
+    required _i34.Task? task,
+    required _i40.Target? target,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6646,9 +6682,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>> schedulePostsubmitBuilds({
-    required _i32.Commit? commit,
-    required List<_i15.Tuple<_i39.Target, _i33.Task, int>>? toBeScheduled,
+  _i20.Future<List<_i15.Tuple<_i40.Target, _i34.Task, int>>> schedulePostsubmitBuilds({
+    required _i33.Commit? commit,
+    required List<_i15.Tuple<_i40.Target, _i34.Task, int>>? toBeScheduled,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6659,14 +6695,14 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>>.value(
-            <_i15.Tuple<_i39.Target, _i33.Task, int>>[]),
-      ) as _i20.Future<List<_i15.Tuple<_i39.Target, _i33.Task, int>>>);
+        returnValue: _i20.Future<List<_i15.Tuple<_i40.Target, _i34.Task, int>>>.value(
+            <_i15.Tuple<_i40.Target, _i34.Task, int>>[]),
+      ) as _i20.Future<List<_i15.Tuple<_i40.Target, _i34.Task, int>>>);
 
   @override
   _i20.Future<void> createPostsubmitCheckRun(
-    _i32.Commit? commit,
-    _i39.Target? target,
+    _i33.Commit? commit,
+    _i40.Target? target,
     Map<String, dynamic>? rawUserData,
   ) =>
       (super.noSuchMethod(
@@ -6684,14 +6720,14 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 
   @override
   _i20.Future<bool> checkRerunBuilder({
-    required _i32.Commit? commit,
-    required _i39.Target? target,
-    required _i33.Task? task,
+    required _i33.Commit? commit,
+    required _i40.Target? target,
+    required _i34.Task? task,
     required _i9.DatastoreService? datastore,
     _i15.FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool? ignoreChecks = false,
-    _i37.Task? taskDocument,
+    _i38.Task? taskDocument,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6715,19 +6751,19 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 /// A class which mocks [ProcessManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
+class MockProcessManager extends _i1.Mock implements _i42.ProcessManager {
   MockProcessManager() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i20.Future<_i23.Process> start(
+  _i20.Future<_i24.Process> start(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i23.ProcessStartMode? mode = _i23.ProcessStartMode.normal,
+    _i24.ProcessStartMode? mode = _i24.ProcessStartMode.normal,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6741,7 +6777,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             #mode: mode,
           },
         ),
-        returnValue: _i20.Future<_i23.Process>.value(_FakeProcess_67(
+        returnValue: _i20.Future<_i24.Process>.value(_FakeProcess_68(
           this,
           Invocation.method(
             #start,
@@ -6755,17 +6791,17 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             },
           ),
         )),
-      ) as _i20.Future<_i23.Process>);
+      ) as _i20.Future<_i24.Process>);
 
   @override
-  _i20.Future<_i23.ProcessResult> run(
+  _i20.Future<_i24.ProcessResult> run(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i24.Encoding? stdoutEncoding = const _i23.SystemEncoding(),
-    _i24.Encoding? stderrEncoding = const _i23.SystemEncoding(),
+    _i25.Encoding? stdoutEncoding = const _i24.SystemEncoding(),
+    _i25.Encoding? stderrEncoding = const _i24.SystemEncoding(),
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6780,7 +6816,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i23.ProcessResult>.value(_i28.dummyValue<_i23.ProcessResult>(
+        returnValue: _i20.Future<_i24.ProcessResult>.value(_i29.dummyValue<_i24.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6795,17 +6831,17 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             },
           ),
         )),
-      ) as _i20.Future<_i23.ProcessResult>);
+      ) as _i20.Future<_i24.ProcessResult>);
 
   @override
-  _i23.ProcessResult runSync(
+  _i24.ProcessResult runSync(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i24.Encoding? stdoutEncoding = const _i23.SystemEncoding(),
-    _i24.Encoding? stderrEncoding = const _i23.SystemEncoding(),
+    _i25.Encoding? stdoutEncoding = const _i24.SystemEncoding(),
+    _i25.Encoding? stderrEncoding = const _i24.SystemEncoding(),
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6820,7 +6856,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i28.dummyValue<_i23.ProcessResult>(
+        returnValue: _i29.dummyValue<_i24.ProcessResult>(
           this,
           Invocation.method(
             #runSync,
@@ -6835,7 +6871,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
             },
           ),
         ),
-      ) as _i23.ProcessResult);
+      ) as _i24.ProcessResult);
 
   @override
   bool canRun(
@@ -6854,7 +6890,7 @@ class MockProcessManager extends _i1.Mock implements _i41.ProcessManager {
   @override
   bool killPid(
     int? pid, [
-    _i23.ProcessSignal? signal = _i23.ProcessSignal.sigterm,
+    _i24.ProcessSignal? signal = _i24.ProcessSignal.sigterm,
   ]) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6924,7 +6960,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
           this,
           Invocation.method(
             #get,
@@ -6949,7 +6985,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
           this,
           Invocation.method(
             #create,
@@ -6984,7 +7020,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #base: base,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_39(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
           this,
           Invocation.method(
             #edit,
@@ -7087,7 +7123,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #requestSha: requestSha,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_68(
+        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_69(
           this,
           Invocation.method(
             #merge,
@@ -7144,7 +7180,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             comment,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_69(
+        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_70(
           this,
           Invocation.method(
             #createComment,
@@ -7170,7 +7206,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             review,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_70(
+        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_71(
           this,
           Invocation.method(
             #createReview,
@@ -7281,7 +7317,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [repository],
           {#org: org},
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
           this,
           Invocation.method(
             #createRepository,
@@ -7297,7 +7333,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLicense,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_72(
+        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_73(
           this,
           Invocation.method(
             #getLicense,
@@ -7312,7 +7348,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getRepository,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
           this,
           Invocation.method(
             #getRepository,
@@ -7355,7 +7391,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #hasDownloads: hasDownloads,
           },
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
           this,
           Invocation.method(
             #editRepository,
@@ -7411,7 +7447,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #listLanguages,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_73(
+        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_74(
           this,
           Invocation.method(
             #listLanguages,
@@ -7462,7 +7498,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_74(
+        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_75(
           this,
           Invocation.method(
             #getBranch,
@@ -7579,7 +7615,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #line: line,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
           this,
           Invocation.method(
             #createCommitComment,
@@ -7608,7 +7644,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
           this,
           Invocation.method(
             #getCommitComment,
@@ -7633,7 +7669,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #body: body,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_75(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
           this,
           Invocation.method(
             #updateCommitComment,
@@ -7699,7 +7735,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_76(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_77(
           this,
           Invocation.method(
             #getCommit,
@@ -7724,7 +7760,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<String>.value(_i28.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
           this,
           Invocation.method(
             #getCommitDiff,
@@ -7751,7 +7787,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             refHead,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_77(
+        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_78(
           this,
           Invocation.method(
             #compareCommits,
@@ -7775,7 +7811,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_78(
+        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_79(
           this,
           Invocation.method(
             #getReadme,
@@ -7800,7 +7836,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_79(
+        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_80(
           this,
           Invocation.method(
             #getContents,
@@ -7826,7 +7862,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             file,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
           this,
           Invocation.method(
             #createFile,
@@ -7859,7 +7895,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#branch: branch},
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
           this,
           Invocation.method(
             #updateFile,
@@ -7894,7 +7930,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_80(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
           this,
           Invocation.method(
             #deleteFile,
@@ -7949,7 +7985,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             fork,
           ],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_71(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
           this,
           Invocation.method(
             #createFork,
@@ -7983,7 +8019,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
           this,
           Invocation.method(
             #getHook,
@@ -8008,7 +8044,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             hook,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
           this,
           Invocation.method(
             #createHook,
@@ -8051,7 +8087,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #active: active,
           },
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_81(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
           this,
           Invocation.method(
             #editHook,
@@ -8141,7 +8177,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
           this,
           Invocation.method(
             #getDeployKey,
@@ -8164,7 +8200,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             key,
           ],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
           this,
           Invocation.method(
             #createDeployKey,
@@ -8206,7 +8242,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             merge,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_76(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_77(
           this,
           Invocation.method(
             #merge,
@@ -8224,7 +8260,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getPagesInfo,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_83(
+        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_84(
           this,
           Invocation.method(
             #getPagesInfo,
@@ -8248,7 +8284,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestPagesBuild,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_84(
+        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_85(
           this,
           Invocation.method(
             #getLatestPagesBuild,
@@ -8272,7 +8308,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestRelease,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
           this,
           Invocation.method(
             #getLatestRelease,
@@ -8294,7 +8330,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
           this,
           Invocation.method(
             #getReleaseById,
@@ -8319,7 +8355,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             tagName,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
           this,
           Invocation.method(
             #getReleaseByTagName,
@@ -8346,7 +8382,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#getIfExists: getIfExists},
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
           this,
           Invocation.method(
             #createRelease,
@@ -8386,7 +8422,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #preRelease: preRelease,
           },
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_85(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
           this,
           Invocation.method(
             #editRelease,
@@ -8453,7 +8489,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#assetId: assetId},
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_86(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_87(
           this,
           Invocation.method(
             #getReleaseAsset,
@@ -8485,7 +8521,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #label: label,
           },
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_86(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_87(
           this,
           Invocation.method(
             #editReleaseAsset,
@@ -8566,7 +8602,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getParticipation,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_87(
+        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_88(
           this,
           Invocation.method(
             #getParticipation,
@@ -8615,7 +8651,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_88(
+        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_89(
           this,
           Invocation.method(
             #createStatus,
@@ -8641,7 +8677,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_89(
+        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_90(
           this,
           Invocation.method(
             #getCombinedStatus,
@@ -8659,7 +8695,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #generateReleaseNotes,
           [crn],
         ),
-        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_90(
+        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_91(
           this,
           Invocation.method(
             #generateReleaseNotes,
@@ -8810,7 +8846,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_91(
+        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_92(
           this,
           Invocation.method(
             #insertAll,
@@ -8852,7 +8888,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_92(
+        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_93(
           this,
           Invocation.method(
             #list,
@@ -8896,7 +8932,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getUser,
           [name],
         ),
-        returnValue: _i20.Future<_i13.User>.value(_FakeUser_93(
+        returnValue: _i20.Future<_i13.User>.value(_FakeUser_94(
           this,
           Invocation.method(
             #getUser,
@@ -8929,7 +8965,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
             #bio: bio,
           },
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_94(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_95(
           this,
           Invocation.method(
             #editCurrentUser,
@@ -8967,7 +9003,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getCurrentUser,
           [],
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_94(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_95(
           this,
           Invocation.method(
             #getCurrentUser,
@@ -9114,7 +9150,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #createPublicKey,
           [key],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_82(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
           this,
           Invocation.method(
             #createPublicKey,
@@ -9127,70 +9163,70 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
 /// A class which mocks [Cache].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCache extends _i1.Mock implements _i25.Cache<_i36.Uint8List> {
+class MockCache extends _i1.Mock implements _i26.Cache<_i37.Uint8List> {
   MockCache() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i25.Entry<_i36.Uint8List> operator [](String? key) => (super.noSuchMethod(
+  _i26.Entry<_i37.Uint8List> operator [](String? key) => (super.noSuchMethod(
         Invocation.method(
           #[],
           [key],
         ),
-        returnValue: _FakeEntry_95<_i36.Uint8List>(
+        returnValue: _FakeEntry_96<_i37.Uint8List>(
           this,
           Invocation.method(
             #[],
             [key],
           ),
         ),
-      ) as _i25.Entry<_i36.Uint8List>);
+      ) as _i26.Entry<_i37.Uint8List>);
 
   @override
-  _i25.Cache<_i36.Uint8List> withPrefix(String? prefix) => (super.noSuchMethod(
+  _i26.Cache<_i37.Uint8List> withPrefix(String? prefix) => (super.noSuchMethod(
         Invocation.method(
           #withPrefix,
           [prefix],
         ),
-        returnValue: _FakeCache_96<_i36.Uint8List>(
+        returnValue: _FakeCache_97<_i37.Uint8List>(
           this,
           Invocation.method(
             #withPrefix,
             [prefix],
           ),
         ),
-      ) as _i25.Cache<_i36.Uint8List>);
+      ) as _i26.Cache<_i37.Uint8List>);
 
   @override
-  _i25.Cache<S> withCodec<S>(_i24.Codec<S, _i36.Uint8List>? codec) => (super.noSuchMethod(
+  _i26.Cache<S> withCodec<S>(_i25.Codec<S, _i37.Uint8List>? codec) => (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],
         ),
-        returnValue: _FakeCache_96<S>(
+        returnValue: _FakeCache_97<S>(
           this,
           Invocation.method(
             #withCodec,
             [codec],
           ),
         ),
-      ) as _i25.Cache<S>);
+      ) as _i26.Cache<S>);
 
   @override
-  _i25.Cache<_i36.Uint8List> withTTL(Duration? ttl) => (super.noSuchMethod(
+  _i26.Cache<_i37.Uint8List> withTTL(Duration? ttl) => (super.noSuchMethod(
         Invocation.method(
           #withTTL,
           [ttl],
         ),
-        returnValue: _FakeCache_96<_i36.Uint8List>(
+        returnValue: _FakeCache_97<_i37.Uint8List>(
           this,
           Invocation.method(
             #withTTL,
             [ttl],
           ),
         ),
-      ) as _i25.Cache<_i36.Uint8List>);
+      ) as _i26.Cache<_i37.Uint8List>);
 }
 
 /// A class which mocks [GitHub].
@@ -9204,7 +9240,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.Authentication get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthentication_97(
+        returnValue: _FakeAuthentication_98(
           this,
           Invocation.getter(#auth),
         ),
@@ -9222,7 +9258,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   String get endpoint => (super.noSuchMethod(
         Invocation.getter(#endpoint),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#endpoint),
         ),
@@ -9231,7 +9267,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   String get version => (super.noSuchMethod(
         Invocation.getter(#version),
-        returnValue: _i28.dummyValue<String>(
+        returnValue: _i29.dummyValue<String>(
           this,
           Invocation.getter(#version),
         ),
@@ -9249,7 +9285,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ActivityService get activity => (super.noSuchMethod(
         Invocation.getter(#activity),
-        returnValue: _FakeActivityService_98(
+        returnValue: _FakeActivityService_99(
           this,
           Invocation.getter(#activity),
         ),
@@ -9258,7 +9294,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.AuthorizationsService get authorizations => (super.noSuchMethod(
         Invocation.getter(#authorizations),
-        returnValue: _FakeAuthorizationsService_99(
+        returnValue: _FakeAuthorizationsService_100(
           this,
           Invocation.getter(#authorizations),
         ),
@@ -9267,7 +9303,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GistsService get gists => (super.noSuchMethod(
         Invocation.getter(#gists),
-        returnValue: _FakeGistsService_100(
+        returnValue: _FakeGistsService_101(
           this,
           Invocation.getter(#gists),
         ),
@@ -9276,7 +9312,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GitService get git => (super.noSuchMethod(
         Invocation.getter(#git),
-        returnValue: _FakeGitService_101(
+        returnValue: _FakeGitService_102(
           this,
           Invocation.getter(#git),
         ),
@@ -9285,7 +9321,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.IssuesService get issues => (super.noSuchMethod(
         Invocation.getter(#issues),
-        returnValue: _FakeIssuesService_102(
+        returnValue: _FakeIssuesService_103(
           this,
           Invocation.getter(#issues),
         ),
@@ -9294,7 +9330,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.MiscService get misc => (super.noSuchMethod(
         Invocation.getter(#misc),
-        returnValue: _FakeMiscService_103(
+        returnValue: _FakeMiscService_104(
           this,
           Invocation.getter(#misc),
         ),
@@ -9303,7 +9339,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.OrganizationsService get organizations => (super.noSuchMethod(
         Invocation.getter(#organizations),
-        returnValue: _FakeOrganizationsService_104(
+        returnValue: _FakeOrganizationsService_105(
           this,
           Invocation.getter(#organizations),
         ),
@@ -9312,7 +9348,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.PullRequestsService get pullRequests => (super.noSuchMethod(
         Invocation.getter(#pullRequests),
-        returnValue: _FakePullRequestsService_105(
+        returnValue: _FakePullRequestsService_106(
           this,
           Invocation.getter(#pullRequests),
         ),
@@ -9321,7 +9357,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.RepositoriesService get repositories => (super.noSuchMethod(
         Invocation.getter(#repositories),
-        returnValue: _FakeRepositoriesService_106(
+        returnValue: _FakeRepositoriesService_107(
           this,
           Invocation.getter(#repositories),
         ),
@@ -9330,7 +9366,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.SearchService get search => (super.noSuchMethod(
         Invocation.getter(#search),
-        returnValue: _FakeSearchService_107(
+        returnValue: _FakeSearchService_108(
           this,
           Invocation.getter(#search),
         ),
@@ -9339,7 +9375,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UrlShortenerService get urlShortener => (super.noSuchMethod(
         Invocation.getter(#urlShortener),
-        returnValue: _FakeUrlShortenerService_108(
+        returnValue: _FakeUrlShortenerService_109(
           this,
           Invocation.getter(#urlShortener),
         ),
@@ -9348,7 +9384,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UsersService get users => (super.noSuchMethod(
         Invocation.getter(#users),
-        returnValue: _FakeUsersService_109(
+        returnValue: _FakeUsersService_110(
           this,
           Invocation.getter(#users),
         ),
@@ -9357,7 +9393,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ChecksService get checks => (super.noSuchMethod(
         Invocation.getter(#checks),
-        returnValue: _FakeChecksService_110(
+        returnValue: _FakeChecksService_111(
           this,
           Invocation.getter(#checks),
         ),
@@ -9386,8 +9422,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<T>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #getJSON,
@@ -9446,7 +9482,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i42.postJsonShim<S, T>(
+        returnValue: _i43.postJsonShim<S, T>(
           path,
           statusCode: statusCode,
           fail: fail,
@@ -9483,8 +9519,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<T>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #putJSON,
@@ -9545,8 +9581,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<T>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #patchJSON,
@@ -9611,8 +9647,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i28.ifNotNull(
-              _i28.dummyValueOrNull<T>(
+        returnValue: _i29.ifNotNull(
+              _i29.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #requestJson,
@@ -9681,7 +9717,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_111(
+        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_112(
           this,
           Invocation.method(
             #request,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951.

The github gold status API has been querying and writing updates to Datastore.
https://github.com/flutter/cocoon/pull/3513 started writing updates to Firestore.

This PR:
1) starts querying from Firestore
2) supports both datastore/Firestore queries and writes
3) updates all unit tests to cover Firestore logics