### PR TITLE
Support Firestore in build status service

### DIFF
--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -4,12 +4,11 @@
 
 import 'dart:async';
 
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../../protos.dart' show BuildStatusResponse, EnumBuildStatus;
-import '../request_handling/body.dart';
-import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
 import '../service/datastore.dart';
 
@@ -34,7 +33,8 @@ class GetBuildStatus extends RequestHandler<Body> {
 
   Future<BuildStatusResponse> createResponse() async {
     final DatastoreService datastore = datastoreProvider(config.db);
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore);
+    final FirestoreService firestoreService = await config.createFirestoreService();
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final String repoName = request!.uri.queryParameters[kRepoParam] ?? 'flutter';
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
     final BuildStatus status = (await buildStatusService.calculateCumulativeStatus(slug))!;

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -15,6 +15,7 @@ import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
 import '../service/config.dart';
 import '../service/datastore.dart';
+import '../service/firestore.dart';
 
 /// Returns [List<String>] of the commit shas that had all passing tests.
 ///
@@ -52,7 +53,8 @@ class GetGreenCommits extends RequestHandler<Body> {
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
     final String branch = request!.uri.queryParameters[kBranchParam] ?? Config.defaultBranch(slug);
     final DatastoreService datastore = datastoreProvider(config.db);
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore);
+    final FirestoreService firestoreService = await config.createFirestoreService();
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final int commitNumber = config.commitNumber;
 
     final List<String?> greenCommits = await buildStatusService

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -16,6 +16,7 @@ import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
 import '../service/config.dart';
 import '../service/datastore.dart';
+import '../service/firestore.dart';
 
 @immutable
 class GetStatus extends RequestHandler<Body> {
@@ -39,7 +40,8 @@ class GetStatus extends RequestHandler<Body> {
     final RepositorySlug slug = RepositorySlug('flutter', repoName);
     final String branch = request!.uri.queryParameters[kBranchParam] ?? Config.defaultBranch(slug);
     final DatastoreService datastore = datastoreProvider(config.db);
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore);
+    final FirestoreService firestoreService = await config.createFirestoreService();
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final KeyHelper keyHelper = config.keyHelper;
     final int commitNumber = config.commitNumber;
     final int lastCommitTimestamp = await _obtainTimestamp(encodedLastCommitKey, keyHelper, datastore);

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -41,7 +41,8 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     final String repository = request!.uri.queryParameters[fullNameRepoParam] ?? 'flutter/flutter';
     final RepositorySlug slug = RepositorySlug.full(repository);
     final DatastoreService datastore = datastoreProvider(config.db);
-    final BuildStatusService buildStatusService = buildStatusServiceProvider(datastore);
+    final FirestoreService firestoreService = await config.createFirestoreService();
+    final BuildStatusService buildStatusService = buildStatusServiceProvider(datastore, firestoreService);
 
     final BuildStatus status = (await buildStatusService.calculateCumulativeStatus(slug))!;
     await _insertBigquery(slug, status.githubStatus, Config.defaultBranch(slug), config);

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
@@ -14,20 +15,27 @@ import '../model/appengine/task.dart';
 import 'datastore.dart';
 
 /// Function signature for a [BuildStatusService] provider.
-typedef BuildStatusServiceProvider = BuildStatusService Function(DatastoreService datastoreService);
+typedef BuildStatusServiceProvider = BuildStatusService Function(
+  DatastoreService datastoreService,
+  FirestoreService firestoreService,
+);
 
 /// Branches that are used to calculate the tree status.
 const Set<String> defaultBranches = <String>{'refs/heads/main', 'refs/heads/master'};
 
 /// Class that calculates the current build status.
 class BuildStatusService {
-  const BuildStatusService(this.datastoreService);
+  const BuildStatusService(
+    this.datastoreService,
+    this.firestoreService,
+  );
 
   final DatastoreService datastoreService;
+  final FirestoreService firestoreService;
 
   /// Creates and returns a [DatastoreService] using [db] and [maxEntityGroups].
-  static BuildStatusService defaultProvider(DatastoreService datastoreService) {
-    return BuildStatusService(datastoreService);
+  static BuildStatusService defaultProvider(DatastoreService datastoreService, FirestoreService firestoreService) {
+    return BuildStatusService(datastoreService, firestoreService);
   }
 
   @visibleForTesting

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -63,6 +63,7 @@ class Scheduler {
   final HttpClientProvider httpClientProvider;
 
   late DatastoreService datastore;
+  late FirestoreService firestoreService;
   LuciBuildService luciBuildService;
 
   /// Name of the subcache to store scheduler related values in redis.
@@ -638,7 +639,8 @@ class Scheduler {
   /// to ensure new targets without `bringup: true` label are not added into the build.
   Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore);
+    firestoreService = await config.createFirestoreService();
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final Commit totCommit = (await buildStatusService
             .retrieveCommitStatus(
               limit: 1,

--- a/app_dart/test/request_handlers/get_green_commits_test.dart
+++ b/app_dart/test/request_handlers/get_green_commits_test.dart
@@ -19,6 +19,7 @@ import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/request_handler_tester.dart';
 import '../src/service/fake_build_status_provider.dart';
 import '../src/utilities/entity_generators.dart';
+import '../src/utilities/mocks.dart';
 
 void main() {
   group('GetGreenCommits', () {
@@ -26,6 +27,7 @@ void main() {
     FakeClientContext clientContext;
     FakeKeyHelper keyHelper;
     FakeBuildStatusService buildStatusService;
+    late MockFirestoreService mockFirestoreService;
     late RequestHandlerTester tester;
     late GetGreenCommits handler;
 
@@ -74,9 +76,10 @@ void main() {
 
     setUp(() {
       clientContext = FakeClientContext();
+      mockFirestoreService = MockFirestoreService();
       keyHelper = FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
-      config = FakeConfig(keyHelperValue: keyHelper);
+      config = FakeConfig(keyHelperValue: keyHelper, firestoreService: mockFirestoreService);
       buildStatusService = FakeBuildStatusService(commitStatuses: <CommitStatus>[]);
       handler = GetGreenCommits(
         config: config,

--- a/app_dart/test/request_handlers/get_green_commits_test.dart
+++ b/app_dart/test/request_handlers/get_green_commits_test.dart
@@ -81,7 +81,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
     });
 
@@ -100,7 +100,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final List<String?> result = (await decodeHandlerBody())!;
@@ -122,7 +122,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final List<String?> result = (await decodeHandlerBody())!;
@@ -141,7 +141,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final List<String?> result = (await decodeHandlerBody())!;
@@ -160,7 +160,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final List<String?> result = (await decodeHandlerBody())!;
@@ -186,7 +186,7 @@ void main() {
       handler = GetGreenCommits(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final List<String?> result = (await decodeHandlerBody())!;

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -45,7 +45,7 @@ void main() {
       handler = GetStatus(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
       commit1 = Commit(
         key: config.db.emptyKey.append(Commit, id: 'flutter/flutter/ea28a9c34dc701de891eaf74503ca4717019f829'),
@@ -79,7 +79,7 @@ void main() {
       handler = GetStatus(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       final Map<String, dynamic> result = (await decodeHandlerBody())!;
@@ -112,7 +112,7 @@ void main() {
       handler = GetStatus(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       const String expectedLastCommitKeyEncoded =
@@ -154,7 +154,7 @@ void main() {
       handler = GetStatus(
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
       );
 
       const String branch = 'flutter-1.1-candidate.1';

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -18,6 +18,7 @@ import '../src/request_handling/fake_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/request_handler_tester.dart';
 import '../src/service/fake_build_status_provider.dart';
+import '../src/utilities/mocks.dart';
 
 void main() {
   group('GetStatus', () {
@@ -27,6 +28,7 @@ void main() {
     FakeBuildStatusService buildStatusService;
     late RequestHandlerTester tester;
     late GetStatus handler;
+    late MockFirestoreService mockFirestoreService;
 
     late Commit commit1;
     late Commit commit2;
@@ -38,9 +40,10 @@ void main() {
 
     setUp(() {
       clientContext = FakeClientContext();
+      mockFirestoreService = MockFirestoreService();
       keyHelper = FakeKeyHelper(applicationContext: clientContext.applicationContext);
       tester = RequestHandlerTester();
-      config = FakeConfig(keyHelperValue: keyHelper);
+      config = FakeConfig(keyHelperValue: keyHelper, firestoreService: mockFirestoreService);
       buildStatusService = FakeBuildStatusService(commitStatuses: <CommitStatus>[]);
       handler = GetStatus(
         config: config,

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -78,7 +78,7 @@ void main() {
       handler = PushBuildStatusToGithub(
         config: config,
         authenticationProvider: FakeAuthenticationProvider(clientContext: clientContext),
-        buildStatusServiceProvider: (_) => buildStatusService,
+        buildStatusServiceProvider: (_, __) => buildStatusService,
         datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
       );
 

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/utilities/entity_generators.dart';
+import '../src/utilities/mocks.dart';
 
 List<Commit> oneCommit = <Commit>[
   Commit(
@@ -95,14 +96,16 @@ void main() {
     late BuildStatusService buildStatusService;
     FakeConfig config;
     DatastoreService datastoreService;
+    late MockFirestoreService mockFirestoreService;
 
     final RepositorySlug slug = RepositorySlug('flutter', 'flutter');
 
     setUp(() {
       db = FakeDatastoreDB();
-      config = FakeConfig(dbValue: db);
+      mockFirestoreService = MockFirestoreService();
+      config = FakeConfig(dbValue: db, firestoreService: mockFirestoreService);
       datastoreService = DatastoreService(config.db, 5);
-      buildStatusService = BuildStatusService.defaultProvider(datastoreService);
+      buildStatusService = BuildStatusService.defaultProvider(datastoreService, mockFirestoreService);
     });
 
     group('calculateStatus', () {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -547,6 +547,7 @@ targets:
             FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         config = FakeConfig(
           githubService: mockGithubService,
+          firestoreService: mockFirestoreService,
         );
         scheduler = Scheduler(
           cache: cache,
@@ -644,7 +645,11 @@ targets:
       test('rerequested postsubmit check triggers postsubmit build', () async {
         // Set up datastore with postsubmit entities matching [checkRunString].
         db = FakeDatastoreDB();
-        config = FakeConfig(dbValue: db, postsubmitSupportedReposValue: {RepositorySlug('abc', 'cocoon')});
+        config = FakeConfig(
+          dbValue: db,
+          postsubmitSupportedReposValue: {RepositorySlug('abc', 'cocoon')},
+          firestoreService: mockFirestoreService,
+        );
         final Commit commit = generateCommit(
           1,
           sha: '66d6bd9a3f79a36fe4f5178ccefbc781488a596c',

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -128,7 +128,7 @@ void main() {
         cache: cache,
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
-        buildStatusProvider: (_) => buildStatusService,
+        buildStatusProvider: (_, __) => buildStatusService,
         githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
         httpClientProvider: () => httpClient,
         luciBuildService: FakeLuciBuildService(
@@ -285,7 +285,7 @@ void main() {
         scheduler = Scheduler(
           cache: cache,
           config: config,
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
@@ -346,7 +346,7 @@ void main() {
         scheduler = Scheduler(
           cache: cache,
           config: config,
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
@@ -469,7 +469,7 @@ targets:
           cache: cache,
           config: config,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
           luciBuildService: FakeLuciBuildService(
@@ -551,7 +551,7 @@ targets:
         scheduler = Scheduler(
           cache: cache,
           config: config,
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
           luciBuildService: FakeLuciBuildService(
@@ -1006,7 +1006,7 @@ targets:
           cache: cache,
           config: config,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
           luciBuildService: FakeLuciBuildService(
@@ -1042,7 +1042,7 @@ targets:
             githubService: mockGithubService,
             githubClient: MockGitHub(),
           ),
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
           httpClientProvider: () => httpClient,
@@ -1197,7 +1197,7 @@ targets:
           config: config,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           httpClientProvider: () => httpClient,
           luciBuildService: FakeLuciBuildService(
             config: config,
@@ -1266,7 +1266,7 @@ targets:
           config: config,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
           githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
-          buildStatusProvider: (_) => buildStatusService,
+          buildStatusProvider: (_, __) => buildStatusService,
           httpClientProvider: () => httpClient,
           luciBuildService: FakeLuciBuildService(
             config: config,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1041,6 +1041,7 @@ targets:
             dbValue: db,
             githubService: mockGithubService,
             githubClient: MockGitHub(),
+            firestoreService: mockFirestoreService,
           ),
           buildStatusProvider: (_, __) => buildStatusService,
           datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -4,6 +4,7 @@
 
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:github/github.dart';
 
 class FakeBuildStatusService implements BuildStatusService {
@@ -48,4 +49,6 @@ class FakeBuildStatusService implements BuildStatusService {
 
   @override
   DatastoreService get datastoreService => throw UnimplementedError();
+  @override
+  FirestoreService get firestoreService => throw UnimplementedError();
 }


### PR DESCRIPTION
This is to prepare query logics switch to Firestore. 

This PR is a no op for existing workflow, but just inject the firestore service to prepare for future logic updates.