### PR TITLE
Calculate tree build status based on Firestore task statuses

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -113,7 +113,10 @@ class FirestoreService {
     final Map<String, Object> filterMap = <String, Object>{
       '$kTaskCommitShaField =': commitSha,
     };
-    final List<Document> documents = await query(kTaskCollectionId, filterMap);
+    final Map<String, String> orderMap = <String, String>{
+      kTaskCreateTimestampField: kQueryOrderDescending,
+    };
+    final List<Document> documents = await query(kTaskCollectionId, filterMap, orderMap: orderMap);
     return documents.map((Document document) => Task.fromDocument(taskDocument: document)).toList();
   }
 

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -2,93 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/model/appengine/commit.dart';
-import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/model/firestore/commit.dart';
+import 'package:cocoon_service/src/model/firestore/task.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/utilities/entity_generators.dart';
 import '../src/utilities/mocks.dart';
-
-List<Commit> oneCommit = <Commit>[
-  Commit(
-    key: Key<String>.emptyKey(Partition('ns')).append(Commit, id: 'sha1'),
-    repository: 'flutter/flutter',
-    sha: 'sha1',
-  ),
-];
-
-List<Commit> twoCommits = <Commit>[
-  Commit(
-    key: Key<String>.emptyKey(Partition('ns')).append(Commit, id: 'sha1'),
-    repository: 'flutter/flutter',
-    sha: 'sha1',
-  ),
-  Commit(
-    key: Key<String>.emptyKey(Partition('ns')).append(Commit, id: 'sha2'),
-    repository: 'flutter/flutter',
-    sha: 'sha2',
-  ),
-];
-
-List<Task> allGreen = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusSucceeded),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> allRed = <Task>[
-  generateTask(1, status: Task.statusFailed),
-  generateTask(2, status: Task.statusFailed),
-  generateTask(3, status: Task.statusFailed),
-];
-
-List<Task> middleTaskFailed = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusFailed),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskCanceled = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusCancelled),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskFlakyFailed = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusFailed, isFlaky: true),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskInProgress = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusInProgress),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskRerunning = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusNew, attempts: 2),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskRerunGreen = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusSucceeded, attempts: 2),
-  generateTask(3, status: Task.statusSucceeded),
-];
-
-List<Task> middleTaskInfraFailure = <Task>[
-  generateTask(1, status: Task.statusSucceeded),
-  generateTask(2, status: Task.statusInfraFailure),
-  generateTask(3, status: Task.statusSucceeded),
-];
 
 void main() {
   group('BuildStatusProvider', () {
@@ -109,143 +34,200 @@ void main() {
     });
 
     group('calculateStatus', () {
+      List<Commit> commits = <Commit>[];
+      List<Task> tasks1 = <Task>[];
+      List<Task> tasks2 = <Task>[];
+      late int row;
+      setUp(() {
+        row = 0;
+        when(
+          mockFirestoreService.queryRecentCommits(
+            limit: captureAnyNamed('limit'),
+            slug: captureAnyNamed('slug'),
+            branch: captureAnyNamed('branch'),
+          ),
+        ).thenAnswer((Invocation invocation) {
+          return Future<List<Commit>>.value(
+            commits,
+          );
+        });
+        when(
+          mockFirestoreService.queryCommitTasks(
+            captureAny,
+          ),
+        ).thenAnswer((Invocation invocation) {
+          if (row == 0) {
+            row++;
+            return Future<List<Task>>.value(
+              tasks1,
+            );
+          } else {
+            return Future<List<Task>>.value(
+              tasks2,
+            );
+          }
+        });
+      });
       test('returns failure if there are no commits', () async {
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>[]));
       });
 
       test('returns success if top commit is all green', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
-        db.addOnQuery<Task>((Iterable<Task> results) => allGreen);
+        commits = <Commit>[generateFirestoreCommit(1)];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.success());
       });
 
       test('returns success if top commit is all green followed by red commit', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? allGreen : middleTaskFailed;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.success());
       });
 
       test('returns failure if last commit contains any red tasks', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
-        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFailed);
+        commits = <Commit>[generateFirestoreCommit(1)];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('returns failure if last commit contains any canceled tasks', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
-        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskCanceled);
+        commits = <Commit>[generateFirestoreCommit(1)];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusCancelled),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('ensure failed task do not have duplicates when last consecutive commits contains red tasks', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFailed);
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed),
+        ];
+        tasks2 = tasks1;
 
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('ignores failures on flaky commits', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => oneCommit);
-        db.addOnQuery<Task>((Iterable<Task> results) => middleTaskFlakyFailed);
+        commits = <Commit>[generateFirestoreCommit(1)];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed, bringup: true),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.success());
       });
 
       test('returns success if partial green, and all unfinished tasks were last green', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskInProgress : allGreen;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusInProgress),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.success());
       });
 
       test('returns failure if partial green, and any unfinished task was last red', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskInProgress : middleTaskFailed;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusInProgress),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('returns failure when green but a task is rerunning', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskRerunning : allGreen;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusInProgress, attempts: 2),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('returns failure when a task has an infra failure', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskInfraFailure : allGreen;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusInfraFailure),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.failure(const <String>['task2']));
       });
 
       test('returns success when all green with a successful rerun', () async {
-        db.addOnQuery<Commit>((Iterable<Commit> results) => twoCommits);
-        int row = 0;
-        db.addOnQuery<Task>((Iterable<Task> results) {
-          return row++ == 0 ? middleTaskRerunGreen : allRed;
-        });
+        commits = <Commit>[
+          generateFirestoreCommit(1),
+          generateFirestoreCommit(2),
+        ];
+        tasks1 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusSucceeded, attempts: 2),
+        ];
+        tasks2 = <Task>[
+          generateFirestoreTask(1, status: Task.statusSucceeded),
+          generateFirestoreTask(2, status: Task.statusFailed),
+        ];
         final BuildStatus? status = await buildStatusService.calculateCumulativeStatus(slug);
         expect(status, BuildStatus.success());
-      });
-
-      test('return status when with branch parameter', () async {
-        final Commit commit1 = generateCommit(1, branch: 'flutter-0.0-candidate.0');
-        final Commit commit2 = generateCommit(2, branch: 'master');
-        db.values[commit1.key] = commit1;
-        db.values[commit2.key] = commit2;
-
-        final Task task1 = Task(
-          key: commit1.key.append(Task, id: 1),
-          commitKey: commit1.key,
-          name: 'task1',
-          status: Task.statusSucceeded,
-          stageName: 'stage1',
-        );
-
-        db.values[task1.key] = task1;
-
-        // Test master branch.
-        final List<CommitStatus> statuses1 = await buildStatusService
-            .retrieveCommitStatus(
-              limit: 5,
-              slug: slug,
-            )
-            .toList();
-        expect(statuses1.length, 1);
-        expect(statuses1.first.commit.branch, 'master');
-
-        // Test dev branch.
-        final List<CommitStatus> statuses2 = await buildStatusService
-            .retrieveCommitStatus(
-              limit: 5,
-              branch: 'flutter-0.0-candidate.0',
-              slug: slug,
-            )
-            .toList();
-        expect(statuses2.length, 1);
-        expect(statuses2.first.commit.branch, 'flutter-0.0-candidate.0');
       });
     });
   });

--- a/app_dart/test/service/build_status_provider_test.dart
+++ b/app_dart/test/service/build_status_provider_test.dart
@@ -34,12 +34,15 @@ void main() {
     });
 
     group('calculateStatus', () {
-      List<Commit> commits = <Commit>[];
-      List<Task> tasks1 = <Task>[];
-      List<Task> tasks2 = <Task>[];
+      List<Commit> commits;
+      List<Task> tasks1;
+      List<Task> tasks2;
       late int row;
       setUp(() {
         row = 0;
+        tasks1 = <Task>[];
+        tasks2 = <Task>[];
+        commits = <Commit>[];
         when(
           mockFirestoreService.queryRecentCommits(
             limit: captureAnyNamed('limit'),

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -15,6 +15,7 @@ class FakeBuildStatusService implements BuildStatusService {
 
   BuildStatus? cumulativeStatus;
   List<CommitStatus>? commitStatuses;
+  List<CommitTasksStatus>? commitTasksStatuses;
 
   @override
   Future<BuildStatus?> calculateCumulativeStatus(RepositorySlug slug) async {
@@ -43,6 +44,29 @@ class FakeBuildStatusService implements BuildStatusService {
                 ? true
                 : commitStatus.commit.timestamp! < timestamp) &&
             commitStatus.commit.branch == branch,
+      ),
+    );
+  }
+
+  @override
+  Stream<CommitTasksStatus> retrieveCommitStatusFirestore({
+    int limit = 100,
+    int? timestamp,
+    String? branch,
+    required RepositorySlug slug,
+  }) {
+    if (commitStatuses == null) {
+      throw AssertionError();
+    }
+    commitStatuses!.sort((CommitStatus a, CommitStatus b) => a.commit.timestamp!.compareTo(b.commit.timestamp!));
+
+    return Stream<CommitTasksStatus>.fromIterable(
+      commitTasksStatuses!.where(
+        (CommitTasksStatus commitTasksStatus) =>
+            ((commitTasksStatus.commit.createTimestamp == null || timestamp == null)
+                ? true
+                : commitTasksStatus.commit.createTimestamp! < timestamp) &&
+            commitTasksStatus.commit.branch == branch,
       ),
     );
   }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

This PR:
1) keeps existing function `retrieveCommitStatus` and creates a new `retrieveCommitStatusFirestore` for `get_build_status` API. This is to avoid affecting other APIs.
2) keeps existing class `CommitStatus` and creates a new `CommitTasksStatus` to support firestore case, preparing to deprecate the `stage` field from the old Task status.
3) maps to the firestore commit/task fields from old Datastore models and updates all related tests.