### PR TITLE
Push build status based on Firestore

### DIFF
--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -63,6 +63,21 @@ class GithubBuildStatus extends Document {
 
   int? get updates => int.parse(fields![kGithubBuildStatusUpdatesField]!.integerValue!);
 
+  String setStatus(String status) {
+    fields![kGithubBuildStatusStatusField] = Value(stringValue: status);
+    return status;
+  }
+
+  int setUpdates(int updates) {
+    fields![kGithubBuildStatusUpdatesField] = Value(integerValue: updates.toString());
+    return updates;
+  }
+
+  int setUpdateTimeMillis(int updateTimeMillis) {
+    fields![kGithubBuildStatusUpdateTimeMillisField] = Value(integerValue: updateTimeMillis.toString());
+    return updateTimeMillis;
+  }
+
   @override
   String toString() {
     final StringBuffer buf = StringBuffer()

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -182,7 +182,8 @@ GithubBuildStatus generateFirestoreGithubBuildStatus(
   int? pr,
   String owner = 'flutter',
   String repo = 'flutter',
-  int? updates,
+  int updates = 0,
+  String status = GithubBuildStatus.statusSuccess,
 }) {
   pr ??= i;
   head ??= 'sha$i';
@@ -193,6 +194,7 @@ GithubBuildStatus generateFirestoreGithubBuildStatus(
       kGithubBuildStatusPrNumberField: Value(integerValue: pr.toString()),
       kGithubBuildStatusRepositoryField: Value(stringValue: '$owner/$repo'),
       kGithubBuildStatusUpdatesField: Value(integerValue: updates.toString()),
+      kGithubBuildStatusStatusField: Value(stringValue: status),
     };
   return githubBuildStatus;
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4,51 +4,52 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i20;
-import 'dart:convert' as _i25;
-import 'dart:io' as _i24;
-import 'dart:typed_data' as _i37;
+import 'dart:convert' as _i26;
+import 'dart:io' as _i25;
+import 'dart:typed_data' as _i38;
 
 import 'package:appengine/appengine.dart' as _i10;
 import 'package:cocoon_service/cocoon_service.dart' as _i15;
-import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i23;
-import 'package:cocoon_service/src/model/appengine/branch.dart' as _i32;
-import 'package:cocoon_service/src/model/appengine/commit.dart' as _i33;
+import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i24;
+import 'package:cocoon_service/src/model/appengine/branch.dart' as _i33;
+import 'package:cocoon_service/src/model/appengine/commit.dart' as _i34;
 import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
 import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
-import 'package:cocoon_service/src/model/appengine/stage.dart' as _i35;
-import 'package:cocoon_service/src/model/appengine/task.dart' as _i34;
-import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i41;
-import 'package:cocoon_service/src/model/firestore/commit.dart' as _i38;
+import 'package:cocoon_service/src/model/appengine/stage.dart' as _i36;
+import 'package:cocoon_service/src/model/appengine/task.dart' as _i35;
+import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i42;
+import 'package:cocoon_service/src/model/firestore/commit.dart' as _i39;
+import 'package:cocoon_service/src/model/firestore/github_build_status.dart' as _i23;
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart' as _i22;
-import 'package:cocoon_service/src/model/firestore/task.dart' as _i39;
-import 'package:cocoon_service/src/model/github/checks.dart' as _i42;
+import 'package:cocoon_service/src/model/firestore/task.dart' as _i40;
+import 'package:cocoon_service/src/model/github/checks.dart' as _i43;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart' as _i8;
-import 'package:cocoon_service/src/model/luci/push_message.dart' as _i40;
+import 'package:cocoon_service/src/model/luci/push_message.dart' as _i41;
 import 'package:cocoon_service/src/service/access_client_provider.dart' as _i5;
-import 'package:cocoon_service/src/service/access_token_provider.dart' as _i27;
+import 'package:cocoon_service/src/service/access_token_provider.dart' as _i28;
 import 'package:cocoon_service/src/service/bigquery.dart' as _i16;
-import 'package:cocoon_service/src/service/commit_service.dart' as _i30;
+import 'package:cocoon_service/src/service/commit_service.dart' as _i31;
 import 'package:cocoon_service/src/service/config.dart' as _i3;
 import 'package:cocoon_service/src/service/datastore.dart' as _i9;
 import 'package:cocoon_service/src/service/gerrit_service.dart' as _i7;
 import 'package:cocoon_service/src/service/github_service.dart' as _i17;
 import 'package:gcloud/db.dart' as _i11;
 import 'package:github/github.dart' as _i13;
-import 'package:github/hooks.dart' as _i31;
+import 'package:github/hooks.dart' as _i32;
 import 'package:googleapis/bigquery/v2.dart' as _i6;
 import 'package:googleapis/firestore/v1.dart' as _i21;
 import 'package:googleapis_auth/auth_io.dart' as _i4;
 import 'package:graphql/client.dart' as _i14;
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i29;
-import 'package:neat_cache/neat_cache.dart' as _i26;
-import 'package:process/src/interface/process_manager.dart' as _i43;
-import 'package:retry/retry.dart' as _i28;
+import 'package:mockito/src/dummies.dart' as _i30;
+import 'package:neat_cache/neat_cache.dart' as _i27;
+import 'package:process/src/interface/process_manager.dart' as _i44;
+import 'package:retry/retry.dart' as _i29;
 
-import '../../service/cache_service_test.dart' as _i36;
-import 'mocks.dart' as _i44;
+import '../../service/cache_service_test.dart' as _i37;
+import 'mocks.dart' as _i45;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -354,8 +355,8 @@ class _FakeGithubGoldStatus_28 extends _i1.SmartFake implements _i22.GithubGoldS
         );
 }
 
-class _FakeValue_29 extends _i1.SmartFake implements _i21.Value {
-  _FakeValue_29(
+class _FakeGithubBuildStatus_29 extends _i1.SmartFake implements _i23.GithubBuildStatus {
+  _FakeGithubBuildStatus_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -364,8 +365,8 @@ class _FakeValue_29 extends _i1.SmartFake implements _i21.Value {
         );
 }
 
-class _FakeFilter_30 extends _i1.SmartFake implements _i21.Filter {
-  _FakeFilter_30(
+class _FakeValue_30 extends _i1.SmartFake implements _i21.Value {
+  _FakeValue_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -374,8 +375,8 @@ class _FakeFilter_30 extends _i1.SmartFake implements _i21.Filter {
         );
 }
 
-class _FakeIssue_31 extends _i1.SmartFake implements _i13.Issue {
-  _FakeIssue_31(
+class _FakeFilter_31 extends _i1.SmartFake implements _i21.Filter {
+  _FakeFilter_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -384,8 +385,8 @@ class _FakeIssue_31 extends _i1.SmartFake implements _i13.Issue {
         );
 }
 
-class _FakeIssueComment_32 extends _i1.SmartFake implements _i13.IssueComment {
-  _FakeIssueComment_32(
+class _FakeIssue_32 extends _i1.SmartFake implements _i13.Issue {
+  _FakeIssue_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -394,8 +395,8 @@ class _FakeIssueComment_32 extends _i1.SmartFake implements _i13.IssueComment {
         );
 }
 
-class _FakeIssueLabel_33 extends _i1.SmartFake implements _i13.IssueLabel {
-  _FakeIssueLabel_33(
+class _FakeIssueComment_33 extends _i1.SmartFake implements _i13.IssueComment {
+  _FakeIssueComment_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -404,8 +405,8 @@ class _FakeIssueLabel_33 extends _i1.SmartFake implements _i13.IssueLabel {
         );
 }
 
-class _FakeMilestone_34 extends _i1.SmartFake implements _i13.Milestone {
-  _FakeMilestone_34(
+class _FakeIssueLabel_34 extends _i1.SmartFake implements _i13.IssueLabel {
+  _FakeIssueLabel_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -414,8 +415,8 @@ class _FakeMilestone_34 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_35 extends _i1.SmartFake implements _i23.GithubChecksUtil {
-  _FakeGithubChecksUtil_35(
+class _FakeMilestone_35 extends _i1.SmartFake implements _i13.Milestone {
+  _FakeMilestone_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,8 +425,8 @@ class _FakeGithubChecksUtil_35 extends _i1.SmartFake implements _i23.GithubCheck
         );
 }
 
-class _FakeCheckRunConclusion_36 extends _i1.SmartFake implements _i13.CheckRunConclusion {
-  _FakeCheckRunConclusion_36(
+class _FakeGithubChecksUtil_36 extends _i1.SmartFake implements _i24.GithubChecksUtil {
+  _FakeGithubChecksUtil_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,8 +435,8 @@ class _FakeCheckRunConclusion_36 extends _i1.SmartFake implements _i13.CheckRunC
         );
 }
 
-class _FakeCheckRunStatus_37 extends _i1.SmartFake implements _i13.CheckRunStatus {
-  _FakeCheckRunStatus_37(
+class _FakeCheckRunConclusion_37 extends _i1.SmartFake implements _i13.CheckRunConclusion {
+  _FakeCheckRunConclusion_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -444,8 +445,8 @@ class _FakeCheckRunStatus_37 extends _i1.SmartFake implements _i13.CheckRunStatu
         );
 }
 
-class _FakeCheckSuite_38 extends _i1.SmartFake implements _i13.CheckSuite {
-  _FakeCheckSuite_38(
+class _FakeCheckRunStatus_38 extends _i1.SmartFake implements _i13.CheckRunStatus {
+  _FakeCheckRunStatus_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,8 +455,8 @@ class _FakeCheckSuite_38 extends _i1.SmartFake implements _i13.CheckSuite {
         );
 }
 
-class _FakeCheckRun_39 extends _i1.SmartFake implements _i13.CheckRun {
-  _FakeCheckRun_39(
+class _FakeCheckSuite_39 extends _i1.SmartFake implements _i13.CheckSuite {
+  _FakeCheckSuite_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -464,8 +465,8 @@ class _FakeCheckRun_39 extends _i1.SmartFake implements _i13.CheckRun {
         );
 }
 
-class _FakePullRequest_40 extends _i1.SmartFake implements _i13.PullRequest {
-  _FakePullRequest_40(
+class _FakeCheckRun_40 extends _i1.SmartFake implements _i13.CheckRun {
+  _FakeCheckRun_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,8 +475,8 @@ class _FakePullRequest_40 extends _i1.SmartFake implements _i13.PullRequest {
         );
 }
 
-class _FakeGitReference_41 extends _i1.SmartFake implements _i13.GitReference {
-  _FakeGitReference_41(
+class _FakePullRequest_41 extends _i1.SmartFake implements _i13.PullRequest {
+  _FakePullRequest_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -484,8 +485,8 @@ class _FakeGitReference_41 extends _i1.SmartFake implements _i13.GitReference {
         );
 }
 
-class _FakeRateLimit_42 extends _i1.SmartFake implements _i13.RateLimit {
-  _FakeRateLimit_42(
+class _FakeGitReference_42 extends _i1.SmartFake implements _i13.GitReference {
+  _FakeGitReference_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -494,8 +495,8 @@ class _FakeRateLimit_42 extends _i1.SmartFake implements _i13.RateLimit {
         );
 }
 
-class _FakeGitBlob_43 extends _i1.SmartFake implements _i13.GitBlob {
-  _FakeGitBlob_43(
+class _FakeRateLimit_43 extends _i1.SmartFake implements _i13.RateLimit {
+  _FakeRateLimit_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -504,8 +505,8 @@ class _FakeGitBlob_43 extends _i1.SmartFake implements _i13.GitBlob {
         );
 }
 
-class _FakeGitCommit_44 extends _i1.SmartFake implements _i13.GitCommit {
-  _FakeGitCommit_44(
+class _FakeGitBlob_44 extends _i1.SmartFake implements _i13.GitBlob {
+  _FakeGitBlob_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,8 +515,8 @@ class _FakeGitCommit_44 extends _i1.SmartFake implements _i13.GitCommit {
         );
 }
 
-class _FakeGitTag_45 extends _i1.SmartFake implements _i13.GitTag {
-  _FakeGitTag_45(
+class _FakeGitCommit_45 extends _i1.SmartFake implements _i13.GitCommit {
+  _FakeGitCommit_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -524,8 +525,8 @@ class _FakeGitTag_45 extends _i1.SmartFake implements _i13.GitTag {
         );
 }
 
-class _FakeGitTree_46 extends _i1.SmartFake implements _i13.GitTree {
-  _FakeGitTree_46(
+class _FakeGitTag_46 extends _i1.SmartFake implements _i13.GitTag {
+  _FakeGitTag_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -534,8 +535,8 @@ class _FakeGitTree_46 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_47 extends _i1.SmartFake implements _i14.DefaultPolicies {
-  _FakeDefaultPolicies_47(
+class _FakeGitTree_47 extends _i1.SmartFake implements _i13.GitTree {
+  _FakeGitTree_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,8 +545,8 @@ class _FakeDefaultPolicies_47 extends _i1.SmartFake implements _i14.DefaultPolic
         );
 }
 
-class _FakeLink_48 extends _i1.SmartFake implements _i14.Link {
-  _FakeLink_48(
+class _FakeDefaultPolicies_48 extends _i1.SmartFake implements _i14.DefaultPolicies {
+  _FakeDefaultPolicies_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -554,8 +555,8 @@ class _FakeLink_48 extends _i1.SmartFake implements _i14.Link {
         );
 }
 
-class _FakeGraphQLCache_49 extends _i1.SmartFake implements _i14.GraphQLCache {
-  _FakeGraphQLCache_49(
+class _FakeLink_49 extends _i1.SmartFake implements _i14.Link {
+  _FakeLink_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +565,8 @@ class _FakeGraphQLCache_49 extends _i1.SmartFake implements _i14.GraphQLCache {
         );
 }
 
-class _FakeQueryManager_50 extends _i1.SmartFake implements _i14.QueryManager {
-  _FakeQueryManager_50(
+class _FakeGraphQLCache_50 extends _i1.SmartFake implements _i14.GraphQLCache {
+  _FakeGraphQLCache_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +575,8 @@ class _FakeQueryManager_50 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_51<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
-  _FakeObservableQuery_51(
+class _FakeQueryManager_51 extends _i1.SmartFake implements _i14.QueryManager {
+  _FakeQueryManager_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,8 +585,8 @@ class _FakeObservableQuery_51<TParsed1> extends _i1.SmartFake implements _i14.Ob
         );
 }
 
-class _FakeQueryResult_52<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
-  _FakeQueryResult_52(
+class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
+  _FakeObservableQuery_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,8 +595,8 @@ class _FakeQueryResult_52<TParsed1 extends Object?> extends _i1.SmartFake implem
         );
 }
 
-class _FakeHttpClientRequest_53 extends _i1.SmartFake implements _i24.HttpClientRequest {
-  _FakeHttpClientRequest_53(
+class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
+  _FakeQueryResult_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -604,8 +605,8 @@ class _FakeHttpClientRequest_53 extends _i1.SmartFake implements _i24.HttpClient
         );
 }
 
-class _FakeUri_54 extends _i1.SmartFake implements Uri {
-  _FakeUri_54(
+class _FakeHttpClientRequest_54 extends _i1.SmartFake implements _i25.HttpClientRequest {
+  _FakeHttpClientRequest_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -614,8 +615,8 @@ class _FakeUri_54 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeHttpHeaders_55 extends _i1.SmartFake implements _i24.HttpHeaders {
-  _FakeHttpHeaders_55(
+class _FakeUri_55 extends _i1.SmartFake implements Uri {
+  _FakeUri_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,8 +625,8 @@ class _FakeHttpHeaders_55 extends _i1.SmartFake implements _i24.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_56 extends _i1.SmartFake implements _i24.HttpClientResponse {
-  _FakeHttpClientResponse_56(
+class _FakeHttpHeaders_56 extends _i1.SmartFake implements _i25.HttpHeaders {
+  _FakeHttpHeaders_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -634,8 +635,8 @@ class _FakeHttpClientResponse_56 extends _i1.SmartFake implements _i24.HttpClien
         );
 }
 
-class _FakeEncoding_57 extends _i1.SmartFake implements _i25.Encoding {
-  _FakeEncoding_57(
+class _FakeHttpClientResponse_57 extends _i1.SmartFake implements _i25.HttpClientResponse {
+  _FakeHttpClientResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -644,8 +645,8 @@ class _FakeEncoding_57 extends _i1.SmartFake implements _i25.Encoding {
         );
 }
 
-class _FakeSocket_58 extends _i1.SmartFake implements _i24.Socket {
-  _FakeSocket_58(
+class _FakeEncoding_58 extends _i1.SmartFake implements _i26.Encoding {
+  _FakeEncoding_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,8 +655,8 @@ class _FakeSocket_58 extends _i1.SmartFake implements _i24.Socket {
         );
 }
 
-class _FakeStreamSubscription_59<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
-  _FakeStreamSubscription_59(
+class _FakeSocket_59 extends _i1.SmartFake implements _i25.Socket {
+  _FakeSocket_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -664,8 +665,8 @@ class _FakeStreamSubscription_59<T> extends _i1.SmartFake implements _i20.Stream
         );
 }
 
-class _FakeJobCancelResponse_60 extends _i1.SmartFake implements _i6.JobCancelResponse {
-  _FakeJobCancelResponse_60(
+class _FakeStreamSubscription_60<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
+  _FakeStreamSubscription_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -674,8 +675,8 @@ class _FakeJobCancelResponse_60 extends _i1.SmartFake implements _i6.JobCancelRe
         );
 }
 
-class _FakeJob_61 extends _i1.SmartFake implements _i6.Job {
-  _FakeJob_61(
+class _FakeJobCancelResponse_61 extends _i1.SmartFake implements _i6.JobCancelResponse {
+  _FakeJobCancelResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -684,8 +685,8 @@ class _FakeJob_61 extends _i1.SmartFake implements _i6.Job {
         );
 }
 
-class _FakeGetQueryResultsResponse_62 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
-  _FakeGetQueryResultsResponse_62(
+class _FakeJob_62 extends _i1.SmartFake implements _i6.Job {
+  _FakeJob_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,8 +695,8 @@ class _FakeGetQueryResultsResponse_62 extends _i1.SmartFake implements _i6.GetQu
         );
 }
 
-class _FakeJobList_63 extends _i1.SmartFake implements _i6.JobList {
-  _FakeJobList_63(
+class _FakeGetQueryResultsResponse_63 extends _i1.SmartFake implements _i6.GetQueryResultsResponse {
+  _FakeGetQueryResultsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -704,8 +705,8 @@ class _FakeJobList_63 extends _i1.SmartFake implements _i6.JobList {
         );
 }
 
-class _FakeQueryResponse_64 extends _i1.SmartFake implements _i6.QueryResponse {
-  _FakeQueryResponse_64(
+class _FakeJobList_64 extends _i1.SmartFake implements _i6.JobList {
+  _FakeJobList_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +715,8 @@ class _FakeQueryResponse_64 extends _i1.SmartFake implements _i6.QueryResponse {
         );
 }
 
-class _FakeBuildBucketClient_65 extends _i1.SmartFake implements _i15.BuildBucketClient {
-  _FakeBuildBucketClient_65(
+class _FakeQueryResponse_65 extends _i1.SmartFake implements _i6.QueryResponse {
+  _FakeQueryResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +725,8 @@ class _FakeBuildBucketClient_65 extends _i1.SmartFake implements _i15.BuildBucke
         );
 }
 
-class _FakeCacheService_66 extends _i1.SmartFake implements _i15.CacheService {
-  _FakeCacheService_66(
+class _FakeBuildBucketClient_66 extends _i1.SmartFake implements _i15.BuildBucketClient {
+  _FakeBuildBucketClient_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,8 +735,8 @@ class _FakeCacheService_66 extends _i1.SmartFake implements _i15.CacheService {
         );
 }
 
-class _FakePubSub_67 extends _i1.SmartFake implements _i15.PubSub {
-  _FakePubSub_67(
+class _FakeCacheService_67 extends _i1.SmartFake implements _i15.CacheService {
+  _FakeCacheService_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -744,8 +745,8 @@ class _FakePubSub_67 extends _i1.SmartFake implements _i15.PubSub {
         );
 }
 
-class _FakeProcess_68 extends _i1.SmartFake implements _i24.Process {
-  _FakeProcess_68(
+class _FakePubSub_68 extends _i1.SmartFake implements _i15.PubSub {
+  _FakePubSub_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +755,8 @@ class _FakeProcess_68 extends _i1.SmartFake implements _i24.Process {
         );
 }
 
-class _FakePullRequestMerge_69 extends _i1.SmartFake implements _i13.PullRequestMerge {
-  _FakePullRequestMerge_69(
+class _FakeProcess_69 extends _i1.SmartFake implements _i25.Process {
+  _FakeProcess_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +765,8 @@ class _FakePullRequestMerge_69 extends _i1.SmartFake implements _i13.PullRequest
         );
 }
 
-class _FakePullRequestComment_70 extends _i1.SmartFake implements _i13.PullRequestComment {
-  _FakePullRequestComment_70(
+class _FakePullRequestMerge_70 extends _i1.SmartFake implements _i13.PullRequestMerge {
+  _FakePullRequestMerge_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +775,8 @@ class _FakePullRequestComment_70 extends _i1.SmartFake implements _i13.PullReque
         );
 }
 
-class _FakePullRequestReview_71 extends _i1.SmartFake implements _i13.PullRequestReview {
-  _FakePullRequestReview_71(
+class _FakePullRequestComment_71 extends _i1.SmartFake implements _i13.PullRequestComment {
+  _FakePullRequestComment_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,8 +785,8 @@ class _FakePullRequestReview_71 extends _i1.SmartFake implements _i13.PullReques
         );
 }
 
-class _FakeRepository_72 extends _i1.SmartFake implements _i13.Repository {
-  _FakeRepository_72(
+class _FakePullRequestReview_72 extends _i1.SmartFake implements _i13.PullRequestReview {
+  _FakePullRequestReview_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -794,8 +795,8 @@ class _FakeRepository_72 extends _i1.SmartFake implements _i13.Repository {
         );
 }
 
-class _FakeLicenseDetails_73 extends _i1.SmartFake implements _i13.LicenseDetails {
-  _FakeLicenseDetails_73(
+class _FakeRepository_73 extends _i1.SmartFake implements _i13.Repository {
+  _FakeRepository_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -804,8 +805,8 @@ class _FakeLicenseDetails_73 extends _i1.SmartFake implements _i13.LicenseDetail
         );
 }
 
-class _FakeLanguageBreakdown_74 extends _i1.SmartFake implements _i13.LanguageBreakdown {
-  _FakeLanguageBreakdown_74(
+class _FakeLicenseDetails_74 extends _i1.SmartFake implements _i13.LicenseDetails {
+  _FakeLicenseDetails_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -814,8 +815,8 @@ class _FakeLanguageBreakdown_74 extends _i1.SmartFake implements _i13.LanguageBr
         );
 }
 
-class _FakeBranch_75 extends _i1.SmartFake implements _i13.Branch {
-  _FakeBranch_75(
+class _FakeLanguageBreakdown_75 extends _i1.SmartFake implements _i13.LanguageBreakdown {
+  _FakeLanguageBreakdown_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,8 +825,8 @@ class _FakeBranch_75 extends _i1.SmartFake implements _i13.Branch {
         );
 }
 
-class _FakeCommitComment_76 extends _i1.SmartFake implements _i13.CommitComment {
-  _FakeCommitComment_76(
+class _FakeBranch_76 extends _i1.SmartFake implements _i13.Branch {
+  _FakeBranch_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,8 +835,8 @@ class _FakeCommitComment_76 extends _i1.SmartFake implements _i13.CommitComment 
         );
 }
 
-class _FakeRepositoryCommit_77 extends _i1.SmartFake implements _i13.RepositoryCommit {
-  _FakeRepositoryCommit_77(
+class _FakeCommitComment_77 extends _i1.SmartFake implements _i13.CommitComment {
+  _FakeCommitComment_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,8 +845,8 @@ class _FakeRepositoryCommit_77 extends _i1.SmartFake implements _i13.RepositoryC
         );
 }
 
-class _FakeGitHubComparison_78 extends _i1.SmartFake implements _i13.GitHubComparison {
-  _FakeGitHubComparison_78(
+class _FakeRepositoryCommit_78 extends _i1.SmartFake implements _i13.RepositoryCommit {
+  _FakeRepositoryCommit_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +855,8 @@ class _FakeGitHubComparison_78 extends _i1.SmartFake implements _i13.GitHubCompa
         );
 }
 
-class _FakeGitHubFile_79 extends _i1.SmartFake implements _i13.GitHubFile {
-  _FakeGitHubFile_79(
+class _FakeGitHubComparison_79 extends _i1.SmartFake implements _i13.GitHubComparison {
+  _FakeGitHubComparison_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +865,8 @@ class _FakeGitHubFile_79 extends _i1.SmartFake implements _i13.GitHubFile {
         );
 }
 
-class _FakeRepositoryContents_80 extends _i1.SmartFake implements _i13.RepositoryContents {
-  _FakeRepositoryContents_80(
+class _FakeGitHubFile_80 extends _i1.SmartFake implements _i13.GitHubFile {
+  _FakeGitHubFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +875,8 @@ class _FakeRepositoryContents_80 extends _i1.SmartFake implements _i13.Repositor
         );
 }
 
-class _FakeContentCreation_81 extends _i1.SmartFake implements _i13.ContentCreation {
-  _FakeContentCreation_81(
+class _FakeRepositoryContents_81 extends _i1.SmartFake implements _i13.RepositoryContents {
+  _FakeRepositoryContents_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,8 +885,8 @@ class _FakeContentCreation_81 extends _i1.SmartFake implements _i13.ContentCreat
         );
 }
 
-class _FakeHook_82 extends _i1.SmartFake implements _i13.Hook {
-  _FakeHook_82(
+class _FakeContentCreation_82 extends _i1.SmartFake implements _i13.ContentCreation {
+  _FakeContentCreation_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,8 +895,8 @@ class _FakeHook_82 extends _i1.SmartFake implements _i13.Hook {
         );
 }
 
-class _FakePublicKey_83 extends _i1.SmartFake implements _i13.PublicKey {
-  _FakePublicKey_83(
+class _FakeHook_83 extends _i1.SmartFake implements _i13.Hook {
+  _FakeHook_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -904,8 +905,8 @@ class _FakePublicKey_83 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeRepositoryPages_84 extends _i1.SmartFake implements _i13.RepositoryPages {
-  _FakeRepositoryPages_84(
+class _FakePublicKey_84 extends _i1.SmartFake implements _i13.PublicKey {
+  _FakePublicKey_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,8 +915,8 @@ class _FakeRepositoryPages_84 extends _i1.SmartFake implements _i13.RepositoryPa
         );
 }
 
-class _FakePageBuild_85 extends _i1.SmartFake implements _i13.PageBuild {
-  _FakePageBuild_85(
+class _FakeRepositoryPages_85 extends _i1.SmartFake implements _i13.RepositoryPages {
+  _FakeRepositoryPages_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -924,8 +925,8 @@ class _FakePageBuild_85 extends _i1.SmartFake implements _i13.PageBuild {
         );
 }
 
-class _FakeRelease_86 extends _i1.SmartFake implements _i13.Release {
-  _FakeRelease_86(
+class _FakePageBuild_86 extends _i1.SmartFake implements _i13.PageBuild {
+  _FakePageBuild_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -934,8 +935,8 @@ class _FakeRelease_86 extends _i1.SmartFake implements _i13.Release {
         );
 }
 
-class _FakeReleaseAsset_87 extends _i1.SmartFake implements _i13.ReleaseAsset {
-  _FakeReleaseAsset_87(
+class _FakeRelease_87 extends _i1.SmartFake implements _i13.Release {
+  _FakeRelease_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -944,8 +945,8 @@ class _FakeReleaseAsset_87 extends _i1.SmartFake implements _i13.ReleaseAsset {
         );
 }
 
-class _FakeContributorParticipation_88 extends _i1.SmartFake implements _i13.ContributorParticipation {
-  _FakeContributorParticipation_88(
+class _FakeReleaseAsset_88 extends _i1.SmartFake implements _i13.ReleaseAsset {
+  _FakeReleaseAsset_88(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -954,8 +955,8 @@ class _FakeContributorParticipation_88 extends _i1.SmartFake implements _i13.Con
         );
 }
 
-class _FakeRepositoryStatus_89 extends _i1.SmartFake implements _i13.RepositoryStatus {
-  _FakeRepositoryStatus_89(
+class _FakeContributorParticipation_89 extends _i1.SmartFake implements _i13.ContributorParticipation {
+  _FakeContributorParticipation_89(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -964,8 +965,8 @@ class _FakeRepositoryStatus_89 extends _i1.SmartFake implements _i13.RepositoryS
         );
 }
 
-class _FakeCombinedRepositoryStatus_90 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
-  _FakeCombinedRepositoryStatus_90(
+class _FakeRepositoryStatus_90 extends _i1.SmartFake implements _i13.RepositoryStatus {
+  _FakeRepositoryStatus_90(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -974,8 +975,8 @@ class _FakeCombinedRepositoryStatus_90 extends _i1.SmartFake implements _i13.Com
         );
 }
 
-class _FakeReleaseNotes_91 extends _i1.SmartFake implements _i13.ReleaseNotes {
-  _FakeReleaseNotes_91(
+class _FakeCombinedRepositoryStatus_91 extends _i1.SmartFake implements _i13.CombinedRepositoryStatus {
+  _FakeCombinedRepositoryStatus_91(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -984,8 +985,8 @@ class _FakeReleaseNotes_91 extends _i1.SmartFake implements _i13.ReleaseNotes {
         );
 }
 
-class _FakeTableDataInsertAllResponse_92 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
-  _FakeTableDataInsertAllResponse_92(
+class _FakeReleaseNotes_92 extends _i1.SmartFake implements _i13.ReleaseNotes {
+  _FakeReleaseNotes_92(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -994,8 +995,8 @@ class _FakeTableDataInsertAllResponse_92 extends _i1.SmartFake implements _i6.Ta
         );
 }
 
-class _FakeTableDataList_93 extends _i1.SmartFake implements _i6.TableDataList {
-  _FakeTableDataList_93(
+class _FakeTableDataInsertAllResponse_93 extends _i1.SmartFake implements _i6.TableDataInsertAllResponse {
+  _FakeTableDataInsertAllResponse_93(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1004,8 +1005,8 @@ class _FakeTableDataList_93 extends _i1.SmartFake implements _i6.TableDataList {
         );
 }
 
-class _FakeUser_94 extends _i1.SmartFake implements _i13.User {
-  _FakeUser_94(
+class _FakeTableDataList_94 extends _i1.SmartFake implements _i6.TableDataList {
+  _FakeTableDataList_94(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1014,8 +1015,8 @@ class _FakeUser_94 extends _i1.SmartFake implements _i13.User {
         );
 }
 
-class _FakeCurrentUser_95 extends _i1.SmartFake implements _i13.CurrentUser {
-  _FakeCurrentUser_95(
+class _FakeUser_95 extends _i1.SmartFake implements _i13.User {
+  _FakeUser_95(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1024,8 +1025,8 @@ class _FakeCurrentUser_95 extends _i1.SmartFake implements _i13.CurrentUser {
         );
 }
 
-class _FakeEntry_96<T> extends _i1.SmartFake implements _i26.Entry<T> {
-  _FakeEntry_96(
+class _FakeCurrentUser_96 extends _i1.SmartFake implements _i13.CurrentUser {
+  _FakeCurrentUser_96(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1034,8 +1035,8 @@ class _FakeEntry_96<T> extends _i1.SmartFake implements _i26.Entry<T> {
         );
 }
 
-class _FakeCache_97<T> extends _i1.SmartFake implements _i26.Cache<T> {
-  _FakeCache_97(
+class _FakeEntry_97<T> extends _i1.SmartFake implements _i27.Entry<T> {
+  _FakeEntry_97(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1044,8 +1045,8 @@ class _FakeCache_97<T> extends _i1.SmartFake implements _i26.Cache<T> {
         );
 }
 
-class _FakeAuthentication_98 extends _i1.SmartFake implements _i13.Authentication {
-  _FakeAuthentication_98(
+class _FakeCache_98<T> extends _i1.SmartFake implements _i27.Cache<T> {
+  _FakeCache_98(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1054,8 +1055,8 @@ class _FakeAuthentication_98 extends _i1.SmartFake implements _i13.Authenticatio
         );
 }
 
-class _FakeActivityService_99 extends _i1.SmartFake implements _i13.ActivityService {
-  _FakeActivityService_99(
+class _FakeAuthentication_99 extends _i1.SmartFake implements _i13.Authentication {
+  _FakeAuthentication_99(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1064,8 +1065,8 @@ class _FakeActivityService_99 extends _i1.SmartFake implements _i13.ActivityServ
         );
 }
 
-class _FakeAuthorizationsService_100 extends _i1.SmartFake implements _i13.AuthorizationsService {
-  _FakeAuthorizationsService_100(
+class _FakeActivityService_100 extends _i1.SmartFake implements _i13.ActivityService {
+  _FakeActivityService_100(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1074,8 +1075,8 @@ class _FakeAuthorizationsService_100 extends _i1.SmartFake implements _i13.Autho
         );
 }
 
-class _FakeGistsService_101 extends _i1.SmartFake implements _i13.GistsService {
-  _FakeGistsService_101(
+class _FakeAuthorizationsService_101 extends _i1.SmartFake implements _i13.AuthorizationsService {
+  _FakeAuthorizationsService_101(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1084,8 +1085,8 @@ class _FakeGistsService_101 extends _i1.SmartFake implements _i13.GistsService {
         );
 }
 
-class _FakeGitService_102 extends _i1.SmartFake implements _i13.GitService {
-  _FakeGitService_102(
+class _FakeGistsService_102 extends _i1.SmartFake implements _i13.GistsService {
+  _FakeGistsService_102(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1094,8 +1095,8 @@ class _FakeGitService_102 extends _i1.SmartFake implements _i13.GitService {
         );
 }
 
-class _FakeIssuesService_103 extends _i1.SmartFake implements _i13.IssuesService {
-  _FakeIssuesService_103(
+class _FakeGitService_103 extends _i1.SmartFake implements _i13.GitService {
+  _FakeGitService_103(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1104,8 +1105,8 @@ class _FakeIssuesService_103 extends _i1.SmartFake implements _i13.IssuesService
         );
 }
 
-class _FakeMiscService_104 extends _i1.SmartFake implements _i13.MiscService {
-  _FakeMiscService_104(
+class _FakeIssuesService_104 extends _i1.SmartFake implements _i13.IssuesService {
+  _FakeIssuesService_104(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1114,8 +1115,8 @@ class _FakeMiscService_104 extends _i1.SmartFake implements _i13.MiscService {
         );
 }
 
-class _FakeOrganizationsService_105 extends _i1.SmartFake implements _i13.OrganizationsService {
-  _FakeOrganizationsService_105(
+class _FakeMiscService_105 extends _i1.SmartFake implements _i13.MiscService {
+  _FakeMiscService_105(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1124,8 +1125,8 @@ class _FakeOrganizationsService_105 extends _i1.SmartFake implements _i13.Organi
         );
 }
 
-class _FakePullRequestsService_106 extends _i1.SmartFake implements _i13.PullRequestsService {
-  _FakePullRequestsService_106(
+class _FakeOrganizationsService_106 extends _i1.SmartFake implements _i13.OrganizationsService {
+  _FakeOrganizationsService_106(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1134,8 +1135,8 @@ class _FakePullRequestsService_106 extends _i1.SmartFake implements _i13.PullReq
         );
 }
 
-class _FakeRepositoriesService_107 extends _i1.SmartFake implements _i13.RepositoriesService {
-  _FakeRepositoriesService_107(
+class _FakePullRequestsService_107 extends _i1.SmartFake implements _i13.PullRequestsService {
+  _FakePullRequestsService_107(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1144,8 +1145,8 @@ class _FakeRepositoriesService_107 extends _i1.SmartFake implements _i13.Reposit
         );
 }
 
-class _FakeSearchService_108 extends _i1.SmartFake implements _i13.SearchService {
-  _FakeSearchService_108(
+class _FakeRepositoriesService_108 extends _i1.SmartFake implements _i13.RepositoriesService {
+  _FakeRepositoriesService_108(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1154,8 +1155,8 @@ class _FakeSearchService_108 extends _i1.SmartFake implements _i13.SearchService
         );
 }
 
-class _FakeUrlShortenerService_109 extends _i1.SmartFake implements _i13.UrlShortenerService {
-  _FakeUrlShortenerService_109(
+class _FakeSearchService_109 extends _i1.SmartFake implements _i13.SearchService {
+  _FakeSearchService_109(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1164,8 +1165,8 @@ class _FakeUrlShortenerService_109 extends _i1.SmartFake implements _i13.UrlShor
         );
 }
 
-class _FakeUsersService_110 extends _i1.SmartFake implements _i13.UsersService {
-  _FakeUsersService_110(
+class _FakeUrlShortenerService_110 extends _i1.SmartFake implements _i13.UrlShortenerService {
+  _FakeUrlShortenerService_110(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1174,8 +1175,8 @@ class _FakeUsersService_110 extends _i1.SmartFake implements _i13.UsersService {
         );
 }
 
-class _FakeChecksService_111 extends _i1.SmartFake implements _i13.ChecksService {
-  _FakeChecksService_111(
+class _FakeUsersService_111 extends _i1.SmartFake implements _i13.UsersService {
+  _FakeUsersService_111(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1184,8 +1185,18 @@ class _FakeChecksService_111 extends _i1.SmartFake implements _i13.ChecksService
         );
 }
 
-class _FakeResponse_112 extends _i1.SmartFake implements _i2.Response {
-  _FakeResponse_112(
+class _FakeChecksService_112 extends _i1.SmartFake implements _i13.ChecksService {
+  _FakeChecksService_112(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeResponse_113 extends _i1.SmartFake implements _i2.Response {
+  _FakeResponse_113(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1233,7 +1244,7 @@ class MockAccessClientProvider extends _i1.Mock implements _i5.AccessClientProvi
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock implements _i27.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock implements _i28.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1374,13 +1385,13 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
       ) as _i7.GerritService);
 
   @override
-  _i28.RetryOptions get retryOptions => (super.noSuchMethod(
+  _i29.RetryOptions get retryOptions => (super.noSuchMethod(
         Invocation.getter(#retryOptions),
-        returnValue: _i29.dummyValue<_i28.RetryOptions>(
+        returnValue: _i30.dummyValue<_i29.RetryOptions>(
           this,
           Invocation.getter(#retryOptions),
         ),
-      ) as _i28.RetryOptions);
+      ) as _i29.RetryOptions);
 
   @override
   _i20.Future<void> branchFlutterRecipes(
@@ -1429,7 +1440,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   String get buildBucketBuildUri => (super.noSuchMethod(
         Invocation.getter(#buildBucketBuildUri),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#buildBucketBuildUri),
         ),
@@ -1438,7 +1449,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   String get buildBucketBuilderUri => (super.noSuchMethod(
         Invocation.getter(#buildBucketBuilderUri),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#buildBucketBuilderUri),
         ),
@@ -1592,7 +1603,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
 /// A class which mocks [CommitService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCommitService extends _i1.Mock implements _i30.CommitService {
+class MockCommitService extends _i1.Mock implements _i31.CommitService {
   MockCommitService() {
     _i1.throwOnMissingStub(this);
   }
@@ -1616,7 +1627,7 @@ class MockCommitService extends _i1.Mock implements _i30.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i31.CreateEvent? createEvent) => (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i32.CreateEvent? createEvent) => (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1659,7 +1670,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get autosubmitBot => (super.noSuchMethod(
         Invocation.getter(#autosubmitBot),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#autosubmitBot),
         ),
@@ -1677,7 +1688,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubPrivateKey => (super.noSuchMethod(
         Invocation.getter(#githubPrivateKey),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#githubPrivateKey),
         )),
@@ -1686,7 +1697,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get overrideTreeStatusLabel => (super.noSuchMethod(
         Invocation.getter(#overrideTreeStatusLabel),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#overrideTreeStatusLabel),
         )),
@@ -1695,7 +1706,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubPublicKey => (super.noSuchMethod(
         Invocation.getter(#githubPublicKey),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#githubPublicKey),
         )),
@@ -1704,7 +1715,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubAppId => (super.noSuchMethod(
         Invocation.getter(#githubAppId),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#githubAppId),
         )),
@@ -1719,7 +1730,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get defaultRecipeBundleRef => (super.noSuchMethod(
         Invocation.getter(#defaultRecipeBundleRef),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#defaultRecipeBundleRef),
         ),
@@ -1773,7 +1784,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get oauthClientId => (super.noSuchMethod(
         Invocation.getter(#oauthClientId),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#oauthClientId),
         )),
@@ -1782,7 +1793,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get frobWebhookKey => (super.noSuchMethod(
         Invocation.getter(#frobWebhookKey),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#frobWebhookKey),
         )),
@@ -1791,7 +1802,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get githubOAuthToken => (super.noSuchMethod(
         Invocation.getter(#githubOAuthToken),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#githubOAuthToken),
         )),
@@ -1800,7 +1811,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get wrongBaseBranchPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#wrongBaseBranchPullRequestMessage),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#wrongBaseBranchPullRequestMessage),
         ),
@@ -1809,7 +1820,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get releaseBranchPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#releaseBranchPullRequestMessage),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#releaseBranchPullRequestMessage),
         ),
@@ -1818,7 +1829,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   _i20.Future<String> get webhookKey => (super.noSuchMethod(
         Invocation.getter(#webhookKey),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.getter(#webhookKey),
         )),
@@ -1827,7 +1838,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get mergeConflictPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#mergeConflictPullRequestMessage),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#mergeConflictPullRequestMessage),
         ),
@@ -1836,7 +1847,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get missingTestsPullRequestMessage => (super.noSuchMethod(
         Invocation.getter(#missingTestsPullRequestMessage),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#missingTestsPullRequestMessage),
         ),
@@ -1845,7 +1856,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldPending => (super.noSuchMethod(
         Invocation.getter(#flutterGoldPending),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldPending),
         ),
@@ -1854,7 +1865,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldSuccess => (super.noSuchMethod(
         Invocation.getter(#flutterGoldSuccess),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldSuccess),
         ),
@@ -1863,7 +1874,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldChanges => (super.noSuchMethod(
         Invocation.getter(#flutterGoldChanges),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldChanges),
         ),
@@ -1872,7 +1883,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldStalePR => (super.noSuchMethod(
         Invocation.getter(#flutterGoldStalePR),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldStalePR),
         ),
@@ -1881,7 +1892,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterGoldDraftChange => (super.noSuchMethod(
         Invocation.getter(#flutterGoldDraftChange),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterGoldDraftChange),
         ),
@@ -1932,7 +1943,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterBuild => (super.noSuchMethod(
         Invocation.getter(#flutterBuild),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterBuild),
         ),
@@ -1941,7 +1952,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get flutterBuildDescription => (super.noSuchMethod(
         Invocation.getter(#flutterBuildDescription),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#flutterBuildDescription),
         ),
@@ -1950,7 +1961,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
   @override
   String get waitingForTreeToGoGreenLabelName => (super.noSuchMethod(
         Invocation.getter(#waitingForTreeToGoGreenLabelName),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#waitingForTreeToGoGreenLabelName),
         ),
@@ -1963,13 +1974,13 @@ class MockConfig extends _i1.Mock implements _i3.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i32.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i33.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
         ),
-        returnValue: _i20.Future<Iterable<_i32.Branch>>.value(<_i32.Branch>[]),
-      ) as _i20.Future<Iterable<_i32.Branch>>);
+        returnValue: _i20.Future<Iterable<_i33.Branch>>.value(<_i33.Branch>[]),
+      ) as _i20.Future<Iterable<_i33.Branch>>);
 
   @override
   String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
@@ -1977,7 +1988,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #wrongHeadBranchPullRequestMessage,
           [branch],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #wrongHeadBranchPullRequestMessage,
@@ -1992,7 +2003,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldInitialAlert,
           [url],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldInitialAlert,
@@ -2007,7 +2018,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldFollowUpAlert,
           [url],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldFollowUpAlert,
@@ -2022,7 +2033,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldAlertConstant,
           [slug],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldAlertConstant,
@@ -2037,7 +2048,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #flutterGoldCommentID,
           [pr],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #flutterGoldCommentID,
@@ -2052,7 +2063,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #generateJsonWebToken,
           [],
         ),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.method(
             #generateJsonWebToken,
@@ -2067,7 +2078,7 @@ class MockConfig extends _i1.Mock implements _i3.Config {
           #generateGithubToken,
           [slug],
         ),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.method(
             #generateGithubToken,
@@ -2249,16 +2260,16 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i11.DatastoreDB);
 
   @override
-  _i28.RetryOptions get retryOptions => (super.noSuchMethod(
+  _i29.RetryOptions get retryOptions => (super.noSuchMethod(
         Invocation.getter(#retryOptions),
-        returnValue: _i29.dummyValue<_i28.RetryOptions>(
+        returnValue: _i30.dummyValue<_i29.RetryOptions>(
           this,
           Invocation.getter(#retryOptions),
         ),
-      ) as _i28.RetryOptions);
+      ) as _i29.RetryOptions);
 
   @override
-  _i20.Stream<_i33.Commit> queryRecentCommits({
+  _i20.Stream<_i34.Commit> queryRecentCommits({
     int? limit = 100,
     int? timestamp,
     String? branch,
@@ -2275,20 +2286,20 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Stream<_i33.Commit>.empty(),
-      ) as _i20.Stream<_i33.Commit>);
+        returnValue: _i20.Stream<_i34.Commit>.empty(),
+      ) as _i20.Stream<_i34.Commit>);
 
   @override
-  _i20.Stream<_i32.Branch> queryBranches() => (super.noSuchMethod(
+  _i20.Stream<_i33.Branch> queryBranches() => (super.noSuchMethod(
         Invocation.method(
           #queryBranches,
           [],
         ),
-        returnValue: _i20.Stream<_i32.Branch>.empty(),
-      ) as _i20.Stream<_i32.Branch>);
+        returnValue: _i20.Stream<_i33.Branch>.empty(),
+      ) as _i20.Stream<_i33.Branch>);
 
   @override
-  _i20.Stream<_i34.Task> queryRecentTasksByName({
+  _i20.Stream<_i35.Task> queryRecentTasksByName({
     int? limit = 100,
     required String? name,
   }) =>
@@ -2301,11 +2312,11 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #name: name,
           },
         ),
-        returnValue: _i20.Stream<_i34.Task>.empty(),
-      ) as _i20.Stream<_i34.Task>);
+        returnValue: _i20.Stream<_i35.Task>.empty(),
+      ) as _i20.Stream<_i35.Task>);
 
   @override
-  _i20.Stream<_i34.FullTask> queryRecentTasks({
+  _i20.Stream<_i35.FullTask> queryRecentTasks({
     String? taskName,
     int? commitLimit = 20,
     String? branch,
@@ -2322,17 +2333,17 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Stream<_i34.FullTask>.empty(),
-      ) as _i20.Stream<_i34.FullTask>);
+        returnValue: _i20.Stream<_i35.FullTask>.empty(),
+      ) as _i20.Stream<_i35.FullTask>);
 
   @override
-  _i20.Future<List<_i35.Stage>> queryTasksGroupedByStage(_i33.Commit? commit) => (super.noSuchMethod(
+  _i20.Future<List<_i36.Stage>> queryTasksGroupedByStage(_i34.Commit? commit) => (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
         ),
-        returnValue: _i20.Future<List<_i35.Stage>>.value(<_i35.Stage>[]),
-      ) as _i20.Future<List<_i35.Stage>>);
+        returnValue: _i20.Future<List<_i36.Stage>>.value(<_i36.Stage>[]),
+      ) as _i20.Future<List<_i36.Stage>>);
 
   @override
   _i20.Future<_i18.GithubBuildStatusUpdate> queryLastStatusUpdate(
@@ -2424,8 +2435,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
           [key],
           {#orElse: orElse},
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<T>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #lookupByValue,
@@ -2455,7 +2466,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T?>);
 
   @override
-  _i20.Future<_i34.Task?> getTaskFromBuildbucketBuild(
+  _i20.Future<_i35.Task?> getTaskFromBuildbucketBuild(
     _i8.Build? build, {
     String? customName,
   }) =>
@@ -2465,26 +2476,26 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
           [build],
           {#customName: customName},
         ),
-        returnValue: _i20.Future<_i34.Task?>.value(),
-      ) as _i20.Future<_i34.Task?>);
+        returnValue: _i20.Future<_i35.Task?>.value(),
+      ) as _i20.Future<_i35.Task?>);
 }
 
 /// A class which mocks [FakeEntry].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
+class MockFakeEntry extends _i1.Mock implements _i37.FakeEntry {
   MockFakeEntry() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i37.Uint8List get value => (super.noSuchMethod(
+  _i38.Uint8List get value => (super.noSuchMethod(
         Invocation.getter(#value),
-        returnValue: _i37.Uint8List(0),
-      ) as _i37.Uint8List);
+        returnValue: _i38.Uint8List(0),
+      ) as _i38.Uint8List);
 
   @override
-  set value(_i37.Uint8List? _value) => super.noSuchMethod(
+  set value(_i38.Uint8List? _value) => super.noSuchMethod(
         Invocation.setter(
           #value,
           _value,
@@ -2493,8 +2504,8 @@ class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
       );
 
   @override
-  _i20.Future<_i37.Uint8List> get([
-    _i20.Future<_i37.Uint8List?> Function()? create,
+  _i20.Future<_i38.Uint8List> get([
+    _i20.Future<_i38.Uint8List?> Function()? create,
     Duration? ttl,
   ]) =>
       (super.noSuchMethod(
@@ -2505,8 +2516,8 @@ class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
             ttl,
           ],
         ),
-        returnValue: _i20.Future<_i37.Uint8List>.value(_i37.Uint8List(0)),
-      ) as _i20.Future<_i37.Uint8List>);
+        returnValue: _i20.Future<_i38.Uint8List>.value(_i38.Uint8List(0)),
+      ) as _i20.Future<_i38.Uint8List>);
 
   @override
   _i20.Future<void> purge({int? retries = 0}) => (super.noSuchMethod(
@@ -2520,8 +2531,8 @@ class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<_i37.Uint8List?> set(
-    _i37.Uint8List? value, [
+  _i20.Future<_i38.Uint8List?> set(
+    _i38.Uint8List? value, [
     Duration? ttl,
   ]) =>
       (super.noSuchMethod(
@@ -2532,8 +2543,8 @@ class MockFakeEntry extends _i1.Mock implements _i36.FakeEntry {
             ttl,
           ],
         ),
-        returnValue: _i20.Future<_i37.Uint8List?>.value(),
-      ) as _i20.Future<_i37.Uint8List?>);
+        returnValue: _i20.Future<_i38.Uint8List?>.value(),
+      ) as _i20.Future<_i38.Uint8List?>);
 }
 
 /// A class which mocks [FirestoreService].
@@ -2625,7 +2636,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.CommitResponse>);
 
   @override
-  _i20.Future<List<_i38.Commit>> queryRecentCommits({
+  _i20.Future<List<_i39.Commit>> queryRecentCommits({
     int? limit = 100,
     int? timestamp,
     String? branch,
@@ -2642,17 +2653,17 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Future<List<_i38.Commit>>.value(<_i38.Commit>[]),
-      ) as _i20.Future<List<_i38.Commit>>);
+        returnValue: _i20.Future<List<_i39.Commit>>.value(<_i39.Commit>[]),
+      ) as _i20.Future<List<_i39.Commit>>);
 
   @override
-  _i20.Future<List<_i39.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
+  _i20.Future<List<_i40.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
         Invocation.method(
           #queryCommitTasks,
           [commitSha],
         ),
-        returnValue: _i20.Future<List<_i39.Task>>.value(<_i39.Task>[]),
-      ) as _i20.Future<List<_i39.Task>>);
+        returnValue: _i20.Future<List<_i40.Task>>.value(<_i40.Task>[]),
+      ) as _i20.Future<List<_i40.Task>>);
 
   @override
   _i20.Future<_i22.GithubGoldStatus> queryLastGoldStatus(
@@ -2680,12 +2691,40 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i22.GithubGoldStatus>);
 
   @override
+  _i20.Future<_i23.GithubBuildStatus> queryLastBuildStatus(
+    _i13.RepositorySlug? slug,
+    int? prNumber,
+    String? head,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryLastBuildStatus,
+          [
+            slug,
+            prNumber,
+            head,
+          ],
+        ),
+        returnValue: _i20.Future<_i23.GithubBuildStatus>.value(_FakeGithubBuildStatus_29(
+          this,
+          Invocation.method(
+            #queryLastBuildStatus,
+            [
+              slug,
+              prNumber,
+              head,
+            ],
+          ),
+        )),
+      ) as _i20.Future<_i23.GithubBuildStatus>);
+
+  @override
   _i21.Value getValueFromFilter(Object? comparisonOject) => (super.noSuchMethod(
         Invocation.method(
           #getValueFromFilter,
           [comparisonOject],
         ),
-        returnValue: _FakeValue_29(
+        returnValue: _FakeValue_30(
           this,
           Invocation.method(
             #getValueFromFilter,
@@ -2707,7 +2746,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             compositeFilterOp,
           ],
         ),
-        returnValue: _FakeFilter_30(
+        returnValue: _FakeFilter_31(
           this,
           Invocation.method(
             #generateFilter,
@@ -2914,7 +2953,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_32(
           this,
           Invocation.method(
             #edit,
@@ -2940,7 +2979,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issueNumber,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_32(
           this,
           Invocation.method(
             #get,
@@ -2965,7 +3004,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             issue,
           ],
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_32(
           this,
           Invocation.method(
             #create,
@@ -3040,7 +3079,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_33(
           this,
           Invocation.method(
             #getComment,
@@ -3067,7 +3106,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_33(
           this,
           Invocation.method(
             #createComment,
@@ -3095,7 +3134,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             body,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_32(
+        returnValue: _i20.Future<_i13.IssueComment>.value(_FakeIssueComment_33(
           this,
           Invocation.method(
             #updateComment,
@@ -3146,7 +3185,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             name,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_34(
           this,
           Invocation.method(
             #getLabel,
@@ -3177,7 +3216,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_34(
           this,
           Invocation.method(
             #createLabel,
@@ -3208,7 +3247,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             color,
           ],
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_34(
           this,
           Invocation.method(
             #editLabel,
@@ -3242,7 +3281,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             #description: description,
           },
         ),
-        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_33(
+        returnValue: _i20.Future<_i13.IssueLabel>.value(_FakeIssueLabel_34(
           this,
           Invocation.method(
             #updateLabel,
@@ -3383,7 +3422,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_34(
+        returnValue: _i20.Future<_i13.Milestone>.value(_FakeMilestone_35(
           this,
           Invocation.method(
             #createMilestone,
@@ -3491,16 +3530,16 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       );
 
   @override
-  _i23.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
+  _i24.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_35(
+        returnValue: _FakeGithubChecksUtil_36(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
-      ) as _i23.GithubChecksUtil);
+      ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i23.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3511,7 +3550,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
   @override
   _i20.Future<void> handleCheckSuite(
     _i13.PullRequest? pullRequest,
-    _i31.CheckSuiteEvent? checkSuiteEvent,
+    _i32.CheckSuiteEvent? checkSuiteEvent,
     _i15.Scheduler? scheduler,
   ) =>
       (super.noSuchMethod(
@@ -3529,7 +3568,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
 
   @override
   _i20.Future<bool> updateCheckStatus(
-    _i40.BuildPushMessage? buildPushMessage,
+    _i41.BuildPushMessage? buildPushMessage,
     _i15.LuciBuildService? luciBuildService,
     _i13.RepositorySlug? slug, {
     bool? rescheduled = false,
@@ -3548,7 +3587,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i20.Future<bool>);
 
   @override
-  bool taskFailed(_i40.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
+  bool taskFailed(_i41.BuildPushMessage? buildPushMessage) => (super.noSuchMethod(
         Invocation.method(
           #taskFailed,
           [buildPushMessage],
@@ -3557,7 +3596,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as bool);
 
   @override
-  int currentAttempt(_i40.Build? build) => (super.noSuchMethod(
+  int currentAttempt(_i41.Build? build) => (super.noSuchMethod(
         Invocation.method(
           #currentAttempt,
           [build],
@@ -3571,7 +3610,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
           #getGithubSummary,
           [summary],
         ),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.method(
             #getGithubSummary,
@@ -3581,12 +3620,12 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i40.Result? result) => (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i41.Result? result) => (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [result],
         ),
-        returnValue: _FakeCheckRunConclusion_36(
+        returnValue: _FakeCheckRunConclusion_37(
           this,
           Invocation.method(
             #conclusionForResult,
@@ -3596,12 +3635,12 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i40.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i41.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
         ),
-        returnValue: _FakeCheckRunStatus_37(
+        returnValue: _FakeCheckRunStatus_38(
           this,
           Invocation.method(
             #statusForResult,
@@ -3632,7 +3671,7 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
 /// A class which mocks [GithubChecksUtil].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
+class MockGithubChecksUtil extends _i1.Mock implements _i24.GithubChecksUtil {
   MockGithubChecksUtil() {
     _i1.throwOnMissingStub(this);
   }
@@ -3640,7 +3679,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
   @override
   _i20.Future<Map<String, _i13.CheckRun>> allCheckRuns(
     _i13.GitHub? gitHubClient,
-    _i31.CheckSuiteEvent? checkSuiteEvent,
+    _i32.CheckSuiteEvent? checkSuiteEvent,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3668,7 +3707,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
             checkSuiteId,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_38(
+        returnValue: _i20.Future<_i13.CheckSuite>.value(_FakeCheckSuite_39(
           this,
           Invocation.method(
             #getCheckSuite,
@@ -3749,7 +3788,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_39(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_40(
           this,
           Invocation.method(
             #getCheckRun,
@@ -3781,7 +3820,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i23.GithubChecksUtil {
           ],
           {#output: output},
         ),
-        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_39(
+        returnValue: _i20.Future<_i13.CheckRun>.value(_FakeCheckRun_40(
           this,
           Invocation.method(
             #createCheckRun,
@@ -3869,7 +3908,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #entries: entries,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
           this,
           Invocation.method(
             #createPullRequest,
@@ -4005,7 +4044,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #assignee: assignee,
           },
         ),
-        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_31(
+        returnValue: _i20.Future<_i13.Issue>.value(_FakeIssue_32(
           this,
           Invocation.method(
             #createIssue,
@@ -4080,7 +4119,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.method(
             #getFileContent,
@@ -4106,7 +4145,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_42(
           this,
           Invocation.method(
             #getReference,
@@ -4124,7 +4163,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
           #getRateLimit,
           [],
         ),
-        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_42(
+        returnValue: _i20.Future<_i13.RateLimit>.value(_FakeRateLimit_43(
           this,
           Invocation.method(
             #getRateLimit,
@@ -4168,7 +4207,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
           this,
           Invocation.method(
             #getPullRequest,
@@ -4211,7 +4250,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_43(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_44(
           this,
           Invocation.method(
             #getBlob,
@@ -4236,7 +4275,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             blob,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_43(
+        returnValue: _i20.Future<_i13.GitBlob>.value(_FakeGitBlob_44(
           this,
           Invocation.method(
             #createBlob,
@@ -4261,7 +4300,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_44(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_45(
           this,
           Invocation.method(
             #getCommit,
@@ -4286,7 +4325,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             commit,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_44(
+        returnValue: _i20.Future<_i13.GitCommit>.value(_FakeGitCommit_45(
           this,
           Invocation.method(
             #createCommit,
@@ -4311,7 +4350,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_42(
           this,
           Invocation.method(
             #getReference,
@@ -4352,7 +4391,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_42(
           this,
           Invocation.method(
             #createReference,
@@ -4382,7 +4421,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#force: force},
         ),
-        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_41(
+        returnValue: _i20.Future<_i13.GitReference>.value(_FakeGitReference_42(
           this,
           Invocation.method(
             #editReference,
@@ -4425,7 +4464,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_45(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_46(
           this,
           Invocation.method(
             #getTag,
@@ -4450,7 +4489,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tag,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_45(
+        returnValue: _i20.Future<_i13.GitTag>.value(_FakeGitTag_46(
           this,
           Invocation.method(
             #createTag,
@@ -4477,7 +4516,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
           ],
           {#recursive: recursive},
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_46(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_47(
           this,
           Invocation.method(
             #getTree,
@@ -4503,7 +4542,7 @@ class MockGitService extends _i1.Mock implements _i13.GitService {
             tree,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_46(
+        returnValue: _i20.Future<_i13.GitTree>.value(_FakeGitTree_47(
           this,
           Invocation.method(
             #createTree,
@@ -4527,7 +4566,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.DefaultPolicies get defaultPolicies => (super.noSuchMethod(
         Invocation.getter(#defaultPolicies),
-        returnValue: _FakeDefaultPolicies_47(
+        returnValue: _FakeDefaultPolicies_48(
           this,
           Invocation.getter(#defaultPolicies),
         ),
@@ -4545,7 +4584,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.Link get link => (super.noSuchMethod(
         Invocation.getter(#link),
-        returnValue: _FakeLink_48(
+        returnValue: _FakeLink_49(
           this,
           Invocation.getter(#link),
         ),
@@ -4554,7 +4593,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.GraphQLCache get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeGraphQLCache_49(
+        returnValue: _FakeGraphQLCache_50(
           this,
           Invocation.getter(#cache),
         ),
@@ -4563,7 +4602,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
   @override
   _i14.QueryManager get queryManager => (super.noSuchMethod(
         Invocation.getter(#queryManager),
-        returnValue: _FakeQueryManager_50(
+        returnValue: _FakeQueryManager_51(
           this,
           Invocation.getter(#queryManager),
         ),
@@ -4617,7 +4656,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchQuery,
           [options],
         ),
-        returnValue: _FakeObservableQuery_51<TParsed>(
+        returnValue: _FakeObservableQuery_52<TParsed>(
           this,
           Invocation.method(
             #watchQuery,
@@ -4632,7 +4671,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #watchMutation,
           [options],
         ),
-        returnValue: _FakeObservableQuery_51<TParsed>(
+        returnValue: _FakeObservableQuery_52<TParsed>(
           this,
           Invocation.method(
             #watchMutation,
@@ -4647,7 +4686,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4662,7 +4701,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4696,7 +4735,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_52<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4779,7 +4818,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
 /// A class which mocks [HttpClient].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
+class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
   MockHttpClient() {
     _i1.throwOnMissingStub(this);
   }
@@ -4861,7 +4900,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
 
   @override
   set connectionFactory(
-          _i20.Future<_i24.ConnectionTask<_i24.Socket>> Function(
+          _i20.Future<_i25.ConnectionTask<_i25.Socket>> Function(
             Uri,
             String?,
             int?,
@@ -4902,7 +4941,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
   @override
   set badCertificateCallback(
           bool Function(
-            _i24.X509Certificate,
+            _i25.X509Certificate,
             String,
             int,
           )? callback) =>
@@ -4924,7 +4963,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
       );
 
   @override
-  _i20.Future<_i24.HttpClientRequest> open(
+  _i20.Future<_i25.HttpClientRequest> open(
     String? method,
     String? host,
     int? port,
@@ -4940,7 +4979,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #open,
@@ -4952,10 +4991,10 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> openUrl(
+  _i20.Future<_i25.HttpClientRequest> openUrl(
     String? method,
     Uri? url,
   ) =>
@@ -4967,7 +5006,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             url,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #openUrl,
@@ -4977,10 +5016,10 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> get(
+  _i20.Future<_i25.HttpClientRequest> get(
     String? host,
     int? port,
     String? path,
@@ -4994,7 +5033,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #get,
@@ -5005,25 +5044,25 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> getUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #getUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #getUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> post(
+  _i20.Future<_i25.HttpClientRequest> post(
     String? host,
     int? port,
     String? path,
@@ -5037,7 +5076,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #post,
@@ -5048,25 +5087,25 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> postUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #postUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #postUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> put(
+  _i20.Future<_i25.HttpClientRequest> put(
     String? host,
     int? port,
     String? path,
@@ -5080,7 +5119,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #put,
@@ -5091,25 +5130,25 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> putUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #putUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #putUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> delete(
+  _i20.Future<_i25.HttpClientRequest> delete(
     String? host,
     int? port,
     String? path,
@@ -5123,7 +5162,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #delete,
@@ -5134,25 +5173,25 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #deleteUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> patch(
+  _i20.Future<_i25.HttpClientRequest> patch(
     String? host,
     int? port,
     String? path,
@@ -5166,7 +5205,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patch,
@@ -5177,25 +5216,25 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> patchUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #patchUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patchUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> head(
+  _i20.Future<_i25.HttpClientRequest> head(
     String? host,
     int? port,
     String? path,
@@ -5209,7 +5248,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #head,
@@ -5220,28 +5259,28 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i24.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> headUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #headUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i24.HttpClientRequest>.value(_FakeHttpClientRequest_53(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #headUrl,
             [url],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientRequest>);
+      ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
   void addCredentials(
     Uri? url,
     String? realm,
-    _i24.HttpClientCredentials? credentials,
+    _i25.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -5260,7 +5299,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
     String? host,
     int? port,
     String? realm,
-    _i24.HttpClientCredentials? credentials,
+    _i25.HttpClientCredentials? credentials,
   ) =>
       super.noSuchMethod(
         Invocation.method(
@@ -5289,7 +5328,7 @@ class MockHttpClient extends _i1.Mock implements _i24.HttpClient {
 /// A class which mocks [HttpClientRequest].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
+class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
   MockHttpClientRequest() {
     _i1.throwOnMissingStub(this);
   }
@@ -5372,7 +5411,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
   @override
   String get method => (super.noSuchMethod(
         Invocation.getter(#method),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#method),
         ),
@@ -5381,47 +5420,47 @@ class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
   @override
   Uri get uri => (super.noSuchMethod(
         Invocation.getter(#uri),
-        returnValue: _FakeUri_54(
+        returnValue: _FakeUri_55(
           this,
           Invocation.getter(#uri),
         ),
       ) as Uri);
 
   @override
-  _i24.HttpHeaders get headers => (super.noSuchMethod(
+  _i25.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_55(
+        returnValue: _FakeHttpHeaders_56(
           this,
           Invocation.getter(#headers),
         ),
-      ) as _i24.HttpHeaders);
+      ) as _i25.HttpHeaders);
 
   @override
-  List<_i24.Cookie> get cookies => (super.noSuchMethod(
+  List<_i25.Cookie> get cookies => (super.noSuchMethod(
         Invocation.getter(#cookies),
-        returnValue: <_i24.Cookie>[],
-      ) as List<_i24.Cookie>);
+        returnValue: <_i25.Cookie>[],
+      ) as List<_i25.Cookie>);
 
   @override
-  _i20.Future<_i24.HttpClientResponse> get done => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.getter(#done),
         )),
-      ) as _i20.Future<_i24.HttpClientResponse>);
+      ) as _i20.Future<_i25.HttpClientResponse>);
 
   @override
-  _i25.Encoding get encoding => (super.noSuchMethod(
+  _i26.Encoding get encoding => (super.noSuchMethod(
         Invocation.getter(#encoding),
-        returnValue: _FakeEncoding_57(
+        returnValue: _FakeEncoding_58(
           this,
           Invocation.getter(#encoding),
         ),
-      ) as _i25.Encoding);
+      ) as _i26.Encoding);
 
   @override
-  set encoding(_i25.Encoding? _encoding) => super.noSuchMethod(
+  set encoding(_i26.Encoding? _encoding) => super.noSuchMethod(
         Invocation.setter(
           #encoding,
           _encoding,
@@ -5430,19 +5469,19 @@ class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
       );
 
   @override
-  _i20.Future<_i24.HttpClientResponse> close() => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientResponse> close() => (super.noSuchMethod(
         Invocation.method(
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #close,
             [],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientResponse>);
+      ) as _i20.Future<_i25.HttpClientResponse>);
 
   @override
   void abort([
@@ -5550,7 +5589,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i24.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5564,7 +5603,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
   @override
   String get reasonPhrase => (super.noSuchMethod(
         Invocation.getter(#reasonPhrase),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#reasonPhrase),
         ),
@@ -5577,10 +5616,10 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
       ) as int);
 
   @override
-  _i24.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
+  _i25.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
         Invocation.getter(#compressionState),
-        returnValue: _i24.HttpClientResponseCompressionState.notCompressed,
-      ) as _i24.HttpClientResponseCompressionState);
+        returnValue: _i25.HttpClientResponseCompressionState.notCompressed,
+      ) as _i25.HttpClientResponseCompressionState);
 
   @override
   bool get persistentConnection => (super.noSuchMethod(
@@ -5595,25 +5634,25 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
       ) as bool);
 
   @override
-  List<_i24.RedirectInfo> get redirects => (super.noSuchMethod(
+  List<_i25.RedirectInfo> get redirects => (super.noSuchMethod(
         Invocation.getter(#redirects),
-        returnValue: <_i24.RedirectInfo>[],
-      ) as List<_i24.RedirectInfo>);
+        returnValue: <_i25.RedirectInfo>[],
+      ) as List<_i25.RedirectInfo>);
 
   @override
-  _i24.HttpHeaders get headers => (super.noSuchMethod(
+  _i25.HttpHeaders get headers => (super.noSuchMethod(
         Invocation.getter(#headers),
-        returnValue: _FakeHttpHeaders_55(
+        returnValue: _FakeHttpHeaders_56(
           this,
           Invocation.getter(#headers),
         ),
-      ) as _i24.HttpHeaders);
+      ) as _i25.HttpHeaders);
 
   @override
-  List<_i24.Cookie> get cookies => (super.noSuchMethod(
+  List<_i25.Cookie> get cookies => (super.noSuchMethod(
         Invocation.getter(#cookies),
-        returnValue: <_i24.Cookie>[],
-      ) as List<_i24.Cookie>);
+        returnValue: <_i25.Cookie>[],
+      ) as List<_i25.Cookie>);
 
   @override
   bool get isBroadcast => (super.noSuchMethod(
@@ -5652,7 +5691,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
       ) as _i20.Future<List<int>>);
 
   @override
-  _i20.Future<_i24.HttpClientResponse> redirect([
+  _i20.Future<_i25.HttpClientResponse> redirect([
     String? method,
     Uri? url,
     bool? followLoops,
@@ -5666,7 +5705,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i24.HttpClientResponse>.value(_FakeHttpClientResponse_56(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #redirect,
@@ -5677,22 +5716,22 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
             ],
           ),
         )),
-      ) as _i20.Future<_i24.HttpClientResponse>);
+      ) as _i20.Future<_i25.HttpClientResponse>);
 
   @override
-  _i20.Future<_i24.Socket> detachSocket() => (super.noSuchMethod(
+  _i20.Future<_i25.Socket> detachSocket() => (super.noSuchMethod(
         Invocation.method(
           #detachSocket,
           [],
         ),
-        returnValue: _i20.Future<_i24.Socket>.value(_FakeSocket_58(
+        returnValue: _i20.Future<_i25.Socket>.value(_FakeSocket_59(
           this,
           Invocation.method(
             #detachSocket,
             [],
           ),
         )),
-      ) as _i20.Future<_i24.Socket>);
+      ) as _i20.Future<_i25.Socket>);
 
   @override
   _i20.Stream<List<int>> asBroadcastStream({
@@ -5728,7 +5767,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
             #cancelOnError: cancelOnError,
           },
         ),
-        returnValue: _FakeStreamSubscription_59<List<int>>(
+        returnValue: _FakeStreamSubscription_60<List<int>>(
           this,
           Invocation.method(
             #listen,
@@ -5849,8 +5888,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
             combine,
           ],
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<S>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<S>(
                 this,
                 Invocation.method(
                   #fold,
@@ -5880,7 +5919,7 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
           #join,
           [separator],
         ),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.method(
             #join,
@@ -5959,8 +5998,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i24.HttpClientResponse
           #drain,
           [futureValue],
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<E>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<E>(
                 this,
                 Invocation.method(
                   #drain,
@@ -6121,7 +6160,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_60(
+        returnValue: _i20.Future<_i6.JobCancelResponse>.value(_FakeJobCancelResponse_61(
           this,
           Invocation.method(
             #cancel,
@@ -6179,7 +6218,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_61(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_62(
           this,
           Invocation.method(
             #get,
@@ -6222,7 +6261,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_62(
+        returnValue: _i20.Future<_i6.GetQueryResultsResponse>.value(_FakeGetQueryResultsResponse_63(
           this,
           Invocation.method(
             #getQueryResults,
@@ -6263,7 +6302,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #uploadMedia: uploadMedia,
           },
         ),
-        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_61(
+        returnValue: _i20.Future<_i6.Job>.value(_FakeJob_62(
           this,
           Invocation.method(
             #insert,
@@ -6309,7 +6348,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_63(
+        returnValue: _i20.Future<_i6.JobList>.value(_FakeJobList_64(
           this,
           Invocation.method(
             #list,
@@ -6344,7 +6383,7 @@ class MockJobsResource extends _i1.Mock implements _i6.JobsResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_64(
+        returnValue: _i20.Future<_i6.QueryResponse>.value(_FakeQueryResponse_65(
           this,
           Invocation.method(
             #query,
@@ -6369,7 +6408,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.BuildBucketClient get buildBucketClient => (super.noSuchMethod(
         Invocation.getter(#buildBucketClient),
-        returnValue: _FakeBuildBucketClient_65(
+        returnValue: _FakeBuildBucketClient_66(
           this,
           Invocation.getter(#buildBucketClient),
         ),
@@ -6387,7 +6426,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.CacheService get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeCacheService_66(
+        returnValue: _FakeCacheService_67(
           this,
           Invocation.getter(#cache),
         ),
@@ -6412,16 +6451,16 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       );
 
   @override
-  _i23.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
+  _i24.GithubChecksUtil get githubChecksUtil => (super.noSuchMethod(
         Invocation.getter(#githubChecksUtil),
-        returnValue: _FakeGithubChecksUtil_35(
+        returnValue: _FakeGithubChecksUtil_36(
           this,
           Invocation.getter(#githubChecksUtil),
         ),
-      ) as _i23.GithubChecksUtil);
+      ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i23.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -6450,7 +6489,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.PubSub get pubsub => (super.noSuchMethod(
         Invocation.getter(#pubsub),
-        returnValue: _FakePubSub_67(
+        returnValue: _FakePubSub_68(
           this,
           Invocation.getter(#pubsub),
         ),
@@ -6540,10 +6579,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<List<_i41.Target>> scheduleTryBuilds({
-    required List<_i41.Target>? targets,
+  _i20.Future<List<_i42.Target>> scheduleTryBuilds({
+    required List<_i42.Target>? targets,
     required _i13.PullRequest? pullRequest,
-    _i31.CheckSuiteEvent? checkSuiteEvent,
+    _i32.CheckSuiteEvent? checkSuiteEvent,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6555,8 +6594,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #checkSuiteEvent: checkSuiteEvent,
           },
         ),
-        returnValue: _i20.Future<List<_i41.Target>>.value(<_i41.Target>[]),
-      ) as _i20.Future<List<_i41.Target>>);
+        returnValue: _i20.Future<List<_i42.Target>>.value(<_i42.Target>[]),
+      ) as _i20.Future<List<_i42.Target>>);
 
   @override
   _i20.Future<void> cancelBuilds(
@@ -6578,7 +6617,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<List<_i8.Build?>> failedBuilds(
     _i13.PullRequest? pullRequest,
-    List<_i41.Target>? targets,
+    List<_i42.Target>? targets,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6594,7 +6633,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i20.Future<_i8.Build> rescheduleBuild({
     required String? builderName,
-    required _i40.BuildPushMessage? buildPushMessage,
+    required _i41.BuildPushMessage? buildPushMessage,
     required int? rescheduleAttempt,
   }) =>
       (super.noSuchMethod(
@@ -6622,7 +6661,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i42.CheckRunEvent? checkRunEvent) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(_i43.CheckRunEvent? checkRunEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6652,10 +6691,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 
   @override
   _i20.Future<_i8.Build> reschedulePostsubmitBuildUsingCheckRunEvent(
-    _i42.CheckRunEvent? checkRunEvent, {
-    required _i33.Commit? commit,
-    required _i34.Task? task,
-    required _i41.Target? target,
+    _i43.CheckRunEvent? checkRunEvent, {
+    required _i34.Commit? commit,
+    required _i35.Task? task,
+    required _i42.Target? target,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6720,9 +6759,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i41.Target, _i34.Task, int>>> schedulePostsubmitBuilds({
-    required _i33.Commit? commit,
-    required List<_i15.Tuple<_i41.Target, _i34.Task, int>>? toBeScheduled,
+  _i20.Future<List<_i15.Tuple<_i42.Target, _i35.Task, int>>> schedulePostsubmitBuilds({
+    required _i34.Commit? commit,
+    required List<_i15.Tuple<_i42.Target, _i35.Task, int>>? toBeScheduled,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6733,14 +6772,14 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i41.Target, _i34.Task, int>>>.value(
-            <_i15.Tuple<_i41.Target, _i34.Task, int>>[]),
-      ) as _i20.Future<List<_i15.Tuple<_i41.Target, _i34.Task, int>>>);
+        returnValue: _i20.Future<List<_i15.Tuple<_i42.Target, _i35.Task, int>>>.value(
+            <_i15.Tuple<_i42.Target, _i35.Task, int>>[]),
+      ) as _i20.Future<List<_i15.Tuple<_i42.Target, _i35.Task, int>>>);
 
   @override
   _i20.Future<void> createPostsubmitCheckRun(
-    _i33.Commit? commit,
-    _i41.Target? target,
+    _i34.Commit? commit,
+    _i42.Target? target,
     Map<String, dynamic>? rawUserData,
   ) =>
       (super.noSuchMethod(
@@ -6758,14 +6797,14 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 
   @override
   _i20.Future<bool> checkRerunBuilder({
-    required _i33.Commit? commit,
-    required _i41.Target? target,
-    required _i34.Task? task,
+    required _i34.Commit? commit,
+    required _i42.Target? target,
+    required _i35.Task? task,
     required _i9.DatastoreService? datastore,
     _i15.FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool? ignoreChecks = false,
-    _i39.Task? taskDocument,
+    _i40.Task? taskDocument,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6789,19 +6828,19 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 /// A class which mocks [ProcessManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
+class MockProcessManager extends _i1.Mock implements _i44.ProcessManager {
   MockProcessManager() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i20.Future<_i24.Process> start(
+  _i20.Future<_i25.Process> start(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i24.ProcessStartMode? mode = _i24.ProcessStartMode.normal,
+    _i25.ProcessStartMode? mode = _i25.ProcessStartMode.normal,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6815,7 +6854,7 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             #mode: mode,
           },
         ),
-        returnValue: _i20.Future<_i24.Process>.value(_FakeProcess_68(
+        returnValue: _i20.Future<_i25.Process>.value(_FakeProcess_69(
           this,
           Invocation.method(
             #start,
@@ -6829,17 +6868,17 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             },
           ),
         )),
-      ) as _i20.Future<_i24.Process>);
+      ) as _i20.Future<_i25.Process>);
 
   @override
-  _i20.Future<_i24.ProcessResult> run(
+  _i20.Future<_i25.ProcessResult> run(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i25.Encoding? stdoutEncoding = const _i24.SystemEncoding(),
-    _i25.Encoding? stderrEncoding = const _i24.SystemEncoding(),
+    _i26.Encoding? stdoutEncoding = const _i25.SystemEncoding(),
+    _i26.Encoding? stderrEncoding = const _i25.SystemEncoding(),
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6854,7 +6893,7 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i24.ProcessResult>.value(_i29.dummyValue<_i24.ProcessResult>(
+        returnValue: _i20.Future<_i25.ProcessResult>.value(_i30.dummyValue<_i25.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6869,17 +6908,17 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             },
           ),
         )),
-      ) as _i20.Future<_i24.ProcessResult>);
+      ) as _i20.Future<_i25.ProcessResult>);
 
   @override
-  _i24.ProcessResult runSync(
+  _i25.ProcessResult runSync(
     List<Object>? command, {
     String? workingDirectory,
     Map<String, String>? environment,
     bool? includeParentEnvironment = true,
     bool? runInShell = false,
-    _i25.Encoding? stdoutEncoding = const _i24.SystemEncoding(),
-    _i25.Encoding? stderrEncoding = const _i24.SystemEncoding(),
+    _i26.Encoding? stdoutEncoding = const _i25.SystemEncoding(),
+    _i26.Encoding? stderrEncoding = const _i25.SystemEncoding(),
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6894,7 +6933,7 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i29.dummyValue<_i24.ProcessResult>(
+        returnValue: _i30.dummyValue<_i25.ProcessResult>(
           this,
           Invocation.method(
             #runSync,
@@ -6909,7 +6948,7 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
             },
           ),
         ),
-      ) as _i24.ProcessResult);
+      ) as _i25.ProcessResult);
 
   @override
   bool canRun(
@@ -6928,7 +6967,7 @@ class MockProcessManager extends _i1.Mock implements _i43.ProcessManager {
   @override
   bool killPid(
     int? pid, [
-    _i24.ProcessSignal? signal = _i24.ProcessSignal.sigterm,
+    _i25.ProcessSignal? signal = _i25.ProcessSignal.sigterm,
   ]) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6998,7 +7037,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             number,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
           this,
           Invocation.method(
             #get,
@@ -7023,7 +7062,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
           this,
           Invocation.method(
             #create,
@@ -7058,7 +7097,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #base: base,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_40(
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
           this,
           Invocation.method(
             #edit,
@@ -7161,7 +7200,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             #requestSha: requestSha,
           },
         ),
-        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_69(
+        returnValue: _i20.Future<_i13.PullRequestMerge>.value(_FakePullRequestMerge_70(
           this,
           Invocation.method(
             #merge,
@@ -7218,7 +7257,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             comment,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_70(
+        returnValue: _i20.Future<_i13.PullRequestComment>.value(_FakePullRequestComment_71(
           this,
           Invocation.method(
             #createComment,
@@ -7244,7 +7283,7 @@ class MockPullRequestsService extends _i1.Mock implements _i13.PullRequestsServi
             review,
           ],
         ),
-        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_71(
+        returnValue: _i20.Future<_i13.PullRequestReview>.value(_FakePullRequestReview_72(
           this,
           Invocation.method(
             #createReview,
@@ -7355,7 +7394,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [repository],
           {#org: org},
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_73(
           this,
           Invocation.method(
             #createRepository,
@@ -7371,7 +7410,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLicense,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_73(
+        returnValue: _i20.Future<_i13.LicenseDetails>.value(_FakeLicenseDetails_74(
           this,
           Invocation.method(
             #getLicense,
@@ -7386,7 +7425,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getRepository,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_73(
           this,
           Invocation.method(
             #getRepository,
@@ -7429,7 +7468,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #hasDownloads: hasDownloads,
           },
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_73(
           this,
           Invocation.method(
             #editRepository,
@@ -7485,7 +7524,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #listLanguages,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_74(
+        returnValue: _i20.Future<_i13.LanguageBreakdown>.value(_FakeLanguageBreakdown_75(
           this,
           Invocation.method(
             #listLanguages,
@@ -7536,7 +7575,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_75(
+        returnValue: _i20.Future<_i13.Branch>.value(_FakeBranch_76(
           this,
           Invocation.method(
             #getBranch,
@@ -7653,7 +7692,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #line: line,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_77(
           this,
           Invocation.method(
             #createCommitComment,
@@ -7682,7 +7721,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_77(
           this,
           Invocation.method(
             #getCommitComment,
@@ -7707,7 +7746,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #body: body,
           },
         ),
-        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_76(
+        returnValue: _i20.Future<_i13.CommitComment>.value(_FakeCommitComment_77(
           this,
           Invocation.method(
             #updateCommitComment,
@@ -7773,7 +7812,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_77(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_78(
           this,
           Invocation.method(
             #getCommit,
@@ -7798,7 +7837,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             sha,
           ],
         ),
-        returnValue: _i20.Future<String>.value(_i29.dummyValue<String>(
+        returnValue: _i20.Future<String>.value(_i30.dummyValue<String>(
           this,
           Invocation.method(
             #getCommitDiff,
@@ -7825,7 +7864,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             refHead,
           ],
         ),
-        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_78(
+        returnValue: _i20.Future<_i13.GitHubComparison>.value(_FakeGitHubComparison_79(
           this,
           Invocation.method(
             #compareCommits,
@@ -7849,7 +7888,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_79(
+        returnValue: _i20.Future<_i13.GitHubFile>.value(_FakeGitHubFile_80(
           this,
           Invocation.method(
             #getReadme,
@@ -7874,7 +7913,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#ref: ref},
         ),
-        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_80(
+        returnValue: _i20.Future<_i13.RepositoryContents>.value(_FakeRepositoryContents_81(
           this,
           Invocation.method(
             #getContents,
@@ -7900,7 +7939,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             file,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_82(
           this,
           Invocation.method(
             #createFile,
@@ -7933,7 +7972,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#branch: branch},
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_82(
           this,
           Invocation.method(
             #updateFile,
@@ -7968,7 +8007,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             branch,
           ],
         ),
-        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_81(
+        returnValue: _i20.Future<_i13.ContentCreation>.value(_FakeContentCreation_82(
           this,
           Invocation.method(
             #deleteFile,
@@ -8023,7 +8062,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             fork,
           ],
         ),
-        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_72(
+        returnValue: _i20.Future<_i13.Repository>.value(_FakeRepository_73(
           this,
           Invocation.method(
             #createFork,
@@ -8057,7 +8096,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_83(
           this,
           Invocation.method(
             #getHook,
@@ -8082,7 +8121,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             hook,
           ],
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_83(
           this,
           Invocation.method(
             #createHook,
@@ -8125,7 +8164,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #active: active,
           },
         ),
-        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_82(
+        returnValue: _i20.Future<_i13.Hook>.value(_FakeHook_83(
           this,
           Invocation.method(
             #editHook,
@@ -8215,7 +8254,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           [slug],
           {#id: id},
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_84(
           this,
           Invocation.method(
             #getDeployKey,
@@ -8238,7 +8277,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             key,
           ],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_84(
           this,
           Invocation.method(
             #createDeployKey,
@@ -8280,7 +8319,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             merge,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_77(
+        returnValue: _i20.Future<_i13.RepositoryCommit>.value(_FakeRepositoryCommit_78(
           this,
           Invocation.method(
             #merge,
@@ -8298,7 +8337,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getPagesInfo,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_84(
+        returnValue: _i20.Future<_i13.RepositoryPages>.value(_FakeRepositoryPages_85(
           this,
           Invocation.method(
             #getPagesInfo,
@@ -8322,7 +8361,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestPagesBuild,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_85(
+        returnValue: _i20.Future<_i13.PageBuild>.value(_FakePageBuild_86(
           this,
           Invocation.method(
             #getLatestPagesBuild,
@@ -8346,7 +8385,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getLatestRelease,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_87(
           this,
           Invocation.method(
             #getLatestRelease,
@@ -8368,7 +8407,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             id,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_87(
           this,
           Invocation.method(
             #getReleaseById,
@@ -8393,7 +8432,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             tagName,
           ],
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_87(
           this,
           Invocation.method(
             #getReleaseByTagName,
@@ -8420,7 +8459,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#getIfExists: getIfExists},
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_87(
           this,
           Invocation.method(
             #createRelease,
@@ -8460,7 +8499,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #preRelease: preRelease,
           },
         ),
-        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_86(
+        returnValue: _i20.Future<_i13.Release>.value(_FakeRelease_87(
           this,
           Invocation.method(
             #editRelease,
@@ -8527,7 +8566,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           ],
           {#assetId: assetId},
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_87(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_88(
           this,
           Invocation.method(
             #getReleaseAsset,
@@ -8559,7 +8598,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             #label: label,
           },
         ),
-        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_87(
+        returnValue: _i20.Future<_i13.ReleaseAsset>.value(_FakeReleaseAsset_88(
           this,
           Invocation.method(
             #editReleaseAsset,
@@ -8640,7 +8679,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #getParticipation,
           [slug],
         ),
-        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_88(
+        returnValue: _i20.Future<_i13.ContributorParticipation>.value(_FakeContributorParticipation_89(
           this,
           Invocation.method(
             #getParticipation,
@@ -8689,7 +8728,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             request,
           ],
         ),
-        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_89(
+        returnValue: _i20.Future<_i13.RepositoryStatus>.value(_FakeRepositoryStatus_90(
           this,
           Invocation.method(
             #createStatus,
@@ -8715,7 +8754,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
             ref,
           ],
         ),
-        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_90(
+        returnValue: _i20.Future<_i13.CombinedRepositoryStatus>.value(_FakeCombinedRepositoryStatus_91(
           this,
           Invocation.method(
             #getCombinedStatus,
@@ -8733,7 +8772,7 @@ class MockRepositoriesService extends _i1.Mock implements _i13.RepositoriesServi
           #generateReleaseNotes,
           [crn],
         ),
-        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_91(
+        returnValue: _i20.Future<_i13.ReleaseNotes>.value(_FakeReleaseNotes_92(
           this,
           Invocation.method(
             #generateReleaseNotes,
@@ -8884,7 +8923,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_92(
+        returnValue: _i20.Future<_i6.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_93(
           this,
           Invocation.method(
             #insertAll,
@@ -8926,7 +8965,7 @@ class MockTabledataResource extends _i1.Mock implements _i6.TabledataResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_93(
+        returnValue: _i20.Future<_i6.TableDataList>.value(_FakeTableDataList_94(
           this,
           Invocation.method(
             #list,
@@ -8970,7 +9009,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getUser,
           [name],
         ),
-        returnValue: _i20.Future<_i13.User>.value(_FakeUser_94(
+        returnValue: _i20.Future<_i13.User>.value(_FakeUser_95(
           this,
           Invocation.method(
             #getUser,
@@ -9003,7 +9042,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
             #bio: bio,
           },
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_95(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_96(
           this,
           Invocation.method(
             #editCurrentUser,
@@ -9041,7 +9080,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getCurrentUser,
           [],
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_95(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_96(
           this,
           Invocation.method(
             #getCurrentUser,
@@ -9188,7 +9227,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #createPublicKey,
           [key],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_83(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_84(
           this,
           Invocation.method(
             #createPublicKey,
@@ -9201,70 +9240,70 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
 /// A class which mocks [Cache].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCache extends _i1.Mock implements _i26.Cache<_i37.Uint8List> {
+class MockCache extends _i1.Mock implements _i27.Cache<_i38.Uint8List> {
   MockCache() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i26.Entry<_i37.Uint8List> operator [](String? key) => (super.noSuchMethod(
+  _i27.Entry<_i38.Uint8List> operator [](String? key) => (super.noSuchMethod(
         Invocation.method(
           #[],
           [key],
         ),
-        returnValue: _FakeEntry_96<_i37.Uint8List>(
+        returnValue: _FakeEntry_97<_i38.Uint8List>(
           this,
           Invocation.method(
             #[],
             [key],
           ),
         ),
-      ) as _i26.Entry<_i37.Uint8List>);
+      ) as _i27.Entry<_i38.Uint8List>);
 
   @override
-  _i26.Cache<_i37.Uint8List> withPrefix(String? prefix) => (super.noSuchMethod(
+  _i27.Cache<_i38.Uint8List> withPrefix(String? prefix) => (super.noSuchMethod(
         Invocation.method(
           #withPrefix,
           [prefix],
         ),
-        returnValue: _FakeCache_97<_i37.Uint8List>(
+        returnValue: _FakeCache_98<_i38.Uint8List>(
           this,
           Invocation.method(
             #withPrefix,
             [prefix],
           ),
         ),
-      ) as _i26.Cache<_i37.Uint8List>);
+      ) as _i27.Cache<_i38.Uint8List>);
 
   @override
-  _i26.Cache<S> withCodec<S>(_i25.Codec<S, _i37.Uint8List>? codec) => (super.noSuchMethod(
+  _i27.Cache<S> withCodec<S>(_i26.Codec<S, _i38.Uint8List>? codec) => (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],
         ),
-        returnValue: _FakeCache_97<S>(
+        returnValue: _FakeCache_98<S>(
           this,
           Invocation.method(
             #withCodec,
             [codec],
           ),
         ),
-      ) as _i26.Cache<S>);
+      ) as _i27.Cache<S>);
 
   @override
-  _i26.Cache<_i37.Uint8List> withTTL(Duration? ttl) => (super.noSuchMethod(
+  _i27.Cache<_i38.Uint8List> withTTL(Duration? ttl) => (super.noSuchMethod(
         Invocation.method(
           #withTTL,
           [ttl],
         ),
-        returnValue: _FakeCache_97<_i37.Uint8List>(
+        returnValue: _FakeCache_98<_i38.Uint8List>(
           this,
           Invocation.method(
             #withTTL,
             [ttl],
           ),
         ),
-      ) as _i26.Cache<_i37.Uint8List>);
+      ) as _i27.Cache<_i38.Uint8List>);
 }
 
 /// A class which mocks [GitHub].
@@ -9278,7 +9317,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.Authentication get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthentication_98(
+        returnValue: _FakeAuthentication_99(
           this,
           Invocation.getter(#auth),
         ),
@@ -9296,7 +9335,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   String get endpoint => (super.noSuchMethod(
         Invocation.getter(#endpoint),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#endpoint),
         ),
@@ -9305,7 +9344,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   String get version => (super.noSuchMethod(
         Invocation.getter(#version),
-        returnValue: _i29.dummyValue<String>(
+        returnValue: _i30.dummyValue<String>(
           this,
           Invocation.getter(#version),
         ),
@@ -9323,7 +9362,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ActivityService get activity => (super.noSuchMethod(
         Invocation.getter(#activity),
-        returnValue: _FakeActivityService_99(
+        returnValue: _FakeActivityService_100(
           this,
           Invocation.getter(#activity),
         ),
@@ -9332,7 +9371,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.AuthorizationsService get authorizations => (super.noSuchMethod(
         Invocation.getter(#authorizations),
-        returnValue: _FakeAuthorizationsService_100(
+        returnValue: _FakeAuthorizationsService_101(
           this,
           Invocation.getter(#authorizations),
         ),
@@ -9341,7 +9380,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GistsService get gists => (super.noSuchMethod(
         Invocation.getter(#gists),
-        returnValue: _FakeGistsService_101(
+        returnValue: _FakeGistsService_102(
           this,
           Invocation.getter(#gists),
         ),
@@ -9350,7 +9389,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.GitService get git => (super.noSuchMethod(
         Invocation.getter(#git),
-        returnValue: _FakeGitService_102(
+        returnValue: _FakeGitService_103(
           this,
           Invocation.getter(#git),
         ),
@@ -9359,7 +9398,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.IssuesService get issues => (super.noSuchMethod(
         Invocation.getter(#issues),
-        returnValue: _FakeIssuesService_103(
+        returnValue: _FakeIssuesService_104(
           this,
           Invocation.getter(#issues),
         ),
@@ -9368,7 +9407,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.MiscService get misc => (super.noSuchMethod(
         Invocation.getter(#misc),
-        returnValue: _FakeMiscService_104(
+        returnValue: _FakeMiscService_105(
           this,
           Invocation.getter(#misc),
         ),
@@ -9377,7 +9416,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.OrganizationsService get organizations => (super.noSuchMethod(
         Invocation.getter(#organizations),
-        returnValue: _FakeOrganizationsService_105(
+        returnValue: _FakeOrganizationsService_106(
           this,
           Invocation.getter(#organizations),
         ),
@@ -9386,7 +9425,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.PullRequestsService get pullRequests => (super.noSuchMethod(
         Invocation.getter(#pullRequests),
-        returnValue: _FakePullRequestsService_106(
+        returnValue: _FakePullRequestsService_107(
           this,
           Invocation.getter(#pullRequests),
         ),
@@ -9395,7 +9434,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.RepositoriesService get repositories => (super.noSuchMethod(
         Invocation.getter(#repositories),
-        returnValue: _FakeRepositoriesService_107(
+        returnValue: _FakeRepositoriesService_108(
           this,
           Invocation.getter(#repositories),
         ),
@@ -9404,7 +9443,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.SearchService get search => (super.noSuchMethod(
         Invocation.getter(#search),
-        returnValue: _FakeSearchService_108(
+        returnValue: _FakeSearchService_109(
           this,
           Invocation.getter(#search),
         ),
@@ -9413,7 +9452,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UrlShortenerService get urlShortener => (super.noSuchMethod(
         Invocation.getter(#urlShortener),
-        returnValue: _FakeUrlShortenerService_109(
+        returnValue: _FakeUrlShortenerService_110(
           this,
           Invocation.getter(#urlShortener),
         ),
@@ -9422,7 +9461,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.UsersService get users => (super.noSuchMethod(
         Invocation.getter(#users),
-        returnValue: _FakeUsersService_110(
+        returnValue: _FakeUsersService_111(
           this,
           Invocation.getter(#users),
         ),
@@ -9431,7 +9470,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
   @override
   _i13.ChecksService get checks => (super.noSuchMethod(
         Invocation.getter(#checks),
-        returnValue: _FakeChecksService_111(
+        returnValue: _FakeChecksService_112(
           this,
           Invocation.getter(#checks),
         ),
@@ -9460,8 +9499,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<T>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #getJSON,
@@ -9520,7 +9559,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i44.postJsonShim<S, T>(
+        returnValue: _i45.postJsonShim<S, T>(
           path,
           statusCode: statusCode,
           fail: fail,
@@ -9557,8 +9596,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<T>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #putJSON,
@@ -9619,8 +9658,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<T>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #patchJSON,
@@ -9685,8 +9724,8 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i29.ifNotNull(
-              _i29.dummyValueOrNull<T>(
+        returnValue: _i30.ifNotNull(
+              _i30.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #requestJson,
@@ -9755,7 +9794,7 @@ class MockGitHub extends _i1.Mock implements _i13.GitHub {
             #preview: preview,
           },
         ),
-        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_112(
+        returnValue: _i20.Future<_i2.Response>.value(_FakeResponse_113(
           this,
           Invocation.method(
             #request,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951.

The github build status API has been querying and writing updates to Datastore.

This PR:

- starts querying from Firestore
- supports both datastore/Firestore queries and writes
- updates all unit tests to cover Firestore logics