### PR TITLE
Support Firestore user data for postsubmit build

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -606,6 +606,7 @@ class LuciBuildService {
     final Map<String, dynamic> rawUserData = <String, dynamic>{
       'commit_key': commitKey,
       'task_key': taskKey,
+      'firestore_commit_document_name': commit.sha,
     };
 
     // Creates post submit checkrun only for unflaky targets from [config.postsubmitSupportedRepos].
@@ -618,6 +619,9 @@ class LuciBuildService {
     tags['scheduler_job_id'] = <String>['flutter/${target.value.name}'];
     // Default attempt is the initial attempt, which is 1.
     tags['current_attempt'] = tags['current_attempt'] ?? <String>['1'];
+    final String currentAttempt = tags['current_attempt']!.single;
+    rawUserData['firestore_task_document_name'] = '${commit.sha}_${task.name}_$currentAttempt';
+
     final Map<String, Object> processedProperties = target.getProperties();
     processedProperties.addAll(properties ?? <String, Object>{});
     processedProperties['git_branch'] = commit.branch!;

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -468,6 +468,8 @@ void main() {
         'builder_name': 'Linux 1',
         'repo_owner': 'flutter',
         'repo_name': 'packages',
+        'firestore_commit_document_name': '0',
+        'firestore_task_document_name': '0_task1_1',
       });
       final Map<String, dynamic> properties = scheduleBuild.properties!;
       expect(properties, <String, dynamic>{
@@ -535,6 +537,8 @@ void main() {
         'builder_name': 'Linux 1',
         'repo_owner': 'flutter',
         'repo_name': 'packages',
+        'firestore_commit_document_name': '0',
+        'firestore_task_document_name': '0_task1_1',
       });
     });
 
@@ -640,6 +644,8 @@ void main() {
       expect(userData, <String, dynamic>{
         'commit_key': 'flutter/packages/master/0',
         'task_key': '1',
+        'firestore_commit_document_name': '0',
+        'firestore_task_document_name': '0_task1_1',
       });
     });
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951.

To migrate postsubmit build API fully to firestore, we need to support user data servicing firestore data models. This PR adds corresponding document names. 