### PR TITLE
Switch to use firestore task for postsubmit_luci_subscription API

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -57,8 +57,9 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
 
     final String? rawTaskKey = buildPushMessage.userData['task_key'] as String?;
     final String? rawCommitKey = buildPushMessage.userData['commit_key'] as String?;
-    if (rawCommitKey == null) {
-      throw const BadRequestException('userData does not contain commit_key');
+    final String? taskDocumentName = buildPushMessage.userData['firestore_task_document_name'] as String?;
+    if (taskDocumentName == null) {
+      throw const BadRequestException('userData does not contain firestore_task_document_name');
     }
     final Build? build = buildPushMessage.build;
     if (build == null) {
@@ -67,35 +68,25 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
     final Key<String> commitKey = Key<String>(Key<dynamic>.emptyKey(Partition(null)), Commit, rawCommitKey);
     Task? task;
-    final String? taskName = build.buildParameters?['builder_name'] as String?;
-    if (rawTaskKey == null || rawTaskKey.isEmpty || rawTaskKey == 'null') {
-      log.fine('Pulling builder name from parameters_json...');
-      log.fine(build.buildParameters);
-      if (taskName == null || taskName.isEmpty) {
-        throw const BadRequestException('task_key is null and parameters_json does not contain the builder name');
-      }
-      final List<Task> tasks = await datastore.queryRecentTasksByName(name: taskName).toList();
-      task = tasks.singleWhere((Task task) => task.parentKey?.id == commitKey.id);
-    } else {
-      log.fine('Looking up key...');
-      final int taskId = int.parse(rawTaskKey);
-      final Key<int> taskKey = Key<int>(commitKey, Task, taskId);
-      task = await datastore.lookupByValue<Task>(taskKey);
-    }
-    log.fine('Found $task');
+    firestore.Task? firestoreTask;
+    log.fine('Looking up task document...');
+    final int taskId = int.parse(rawTaskKey!);
+    final Key<int> taskKey = Key<int>(commitKey, Task, taskId);
+    task = await datastore.lookupByValue<Task>(taskKey);
+    firestoreTask = await firestore.Task.fromFirestore(
+      firestoreService: firestoreService,
+      documentName: taskDocumentName,
+    );
+    log.fine('Found $firestoreTask');
 
-    firestore.Task taskDocument = firestore.Task();
-
-    if (_shouldUpdateTask(build, task)) {
-      final String oldTaskStatus = task.status;
+    if (_shouldUpdateTask(build, firestoreTask)) {
+      final String oldTaskStatus = firestoreTask.status;
+      firestoreTask.updateFromBuild(build);
       task.updateFromBuild(build);
       await datastore.insert(<Task>[task]);
-      try {
-        taskDocument = await updateFirestore(build, rawCommitKey, task.name!, firestoreService);
-      } catch (error) {
-        log.warning('Failed to update task in Firestore: $error');
-      }
-      log.fine('Updated datastore from $oldTaskStatus to ${task.status}');
+      final List<Write> writes = documentsToWrites([firestoreTask], exists: true);
+      await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
+      log.fine('Updated datastore from $oldTaskStatus to ${firestoreTask.status}');
     } else {
       log.fine('skip processing for build with status scheduled or task with status finished.');
     }
@@ -103,21 +94,22 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
     final List<Target> postsubmitTargets = ciYaml.postsubmitTargets;
-    if (!postsubmitTargets.any((element) => element.value.name == task!.name)) {
-      log.warning('Target ${task.name} has been deleted from TOT. Skip updating.');
+    if (!postsubmitTargets.any((element) => element.value.name == firestoreTask!.taskName)) {
+      log.warning('Target ${firestoreTask.taskName} has been deleted from TOT. Skip updating.');
       return Body.empty;
     }
-    final Target target = postsubmitTargets.singleWhere((Target target) => target.value.name == task!.name);
-    if (task.status == Task.statusFailed ||
-        task.status == Task.statusInfraFailure ||
-        task.status == Task.statusCancelled) {
+    final Target target =
+        postsubmitTargets.singleWhere((Target target) => target.value.name == firestoreTask!.taskName);
+    if (firestoreTask.status == firestore.Task.statusFailed ||
+        firestoreTask.status == firestore.Task.statusInfraFailure ||
+        firestoreTask.status == firestore.Task.statusCancelled) {
       log.fine('Trying to auto-retry...');
       final bool retried = await scheduler.luciBuildService.checkRerunBuilder(
         commit: commit,
         target: target,
         task: task,
         datastore: datastore,
-        taskDocument: taskDocument,
+        taskDocument: firestoreTask,
         firestoreService: firestoreService,
       );
       log.info('Retried: $retried');
@@ -144,28 +136,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   //    b) `completed`: update info like status.
   // 2) the task is already completed.
   //    The task may have been marked as completed from test framework via update-task-status API.
-  bool _shouldUpdateTask(Build build, Task task) {
-    return build.status != Status.scheduled && !Task.finishedStatusValues.contains(task.status);
-  }
-
-  /// Queries the task document and updates based on the latest build data.
-  Future<firestore.Task> updateFirestore(
-    Build build,
-    String commitKeyId,
-    String taskName,
-    FirestoreService firestoreService,
-  ) async {
-    final int currentAttempt = githubChecksService.currentAttempt(build);
-    final String sha = commitKeyId.split('/').last;
-    final String documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_$currentAttempt';
-    log.info('getting firestore document: $documentName');
-    final firestore.Task firestoreTask =
-        await firestore.Task.fromFirestore(firestoreService: firestoreService, documentName: documentName);
-    log.info('updating firestoreTask based on build');
-    firestoreTask.updateFromBuild(build);
-    log.info('finished updating firestoreTask based on builds');
-    final List<Write> writes = documentsToWrites([firestoreTask], exists: true);
-    await firestoreService.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
-    return firestoreTask;
+  bool _shouldUpdateTask(Build build, firestore.Task task) {
+    return build.status != Status.scheduled && !firestore.Task.finishedStatusValues.contains(task.status);
   }
 }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -16,7 +16,7 @@ import 'package:googleapis/pubsub/v1.dart';
 import '../foundation/github_checks_util.dart';
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
-import '../model/firestore/task.dart' as f;
+import '../model/firestore/task.dart' as firestore;
 import '../model/ci_yaml/target.dart';
 import '../model/github/checks.dart' as cocoon_checks;
 import '../model/luci/buildbucket.dart';
@@ -688,7 +688,7 @@ class LuciBuildService {
     FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool ignoreChecks = false,
-    f.Task? taskDocument,
+    firestore.Task? taskDocument,
   }) async {
     if (ignoreChecks == false && await _shouldRerunBuilder(task, commit, datastore) == false) {
       return false;
@@ -703,6 +703,7 @@ class LuciBuildService {
         final int newAttempt = int.parse(taskDocument.name!.split('_').last) + 1;
         tags['current_attempt'] = <String>[newAttempt.toString()];
         taskDocument.resetAsRetry(attempt: newAttempt);
+        taskDocument.setStatus(firestore.Task.statusInProgress);
         final List<Write> writes = documentsToWrites([taskDocument], exists: false);
         await firestoreService!.batchWriteDocuments(BatchWriteRequest(writes: writes), kDatabase);
       } catch (error) {

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -8,7 +8,6 @@ import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:gcloud/db.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -32,8 +31,10 @@ void main() {
   late MockGithubChecksService mockGithubChecksService;
   late MockGithubChecksUtil mockGithubChecksUtil;
   late FakeScheduler scheduler;
+  firestore.Task? firestoreTask;
 
   setUp(() async {
+    firestoreTask = null;
     mockGithubChecksUtil = MockGithubChecksUtil();
     mockFirestoreService = MockFirestoreService();
     config = FakeConfig(
@@ -45,6 +46,23 @@ void main() {
     when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
         .thenAnswer((_) async => generateCheckRun(1, name: 'Linux A'));
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
+    when(
+      mockFirestoreService.getDocument(
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<Document>.value(
+        firestoreTask,
+      );
+    });
+    when(
+      mockFirestoreService.batchWriteDocuments(
+        captureAny,
+        captureAny,
+      ),
+    ).thenAnswer((Invocation invocation) {
+      return Future<BatchWriteResponse>.value(BatchWriteResponse());
+    });
     final FakeLuciBuildService luciBuildService = FakeLuciBuildService(
       config: config,
       githubChecksUtil: mockGithubChecksUtil,
@@ -69,7 +87,7 @@ void main() {
     );
   });
 
-  test('throws exception when task key is not in message', () async {
+  test('throws exception when task document name is not in message', () async {
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       result: 'SUCCESS',
@@ -80,36 +98,8 @@ void main() {
     expect(() => tester.post(handler), throwsA(isA<BadRequestException>()));
   });
 
-  test('throws exception if task key does not exist in datastore', () {
-    final Task task = generateTask(1);
-    tester.message = createBuildbucketPushMessage(
-      'COMPLETED',
-      result: 'SUCCESS',
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
-    );
-
-    expect(() => tester.post(handler), throwsA(isA<KeyNotFoundException>()));
-  });
-
   test('updates task based on message', () async {
-    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
-    when(
-      mockFirestoreService.getDocument(
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<Document>.value(
-        firestoreTask,
-      );
-    });
-    when(
-      mockFirestoreService.batchWriteDocuments(
-        captureAny,
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<BatchWriteResponse>.value(BatchWriteResponse());
-    });
+    firestoreTask = generateFirestoreTask(1, attempts: 2, name: 'Linux A');
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
@@ -117,11 +107,13 @@ void main() {
       parent: commit,
       name: 'Linux A',
     );
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
 
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       result: 'SUCCESS',
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
     config.db.values[commit.key] = commit;
@@ -131,8 +123,8 @@ void main() {
     expect(task.endTimestamp, 0);
 
     // Firestore checks before API call.
-    expect(firestoreTask.status, Task.statusNew);
-    expect(firestoreTask.buildNumber, null);
+    expect(firestoreTask!.status, Task.statusNew);
+    expect(firestoreTask!.buildNumber, null);
 
     await tester.post(handler);
 
@@ -145,12 +137,13 @@ void main() {
     final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final Document updatedDocument = batchWriteRequest.writes![0].update!;
-    expect(updatedDocument.name, firestoreTask.name);
-    expect(firestoreTask.status, Task.statusSucceeded);
-    expect(firestoreTask.buildNumber, 1698);
+    expect(updatedDocument.name, firestoreTask!.name);
+    expect(firestoreTask!.status, Task.statusSucceeded);
+    expect(firestoreTask!.buildNumber, 1698);
   });
 
   test('skips task processing when build is with scheduled status', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux A', status: firestore.Task.statusInProgress);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -160,20 +153,23 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'SCHEDULED',
       builderName: 'Linux A',
       result: null,
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
-    expect(task.status, Task.statusInProgress);
-    expect(task.attempts, 1);
+    expect(firestoreTask!.status, firestore.Task.statusInProgress);
+    expect(firestoreTask!.attempts, 1);
     expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusInProgress);
+    expect(firestoreTask!.status, firestore.Task.statusInProgress);
   });
 
   test('skips task processing when task has already finished', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux A', status: firestore.Task.statusSucceeded);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -183,11 +179,13 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'STARTED',
       builderName: 'Linux A',
       result: null,
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
     expect(task.status, Task.statusSucceeded);
@@ -197,6 +195,7 @@ void main() {
   });
 
   test('skips task processing when target has been deleted', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux B', status: firestore.Task.statusSucceeded);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -206,11 +205,13 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'STARTED',
       builderName: 'Linux B',
       result: null,
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
     expect(task.status, Task.statusSucceeded);
@@ -229,6 +230,7 @@ void main() {
   });
 
   test('on failed builds auto-rerun the build', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux A', status: firestore.Task.statusFailed);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -238,21 +240,30 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       builderName: 'Linux A',
       result: 'FAILURE',
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
-    expect(task.status, Task.statusFailed);
-    expect(task.attempts, 1);
+    expect(firestoreTask!.status, firestore.Task.statusFailed);
+    expect(firestoreTask!.attempts, 1);
     expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusInProgress);
-    expect(task.attempts, 2);
+    final List<dynamic> captured = verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+    expect(captured.length, 2);
+    final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+    expect(batchWriteRequest.writes!.length, 1);
+    final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
+    final firestore.Task resultTask = firestore.Task.fromDocument(taskDocument: insertedTaskDocument);
+    expect(resultTask.status, firestore.Task.statusInProgress);
+    expect(resultTask.attempts, 2);
   });
 
   test('on canceled builds auto-rerun the build if they timed out', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux A', status: firestore.Task.statusInfraFailure);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -262,21 +273,30 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       builderName: 'Linux A',
       result: 'CANCELED',
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
-    expect(task.status, Task.statusInfraFailure);
-    expect(task.attempts, 1);
+    expect(firestoreTask!.status, firestore.Task.statusInfraFailure);
+    expect(firestoreTask!.attempts, 1);
     expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusInProgress);
-    expect(task.attempts, 2);
+    final List<dynamic> captured = verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+    expect(captured.length, 2);
+    final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+    expect(batchWriteRequest.writes!.length, 1);
+    final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
+    final firestore.Task resultTask = firestore.Task.fromDocument(taskDocument: insertedTaskDocument);
+    expect(resultTask.status, firestore.Task.statusInProgress);
+    expect(resultTask.attempts, 2);
   });
 
   test('on builds resulting in an infra failure auto-rerun the build if they timed out', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux A', status: firestore.Task.statusInfraFailure);
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -286,84 +306,34 @@ void main() {
     );
     config.db.values[task.key] = task;
     config.db.values[commit.key] = commit;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
       builderName: 'Linux A',
       result: 'FAILURE',
       failureReason: 'INFRA_FAILURE',
-      userData: '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
+      userData:
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
 
     expect(task.status, Task.statusInfraFailure);
     expect(task.attempts, 1);
     expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusInProgress);
-    expect(task.attempts, 2);
-  });
-
-  test('fallback to build parameters if task_key is not present', () async {
-    when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
-    when(
-      mockFirestoreService.getDocument(
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<Document>.value(
-        firestoreTask,
-      );
-    });
-    when(
-      mockFirestoreService.batchWriteDocuments(
-        captureAny,
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<BatchWriteResponse>.value(BatchWriteResponse());
-    });
-    final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
-    final Task task = generateTask(
-      4507531199512576,
-      name: 'Linux A',
-      parent: commit,
-      status: Task.statusNew,
-    );
-    config.db.values[task.key] = task;
-    config.db.values[commit.key] = commit;
-    tester.message = createBuildbucketPushMessage(
-      'COMPLETED',
-      builderName: 'Linux A',
-      result: 'FAILURE',
-      userData: '{\\"task_key\\":\\"null\\", \\"commit_key\\":\\"${task.key.parent?.id}\\"}',
-    );
-
-    expect(task.status, Task.statusNew);
-    expect(await tester.post(handler), Body.empty);
-    expect(task.status, Task.statusInProgress);
+    final List<dynamic> captured = verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+    expect(captured.length, 2);
+    final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+    expect(batchWriteRequest.writes!.length, 1);
+    final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
+    final firestore.Task resultTask = firestore.Task.fromDocument(taskDocument: insertedTaskDocument);
+    expect(resultTask.status, firestore.Task.statusInProgress);
+    expect(resultTask.attempts, 2);
   });
 
   test('non-bringup target updates check run', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux nonbringup');
     scheduler.ciYaml = nonBringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
-    when(
-      mockFirestoreService.getDocument(
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<Document>.value(
-        firestoreTask,
-      );
-    });
-    when(
-      mockFirestoreService.batchWriteDocuments(
-        captureAny,
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<BatchWriteResponse>.value(BatchWriteResponse());
-    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822', repo: 'packages');
     final Task task = generateTask(
       4507531199512576,
@@ -372,6 +342,7 @@ void main() {
     );
     config.db.values[commit.key] = commit;
     config.db.values[task.key] = task;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
 
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
@@ -379,34 +350,17 @@ void main() {
       builderName: 'Linux A',
       // Use escaped string to mock json decoded ones.
       userData:
-          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"repo_owner\\": \\"flutter\\", \\"repo_name\\": \\"packages\\"}',
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
     await tester.post(handler);
     verify(mockGithubChecksService.updateCheckStatus(any, any, any)).called(1);
   });
 
   test('bringup target does not update check run', () async {
+    firestoreTask = generateFirestoreTask(1, name: 'Linux bringup');
     scheduler.ciYaml = bringupPackagesConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
-    when(
-      mockFirestoreService.getDocument(
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<Document>.value(
-        firestoreTask,
-      );
-    });
-    when(
-      mockFirestoreService.batchWriteDocuments(
-        captureAny,
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<BatchWriteResponse>.value(BatchWriteResponse());
-    });
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -415,6 +369,7 @@ void main() {
     );
     config.db.values[commit.key] = commit;
     config.db.values[task.key] = task;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
 
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
@@ -422,7 +377,7 @@ void main() {
       builderName: 'Linux bringup',
       // Use escaped string to mock json decoded ones.
       userData:
-          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"repo_owner\\": \\"flutter\\", \\"repo_name\\": \\"packages\\"}',
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
     await tester.post(handler);
     verifyNever(mockGithubChecksService.updateCheckStatus(any, any, any));
@@ -432,24 +387,8 @@ void main() {
     scheduler.ciYaml = unsupportedPostsubmitCheckrunConfig;
     when(mockGithubChecksService.updateCheckStatus(any, any, any)).thenAnswer((_) async => true);
     when(mockGithubChecksService.currentAttempt(any)).thenAnswer((_) => 2);
-    final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 2);
-    when(
-      mockFirestoreService.getDocument(
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<Document>.value(
-        firestoreTask,
-      );
-    });
-    when(
-      mockFirestoreService.batchWriteDocuments(
-        captureAny,
-        captureAny,
-      ),
-    ).thenAnswer((Invocation invocation) {
-      return Future<BatchWriteResponse>.value(BatchWriteResponse());
-    });
+    firestoreTask = generateFirestoreTask(1, attempts: 2, name: 'Linux flutter');
+
     final Commit commit = generateCommit(1, sha: '87f88734747805589f2131753620d61b22922822');
     final Task task = generateTask(
       4507531199512576,
@@ -458,6 +397,7 @@ void main() {
     );
     config.db.values[commit.key] = commit;
     config.db.values[task.key] = task;
+    final String taskDocumentName = '${commit.sha}_${task.name}_${task.attempts}';
 
     tester.message = createBuildbucketPushMessage(
       'COMPLETED',
@@ -465,7 +405,7 @@ void main() {
       builderName: 'Linux bringup',
       // Use escaped string to mock json decoded ones.
       userData:
-          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"repo_owner\\": \\"flutter\\", \\"repo_name\\": \\"flutter\\"}',
+          '{\\"task_key\\":\\"${task.key.id}\\", \\"commit_key\\":\\"${task.key.parent?.id}\\", \\"firestore_commit_document_name\\":\\"${commit.sha}\\", \\"firestore_task_document_name\\":\\"$taskDocumentName\\"}',
     );
     await tester.post(handler);
     verifyNever(mockGithubChecksService.updateCheckStatus(any, any, any));

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -8,7 +8,7 @@ import 'dart:core';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
-import 'package:cocoon_service/src/model/firestore/task.dart' as f;
+import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_checks;
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
@@ -1077,7 +1077,7 @@ void main() {
     });
 
     test('insert retried task document to firestore', () async {
-      final f.Task firestoreTask = generateFirestoreTask(1, attempts: 1);
+      final firestore.Task firestoreTask = generateFirestoreTask(1, attempts: 1);
       when(
         mockFirestoreService.batchWriteDocuments(
           captureAny,
@@ -1114,6 +1114,7 @@ void main() {
       expect(batchWriteRequest.writes!.length, 1);
       final Document insertedTaskDocument = batchWriteRequest.writes![0].update!;
       expect(insertedTaskDocument, firestoreTask);
+      expect(firestoreTask.status, firestore.Task.statusInProgress);
     });
   });
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951

Following https://github.com/flutter/cocoon/pull/3583, this PR:
1) switches logics to use firestore task
2) keeps querying/writing task status for both Datastore and Firestore, in case fallback happens
3) updates all unit tests
4) removes the condition when `taskKey` doesn't exist (seems all builds are enforced with the `userData`, and confirmed no call for the past week)