### PR TITLE
Fix document name when querying Firestore tasks

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -75,7 +75,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     task = await datastore.lookupByValue<Task>(taskKey);
     firestoreTask = await firestore.Task.fromFirestore(
       firestoreService: firestoreService,
-      documentName: taskDocumentName,
+      documentName: '$kDatabase/documents/${firestore.kTaskCollectionId}/$taskDocumentName',
     );
     log.fine('Found $firestoreTask');
 


### PR DESCRIPTION
Follow up of https://github.com/flutter/cocoon/pull/3584 to fix the query document name.