### PR TITLE
Save commit/tasks to firestore first before scheduling LUCI builds

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -165,8 +165,6 @@ class Scheduler {
       log.severe('Failed to add commit ${commit.sha!}: $error');
     }
 
-    await _batchScheduleBuilds(commit, toBeScheduled);
-    await _uploadToBigQuery(commit);
     final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
     final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
     final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
@@ -177,6 +175,9 @@ class Scheduler {
     } catch (error) {
       log.warning('Failed to add to Firestore: $error');
     }
+
+    await _batchScheduleBuilds(commit, toBeScheduled);
+    await _uploadToBigQuery(commit);
   }
 
   /// Schedule all builds in batch requests instead of a single request.


### PR DESCRIPTION
This is to resolve issues:
1) data mismatch between datastore and firestore when LUCI schedule fails
2) postsubmit-luci-scheduler failures if LUCI schedules a task before the data is saved to firestore