### PR TITLE
Add more logs to identify where summary gets garbled.

### DIFF
--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -113,6 +113,8 @@ class GithubChecksService {
       } else {
         final Build buildbucketBuild =
             await luciBuildService.getBuildById(buildPushMessage.build!.id, fields: 'id,builder,summaryMarkdown');
+        final String summary = getGithubSummary(buildbucketBuild.summaryMarkdown);
+        log.fine('From LUCI: ${buildbucketBuild.summaryMarkdown} after summary: $summary');
         output = github.CheckRunOutput(
           title: checkRun.name!,
           summary: getGithubSummary(buildbucketBuild.summaryMarkdown),


### PR DESCRIPTION
The logs showed that once the output is sent to the checkrun update is already garbled. We need to see the state of the data from LUCI and also after the summary.

Bug: https://github.com/flutter/flutter/issues/143162

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
