### PR TITLE
Use utf-8 encoding on getbuild requests.

### DIFF
--- a/app_dart/lib/src/service/buildbucket.dart
+++ b/app_dart/lib/src/service/buildbucket.dart
@@ -75,7 +75,7 @@ class BuildBucketClient {
       url,
       body: json.encode(request),
       headers: <String, String>{
-        HttpHeaders.contentTypeHeader: 'application/json',
+        HttpHeaders.contentTypeHeader: 'application/json; charset=utf-8',
         HttpHeaders.acceptHeader: 'application/json',
         if (token != null) HttpHeaders.authorizationHeader: '${token.type} ${token.data}',
       },
@@ -83,7 +83,7 @@ class BuildBucketClient {
 
     if (response.statusCode < 300) {
       return responseFromJson(
-        json.decode(response.body.substring(kRpcResponseGarbage.length)) as Map<String, dynamic>?,
+        json.decode(utf8.decode(response.bodyBytes).substring(kRpcResponseGarbage.length)) as Map<String, dynamic>?,
       );
     }
     throw BuildBucketException(response.statusCode, response.body);

--- a/app_dart/test/service/buildbucket_test.dart
+++ b/app_dart/test/service/buildbucket_test.dart
@@ -58,7 +58,13 @@ void main() {
         expect(request.headers['accept'], 'application/json');
         expect(request.headers['authorization'], 'Bearer data');
         if (request.method == 'POST' && request.url.toString() == 'https://localhost/$urlPrefix/$expectedPath') {
-          return http.Response(response, HttpStatus.accepted);
+          return http.Response(
+            response,
+            HttpStatus.accepted,
+            headers: {
+              HttpHeaders.contentTypeHeader: 'application/json; charset=utf-8',
+            },
+          );
         }
         return http.Response('Test exception: A mock response was not returned', HttpStatus.internalServerError);
       });
@@ -216,6 +222,7 @@ void main() {
 
       expect(build.id, '123');
       expect(build.tags!.length, 3);
+      expect(build.summaryMarkdown, '```╔═╡ERROR #1╞```');
     });
 
     test('SearchBuilds', () async {
@@ -359,7 +366,9 @@ const String buildJson = '''${BuildBucketClient.kRpcResponseGarbage}
   "canceledBy": null,
   "startTime": "2019-08-01T11:00:00",
   "endTime": null,
-  "status": "SCHEDULED",
+  "status": "SUCCESS",
+  "status": "FAILURE",
+  "summaryMarkdown": "```╔═╡ERROR #1╞```",
   "input": {
     "experimental": true
   },


### PR DESCRIPTION
Dart uses latin1 encoding by default instead of utf-8 causing garbled output in summary markdown. This change send the proper headers to get utf-8 from server and decode utf from bytes before passing it to the json decoder.

Bug: https://github.com/flutter/flutter/issues/143162

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
