### PR TITLE
Switch scheduler to firestore

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:cocoon_service/src/service/scheduler/policy.dart';
+import 'package:cocoon_service/src/service/scheduler/policy_firestore.dart' as firestore_policy;
 import 'package:github/github.dart';
 
 import '../../service/config.dart';
@@ -90,6 +91,21 @@ class Target {
       return GuaranteedPolicy();
     }
     return BatchPolicy();
+  }
+
+  /// [SchedulerPolicy] this target follows.
+  ///
+  /// Targets not triggered by Cocoon will not be triggered.
+  ///
+  /// All targets except from [Config.guaranteedSchedulingRepos] run with [BatchPolicy] to reduce queue time.
+  firestore_policy.SchedulerPolicy get schedulerPolicyFirestore {
+    if (value.scheduler != pb.SchedulerSystem.cocoon) {
+      return firestore_policy.OmitPolicy();
+    }
+    if (Config.guaranteedSchedulingRepos.contains(slug)) {
+      return firestore_policy.GuaranteedPolicy();
+    }
+    return firestore_policy.BatchPolicy();
   }
 
   /// Get the tags from the defined properties in the ci.

--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -39,6 +39,29 @@ class Commit extends Document {
       ..name = commitDocument.name!;
   }
 
+  /// Createa a new [Commit]
+  static Commit newCommit({
+    required String author,
+    required String avatar,
+    required String branch,
+    required String message,
+    required String repositoryPath,
+    required String sha,
+    required int createTimestamp,
+  }) {
+    return Commit()
+      ..name = '$kDatabase/documents/$kCommitCollectionId/$sha'
+      ..fields = <String, Value>{
+        kCommitAuthorField: Value(stringValue: author),
+        kCommitAvatarField: Value(stringValue: avatar),
+        kCommitBranchField: Value(stringValue: branch),
+        kCommitMessageField: Value(stringValue: message),
+        kCommitRepositoryPathField: Value(stringValue: repositoryPath),
+        kCommitShaField: Value(stringValue: sha),
+        kCommitCreateTimestampField: Value(integerValue: createTimestamp.toString()),
+      };
+  }
+
   /// The timestamp (in milliseconds since the Epoch) of when the commit
   /// landed.
   int? get createTimestamp => int.parse(fields![kCommitCreateTimestampField]!.integerValue!);

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -11,6 +11,7 @@ import '../../service/logging.dart';
 import '../appengine/commit.dart';
 import '../appengine/task.dart' as datastore;
 import '../ci_yaml/target.dart';
+import '../firestore/commit.dart' as firestore_commit;
 import '../luci/push_message.dart';
 
 const String kTaskCollectionId = 'tasks';
@@ -276,6 +277,27 @@ List<Task> targetsToTaskDocuments(Commit commit, List<Target> targets) {
         name: '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${target.value.name}_$kTaskInitialAttempt',
         fields: <String, Value>{
           kTaskCreateTimestampField: Value(integerValue: commit.timestamp!.toString()),
+          kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
+          kTaskBringupField: Value(booleanValue: target.value.bringup),
+          kTaskNameField: Value(stringValue: target.value.name),
+          kTaskStartTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
+          kTaskStatusField: Value(stringValue: Task.statusNew),
+          kTaskTestFlakyField: Value(booleanValue: false),
+          kTaskCommitShaField: Value(stringValue: commit.sha),
+        },
+      ),
+    ),
+  );
+  return iterableDocuments.toList();
+}
+
+List<Task> targetsToTaskDocumentsFirestore(firestore_commit.Commit commit, List<Target> targets) {
+  final Iterable<Task> iterableDocuments = targets.map(
+    (Target target) => Task.fromDocument(
+      taskDocument: Document(
+        name: '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${target.value.name}_$kTaskInitialAttempt',
+        fields: <String, Value>{
+          kTaskCreateTimestampField: Value(integerValue: commit.createTimestamp!.toString()),
           kTaskEndTimestampField: Value(integerValue: kTaskDefaultTimestampValue.toString()),
           kTaskBringupField: Value(booleanValue: target.value.bringup),
           kTaskNameField: Value(stringValue: target.value.name),

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -88,7 +88,7 @@ class FirestoreService {
   ///
   /// The [limit] argument specifies the maximum number of commits to retrieve.
   ///
-  /// The returned commits will be ordered by most recent [Commit.timestamp].
+  /// The returned commits will be ordered by most recent [Commit.createTimestamp].
   Future<List<Commit>> queryRecentCommits({
     int limit = 100,
     int? timestamp,
@@ -107,6 +107,25 @@ class FirestoreService {
     };
     final List<Document> documents = await query(kCommitCollectionId, filterMap, orderMap: orderMap, limit: limit);
     return documents.map((Document document) => Commit.fromDocument(commitDocument: document)).toList();
+  }
+
+  /// Queries for recent tasks.
+  ///
+  /// The [limit] argument specifies the maximum number of tasks to retrieve.
+  ///
+  /// The returned tasks will be ordered by most recent [task.createTimestamp].
+  Future<List<Task>> queryRecentTasksByName({
+    int limit = 100,
+    required String name,
+  }) async {
+    final Map<String, Object> filterMap = <String, Object>{
+      '$kTaskNameField =': name,
+    };
+    final Map<String, String> orderMap = <String, String>{
+      kTaskCreateTimestampField: kQueryOrderDescending,
+    };
+    final List<Document> documents = await query(kTaskCollectionId, filterMap, orderMap: orderMap, limit: limit);
+    return documents.map((Document document) => Task.fromDocument(taskDocument: document)).toList();
   }
 
   /// Returns all tasks running against the speificed [commitSha].

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -267,7 +267,9 @@ class Scheduler {
   }
 
   Future<void> _batchScheduleBuildsFirestore(
-      firestore_commit.Commit commit, List<BuildSchedule> toBeScheduled,) async {
+    firestore_commit.Commit commit,
+    List<BuildSchedule> toBeScheduled,
+  ) async {
     log.info('Batching ${toBeScheduled.length} for ${commit.sha}');
     final List<Future<void>> futures = <Future<void>>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -855,8 +855,10 @@ class Scheduler {
     return totCommit;
   }
 
-  Future<firestore_commit.Commit> generateTotCommitFirestore(
-      {required String branch, required RepositorySlug slug}) async {
+  Future<firestore_commit.Commit> generateTotCommitFirestore({
+    required String branch,
+    required RepositorySlug slug,
+  }) async {
     datastore = datastoreProvider(config.db);
     firestoreService = await config.createFirestoreService();
     final firestore_commit.Commit totCommit = (await firestoreService.queryRecentCommits(

--- a/app_dart/lib/src/service/scheduler/policy_firestore.dart
+++ b/app_dart/lib/src/service/scheduler/policy_firestore.dart
@@ -1,0 +1,118 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/cocoon_service.dart';
+
+import '../../model/firestore/task.dart';
+import '../logging.dart';
+
+/// Interface for implementing various scheduling policies in the Cocoon scheduler.
+abstract class SchedulerPolicy {
+  /// Returns the priority of [Task].
+  ///
+  /// If null is returned, the task should not be scheduled.
+  Future<int?> triggerPriority({
+    required Task task,
+    required FirestoreService firestoreService,
+  });
+}
+
+/// Every [Task] is triggered to run.
+class GuaranteedPolicy implements SchedulerPolicy {
+  @override
+  Future<int?> triggerPriority({
+    required Task task,
+    required FirestoreService firestoreService,
+  }) async {
+    final List<Task> recentTasks = await firestoreService.queryRecentTasksByName(name: task.taskName!);
+    // Ensure task isn't considered in recentTasks
+    recentTasks.removeWhere((Task t) => t.commitSha == task.commitSha);
+    if (recentTasks.isEmpty) {
+      log.warning('${task.name} is newly added, triggerring builds regardless of policy');
+      return LuciBuildService.kDefaultPriority;
+    }
+    // Prioritize tasks that recently failed.
+    if (shouldRerunPriority(recentTasks, 1)) {
+      return LuciBuildService.kRerunPriority;
+    }
+    return LuciBuildService.kDefaultPriority;
+  }
+}
+
+/// [Task] is run at least every 6 commits.
+///
+/// If there is capacity, a backfiller cron triggers the latest task that was not run
+/// to ensure ToT is always tested.
+///
+/// This is intended for targets that are run in an infra pool that has limited capacity,
+/// such as the on device tests in the DeviceLab.
+class BatchPolicy implements SchedulerPolicy {
+  static const int kBatchSize = 6;
+  @override
+  Future<int?> triggerPriority({
+    required Task task,
+    required FirestoreService firestoreService,
+  }) async {
+    final List<Task> recentTasks = await firestoreService.queryRecentTasksByName(name: task.taskName!);
+    // Skip scheduling if there is already a running task.
+    if (recentTasks.any((Task task) => task.status == Task.statusInProgress)) {
+      return null;
+    }
+
+    // Ensure task isn't considered in recentTasks
+    recentTasks.removeWhere((Task t) => t.commitSha == task.commitSha);
+    if (recentTasks.length < kBatchSize) {
+      log.warning('${task.taskName} has less than $kBatchSize, skip scheduling to wait for ci.yaml roll.');
+      return null;
+    }
+
+    // Prioritize tasks that recently failed.
+    if (shouldRerunPriority(recentTasks, kBatchSize)) {
+      return LuciBuildService.kRerunPriority;
+    }
+
+    if (allNew(recentTasks.sublist(0, kBatchSize - 1))) {
+      return LuciBuildService.kDefaultPriority;
+    }
+
+    return null;
+  }
+}
+
+/// Checks if all tasks are with [firestore.Task.statusNew].
+bool allNew(List<Task> tasks) {
+  for (Task task in tasks) {
+    if (task.status != Task.statusNew) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Return true if there is an earlier failed build.
+bool shouldRerunPriority(List<Task> tasks, int pastTaskNumber) {
+  // Prioritize tasks that recently failed.
+  bool hasRecentFailure = false;
+  for (int i = 0; i < pastTaskNumber && i < tasks.length; i++) {
+    if (_isFailed(tasks[i])) {
+      hasRecentFailure = true;
+      break;
+    }
+  }
+  return hasRecentFailure;
+}
+
+bool _isFailed(Task task) {
+  return task.status == Task.statusFailed || task.status == Task.statusInfraFailure;
+}
+
+/// [Task] run outside of Cocoon are not triggered by the Cocoon scheduler.
+class OmitPolicy implements SchedulerPolicy {
+  @override
+  Future<int?> triggerPriority({
+    required Task task,
+    required FirestoreService firestoreService,
+  }) async =>
+      null;
+}

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -237,12 +237,16 @@ void main() {
     group('scheduler policy - firestore', () {
       test('devicelab targets use batch policy', () {
         expect(
-            generateTarget(1, platform: 'Linux_android').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+          generateTarget(1, platform: 'Linux_android').schedulerPolicyFirestore,
+          isA<firestore_policy.BatchPolicy>(),
+        );
       });
 
       test('devicelab samsung targets use batch policy', () {
-        expect(generateTarget(1, platform: 'Linux_samsung_a02').schedulerPolicyFirestore,
-            isA<firestore_policy.BatchPolicy>());
+        expect(
+          generateTarget(1, platform: 'Linux_samsung_a02').schedulerPolicyFirestore,
+          isA<firestore_policy.BatchPolicy>(),
+        );
       });
 
       test('mac host only targets use batch policy', () {

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -236,11 +236,13 @@ void main() {
 
     group('scheduler policy - firestore', () {
       test('devicelab targets use batch policy', () {
-        expect(generateTarget(1, platform: 'Linux_android').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+        expect(
+            generateTarget(1, platform: 'Linux_android').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
       });
 
       test('devicelab samsung targets use batch policy', () {
-        expect(generateTarget(1, platform: 'Linux_samsung_a02').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+        expect(generateTarget(1, platform: 'Linux_samsung_a02').schedulerPolicyFirestore,
+            isA<firestore_policy.BatchPolicy>());
       });
 
       test('mac host only targets use batch policy', () {
@@ -249,7 +251,8 @@ void main() {
 
       test('non-cocoon scheduler targets return omit policy', () {
         expect(
-          generateTarget(1, platform: 'Linux_android', schedulerSystem: pb.SchedulerSystem.luci).schedulerPolicyFirestore,
+          generateTarget(1, platform: 'Linux_android', schedulerSystem: pb.SchedulerSystem.luci)
+              .schedulerPolicyFirestore,
           isA<firestore_policy.OmitPolicy>(),
         );
       });

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/luci/buildbucket.dart';
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:cocoon_service/src/service/scheduler/policy.dart';
+import 'package:cocoon_service/src/service/scheduler/policy_firestore.dart' as firestore_policy;
 import 'package:github/github.dart' as github;
 import 'package:test/test.dart';
 
@@ -218,6 +219,38 @@ void main() {
         expect(
           generateTarget(1, platform: 'Linux_android', schedulerSystem: pb.SchedulerSystem.luci).schedulerPolicy,
           isA<OmitPolicy>(),
+        );
+      });
+
+      test('vm cocoon targets return batch policy', () {
+        expect(generateTarget(1, platform: 'Linux').schedulerPolicy, isA<BatchPolicy>());
+      });
+
+      test('packages targets use guaranteed policy', () {
+        expect(
+          generateTarget(1, platform: 'Mac', slug: github.RepositorySlug('flutter', 'packages')).schedulerPolicy,
+          isA<GuaranteedPolicy>(),
+        );
+      });
+    });
+
+    group('scheduler policy - firestore', () {
+      test('devicelab targets use batch policy', () {
+        expect(generateTarget(1, platform: 'Linux_android').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+      });
+
+      test('devicelab samsung targets use batch policy', () {
+        expect(generateTarget(1, platform: 'Linux_samsung_a02').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+      });
+
+      test('mac host only targets use batch policy', () {
+        expect(generateTarget(1, platform: 'Mac').schedulerPolicyFirestore, isA<firestore_policy.BatchPolicy>());
+      });
+
+      test('non-cocoon scheduler targets return omit policy', () {
+        expect(
+          generateTarget(1, platform: 'Linux_android', schedulerSystem: pb.SchedulerSystem.luci).schedulerPolicyFirestore,
+          isA<firestore_policy.OmitPolicy>(),
         );
       });
 

--- a/app_dart/test/model/firestore/commit_test.dart
+++ b/app_dart/test/model/firestore/commit_test.dart
@@ -51,4 +51,25 @@ void main() {
     expect(commitDocument.fields![kCommitRepositoryPathField]!.stringValue, commit.repository);
     expect(commitDocument.fields![kCommitShaField]!.stringValue, commit.sha);
   });
+
+  test('creates a new Commit document', () {
+    final Commit initialCommit = generateFirestoreCommit(1);
+    final Commit resultedCommit = Commit.newCommit(
+      author: initialCommit.author!,
+      avatar: initialCommit.avatar!,
+      branch: initialCommit.branch!,
+      message: initialCommit.message!,
+      repositoryPath: initialCommit.repositoryPath!,
+      sha: initialCommit.sha!,
+      createTimestamp: initialCommit.createTimestamp!,
+    );
+    expect(initialCommit.name, resultedCommit.name);
+    expect(initialCommit.author, resultedCommit.author);
+    expect(initialCommit.avatar, resultedCommit.avatar);
+    expect(initialCommit.branch, resultedCommit.branch);
+    expect(initialCommit.message, resultedCommit.message);
+    expect(initialCommit.repositoryPath, resultedCommit.repositoryPath);
+    expect(initialCommit.sha, resultedCommit.sha);
+    expect(initialCommit.createTimestamp, resultedCommit.createTimestamp);
+  });
 }

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -260,10 +260,10 @@ void main() {
     test('Acts on closed, cancels presubmit targets, add pr for postsubmit target create', () async {
       const int issueNumber = 123;
       final firestore_commit.Commit commitDocument = generateFirestoreCommit(
-          1,
-          sha: 'sha1',
-          branch: 'dev',
-        );
+        1,
+        sha: 'sha1',
+        branch: 'dev',
+      );
       when(
         mockFirestoreService.getDocument(
           captureAny,
@@ -2064,9 +2064,9 @@ void foo() {
         ),
       ).thenThrow(ApiRequestError('test'));
       final firestore_commit.Commit commitDocument = generateFirestoreCommit(
-          1,
-          sha: 'sha2',
-        );
+        1,
+        sha: 'sha2',
+      );
       when(
         mockFirestoreService.queryRecentCommits(
           limit: captureAnyNamed('limit'),
@@ -2092,13 +2092,13 @@ void foo() {
       expect(db.values.values.whereType<Commit>().length, 1);
 
       final List<dynamic> captured = verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
-        expect(captured.length, 1);
-        final List<Write> commitResponse = captured[0] as List<Write>;
-        expect(commitResponse.length, 2);
-        final firestore_commit.Commit resultCommitDocument =
-            firestore_commit.Commit.fromDocument(commitDocument: commitResponse[1].update!);
-        expect(resultCommitDocument.repositoryPath, 'flutter/flutter');
-        expect(resultCommitDocument.sha, 'sha2');
+      expect(captured.length, 1);
+      final List<Write> commitResponse = captured[0] as List<Write>;
+      expect(commitResponse.length, 2);
+      final firestore_commit.Commit resultCommitDocument =
+          firestore_commit.Commit.fromDocument(commitDocument: commitResponse[1].update!);
+      expect(resultCommitDocument.repositoryPath, 'flutter/flutter');
+      expect(resultCommitDocument.sha, 'sha2');
     });
 
     test('Fail when pull request is closed and merged, but merged commit is not found on GoB', () async {

--- a/app_dart/test/service/scheduler/policy_firestore_test.dart
+++ b/app_dart/test/service/scheduler/policy_firestore_test.dart
@@ -1,0 +1,203 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/firestore/task.dart';
+import 'package:cocoon_service/src/service/luci_build_service.dart';
+import 'package:cocoon_service/src/service/scheduler/policy_firestore.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../src/utilities/entity_generators.dart';
+import '../../src/utilities/mocks.dart';
+
+void main() {
+  group('BatchPolicy', () {
+    late MockFirestoreService mockFirestoreService;
+    List<Task> tasks = <Task>[];
+
+    final BatchPolicy policy = BatchPolicy();
+
+    setUp(() {
+      tasks.clear();
+      mockFirestoreService = MockFirestoreService();
+      when(
+        mockFirestoreService.queryRecentTasksByName(
+          name: captureAnyNamed('name'),
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<List<Task>>.value(
+          tasks,
+        );
+      });
+    });
+
+    test('triggers if less tasks than batch size', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1'),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(4),
+          firestoreService: mockFirestoreService,
+        ),
+        null,
+      );
+    });
+
+    test('triggers after batch size', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1'),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+        generateFirestoreTask(4, name: 'task1', commitSha: 'sha4'),
+        generateFirestoreTask(5, name: 'task1', commitSha: 'sha5'),
+        generateFirestoreTask(6, name: 'task1', commitSha: 'sha6', status: Task.statusSucceeded),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(7, name: 'task1', commitSha: 'sha7'),
+          firestoreService: mockFirestoreService,
+        ),
+        LuciBuildService.kDefaultPriority,
+      );
+    });
+
+    test('triggers with higher priority on recent failures', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1', status: Task.statusFailed),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+        generateFirestoreTask(4, name: 'task1', commitSha: 'sha4'),
+        generateFirestoreTask(5, name: 'task1', commitSha: 'sha5'),
+        generateFirestoreTask(6, name: 'task1', commitSha: 'sha6'),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(7, name: 'task1', commitSha: 'sha7'),
+          firestoreService: mockFirestoreService,
+        ),
+        LuciBuildService.kRerunPriority,
+      );
+    });
+
+    test('does not trigger on recent failures if there is already a running task', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1'),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+        generateFirestoreTask(4, name: 'task1', commitSha: 'sha4', status: Task.statusFailed),
+        generateFirestoreTask(5, name: 'task1', commitSha: 'sha5', status: Task.statusInProgress),
+        generateFirestoreTask(6, name: 'task1', commitSha: 'sha6'),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(7, name: 'task1', commitSha: 'sha7'),
+          firestoreService: mockFirestoreService,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not trigger when a test was recently scheduled', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1', status: Task.statusSucceeded),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+        generateFirestoreTask(4, name: 'task1', commitSha: 'sha4'),
+        generateFirestoreTask(5, name: 'task1', commitSha: 'sha5'),
+        generateFirestoreTask(6, name: 'task1', commitSha: 'sha6'),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(7, name: 'task1', commitSha: 'sha7'),
+          firestoreService: mockFirestoreService,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not trigger when pending queue is smaller than batch', () async {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1'),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+        generateFirestoreTask(4, name: 'task1', commitSha: 'sha4'),
+        generateFirestoreTask(5, name: 'task1', commitSha: 'sha5', status: Task.statusSucceeded),
+        generateFirestoreTask(6, name: 'task1', commitSha: 'sha6', status: Task.statusSucceeded),
+      ];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(7, name: 'task1', commitSha: 'sha7'),
+          firestoreService: mockFirestoreService,
+        ),
+        isNull,
+      );
+    });
+
+    test('do not return rerun priority when no task failed', () {
+      tasks = [
+        generateFirestoreTask(1, name: 'task1', commitSha: 'sha1'),
+        generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+        generateFirestoreTask(3, name: 'task1', commitSha: 'sha3'),
+      ];
+      expect(shouldRerunPriority(tasks, 5), false);
+    });
+  });
+
+  group('GuaranteedPolicy', () {
+    late MockFirestoreService mockFirestoreService;
+    List<Task> tasks = <Task>[];
+
+    final GuaranteedPolicy policy = GuaranteedPolicy();
+
+    setUp(() {
+      tasks.clear();
+      mockFirestoreService = MockFirestoreService();
+      when(
+        mockFirestoreService.queryRecentTasksByName(
+          name: captureAnyNamed('name'),
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<List<Task>>.value(
+          tasks,
+        );
+      });
+    });
+
+    //   final List<Task> pending = <Task>[
+    //     generateTask(1),
+    //   ];
+
+    //   final List<Task> latestFailed = <Task>[generateTask(1, status: Task.statusFailed)];
+
+    test('triggers every task', () async {
+      tasks = [generateFirestoreTask(1, name: 'task1', commitSha: 'sha1')];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(
+            2,
+            name: 'task1',
+            commitSha: 'sha2',
+          ),
+          firestoreService: mockFirestoreService,
+        ),
+        LuciBuildService.kDefaultPriority,
+      );
+    });
+
+    test('triggers with a higher priority on recent failure', () async {
+      tasks = [generateFirestoreTask(1, name: 'task1', commitSha: 'sha1', status: Task.statusFailed)];
+      expect(
+        await policy.triggerPriority(
+          task: generateFirestoreTask(2, name: 'task1', commitSha: 'sha2'),
+          firestoreService: mockFirestoreService,
+        ),
+        LuciBuildService.kRerunPriority,
+      );
+    });
+  });
+}

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -4,6 +4,7 @@
 
 import 'package:cocoon_service/src/foundation/github_checks_util.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
+import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commit;
 import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:cocoon_service/src/service/buildbucket.dart';
@@ -57,6 +58,23 @@ class FakeScheduler extends Scheduler {
   @override
   Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     return generateCommit(1);
+  }
+
+  @override
+  Future<CiYaml> getCiYamlFirestore(
+    firestore_commit.Commit commit, {
+    CiYaml? totCiYaml,
+    RetryOptions? retryOptions,
+    bool validate = false,
+  }) async =>
+      ciYaml ?? _defaultConfig;
+
+  @override
+  Future<firestore_commit.Commit> generateTotCommitFirestore({
+    required String branch,
+    required RepositorySlug slug,
+  }) async {
+    return generateFirestoreCommit(1);
   }
 
   int cancelPreSubmitTargetsCallCnt = 0;

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/ci_yaml.dart';
+import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_commit;
@@ -139,14 +140,21 @@ firestore_commit.Commit generateFirestoreCommit(
   String? owner = 'flutter',
   String repo = 'flutter',
   int? createTimestamp,
+  String? author,
+  String? avatar,
+  String? message,
 }) {
+  final String commitSha = sha ?? '$i';
   final firestore_commit.Commit commit = firestore_commit.Commit()
-    ..name = sha ?? '$i'
+    ..name = '$kDatabase/documents/${firestore_commit.kCommitCollectionId}/$commitSha'
     ..fields = <String, Value>{
       firestore_commit.kCommitCreateTimestampField: Value(integerValue: (createTimestamp ?? i).toString()),
       firestore_commit.kCommitRepositoryPathField: Value(stringValue: '$owner/$repo'),
+      firestore_commit.kCommitAuthorField: Value(stringValue: 'author$i'),
+      firestore_commit.kCommitAvatarField: Value(stringValue: 'avatar$i'),
       firestore_commit.kCommitBranchField: Value(stringValue: branch),
-      firestore_commit.kCommitShaField: Value(stringValue: sha ?? '$i'),
+      firestore_commit.kCommitShaField: Value(stringValue: commitSha),
+      firestore_commit.kCommitMessageField: Value(stringValue: 'message$i'),
     };
   return commit;
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -2657,6 +2657,23 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<List<_i39.Commit>>);
 
   @override
+  _i20.Future<List<_i40.Task>> queryRecentTasksByName({
+    int? limit = 100,
+    required String? name,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryRecentTasksByName,
+          [],
+          {
+            #limit: limit,
+            #name: name,
+          },
+        ),
+        returnValue: _i20.Future<List<_i40.Task>>.value(<_i40.Task>[]),
+      ) as _i20.Future<List<_i40.Task>>);
+
+  @override
   _i20.Future<List<_i40.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
         Invocation.method(
           #queryCommitTasks,
@@ -6777,6 +6794,23 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<List<_i15.Tuple<_i42.Target, _i35.Task, int>>>);
 
   @override
+  _i20.Future<List<_i15.BuildSchedule>> schedulePostsubmitBuildsFirestore({
+    required _i39.Commit? commit,
+    required List<_i15.BuildSchedule>? toBeScheduled,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #schedulePostsubmitBuildsFirestore,
+          [],
+          {
+            #commit: commit,
+            #toBeScheduled: toBeScheduled,
+          },
+        ),
+        returnValue: _i20.Future<List<_i15.BuildSchedule>>.value(<_i15.BuildSchedule>[]),
+      ) as _i20.Future<List<_i15.BuildSchedule>>);
+
+  @override
   _i20.Future<void> createPostsubmitCheckRun(
     _i34.Commit? commit,
     _i42.Target? target,
@@ -6796,15 +6830,34 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<void>);
 
   @override
+  _i20.Future<void> createPostsubmitCheckRunFirestore(
+    _i39.Commit? commit,
+    _i42.Target? target,
+    Map<String, dynamic>? rawUserData,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #createPostsubmitCheckRunFirestore,
+          [
+            commit,
+            target,
+            rawUserData,
+          ],
+        ),
+        returnValue: _i20.Future<void>.value(),
+        returnValueForMissingStub: _i20.Future<void>.value(),
+      ) as _i20.Future<void>);
+
+  @override
   _i20.Future<bool> checkRerunBuilder({
     required _i34.Commit? commit,
     required _i42.Target? target,
     required _i35.Task? task,
     required _i9.DatastoreService? datastore,
-    _i15.FirestoreService? firestoreService,
+    required _i40.Task? taskDocument,
+    required _i15.FirestoreService? firestoreService,
     Map<String, List<String>>? tags,
     bool? ignoreChecks = false,
-    _i40.Task? taskDocument,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6815,10 +6868,10 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #target: target,
             #task: task,
             #datastore: datastore,
+            #taskDocument: taskDocument,
             #firestoreService: firestoreService,
             #tags: tags,
             #ignoreChecks: ignoreChecks,
-            #taskDocument: taskDocument,
           },
         ),
         returnValue: _i20.Future<bool>.value(false),


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/142951.

This PR:
1) adds a new firestore policy file
2) duplicates datastore-based scheduling logics for firestore
3) duplicates datasore-based luci-build-service logics for firestore
4) updates/adds related firestore logics to support above logics

(I guess I will need to separate this PR into smaller pieces for easier review and better tracking)