### PR TITLE
Add firestore data model protos

### DIFF
--- a/dashboard/lib/model/commit_firestore.pb.dart
+++ b/dashboard/lib/model/commit_firestore.pb.dart
@@ -1,0 +1,168 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class CommitDocument extends $pb.GeneratedMessage {
+  factory CommitDocument({
+    $core.String? documentName,
+    $fixnum.Int64? createTimestamp,
+    $core.String? sha,
+    $core.String? author,
+    $core.String? avatar,
+    $core.String? repositoryPath,
+    $core.String? branch,
+    $core.String? message,
+  }) {
+    final $result = create();
+    if (documentName != null) {
+      $result.documentName = documentName;
+    }
+    if (createTimestamp != null) {
+      $result.createTimestamp = createTimestamp;
+    }
+    if (sha != null) {
+      $result.sha = sha;
+    }
+    if (author != null) {
+      $result.author = author;
+    }
+    if (avatar != null) {
+      $result.avatar = avatar;
+    }
+    if (repositoryPath != null) {
+      $result.repositoryPath = repositoryPath;
+    }
+    if (branch != null) {
+      $result.branch = branch;
+    }
+    if (message != null) {
+      $result.message = message;
+    }
+    return $result;
+  }
+  CommitDocument._() : super();
+  factory CommitDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CommitDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitDocument', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'documentName', protoName: 'documentName')
+    ..aInt64(2, _omitFieldNames ? '' : 'createTimestamp', protoName: 'createTimestamp')
+    ..aOS(3, _omitFieldNames ? '' : 'sha')
+    ..aOS(4, _omitFieldNames ? '' : 'author')
+    ..aOS(5, _omitFieldNames ? '' : 'avatar')
+    ..aOS(6, _omitFieldNames ? '' : 'repositoryPath', protoName: 'repositoryPath')
+    ..aOS(7, _omitFieldNames ? '' : 'branch')
+    ..aOS(8, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CommitDocument clone() => CommitDocument()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CommitDocument copyWith(void Function(CommitDocument) updates) => super.copyWith((message) => updates(message as CommitDocument)) as CommitDocument;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CommitDocument create() => CommitDocument._();
+  CommitDocument createEmptyInstance() => create();
+  static $pb.PbList<CommitDocument> createRepeated() => $pb.PbList<CommitDocument>();
+  @$core.pragma('dart2js:noInline')
+  static CommitDocument getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CommitDocument>(create);
+  static CommitDocument? _defaultInstance;
+
+  /// Next ID: 9
+  @$pb.TagNumber(1)
+  $core.String get documentName => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set documentName($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDocumentName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDocumentName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get createTimestamp => $_getI64(1);
+  @$pb.TagNumber(2)
+  set createTimestamp($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCreateTimestamp() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCreateTimestamp() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get sha => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set sha($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSha() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSha() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get author => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set author($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasAuthor() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearAuthor() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get avatar => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set avatar($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasAvatar() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearAvatar() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.String get repositoryPath => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set repositoryPath($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasRepositoryPath() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearRepositoryPath() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.String get branch => $_getSZ(6);
+  @$pb.TagNumber(7)
+  set branch($core.String v) { $_setString(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBranch() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBranch() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get message => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set message($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasMessage() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearMessage() => clearField(8);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/commit_firestore.pb.dart
+++ b/dashboard/lib/model/commit_firestore.pb.dart
@@ -53,10 +53,13 @@ class CommitDocument extends $pb.GeneratedMessage {
     return $result;
   }
   CommitDocument._() : super();
-  factory CommitDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CommitDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory CommitDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CommitDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitDocument', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitDocument',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'documentName', protoName: 'documentName')
     ..aInt64(2, _omitFieldNames ? '' : 'createTimestamp', protoName: 'createTimestamp')
     ..aOS(3, _omitFieldNames ? '' : 'sha')
@@ -65,19 +68,17 @@ class CommitDocument extends $pb.GeneratedMessage {
     ..aOS(6, _omitFieldNames ? '' : 'repositoryPath', protoName: 'repositoryPath')
     ..aOS(7, _omitFieldNames ? '' : 'branch')
     ..aOS(8, _omitFieldNames ? '' : 'message')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CommitDocument clone() => CommitDocument()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CommitDocument copyWith(void Function(CommitDocument) updates) => super.copyWith((message) => updates(message as CommitDocument)) as CommitDocument;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CommitDocument copyWith(void Function(CommitDocument) updates) =>
+      super.copyWith((message) => updates(message as CommitDocument)) as CommitDocument;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -93,7 +94,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get documentName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set documentName($core.String v) { $_setString(0, v); }
+  set documentName($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDocumentName() => $_has(0);
   @$pb.TagNumber(1)
@@ -102,7 +106,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get createTimestamp => $_getI64(1);
   @$pb.TagNumber(2)
-  set createTimestamp($fixnum.Int64 v) { $_setInt64(1, v); }
+  set createTimestamp($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCreateTimestamp() => $_has(1);
   @$pb.TagNumber(2)
@@ -111,7 +118,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get sha => $_getSZ(2);
   @$pb.TagNumber(3)
-  set sha($core.String v) { $_setString(2, v); }
+  set sha($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSha() => $_has(2);
   @$pb.TagNumber(3)
@@ -120,7 +130,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get author => $_getSZ(3);
   @$pb.TagNumber(4)
-  set author($core.String v) { $_setString(3, v); }
+  set author($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasAuthor() => $_has(3);
   @$pb.TagNumber(4)
@@ -129,7 +142,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get avatar => $_getSZ(4);
   @$pb.TagNumber(5)
-  set avatar($core.String v) { $_setString(4, v); }
+  set avatar($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasAvatar() => $_has(4);
   @$pb.TagNumber(5)
@@ -138,7 +154,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get repositoryPath => $_getSZ(5);
   @$pb.TagNumber(6)
-  set repositoryPath($core.String v) { $_setString(5, v); }
+  set repositoryPath($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasRepositoryPath() => $_has(5);
   @$pb.TagNumber(6)
@@ -147,7 +166,10 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get branch => $_getSZ(6);
   @$pb.TagNumber(7)
-  set branch($core.String v) { $_setString(6, v); }
+  set branch($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasBranch() => $_has(6);
   @$pb.TagNumber(7)
@@ -156,13 +178,15 @@ class CommitDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get message => $_getSZ(7);
   @$pb.TagNumber(8)
-  set message($core.String v) { $_setString(7, v); }
+  set message($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasMessage() => $_has(7);
   @$pb.TagNumber(8)
   void clearMessage() => clearField(8);
 }
-
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/commit_firestore.pbenum.dart
+++ b/dashboard/lib/model/commit_firestore.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/dashboard/lib/model/commit_firestore.pbenum.dart
+++ b/dashboard/lib/model/commit_firestore.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/dashboard/lib/model/commit_firestore.pbjson.dart
+++ b/dashboard/lib/model/commit_firestore.pbjson.dart
@@ -29,9 +29,9 @@ const CommitDocument$json = {
 };
 
 /// Descriptor for `CommitDocument`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List commitDocumentDescriptor = $convert.base64Decode(
-    'Cg5Db21taXREb2N1bWVudBIiCgxkb2N1bWVudE5hbWUYASABKAlSDGRvY3VtZW50TmFtZRIoCg'
-    '9jcmVhdGVUaW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBIQCgNzaGEYAyABKAlSA3No'
-    'YRIWCgZhdXRob3IYBCABKAlSBmF1dGhvchIWCgZhdmF0YXIYBSABKAlSBmF2YXRhchImCg5yZX'
-    'Bvc2l0b3J5UGF0aBgGIAEoCVIOcmVwb3NpdG9yeVBhdGgSFgoGYnJhbmNoGAcgASgJUgZicmFu'
-    'Y2gSGAoHbWVzc2FnZRgIIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List commitDocumentDescriptor =
+    $convert.base64Decode('Cg5Db21taXREb2N1bWVudBIiCgxkb2N1bWVudE5hbWUYASABKAlSDGRvY3VtZW50TmFtZRIoCg'
+        '9jcmVhdGVUaW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBIQCgNzaGEYAyABKAlSA3No'
+        'YRIWCgZhdXRob3IYBCABKAlSBmF1dGhvchIWCgZhdmF0YXIYBSABKAlSBmF2YXRhchImCg5yZX'
+        'Bvc2l0b3J5UGF0aBgGIAEoCVIOcmVwb3NpdG9yeVBhdGgSFgoGYnJhbmNoGAcgASgJUgZicmFu'
+        'Y2gSGAoHbWVzc2FnZRgIIAEoCVIHbWVzc2FnZQ==');

--- a/dashboard/lib/model/commit_firestore.pbjson.dart
+++ b/dashboard/lib/model/commit_firestore.pbjson.dart
@@ -1,0 +1,38 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use commitDocumentDescriptor instead')
+const CommitDocument$json = {
+  '1': 'CommitDocument',
+  '2': [
+    {'1': 'documentName', '3': 1, '4': 1, '5': 9, '10': 'documentName'},
+    {'1': 'createTimestamp', '3': 2, '4': 1, '5': 3, '10': 'createTimestamp'},
+    {'1': 'sha', '3': 3, '4': 1, '5': 9, '10': 'sha'},
+    {'1': 'author', '3': 4, '4': 1, '5': 9, '10': 'author'},
+    {'1': 'avatar', '3': 5, '4': 1, '5': 9, '10': 'avatar'},
+    {'1': 'repositoryPath', '3': 6, '4': 1, '5': 9, '10': 'repositoryPath'},
+    {'1': 'branch', '3': 7, '4': 1, '5': 9, '10': 'branch'},
+    {'1': 'message', '3': 8, '4': 1, '5': 9, '10': 'message'},
+  ],
+};
+
+/// Descriptor for `CommitDocument`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List commitDocumentDescriptor = $convert.base64Decode(
+    'Cg5Db21taXREb2N1bWVudBIiCgxkb2N1bWVudE5hbWUYASABKAlSDGRvY3VtZW50TmFtZRIoCg'
+    '9jcmVhdGVUaW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBIQCgNzaGEYAyABKAlSA3No'
+    'YRIWCgZhdXRob3IYBCABKAlSBmF1dGhvchIWCgZhdmF0YXIYBSABKAlSBmF2YXRhchImCg5yZX'
+    'Bvc2l0b3J5UGF0aBgGIAEoCVIOcmVwb3NpdG9yeVBhdGgSFgoGYnJhbmNoGAcgASgJUgZicmFu'
+    'Y2gSGAoHbWVzc2FnZRgIIAEoCVIHbWVzc2FnZQ==');
+

--- a/dashboard/lib/model/commit_firestore.pbjson.dart
+++ b/dashboard/lib/model/commit_firestore.pbjson.dart
@@ -35,4 +35,3 @@ final $typed_data.Uint8List commitDocumentDescriptor = $convert.base64Decode(
     'YRIWCgZhdXRob3IYBCABKAlSBmF1dGhvchIWCgZhdmF0YXIYBSABKAlSBmF2YXRhchImCg5yZX'
     'Bvc2l0b3J5UGF0aBgGIAEoCVIOcmVwb3NpdG9yeVBhdGgSFgoGYnJhbmNoGAcgASgJUgZicmFu'
     'Y2gSGAoHbWVzc2FnZRgIIAEoCVIHbWVzc2FnZQ==');
-

--- a/dashboard/lib/model/commit_firestore.pbserver.dart
+++ b/dashboard/lib/model/commit_firestore.pbserver.dart
@@ -11,4 +11,3 @@
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'commit_firestore.pb.dart';
-

--- a/dashboard/lib/model/commit_firestore.pbserver.dart
+++ b/dashboard/lib/model/commit_firestore.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'commit_firestore.pb.dart';
+

--- a/dashboard/lib/model/commit_firestore.proto
+++ b/dashboard/lib/model/commit_firestore.proto
@@ -1,0 +1,19 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto2";
+
+package dashboard;
+
+message CommitDocument {
+    // Next ID: 9
+    optional string documentName = 1;
+    optional int64 createTimestamp = 2;
+    optional string sha = 3;
+    optional string author = 4;
+    optional string avatar = 5;
+    optional string repositoryPath = 6;
+    optional string branch = 7;
+    optional string message = 8;
+}

--- a/dashboard/lib/model/commit_tasks_status.pb.dart
+++ b/dashboard/lib/model/commit_tasks_status.pb.dart
@@ -1,0 +1,95 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_tasks_status.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'commit_firestore.pb.dart' as $0;
+import 'task_firestore.pb.dart' as $1;
+
+class CommitTasksStatus extends $pb.GeneratedMessage {
+  factory CommitTasksStatus({
+    $0.CommitDocument? commit,
+    $core.Iterable<$1.TaskDocument>? tasks,
+    $core.String? branch,
+  }) {
+    final $result = create();
+    if (commit != null) {
+      $result.commit = commit;
+    }
+    if (tasks != null) {
+      $result.tasks.addAll(tasks);
+    }
+    if (branch != null) {
+      $result.branch = branch;
+    }
+    return $result;
+  }
+  CommitTasksStatus._() : super();
+  factory CommitTasksStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CommitTasksStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitTasksStatus', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+    ..aOM<$0.CommitDocument>(1, _omitFieldNames ? '' : 'commit', subBuilder: $0.CommitDocument.create)
+    ..pc<$1.TaskDocument>(2, _omitFieldNames ? '' : 'tasks', $pb.PbFieldType.PM, subBuilder: $1.TaskDocument.create)
+    ..aOS(3, _omitFieldNames ? '' : 'branch')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CommitTasksStatus clone() => CommitTasksStatus()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CommitTasksStatus copyWith(void Function(CommitTasksStatus) updates) => super.copyWith((message) => updates(message as CommitTasksStatus)) as CommitTasksStatus;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CommitTasksStatus create() => CommitTasksStatus._();
+  CommitTasksStatus createEmptyInstance() => create();
+  static $pb.PbList<CommitTasksStatus> createRepeated() => $pb.PbList<CommitTasksStatus>();
+  @$core.pragma('dart2js:noInline')
+  static CommitTasksStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CommitTasksStatus>(create);
+  static CommitTasksStatus? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.CommitDocument get commit => $_getN(0);
+  @$pb.TagNumber(1)
+  set commit($0.CommitDocument v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasCommit() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearCommit() => clearField(1);
+  @$pb.TagNumber(1)
+  $0.CommitDocument ensureCommit() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$1.TaskDocument> get tasks => $_getList(1);
+
+  @$pb.TagNumber(3)
+  $core.String get branch => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set branch($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasBranch() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearBranch() => clearField(3);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/commit_tasks_status.pb.dart
+++ b/dashboard/lib/model/commit_tasks_status.pb.dart
@@ -35,26 +35,28 @@ class CommitTasksStatus extends $pb.GeneratedMessage {
     return $result;
   }
   CommitTasksStatus._() : super();
-  factory CommitTasksStatus.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CommitTasksStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory CommitTasksStatus.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CommitTasksStatus.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitTasksStatus', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CommitTasksStatus',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
     ..aOM<$0.CommitDocument>(1, _omitFieldNames ? '' : 'commit', subBuilder: $0.CommitDocument.create)
     ..pc<$1.TaskDocument>(2, _omitFieldNames ? '' : 'tasks', $pb.PbFieldType.PM, subBuilder: $1.TaskDocument.create)
     ..aOS(3, _omitFieldNames ? '' : 'branch')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CommitTasksStatus clone() => CommitTasksStatus()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CommitTasksStatus copyWith(void Function(CommitTasksStatus) updates) => super.copyWith((message) => updates(message as CommitTasksStatus)) as CommitTasksStatus;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CommitTasksStatus copyWith(void Function(CommitTasksStatus) updates) =>
+      super.copyWith((message) => updates(message as CommitTasksStatus)) as CommitTasksStatus;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -63,13 +65,17 @@ class CommitTasksStatus extends $pb.GeneratedMessage {
   CommitTasksStatus createEmptyInstance() => create();
   static $pb.PbList<CommitTasksStatus> createRepeated() => $pb.PbList<CommitTasksStatus>();
   @$core.pragma('dart2js:noInline')
-  static CommitTasksStatus getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CommitTasksStatus>(create);
+  static CommitTasksStatus getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CommitTasksStatus>(create);
   static CommitTasksStatus? _defaultInstance;
 
   @$pb.TagNumber(1)
   $0.CommitDocument get commit => $_getN(0);
   @$pb.TagNumber(1)
-  set commit($0.CommitDocument v) { setField(1, v); }
+  set commit($0.CommitDocument v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCommit() => $_has(0);
   @$pb.TagNumber(1)
@@ -83,13 +89,15 @@ class CommitTasksStatus extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get branch => $_getSZ(2);
   @$pb.TagNumber(3)
-  set branch($core.String v) { $_setString(2, v); }
+  set branch($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasBranch() => $_has(2);
   @$pb.TagNumber(3)
   void clearBranch() => clearField(3);
 }
-
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/commit_tasks_status.pbenum.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/dashboard/lib/model/commit_tasks_status.pbenum.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_tasks_status.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/dashboard/lib/model/commit_tasks_status.pbjson.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbjson.dart
@@ -1,0 +1,31 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_tasks_status.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use commitTasksStatusDescriptor instead')
+const CommitTasksStatus$json = {
+  '1': 'CommitTasksStatus',
+  '2': [
+    {'1': 'commit', '3': 1, '4': 1, '5': 11, '6': '.dashboard.CommitDocument', '10': 'commit'},
+    {'1': 'tasks', '3': 2, '4': 3, '5': 11, '6': '.dashboard.TaskDocument', '10': 'tasks'},
+    {'1': 'branch', '3': 3, '4': 1, '5': 9, '10': 'branch'},
+  ],
+};
+
+/// Descriptor for `CommitTasksStatus`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List commitTasksStatusDescriptor = $convert.base64Decode(
+    'ChFDb21taXRUYXNrc1N0YXR1cxIxCgZjb21taXQYASABKAsyGS5kYXNoYm9hcmQuQ29tbWl0RG'
+    '9jdW1lbnRSBmNvbW1pdBItCgV0YXNrcxgCIAMoCzIXLmRhc2hib2FyZC5UYXNrRG9jdW1lbnRS'
+    'BXRhc2tzEhYKBmJyYW5jaBgDIAEoCVIGYnJhbmNo');
+

--- a/dashboard/lib/model/commit_tasks_status.pbjson.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbjson.dart
@@ -24,7 +24,7 @@ const CommitTasksStatus$json = {
 };
 
 /// Descriptor for `CommitTasksStatus`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List commitTasksStatusDescriptor = $convert.base64Decode(
-    'ChFDb21taXRUYXNrc1N0YXR1cxIxCgZjb21taXQYASABKAsyGS5kYXNoYm9hcmQuQ29tbWl0RG'
-    '9jdW1lbnRSBmNvbW1pdBItCgV0YXNrcxgCIAMoCzIXLmRhc2hib2FyZC5UYXNrRG9jdW1lbnRS'
-    'BXRhc2tzEhYKBmJyYW5jaBgDIAEoCVIGYnJhbmNo');
+final $typed_data.Uint8List commitTasksStatusDescriptor =
+    $convert.base64Decode('ChFDb21taXRUYXNrc1N0YXR1cxIxCgZjb21taXQYASABKAsyGS5kYXNoYm9hcmQuQ29tbWl0RG'
+        '9jdW1lbnRSBmNvbW1pdBItCgV0YXNrcxgCIAMoCzIXLmRhc2hib2FyZC5UYXNrRG9jdW1lbnRS'
+        'BXRhc2tzEhYKBmJyYW5jaBgDIAEoCVIGYnJhbmNo');

--- a/dashboard/lib/model/commit_tasks_status.pbjson.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbjson.dart
@@ -28,4 +28,3 @@ final $typed_data.Uint8List commitTasksStatusDescriptor = $convert.base64Decode(
     'ChFDb21taXRUYXNrc1N0YXR1cxIxCgZjb21taXQYASABKAsyGS5kYXNoYm9hcmQuQ29tbWl0RG'
     '9jdW1lbnRSBmNvbW1pdBItCgV0YXNrcxgCIAMoCzIXLmRhc2hib2FyZC5UYXNrRG9jdW1lbnRS'
     'BXRhc2tzEhYKBmJyYW5jaBgDIAEoCVIGYnJhbmNo');
-

--- a/dashboard/lib/model/commit_tasks_status.pbserver.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/commit_tasks_status.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'commit_tasks_status.pb.dart';
+

--- a/dashboard/lib/model/commit_tasks_status.pbserver.dart
+++ b/dashboard/lib/model/commit_tasks_status.pbserver.dart
@@ -11,4 +11,3 @@
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'commit_tasks_status.pb.dart';
-

--- a/dashboard/lib/model/commit_tasks_status.proto
+++ b/dashboard/lib/model/commit_tasks_status.proto
@@ -1,0 +1,16 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto2";
+
+package dashboard;
+
+import "lib/model/commit_firestore.proto";
+import "lib/model/task_firestore.proto";
+
+message CommitTasksStatus {
+    optional CommitDocument commit = 1;
+    repeated TaskDocument tasks = 2;
+    optional string branch = 3;
+}

--- a/dashboard/lib/model/task_firestore.pb.dart
+++ b/dashboard/lib/model/task_firestore.pb.dart
@@ -61,10 +61,13 @@ class TaskDocument extends $pb.GeneratedMessage {
     return $result;
   }
   TaskDocument._() : super();
-  factory TaskDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory TaskDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory TaskDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory TaskDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TaskDocument', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TaskDocument',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'documentName')
     ..aInt64(2, _omitFieldNames ? '' : 'createTimestamp')
     ..aInt64(3, _omitFieldNames ? '' : 'startTimestamp')
@@ -75,19 +78,17 @@ class TaskDocument extends $pb.GeneratedMessage {
     ..aOB(8, _omitFieldNames ? '' : 'testFlaky')
     ..a<$core.int>(9, _omitFieldNames ? '' : 'buildNumber', $pb.PbFieldType.O3)
     ..aOS(10, _omitFieldNames ? '' : 'status')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   TaskDocument clone() => TaskDocument()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  TaskDocument copyWith(void Function(TaskDocument) updates) => super.copyWith((message) => updates(message as TaskDocument)) as TaskDocument;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  TaskDocument copyWith(void Function(TaskDocument) updates) =>
+      super.copyWith((message) => updates(message as TaskDocument)) as TaskDocument;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -103,7 +104,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get documentName => $_getSZ(0);
   @$pb.TagNumber(1)
-  set documentName($core.String v) { $_setString(0, v); }
+  set documentName($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasDocumentName() => $_has(0);
   @$pb.TagNumber(1)
@@ -112,7 +116,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $fixnum.Int64 get createTimestamp => $_getI64(1);
   @$pb.TagNumber(2)
-  set createTimestamp($fixnum.Int64 v) { $_setInt64(1, v); }
+  set createTimestamp($fixnum.Int64 v) {
+    $_setInt64(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasCreateTimestamp() => $_has(1);
   @$pb.TagNumber(2)
@@ -121,7 +128,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $fixnum.Int64 get startTimestamp => $_getI64(2);
   @$pb.TagNumber(3)
-  set startTimestamp($fixnum.Int64 v) { $_setInt64(2, v); }
+  set startTimestamp($fixnum.Int64 v) {
+    $_setInt64(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasStartTimestamp() => $_has(2);
   @$pb.TagNumber(3)
@@ -130,7 +140,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $fixnum.Int64 get endTimestamp => $_getI64(3);
   @$pb.TagNumber(4)
-  set endTimestamp($fixnum.Int64 v) { $_setInt64(3, v); }
+  set endTimestamp($fixnum.Int64 v) {
+    $_setInt64(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasEndTimestamp() => $_has(3);
   @$pb.TagNumber(4)
@@ -139,7 +152,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get taskName => $_getSZ(4);
   @$pb.TagNumber(5)
-  set taskName($core.String v) { $_setString(4, v); }
+  set taskName($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasTaskName() => $_has(4);
   @$pb.TagNumber(5)
@@ -148,7 +164,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get attempts => $_getIZ(5);
   @$pb.TagNumber(6)
-  set attempts($core.int v) { $_setSignedInt32(5, v); }
+  set attempts($core.int v) {
+    $_setSignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasAttempts() => $_has(5);
   @$pb.TagNumber(6)
@@ -157,7 +176,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.bool get bringup => $_getBF(6);
   @$pb.TagNumber(7)
-  set bringup($core.bool v) { $_setBool(6, v); }
+  set bringup($core.bool v) {
+    $_setBool(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasBringup() => $_has(6);
   @$pb.TagNumber(7)
@@ -166,7 +188,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.bool get testFlaky => $_getBF(7);
   @$pb.TagNumber(8)
-  set testFlaky($core.bool v) { $_setBool(7, v); }
+  set testFlaky($core.bool v) {
+    $_setBool(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasTestFlaky() => $_has(7);
   @$pb.TagNumber(8)
@@ -175,7 +200,10 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.int get buildNumber => $_getIZ(8);
   @$pb.TagNumber(9)
-  set buildNumber($core.int v) { $_setSignedInt32(8, v); }
+  set buildNumber($core.int v) {
+    $_setSignedInt32(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasBuildNumber() => $_has(8);
   @$pb.TagNumber(9)
@@ -184,13 +212,15 @@ class TaskDocument extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get status => $_getSZ(9);
   @$pb.TagNumber(10)
-  set status($core.String v) { $_setString(9, v); }
+  set status($core.String v) {
+    $_setString(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasStatus() => $_has(9);
   @$pb.TagNumber(10)
   void clearStatus() => clearField(10);
 }
-
 
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
 const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/task_firestore.pb.dart
+++ b/dashboard/lib/model/task_firestore.pb.dart
@@ -1,0 +1,196 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/task_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class TaskDocument extends $pb.GeneratedMessage {
+  factory TaskDocument({
+    $core.String? documentName,
+    $fixnum.Int64? createTimestamp,
+    $fixnum.Int64? startTimestamp,
+    $fixnum.Int64? endTimestamp,
+    $core.String? taskName,
+    $core.int? attempts,
+    $core.bool? bringup,
+    $core.bool? testFlaky,
+    $core.int? buildNumber,
+    $core.String? status,
+  }) {
+    final $result = create();
+    if (documentName != null) {
+      $result.documentName = documentName;
+    }
+    if (createTimestamp != null) {
+      $result.createTimestamp = createTimestamp;
+    }
+    if (startTimestamp != null) {
+      $result.startTimestamp = startTimestamp;
+    }
+    if (endTimestamp != null) {
+      $result.endTimestamp = endTimestamp;
+    }
+    if (taskName != null) {
+      $result.taskName = taskName;
+    }
+    if (attempts != null) {
+      $result.attempts = attempts;
+    }
+    if (bringup != null) {
+      $result.bringup = bringup;
+    }
+    if (testFlaky != null) {
+      $result.testFlaky = testFlaky;
+    }
+    if (buildNumber != null) {
+      $result.buildNumber = buildNumber;
+    }
+    if (status != null) {
+      $result.status = status;
+    }
+    return $result;
+  }
+  TaskDocument._() : super();
+  factory TaskDocument.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TaskDocument.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TaskDocument', package: const $pb.PackageName(_omitMessageNames ? '' : 'dashboard'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'documentName')
+    ..aInt64(2, _omitFieldNames ? '' : 'createTimestamp')
+    ..aInt64(3, _omitFieldNames ? '' : 'startTimestamp')
+    ..aInt64(4, _omitFieldNames ? '' : 'endTimestamp')
+    ..aOS(5, _omitFieldNames ? '' : 'taskName')
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'attempts', $pb.PbFieldType.O3)
+    ..aOB(7, _omitFieldNames ? '' : 'bringup')
+    ..aOB(8, _omitFieldNames ? '' : 'testFlaky')
+    ..a<$core.int>(9, _omitFieldNames ? '' : 'buildNumber', $pb.PbFieldType.O3)
+    ..aOS(10, _omitFieldNames ? '' : 'status')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TaskDocument clone() => TaskDocument()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TaskDocument copyWith(void Function(TaskDocument) updates) => super.copyWith((message) => updates(message as TaskDocument)) as TaskDocument;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TaskDocument create() => TaskDocument._();
+  TaskDocument createEmptyInstance() => create();
+  static $pb.PbList<TaskDocument> createRepeated() => $pb.PbList<TaskDocument>();
+  @$core.pragma('dart2js:noInline')
+  static TaskDocument getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TaskDocument>(create);
+  static TaskDocument? _defaultInstance;
+
+  /// Next ID: 11
+  @$pb.TagNumber(1)
+  $core.String get documentName => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set documentName($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasDocumentName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDocumentName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $fixnum.Int64 get createTimestamp => $_getI64(1);
+  @$pb.TagNumber(2)
+  set createTimestamp($fixnum.Int64 v) { $_setInt64(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasCreateTimestamp() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCreateTimestamp() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $fixnum.Int64 get startTimestamp => $_getI64(2);
+  @$pb.TagNumber(3)
+  set startTimestamp($fixnum.Int64 v) { $_setInt64(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasStartTimestamp() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearStartTimestamp() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $fixnum.Int64 get endTimestamp => $_getI64(3);
+  @$pb.TagNumber(4)
+  set endTimestamp($fixnum.Int64 v) { $_setInt64(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasEndTimestamp() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearEndTimestamp() => clearField(4);
+
+  @$pb.TagNumber(5)
+  $core.String get taskName => $_getSZ(4);
+  @$pb.TagNumber(5)
+  set taskName($core.String v) { $_setString(4, v); }
+  @$pb.TagNumber(5)
+  $core.bool hasTaskName() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearTaskName() => clearField(5);
+
+  @$pb.TagNumber(6)
+  $core.int get attempts => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set attempts($core.int v) { $_setSignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasAttempts() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearAttempts() => clearField(6);
+
+  @$pb.TagNumber(7)
+  $core.bool get bringup => $_getBF(6);
+  @$pb.TagNumber(7)
+  set bringup($core.bool v) { $_setBool(6, v); }
+  @$pb.TagNumber(7)
+  $core.bool hasBringup() => $_has(6);
+  @$pb.TagNumber(7)
+  void clearBringup() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.bool get testFlaky => $_getBF(7);
+  @$pb.TagNumber(8)
+  set testFlaky($core.bool v) { $_setBool(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasTestFlaky() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearTestFlaky() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.int get buildNumber => $_getIZ(8);
+  @$pb.TagNumber(9)
+  set buildNumber($core.int v) { $_setSignedInt32(8, v); }
+  @$pb.TagNumber(9)
+  $core.bool hasBuildNumber() => $_has(8);
+  @$pb.TagNumber(9)
+  void clearBuildNumber() => clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.String get status => $_getSZ(9);
+  @$pb.TagNumber(10)
+  set status($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasStatus() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearStatus() => clearField(10);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/dashboard/lib/model/task_firestore.pbenum.dart
+++ b/dashboard/lib/model/task_firestore.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/dashboard/lib/model/task_firestore.pbenum.dart
+++ b/dashboard/lib/model/task_firestore.pbenum.dart
@@ -1,0 +1,11 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/task_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/dashboard/lib/model/task_firestore.pbjson.dart
+++ b/dashboard/lib/model/task_firestore.pbjson.dart
@@ -39,4 +39,3 @@ final $typed_data.Uint8List taskDocumentDescriptor = $convert.base64Decode(
     'dHRlbXB0cxIYCgdicmluZ3VwGAcgASgIUgdicmluZ3VwEh0KCnRlc3RfZmxha3kYCCABKAhSCX'
     'Rlc3RGbGFreRIhCgxidWlsZF9udW1iZXIYCSABKAVSC2J1aWxkTnVtYmVyEhYKBnN0YXR1cxgK'
     'IAEoCVIGc3RhdHVz');
-

--- a/dashboard/lib/model/task_firestore.pbjson.dart
+++ b/dashboard/lib/model/task_firestore.pbjson.dart
@@ -1,0 +1,42 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/task_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use taskDocumentDescriptor instead')
+const TaskDocument$json = {
+  '1': 'TaskDocument',
+  '2': [
+    {'1': 'document_name', '3': 1, '4': 1, '5': 9, '10': 'documentName'},
+    {'1': 'create_timestamp', '3': 2, '4': 1, '5': 3, '10': 'createTimestamp'},
+    {'1': 'start_timestamp', '3': 3, '4': 1, '5': 3, '10': 'startTimestamp'},
+    {'1': 'end_timestamp', '3': 4, '4': 1, '5': 3, '10': 'endTimestamp'},
+    {'1': 'task_name', '3': 5, '4': 1, '5': 9, '10': 'taskName'},
+    {'1': 'attempts', '3': 6, '4': 1, '5': 5, '10': 'attempts'},
+    {'1': 'bringup', '3': 7, '4': 1, '5': 8, '10': 'bringup'},
+    {'1': 'test_flaky', '3': 8, '4': 1, '5': 8, '10': 'testFlaky'},
+    {'1': 'build_number', '3': 9, '4': 1, '5': 5, '10': 'buildNumber'},
+    {'1': 'status', '3': 10, '4': 1, '5': 9, '10': 'status'},
+  ],
+};
+
+/// Descriptor for `TaskDocument`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List taskDocumentDescriptor = $convert.base64Decode(
+    'CgxUYXNrRG9jdW1lbnQSIwoNZG9jdW1lbnRfbmFtZRgBIAEoCVIMZG9jdW1lbnROYW1lEikKEG'
+    'NyZWF0ZV90aW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBInCg9zdGFydF90aW1lc3Rh'
+    'bXAYAyABKANSDnN0YXJ0VGltZXN0YW1wEiMKDWVuZF90aW1lc3RhbXAYBCABKANSDGVuZFRpbW'
+    'VzdGFtcBIbCgl0YXNrX25hbWUYBSABKAlSCHRhc2tOYW1lEhoKCGF0dGVtcHRzGAYgASgFUghh'
+    'dHRlbXB0cxIYCgdicmluZ3VwGAcgASgIUgdicmluZ3VwEh0KCnRlc3RfZmxha3kYCCABKAhSCX'
+    'Rlc3RGbGFreRIhCgxidWlsZF9udW1iZXIYCSABKAVSC2J1aWxkTnVtYmVyEhYKBnN0YXR1cxgK'
+    'IAEoCVIGc3RhdHVz');
+

--- a/dashboard/lib/model/task_firestore.pbjson.dart
+++ b/dashboard/lib/model/task_firestore.pbjson.dart
@@ -31,11 +31,11 @@ const TaskDocument$json = {
 };
 
 /// Descriptor for `TaskDocument`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List taskDocumentDescriptor = $convert.base64Decode(
-    'CgxUYXNrRG9jdW1lbnQSIwoNZG9jdW1lbnRfbmFtZRgBIAEoCVIMZG9jdW1lbnROYW1lEikKEG'
-    'NyZWF0ZV90aW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBInCg9zdGFydF90aW1lc3Rh'
-    'bXAYAyABKANSDnN0YXJ0VGltZXN0YW1wEiMKDWVuZF90aW1lc3RhbXAYBCABKANSDGVuZFRpbW'
-    'VzdGFtcBIbCgl0YXNrX25hbWUYBSABKAlSCHRhc2tOYW1lEhoKCGF0dGVtcHRzGAYgASgFUghh'
-    'dHRlbXB0cxIYCgdicmluZ3VwGAcgASgIUgdicmluZ3VwEh0KCnRlc3RfZmxha3kYCCABKAhSCX'
-    'Rlc3RGbGFreRIhCgxidWlsZF9udW1iZXIYCSABKAVSC2J1aWxkTnVtYmVyEhYKBnN0YXR1cxgK'
-    'IAEoCVIGc3RhdHVz');
+final $typed_data.Uint8List taskDocumentDescriptor =
+    $convert.base64Decode('CgxUYXNrRG9jdW1lbnQSIwoNZG9jdW1lbnRfbmFtZRgBIAEoCVIMZG9jdW1lbnROYW1lEikKEG'
+        'NyZWF0ZV90aW1lc3RhbXAYAiABKANSD2NyZWF0ZVRpbWVzdGFtcBInCg9zdGFydF90aW1lc3Rh'
+        'bXAYAyABKANSDnN0YXJ0VGltZXN0YW1wEiMKDWVuZF90aW1lc3RhbXAYBCABKANSDGVuZFRpbW'
+        'VzdGFtcBIbCgl0YXNrX25hbWUYBSABKAlSCHRhc2tOYW1lEhoKCGF0dGVtcHRzGAYgASgFUghh'
+        'dHRlbXB0cxIYCgdicmluZ3VwGAcgASgIUgdicmluZ3VwEh0KCnRlc3RfZmxha3kYCCABKAhSCX'
+        'Rlc3RGbGFreRIhCgxidWlsZF9udW1iZXIYCSABKAVSC2J1aWxkTnVtYmVyEhYKBnN0YXR1cxgK'
+        'IAEoCVIGc3RhdHVz');

--- a/dashboard/lib/model/task_firestore.pbserver.dart
+++ b/dashboard/lib/model/task_firestore.pbserver.dart
@@ -1,0 +1,14 @@
+//
+//  Generated code. Do not modify.
+//  source: lib/model/task_firestore.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+export 'task_firestore.pb.dart';
+

--- a/dashboard/lib/model/task_firestore.pbserver.dart
+++ b/dashboard/lib/model/task_firestore.pbserver.dart
@@ -11,4 +11,3 @@
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'task_firestore.pb.dart';
-

--- a/dashboard/lib/model/task_firestore.proto
+++ b/dashboard/lib/model/task_firestore.proto
@@ -1,0 +1,21 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto2";
+
+package dashboard;
+
+message TaskDocument {
+    // Next ID: 11
+    optional string document_name = 1;
+    optional int64 create_timestamp = 2;
+    optional int64 start_timestamp = 3;
+    optional int64 end_timestamp = 4;
+    optional string task_name = 5;
+    optional int32 attempts = 6;
+    optional bool bringup = 7;
+    optional bool test_flaky = 8;
+    optional int32 build_number = 9;
+    optional string status = 10;
+}


### PR DESCRIPTION
This is to prepare frontend firestore migration for Cocoon dashboard.

Part of https://github.com/flutter/flutter/issues/142951.
One can view https://github.com/flutter/cocoon/pull/3619 for a quick reference how we are gonna to use these protos.

This PR adds:

- commit_firestore.proto, a replacement of commit.proto for Datastore case
- task_firestore.proto, a replacement of task.proto for Datastore case
- commit_tasks_status.proto, a replacement of commit_status.proto for Datastore case

Note: *.pb.dart, *.pbenum.dart, *.pbjson.dart, *.pbserver.dart are auto generated based on the proto.