### PR TITLE
Add logics to fetch commit status from Firestore

### DIFF
--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -12,10 +12,13 @@ import 'package:http/http.dart' as http;
 
 import '../logic/qualified_task.dart';
 import '../model/build_status_response.pb.dart';
+import '../model/commit_firestore.pb.dart';
 import '../model/commit.pb.dart';
 import '../model/commit_status.pb.dart';
+import '../model/commit_tasks_status.pb.dart';
 import '../model/key.pb.dart';
 import '../model/task.pb.dart';
+import '../model/task_firestore.pb.dart';
 import 'cocoon.dart';
 
 /// CocoonService for interacting with flutter/flutter production build data.
@@ -64,6 +67,36 @@ class AppEngineCocoonService implements CocoonService {
       );
     } catch (error) {
       return CocoonResponse<List<CommitStatus>>.error(error.toString());
+    }
+  }
+
+  @override
+  Future<CocoonResponse<List<CommitTasksStatus>>> fetchCommitStatusesFirestore({
+    CommitStatus? lastCommitStatus,
+    String? branch,
+    required String repo,
+  }) async {
+    final Map<String, String?> queryParameters = <String, String?>{
+      if (lastCommitStatus != null) 'lastCommitKey': lastCommitStatus.commit.key.child.name,
+      'branch': branch ?? _defaultBranch,
+      'repo': repo,
+    };
+    final Uri getStatusUrl = apiEndpoint('/api/public/get-status-firestore', queryParameters: queryParameters);
+
+    /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
+    final http.Response response = await _client.get(getStatusUrl);
+
+    if (response.statusCode != HttpStatus.ok) {
+      return CocoonResponse<List<CommitTasksStatus>>.error('/api/public/get-status-firestore returned ${response.statusCode}');
+    }
+
+    try {
+      final Map<String, dynamic> jsonResponse = jsonDecode(response.body);
+      return CocoonResponse<List<CommitTasksStatus>>.data(
+        _commitStatusesFromJsonFirestore(jsonResponse['Statuses']),
+      );
+    } catch (error) {
+      return CocoonResponse<List<CommitTasksStatus>>.error(error.toString());
     }
   }
 
@@ -224,9 +257,32 @@ class AppEngineCocoonService implements CocoonService {
     return statuses;
   }
 
+  List<CommitTasksStatus> _commitStatusesFromJsonFirestore(List<dynamic>? jsonCommitStatuses) {
+    assert(jsonCommitStatuses != null);
+    // TODO(chillers): Remove adapter code to just use proto fromJson method. https://github.com/flutter/cocoon/issues/441
+
+    final List<CommitTasksStatus> statuses = <CommitTasksStatus>[];
+    for (final Map<String, dynamic> jsonCommitStatus in jsonCommitStatuses!) {
+      final Map<String, dynamic> jsonCommit = jsonCommitStatus['Commit'];
+
+      statuses.add(
+        CommitTasksStatus()
+          ..commit = _commitFromJsonFirestore(jsonCommit)
+          ..branch = _branchFromJsonFirestore(jsonCommit)!
+          ..tasks.addAll(_tasksFromJsonFirestore(jsonCommitStatus['Tasks'])),
+      );
+    }
+
+    return statuses;
+  }
+
   String? _branchFromJson(Map<String, dynamic> jsonChecklist) {
     final Map<String, dynamic> checklist = jsonChecklist['Checklist'];
     return checklist['Branch'] as String?;
+  }
+
+  String? _branchFromJsonFirestore(Map<String, dynamic> jsonCommit) {
+    return jsonCommit['Branch'] as String?;
   }
 
   Commit _commitFromJson(Map<String, dynamic> jsonChecklist) {
@@ -249,6 +305,21 @@ class AppEngineCocoonService implements CocoonService {
     return result;
   }
 
+  CommitDocument _commitFromJsonFirestore(Map<String, dynamic> jsonCommit) {
+    final CommitDocument result = CommitDocument()
+      ..documentName = jsonCommit['DocumentName']
+      ..createTimestamp = Int64() + jsonCommit['CreateTimestamp']!
+      ..sha = jsonCommit['Sha'] as String
+      ..author = jsonCommit['Author'] as String
+      ..avatar = jsonCommit['Avatar'] as String
+      ..repositoryPath = jsonCommit['RepositoryPath'] as String
+      ..branch = jsonCommit['Branch'] as String;
+    if (jsonCommit['Message'] != null) {
+      result.message = jsonCommit['Message'] as String;
+    }
+    return result;
+  }
+
   List<Task> _tasksFromStagesJson(List<dynamic> json) {
     final List<Task> tasks = <Task>[];
 
@@ -265,6 +336,17 @@ class AppEngineCocoonService implements CocoonService {
     for (final Map<String, dynamic> jsonTask in json) {
       //as Iterable<Map<String, Object>>
       tasks.add(_taskFromJson(jsonTask));
+    }
+
+    return tasks;
+  }
+
+  List<TaskDocument> _tasksFromJsonFirestore(List<dynamic> json) {
+    final List<TaskDocument> tasks = <TaskDocument>[];
+
+    for (final Map<String, dynamic> jsonTask in json) {
+      //as Iterable<Map<String, Object>>
+      tasks.add(_taskFromJsonFirestore(jsonTask));
     }
 
     return tasks;
@@ -294,6 +376,23 @@ class AppEngineCocoonService implements CocoonService {
       ..buildNumberList = taskData['BuildNumberList'] as String? ?? ''
       ..builderName = taskData['BuilderName'] as String? ?? ''
       ..luciBucket = taskData['LuciBucket'] as String? ?? '';
+    return task;
+  }
+
+  TaskDocument _taskFromJsonFirestore(Map<String, dynamic> taskData) {
+    final TaskDocument task = TaskDocument()
+      ..createTimestamp = Int64(taskData['CreateTimestamp'] as int)
+      ..startTimestamp = Int64(taskData['StartTimestamp'] as int)
+      ..endTimestamp = Int64(taskData['EndTimestamp'] as int)
+      ..documentName = taskData['DocumentName'] as String
+      ..taskName = taskData['TaskName'] as String
+      ..attempts = taskData['Attempts'] as int
+      ..bringup = taskData['Bringup'] as bool
+      ..status = taskData['Status'] as String
+      ..testFlaky = taskData['TestFlaky'] as bool? ?? false;
+    if (taskData['BuildNumber'] != null) {
+      task.buildNumber = taskData['BuildNumber'] as int;
+    }
     return task;
   }
 }

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -83,11 +83,13 @@ class AppEngineCocoonService implements CocoonService {
     };
     final Uri getStatusUrl = apiEndpoint('/api/public/get-status-firestore', queryParameters: queryParameters);
 
-    /// This endpoint returns JSON [List<Agent>, List<CommitStatus>]
+    /// This endpoint returns JSON [List<CommitTasksStatus>]
     final http.Response response = await _client.get(getStatusUrl);
 
     if (response.statusCode != HttpStatus.ok) {
-      return CocoonResponse<List<CommitTasksStatus>>.error('/api/public/get-status-firestore returned ${response.statusCode}');
+      return CocoonResponse<List<CommitTasksStatus>>.error(
+        '/api/public/get-status-firestore returned ${response.statusCode}',
+      );
     }
 
     try {

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -38,6 +38,27 @@ class AppEngineCocoonService implements CocoonService {
   /// This is the base for all API requests to cocoon
   static const String _baseApiUrl = 'flutter-dashboard.appspot.com';
 
+  /// Json keys from response data.
+  static const String kCommitAvatar = 'Avatar';
+  static const String kCommitAuthor = 'Author';
+  static const String kCommitBranch = 'Branch';
+  static const String kCommitCreateTimestamp = 'CreateTimestamp';
+  static const String kCommitDocumentName = 'DocumentName';
+  static const String kCommitMessage = 'Message';
+  static const String kCommitRepositoryPath = 'RepositoryPath';
+  static const String kCommitSha = 'Sha';
+
+  static const String kTaskAttempts = 'Attempts';
+  static const String kTaskBringup = 'Bringup';
+  static const String kTaskBuildNumber = 'BuildNumber';
+  static const String kTaskCreateTimestamp = 'CreateTimestamp';
+  static const String kTaskDocumentName = 'DocumentName';
+  static const String kTaskEndTimestamp = 'EndTimestamp';
+  static const String kTaskStartTimestamp = 'StartTimestamp';
+  static const String kTaskStatus = 'Status';
+  static const String kTaskTaskNmae = 'TaskName';
+  static const String kTaskTestFlaky = 'TestFlaky';
+
   final http.Client _client;
 
   @override
@@ -242,7 +263,6 @@ class AppEngineCocoonService implements CocoonService {
 
   List<CommitStatus> _commitStatusesFromJson(List<dynamic>? jsonCommitStatuses) {
     assert(jsonCommitStatuses != null);
-    // TODO(chillers): Remove adapter code to just use proto fromJson method. https://github.com/flutter/cocoon/issues/441
 
     final List<CommitStatus> statuses = <CommitStatus>[];
 
@@ -309,15 +329,15 @@ class AppEngineCocoonService implements CocoonService {
 
   CommitDocument _commitFromJsonFirestore(Map<String, dynamic> jsonCommit) {
     final CommitDocument result = CommitDocument()
-      ..documentName = jsonCommit['DocumentName']
-      ..createTimestamp = Int64() + jsonCommit['CreateTimestamp']!
-      ..sha = jsonCommit['Sha'] as String
-      ..author = jsonCommit['Author'] as String
-      ..avatar = jsonCommit['Avatar'] as String
-      ..repositoryPath = jsonCommit['RepositoryPath'] as String
-      ..branch = jsonCommit['Branch'] as String;
-    if (jsonCommit['Message'] != null) {
-      result.message = jsonCommit['Message'] as String;
+      ..documentName = jsonCommit[kCommitDocumentName]
+      ..createTimestamp = Int64(jsonCommit[kCommitCreateTimestamp] as int)
+      ..sha = jsonCommit[kCommitSha] as String
+      ..author = jsonCommit[kCommitAuthor] as String
+      ..avatar = jsonCommit[kCommitAvatar] as String
+      ..repositoryPath = jsonCommit[kCommitRepositoryPath] as String
+      ..branch = jsonCommit[kCommitBranch] as String;
+    if (jsonCommit[kCommitMessage] != null) {
+      result.message = jsonCommit[kCommitMessage] as String;
     }
     return result;
   }
@@ -383,17 +403,17 @@ class AppEngineCocoonService implements CocoonService {
 
   TaskDocument _taskFromJsonFirestore(Map<String, dynamic> taskData) {
     final TaskDocument task = TaskDocument()
-      ..createTimestamp = Int64(taskData['CreateTimestamp'] as int)
-      ..startTimestamp = Int64(taskData['StartTimestamp'] as int)
-      ..endTimestamp = Int64(taskData['EndTimestamp'] as int)
-      ..documentName = taskData['DocumentName'] as String
-      ..taskName = taskData['TaskName'] as String
-      ..attempts = taskData['Attempts'] as int
-      ..bringup = taskData['Bringup'] as bool
-      ..status = taskData['Status'] as String
-      ..testFlaky = taskData['TestFlaky'] as bool? ?? false;
-    if (taskData['BuildNumber'] != null) {
-      task.buildNumber = taskData['BuildNumber'] as int;
+      ..createTimestamp = Int64(taskData[kTaskCreateTimestamp] as int)
+      ..startTimestamp = Int64(taskData[kTaskStartTimestamp] as int)
+      ..endTimestamp = Int64(taskData[kTaskEndTimestamp] as int)
+      ..documentName = taskData[kTaskDocumentName] as String
+      ..taskName = taskData[kTaskTaskNmae] as String
+      ..attempts = taskData[kTaskAttempts] as int
+      ..bringup = taskData[kTaskBringup] as bool
+      ..status = taskData[kTaskStatus] as String
+      ..testFlaky = taskData[kTaskTestFlaky] as bool? ?? false;
+    if (taskData[kTaskBuildNumber] != null) {
+      task.buildNumber = taskData[kTaskBuildNumber] as int;
     }
     return task;
   }

--- a/dashboard/lib/service/cocoon.dart
+++ b/dashboard/lib/service/cocoon.dart
@@ -7,6 +7,7 @@ import 'package:flutter_dashboard/model/branch.pb.dart';
 
 import '../model/build_status_response.pb.dart';
 import '../model/commit_status.pb.dart';
+import '../model/commit_tasks_status.pb.dart';
 import '../model/task.pb.dart';
 import 'appengine_cocoon.dart';
 import 'dev_cocoon.dart';
@@ -33,6 +34,16 @@ abstract class CocoonService {
   /// If [lastCommitStatus] is given, it will return the next page of
   /// [List<CommitStatus>] after [lastCommitStatus], not including it.
   Future<CocoonResponse<List<CommitStatus>>> fetchCommitStatuses({
+    CommitStatus? lastCommitStatus,
+    String? branch,
+    required String repo,
+  });
+
+  /// Gets build information on the most recent commits.
+  ///
+  /// If [lastCommitStatus] is given, it will return the next page of
+  /// [List<CommitTasksStatus>] after [lastCommitStatus], not including it.
+  Future<CocoonResponse<List<CommitTasksStatus>>> fetchCommitStatusesFirestore({
     CommitStatus? lastCommitStatus,
     String? branch,
     required String repo,

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -12,6 +12,7 @@ import '../logic/qualified_task.dart';
 import '../model/build_status_response.pb.dart';
 import '../model/commit.pb.dart';
 import '../model/commit_status.pb.dart';
+import '../model/commit_tasks_status.pb.dart';
 import '../model/key.pb.dart';
 import '../model/task.pb.dart';
 import 'cocoon.dart';
@@ -66,6 +67,16 @@ class DevelopmentCocoonService implements CocoonService {
       _pausedStatus = null;
     }
     _paused = pause;
+  }
+
+  @override
+  Future<CocoonResponse<List<CommitTasksStatus>>> fetchCommitStatusesFirestore({
+    CommitStatus? lastCommitStatus,
+    String? branch,
+    required String repo,
+  }) async {
+    // TODO(keyonghan): to be impelemented when logics are switched to Firestore.
+    return const CocoonResponse<List<CommitTasksStatus>>.error('');
   }
 
   @override

--- a/dashboard/test/service/appengine_cocoon_test.dart
+++ b/dashboard/test/service/appengine_cocoon_test.dart
@@ -8,9 +8,12 @@ import 'package:flutter_dashboard/logic/qualified_task.dart';
 import 'package:flutter_dashboard/model/branch.pb.dart';
 import 'package:flutter_dashboard/model/build_status_response.pb.dart';
 import 'package:flutter_dashboard/model/commit.pb.dart';
+import 'package:flutter_dashboard/model/commit_firestore.pb.dart';
 import 'package:flutter_dashboard/model/commit_status.pb.dart';
+import 'package:flutter_dashboard/model/commit_tasks_status.pb.dart';
 import 'package:flutter_dashboard/model/key.pb.dart';
 import 'package:flutter_dashboard/model/task.pb.dart';
+import 'package:flutter_dashboard/model/task_firestore.pb.dart';
 import 'package:flutter_dashboard/service/appengine_cocoon.dart';
 import 'package:flutter_dashboard/service/cocoon.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -88,6 +91,74 @@ void main() {
       service = AppEngineCocoonService(client: MockClient((Request request) async => Response('bad', 200)));
 
       final CocoonResponse<List<CommitStatus>> response = await service.fetchCommitStatuses(repo: 'engine');
+      expect(response.error, isNotNull);
+    });
+  });
+
+  group('AppEngine CocoonService fetchCommitStatusFirestore', () {
+    late AppEngineCocoonService service;
+
+    setUp(() async {
+      service = AppEngineCocoonService(
+        client: MockClient((Request request) async {
+          return Response(luciJsonGetStatsResponseFirestore, 200);
+        }),
+      );
+    });
+
+    test('should return CocoonResponse<List<CommitStatus>>', () {
+      expect(
+        service.fetchCommitStatusesFirestore(repo: 'engine'),
+        const TypeMatcher<Future<CocoonResponse<List<CommitTasksStatus>>>>(),
+      );
+    });
+
+    test('should return expected List<CommitTasksStatus>', () async {
+      final CocoonResponse<List<CommitTasksStatus>> statuses =
+          await service.fetchCommitStatusesFirestore(repo: 'engine');
+
+      final CommitTasksStatus expectedStatus = CommitTasksStatus()
+        ..branch = 'master'
+        ..commit = (CommitDocument()
+          ..documentName = 'commit/document/name'
+          ..createTimestamp = Int64(123456789)
+          ..sha = 'ShaShankHash'
+          ..author = 'ShaSha'
+          ..avatar = 'https://flutter.dev'
+          ..repositoryPath = 'flutter/cocoon'
+          ..branch = 'master'
+          ..message = 'message')
+        ..tasks.add(
+          TaskDocument()
+            ..documentName = 'task/document/name'
+            ..createTimestamp = Int64(1569353940885)
+            ..startTimestamp = Int64(1569354594672)
+            ..endTimestamp = Int64(1569354700642)
+            ..taskName = 'linux'
+            ..attempts = 1
+            ..bringup = false
+            ..status = 'Succeeded'
+            ..testFlaky = false
+            ..buildNumber = 123,
+        );
+
+      expect(statuses.data!.length, 1);
+      expect(statuses.data!.first, expectedStatus);
+    });
+
+    test('should have error if given non-200 response', () async {
+      service = AppEngineCocoonService(client: MockClient((Request request) async => Response('', 404)));
+
+      final CocoonResponse<List<CommitTasksStatus>> response =
+          await service.fetchCommitStatusesFirestore(repo: 'engine');
+      expect(response.error, isNotNull);
+    });
+
+    test('should have error if given bad response', () async {
+      service = AppEngineCocoonService(client: MockClient((Request request) async => Response('bad', 200)));
+
+      final CocoonResponse<List<CommitTasksStatus>> response =
+          await service.fetchCommitStatusesFirestore(repo: 'engine');
       expect(response.error, isNotNull);
     });
   });

--- a/dashboard/test/utils/appengine_cocoon_test_data.dart
+++ b/dashboard/test/utils/appengine_cocoon_test_data.dart
@@ -57,6 +57,39 @@ const String luciJsonGetStatsResponse = '''
   }
 ''';
 
+const String luciJsonGetStatsResponseFirestore = '''
+      {
+        "Statuses": [
+          {
+          "Commit": {
+            "DocumentName": "commit/document/name",
+            "Branch": "master",
+            "RepositoryPath": "flutter/cocoon",
+            "CreateTimestamp": 123456789,
+            "Sha": "ShaShankHash",
+            "Author": "ShaSha",
+            "Avatar": "https://flutter.dev",
+            "Message": "message"
+            },
+          "Tasks": [
+            {
+              "DocumentName": "task/document/name",
+              "Status": "Succeeded",
+              "Attempts": 1,
+              "CreateTimestamp": 1569353940885,
+              "EndTimestamp": 1569354700642,
+              "Bringup": false,
+              "TaskName": "linux",
+              "StartTimestamp": 1569354594672,
+              "BuildNumber": 123,
+              "TestFlaky": false
+            }
+          ]
+        }
+      ]
+  }
+''';
+
 const String jsonGetBranchesResponse = '''[
   {
     "branch":"flutter-3.13-candidate.0",


### PR DESCRIPTION
This is part of https://github.com/flutter/flutter/issues/142951

This PR adds logics to fetch commit tasks status from Firestore based on newly added Firestore data model protos. After this lands, next step is to switch the build logic to reference this PR's changes from Datastore.

This PR is a no-op change by this point.