### PR TITLE
Adds skia gold to engine release branches.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -78,9 +78,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         continue;
       }
 
-      final String defaultBranch = Config.defaultBranch(slug);
-      if (pr.base!.ref != defaultBranch) {
-        log.fine('This change is not staged to land on $defaultBranch, skipping.');
+      if (!Config.doesSkiaGoldRunOnBranch(slug, pr.base!.ref)) {
+        log.fine('This change\'s destination, ${pr.base!.ref}, does not run Skia Gold checks, skipping.');
         // This is potentially a release branch, or another change not landing
         // on master, we don't need a Gold check.
         continue;

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -49,7 +49,8 @@ class Config {
       };
 
   /// List of guaranteed scheduling Github repos.
-  static Set<gh.RepositorySlug> get guaranteedSchedulingRepos => <gh.RepositorySlug>{
+  static Set<gh.RepositorySlug> get guaranteedSchedulingRepos =>
+      <gh.RepositorySlug>{
         engineSlug,
         packagesSlug,
       };
@@ -79,7 +80,8 @@ class Config {
 
   /// The tip of tree branch for [slug].
   static String defaultBranch(gh.RepositorySlug slug) {
-    final Map<gh.RepositorySlug, String> defaultBranches = <gh.RepositorySlug, String>{
+    final Map<gh.RepositorySlug, String> defaultBranches =
+        <gh.RepositorySlug, String>{
       cocoonSlug: 'main',
       flutterSlug: 'master',
       engineSlug: 'main',
@@ -101,7 +103,9 @@ class Config {
   static const String configCacheName = 'config';
 
   /// Default properties when rerunning a prod build.
-  static const Map<String, Object> defaultProperties = <String, Object>{'force_upload': true};
+  static const Map<String, Object> defaultProperties = <String, Object>{
+    'force_upload': true
+  };
 
   /// GCP project ID.
   static const String flutterGcpProjectId = 'flutter-dashboard';
@@ -115,14 +119,16 @@ class Config {
   Logging get loggingService => ss.lookup(#appengine.logging) as Logging;
 
   Future<Iterable<Branch>> getBranches(gh.RepositorySlug slug) async {
-    final DatastoreService datastore = DatastoreService(db, defaultMaxEntityGroups);
+    final DatastoreService datastore =
+        DatastoreService(db, defaultMaxEntityGroups);
     final List<Branch> branches = await (datastore.queryBranches().toList());
 
     return branches.where((Branch branch) => branch.slug == slug);
   }
 
   Future<List<String>> _getReleaseAccounts() async {
-    final String releaseAccountsConcat = await _getSingleValue('ReleaseAccounts');
+    final String releaseAccountsConcat =
+        await _getSingleValue('ReleaseAccounts');
     return releaseAccountsConcat.split(',');
   }
 
@@ -145,12 +151,15 @@ class Config {
   }
 
   // GitHub App properties.
-  Future<String> get githubPrivateKey => _getSingleValue('githubapp_private_pem');
-  Future<String> get overrideTreeStatusLabel => _getSingleValue('override_tree_status_label');
+  Future<String> get githubPrivateKey =>
+      _getSingleValue('githubapp_private_pem');
+  Future<String> get overrideTreeStatusLabel =>
+      _getSingleValue('override_tree_status_label');
   Future<String> get githubPublicKey => _getSingleValue('githubapp_public_pem');
   Future<String> get githubAppId => _getSingleValue('githubapp_id');
   Future<Map<String, dynamic>> get githubAppInstallations async {
-    final String installations = await _getSingleValue('githubapp_installations');
+    final String installations =
+        await _getSingleValue('githubapp_installations');
     return jsonDecode(installations) as Map<String, dynamic>;
   }
 
@@ -198,7 +207,8 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  String get wrongBaseBranchPullRequestMessage => 'This pull request was opened against a branch other than '
+  String get wrongBaseBranchPullRequestMessage =>
+      'This pull request was opened against a branch other than '
       '_{{default_branch}}_. Since Flutter pull requests should not '
       'normally be opened against branches other than {{default_branch}}, I '
       'have changed the base to {{default_branch}}. If this was intended, you '
@@ -255,7 +265,8 @@ class Config {
       '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
       'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get flutterGoldPending => 'Waiting for all other checks to be successful before querying Gold.';
+  String get flutterGoldPending =>
+      'Waiting for all other checks to be successful before querying Gold.';
 
   String get flutterGoldSuccess => 'All golden file tests have passed.';
 
@@ -267,12 +278,14 @@ class Config {
       'Gold expire after as many days, so this pull request will need to be '
       'updated with a fresh commit in order to get results from Gold.';
 
-  String get flutterGoldDraftChange => 'This pull request has been changed to a '
+  String get flutterGoldDraftChange =>
+      'This pull request has been changed to a '
       'draft. The currently pending flutter-gold status will not be able '
       'to resolve until a new commit is pushed or the change is marked ready for '
       'review again.';
 
-  String flutterGoldInitialAlert(String url) => 'Golden file changes have been found for this pull '
+  String flutterGoldInitialAlert(String url) =>
+      'Golden file changes have been found for this pull '
       'request. Click [here to view and triage]($url) '
       '(e.g. because this is an intentional change).\n\n'
       'If you are still iterating on this change and are not ready to '
@@ -281,7 +294,8 @@ class Config {
       'on the dashboard, commenting will be silenced, and the check will not try to resolve itself until '
       'marked ready for review.\n\n';
 
-  String flutterGoldFollowUpAlert(String url) => 'Golden file changes are available for triage from new commit, '
+  String flutterGoldFollowUpAlert(String url) =>
+      'Golden file changes are available for triage from new commit, '
       'Click [here to view]($url).\n\n';
 
   String flutterGoldAlertConstant(gh.RepositorySlug slug) {
@@ -298,10 +312,12 @@ class Config {
       '_Changes reported for pull request #${pr.number} at sha ${pr.head!.sha}_\n\n';
 
   /// Post submit service account email used by LUCI swarming tasks.
-  static const String luciProdAccount = 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
+  static const String luciProdAccount =
+      'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 
   /// Internal Google service account used to surface FRoB results.
-  static const String frobAccount = 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
+  static const String frobAccount =
+      'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
 
   /// Service accounts used for PubSub messages.
   static const Set<String> allowedPubsubServiceAccounts = <String>{
@@ -315,7 +331,8 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 30;
 
-  KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
+  KeyHelper get keyHelper =>
+      KeyHelper(applicationContext: context.applicationContext);
 
   // Default number of commits to return for benchmark dashboard.
   int /*!*/ get maxRecords => 50;
@@ -327,16 +344,22 @@ class Config {
   String get flutterBuild => 'flutter-build';
 
   // Repository status description for github status.
-  String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
+  String get flutterBuildDescription =>
+      'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
 
-  static gh.RepositorySlug get cocoonSlug => gh.RepositorySlug('flutter', 'cocoon');
-  static gh.RepositorySlug get engineSlug => gh.RepositorySlug('flutter', 'engine');
-  static gh.RepositorySlug get flutterSlug => gh.RepositorySlug('flutter', 'flutter');
-  static gh.RepositorySlug get packagesSlug => gh.RepositorySlug('flutter', 'packages');
+  static gh.RepositorySlug get cocoonSlug =>
+      gh.RepositorySlug('flutter', 'cocoon');
+  static gh.RepositorySlug get engineSlug =>
+      gh.RepositorySlug('flutter', 'engine');
+  static gh.RepositorySlug get flutterSlug =>
+      gh.RepositorySlug('flutter', 'flutter');
+  static gh.RepositorySlug get packagesSlug =>
+      gh.RepositorySlug('flutter', 'packages');
 
   /// Flutter recipes is hosted on Gerrit instead of GitHub.
-  static gh.RepositorySlug get recipesSlug => gh.RepositorySlug('flutter', 'recipes');
+  static gh.RepositorySlug get recipesSlug =>
+      gh.RepositorySlug('flutter', 'recipes');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
 
@@ -360,7 +383,8 @@ class Config {
       ..issuer = await githubAppId
       ..issuedAt = now
       ..expiresAt = now.add(const Duration(minutes: 10));
-    final JWTRsaSha256Signer signer = JWTRsaSha256Signer(privateKey: privateKey, publicKey: publicKey);
+    final JWTRsaSha256Signer signer =
+        JWTRsaSha256Signer(privateKey: privateKey, publicKey: publicKey);
     final JWT signedToken = builder.getSignedToken(signer);
     return signedToken.toString();
   }
@@ -380,25 +404,31 @@ class Config {
 
   Future<Uint8List> _generateGithubToken(gh.RepositorySlug slug) async {
     final Map<String, dynamic> appInstallations = await githubAppInstallations;
-    final String? appInstallation = appInstallations[slug.fullName]['installation_id'] as String?;
+    final String? appInstallation =
+        appInstallations[slug.fullName]['installation_id'] as String?;
     final String jsonWebToken = await generateJsonWebToken();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jsonWebToken',
       'Accept': 'application/vnd.github.machine-man-preview+json',
     };
-    final Uri githubAccessTokensUri = Uri.https('api.github.com', 'app/installations/$appInstallation/access_tokens');
-    final http.Response response = await http.post(githubAccessTokensUri, headers: headers);
-    final Map<String, dynamic> jsonBody = jsonDecode(response.body) as Map<String, dynamic>;
+    final Uri githubAccessTokensUri = Uri.https(
+        'api.github.com', 'app/installations/$appInstallation/access_tokens');
+    final http.Response response =
+        await http.post(githubAccessTokensUri, headers: headers);
+    final Map<String, dynamic> jsonBody =
+        jsonDecode(response.body) as Map<String, dynamic>;
     if (jsonBody.containsKey('token') == false) {
       log.warning(response.body);
-      throw Exception('generateGitHubToken failed to get token from Github for repo=${slug.fullName}');
+      throw Exception(
+          'generateGitHubToken failed to get token from Github for repo=${slug.fullName}');
     }
     final String token = jsonBody['token'] as String;
     log.fine('Generated a new GitHub token for ${slug.fullName}');
     return Uint8List.fromList(token.codeUnits);
   }
 
-  Future<gh.GitHub> createGitHubClient({gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async {
+  Future<gh.GitHub> createGitHubClient(
+      {gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async {
     slug ??= pullRequest!.base!.repo!.slug();
     final String githubToken = await generateGithubToken(slug);
     return createGitHubClientWithToken(githubToken);

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -67,6 +67,16 @@ class Config {
     flutterSlug,
   };
 
+  static bool doesSkiaGoldRunOnBranch(gh.RepositorySlug slug, String? branch) {
+    if (slug == engineSlug) {
+      final RegExp releaseRegex = RegExp(r'flutter-\d?\.\d?-candidate\.\d?');
+      return defaultBranch(slug) == branch ||
+          (branch != null && releaseRegex.hasMatch(branch));
+    } else {
+      return defaultBranch(slug) == branch;
+    }
+  }
+
   /// The tip of tree branch for [slug].
   static String defaultBranch(gh.RepositorySlug slug) {
     final Map<gh.RepositorySlug, String> defaultBranches = <gh.RepositorySlug, String>{

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -49,8 +49,7 @@ class Config {
       };
 
   /// List of guaranteed scheduling Github repos.
-  static Set<gh.RepositorySlug> get guaranteedSchedulingRepos =>
-      <gh.RepositorySlug>{
+  static Set<gh.RepositorySlug> get guaranteedSchedulingRepos => <gh.RepositorySlug>{
         engineSlug,
         packagesSlug,
       };
@@ -71,8 +70,7 @@ class Config {
   static bool doesSkiaGoldRunOnBranch(gh.RepositorySlug slug, String? branch) {
     if (slug == engineSlug) {
       final RegExp releaseRegex = RegExp(r'flutter-\d?\.\d?-candidate\.\d?');
-      return defaultBranch(slug) == branch ||
-          (branch != null && releaseRegex.hasMatch(branch));
+      return defaultBranch(slug) == branch || (branch != null && releaseRegex.hasMatch(branch));
     } else {
       return defaultBranch(slug) == branch;
     }
@@ -80,8 +78,7 @@ class Config {
 
   /// The tip of tree branch for [slug].
   static String defaultBranch(gh.RepositorySlug slug) {
-    final Map<gh.RepositorySlug, String> defaultBranches =
-        <gh.RepositorySlug, String>{
+    final Map<gh.RepositorySlug, String> defaultBranches = <gh.RepositorySlug, String>{
       cocoonSlug: 'main',
       flutterSlug: 'master',
       engineSlug: 'main',
@@ -103,9 +100,7 @@ class Config {
   static const String configCacheName = 'config';
 
   /// Default properties when rerunning a prod build.
-  static const Map<String, Object> defaultProperties = <String, Object>{
-    'force_upload': true
-  };
+  static const Map<String, Object> defaultProperties = <String, Object>{'force_upload': true};
 
   /// GCP project ID.
   static const String flutterGcpProjectId = 'flutter-dashboard';
@@ -119,16 +114,14 @@ class Config {
   Logging get loggingService => ss.lookup(#appengine.logging) as Logging;
 
   Future<Iterable<Branch>> getBranches(gh.RepositorySlug slug) async {
-    final DatastoreService datastore =
-        DatastoreService(db, defaultMaxEntityGroups);
+    final DatastoreService datastore = DatastoreService(db, defaultMaxEntityGroups);
     final List<Branch> branches = await (datastore.queryBranches().toList());
 
     return branches.where((Branch branch) => branch.slug == slug);
   }
 
   Future<List<String>> _getReleaseAccounts() async {
-    final String releaseAccountsConcat =
-        await _getSingleValue('ReleaseAccounts');
+    final String releaseAccountsConcat = await _getSingleValue('ReleaseAccounts');
     return releaseAccountsConcat.split(',');
   }
 
@@ -151,15 +144,12 @@ class Config {
   }
 
   // GitHub App properties.
-  Future<String> get githubPrivateKey =>
-      _getSingleValue('githubapp_private_pem');
-  Future<String> get overrideTreeStatusLabel =>
-      _getSingleValue('override_tree_status_label');
+  Future<String> get githubPrivateKey => _getSingleValue('githubapp_private_pem');
+  Future<String> get overrideTreeStatusLabel => _getSingleValue('override_tree_status_label');
   Future<String> get githubPublicKey => _getSingleValue('githubapp_public_pem');
   Future<String> get githubAppId => _getSingleValue('githubapp_id');
   Future<Map<String, dynamic>> get githubAppInstallations async {
-    final String installations =
-        await _getSingleValue('githubapp_installations');
+    final String installations = await _getSingleValue('githubapp_installations');
     return jsonDecode(installations) as Map<String, dynamic>;
   }
 
@@ -207,8 +197,7 @@ class Config {
 
   Future<String> get githubOAuthToken => _getSingleValue('GitHubPRToken');
 
-  String get wrongBaseBranchPullRequestMessage =>
-      'This pull request was opened against a branch other than '
+  String get wrongBaseBranchPullRequestMessage => 'This pull request was opened against a branch other than '
       '_{{default_branch}}_. Since Flutter pull requests should not '
       'normally be opened against branches other than {{default_branch}}, I '
       'have changed the base to {{default_branch}}. If this was intended, you '
@@ -265,8 +254,7 @@ class Config {
       '(https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code) '
       'and make sure this patch meets those guidelines before LGTMing.';
 
-  String get flutterGoldPending =>
-      'Waiting for all other checks to be successful before querying Gold.';
+  String get flutterGoldPending => 'Waiting for all other checks to be successful before querying Gold.';
 
   String get flutterGoldSuccess => 'All golden file tests have passed.';
 
@@ -278,14 +266,12 @@ class Config {
       'Gold expire after as many days, so this pull request will need to be '
       'updated with a fresh commit in order to get results from Gold.';
 
-  String get flutterGoldDraftChange =>
-      'This pull request has been changed to a '
+  String get flutterGoldDraftChange => 'This pull request has been changed to a '
       'draft. The currently pending flutter-gold status will not be able '
       'to resolve until a new commit is pushed or the change is marked ready for '
       'review again.';
 
-  String flutterGoldInitialAlert(String url) =>
-      'Golden file changes have been found for this pull '
+  String flutterGoldInitialAlert(String url) => 'Golden file changes have been found for this pull '
       'request. Click [here to view and triage]($url) '
       '(e.g. because this is an intentional change).\n\n'
       'If you are still iterating on this change and are not ready to '
@@ -294,8 +280,7 @@ class Config {
       'on the dashboard, commenting will be silenced, and the check will not try to resolve itself until '
       'marked ready for review.\n\n';
 
-  String flutterGoldFollowUpAlert(String url) =>
-      'Golden file changes are available for triage from new commit, '
+  String flutterGoldFollowUpAlert(String url) => 'Golden file changes are available for triage from new commit, '
       'Click [here to view]($url).\n\n';
 
   String flutterGoldAlertConstant(gh.RepositorySlug slug) {
@@ -312,12 +297,10 @@ class Config {
       '_Changes reported for pull request #${pr.number} at sha ${pr.head!.sha}_\n\n';
 
   /// Post submit service account email used by LUCI swarming tasks.
-  static const String luciProdAccount =
-      'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
+  static const String luciProdAccount = 'flutter-prod-builder@chops-service-accounts.iam.gserviceaccount.com';
 
   /// Internal Google service account used to surface FRoB results.
-  static const String frobAccount =
-      'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
+  static const String frobAccount = 'flutter-roll-on-borg@flutter-roll-on-borg.google.com.iam.gserviceaccount.com';
 
   /// Service accounts used for PubSub messages.
   static const Set<String> allowedPubsubServiceAccounts = <String>{
@@ -331,8 +314,7 @@ class Config {
   /// The default number of commit shown in flutter build dashboard.
   int get commitNumber => 30;
 
-  KeyHelper get keyHelper =>
-      KeyHelper(applicationContext: context.applicationContext);
+  KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
 
   // Default number of commits to return for benchmark dashboard.
   int /*!*/ get maxRecords => 50;
@@ -344,22 +326,16 @@ class Config {
   String get flutterBuild => 'flutter-build';
 
   // Repository status description for github status.
-  String get flutterBuildDescription =>
-      'Tree is currently broken. Please do not merge this '
+  String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
 
-  static gh.RepositorySlug get cocoonSlug =>
-      gh.RepositorySlug('flutter', 'cocoon');
-  static gh.RepositorySlug get engineSlug =>
-      gh.RepositorySlug('flutter', 'engine');
-  static gh.RepositorySlug get flutterSlug =>
-      gh.RepositorySlug('flutter', 'flutter');
-  static gh.RepositorySlug get packagesSlug =>
-      gh.RepositorySlug('flutter', 'packages');
+  static gh.RepositorySlug get cocoonSlug => gh.RepositorySlug('flutter', 'cocoon');
+  static gh.RepositorySlug get engineSlug => gh.RepositorySlug('flutter', 'engine');
+  static gh.RepositorySlug get flutterSlug => gh.RepositorySlug('flutter', 'flutter');
+  static gh.RepositorySlug get packagesSlug => gh.RepositorySlug('flutter', 'packages');
 
   /// Flutter recipes is hosted on Gerrit instead of GitHub.
-  static gh.RepositorySlug get recipesSlug =>
-      gh.RepositorySlug('flutter', 'recipes');
+  static gh.RepositorySlug get recipesSlug => gh.RepositorySlug('flutter', 'recipes');
 
   String get waitingForTreeToGoGreenLabelName => 'waiting for tree to go green';
 
@@ -383,8 +359,7 @@ class Config {
       ..issuer = await githubAppId
       ..issuedAt = now
       ..expiresAt = now.add(const Duration(minutes: 10));
-    final JWTRsaSha256Signer signer =
-        JWTRsaSha256Signer(privateKey: privateKey, publicKey: publicKey);
+    final JWTRsaSha256Signer signer = JWTRsaSha256Signer(privateKey: privateKey, publicKey: publicKey);
     final JWT signedToken = builder.getSignedToken(signer);
     return signedToken.toString();
   }
@@ -404,31 +379,25 @@ class Config {
 
   Future<Uint8List> _generateGithubToken(gh.RepositorySlug slug) async {
     final Map<String, dynamic> appInstallations = await githubAppInstallations;
-    final String? appInstallation =
-        appInstallations[slug.fullName]['installation_id'] as String?;
+    final String? appInstallation = appInstallations[slug.fullName]['installation_id'] as String?;
     final String jsonWebToken = await generateJsonWebToken();
     final Map<String, String> headers = <String, String>{
       'Authorization': 'Bearer $jsonWebToken',
       'Accept': 'application/vnd.github.machine-man-preview+json',
     };
-    final Uri githubAccessTokensUri = Uri.https(
-        'api.github.com', 'app/installations/$appInstallation/access_tokens');
-    final http.Response response =
-        await http.post(githubAccessTokensUri, headers: headers);
-    final Map<String, dynamic> jsonBody =
-        jsonDecode(response.body) as Map<String, dynamic>;
+    final Uri githubAccessTokensUri = Uri.https('api.github.com', 'app/installations/$appInstallation/access_tokens');
+    final http.Response response = await http.post(githubAccessTokensUri, headers: headers);
+    final Map<String, dynamic> jsonBody = jsonDecode(response.body) as Map<String, dynamic>;
     if (jsonBody.containsKey('token') == false) {
       log.warning(response.body);
-      throw Exception(
-          'generateGitHubToken failed to get token from Github for repo=${slug.fullName}');
+      throw Exception('generateGitHubToken failed to get token from Github for repo=${slug.fullName}');
     }
     final String token = jsonBody['token'] as String;
     log.fine('Generated a new GitHub token for ${slug.fullName}');
     return Uint8List.fromList(token.codeUnits);
   }
 
-  Future<gh.GitHub> createGitHubClient(
-      {gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async {
+  Future<gh.GitHub> createGitHubClient({gh.PullRequest? pullRequest, gh.RepositorySlug? slug}) async {
     slug ??= pullRequest!.base!.repo!.slug();
     final String githubToken = await generateGithubToken(slug);
     return createGitHubClientWithToken(githubToken);

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   github: 9.24.0
   googleapis: 12.0.0
   googleapis_auth: 1.6.0
-  gql: 1.0.1-alpha+1696717343881
+  gql: 1.0.1-alpha+1709845491443
   graphql: 5.2.0-beta.7
   grpc: 3.2.4
   http: 1.2.1


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/146078

This starts running skia gold bot checks on release branches for the engine.  This works for the engine because our infrastructure forks all gold tests when a release branch is created.

See also:
 - https://github.com/flutter/engine/tree/main/testing/skia_gold_client#release-testing

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
