### PR TITLE
Add `BuildList` field to ease frontend logics

### DIFF
--- a/app_dart/lib/src/model/firestore/commit_tasks_status.dart
+++ b/app_dart/lib/src/model/firestore/commit_tasks_status.dart
@@ -19,17 +19,51 @@ class CommitTasksStatus {
 
   /// Tasks running against the commit.
   final List<Task> tasks;
-}
 
-class SerializableCommitTasksStatus {
-  const SerializableCommitTasksStatus(this.status);
-
-  final CommitTasksStatus status;
+  /// Refactors task list to fullTask list.
+  ///
+  /// After migrated to Firestore, we are tracking each rerun as a separate Task entry.
+  /// But from Frontend side, it is expecting a build list for all retries.
+  ///
+  /// Instead of adding burden to the frondend loading, a proactive preparation is
+  /// added here to provide build list explicitly.
+  ///
+  /// Note we use the lastest run as the `task`, surfacing on the dashboard.
+  List<FullTask> toFullTasks(List<Task> tasks) {
+    final Map<String, FullTask> fullTasksMap = <String, FullTask>{};
+    for (Task task in tasks) {
+      if (!fullTasksMap.containsKey(task.taskName)) {
+        if (task.buildNumber == null) {
+          fullTasksMap[task.taskName!] = FullTask(task, <int>[]);
+        } else {
+          fullTasksMap[task.taskName!] = FullTask(task, <int>[task.buildNumber!]);
+        }
+      } else if (fullTasksMap.containsKey(task.taskName)) {
+        fullTasksMap[task.taskName]!.buildList.add(task.buildNumber!);
+      }
+    }
+    return fullTasksMap.entries.map((entry) => entry.value).toList();
+  }
 
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'Commit': status.commit.facade,
-      'Tasks': status.tasks.map((task) => task.facade).toList(),
+      'Commit': commit.facade,
+      'Tasks': toFullTasks(tasks).map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+/// Latest task entry and its rerun build list.
+class FullTask {
+  const FullTask(this.task, this.buildList);
+
+  final Task task;
+  final List<int> buildList;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'Task': task.facade,
+      'BuildList': buildList.join(','),
     };
   }
 }

--- a/app_dart/lib/src/request_handlers/get_status_firestore.dart
+++ b/app_dart/lib/src/request_handlers/get_status_firestore.dart
@@ -47,15 +47,12 @@ class GetStatusFirestore extends RequestHandler<Body> {
     final int commitNumber = config.commitNumber;
     final int lastCommitTimestamp = await _obtainTimestamp(encodedLastCommitKey, keyHelper, datastore);
 
-    final List<SerializableCommitTasksStatus> statuses = await buildStatusService
+    final List<CommitTasksStatus> statuses = await buildStatusService
         .retrieveCommitStatusFirestore(
           limit: commitNumber,
           timestamp: lastCommitTimestamp,
           branch: branch,
           slug: slug,
-        )
-        .map<SerializableCommitTasksStatus>(
-          (CommitTasksStatus status) => SerializableCommitTasksStatus(status),
         )
         .toList();
 

--- a/app_dart/test/model/firestore/commit_tasks_status_test.dart
+++ b/app_dart/test/model/firestore/commit_tasks_status_test.dart
@@ -14,7 +14,7 @@ void main() {
     test('generates json correctly', () async {
       final Commit commit = generateFirestoreCommit(1, sha: 'sha1');
       final CommitTasksStatus commitTasksStatus = CommitTasksStatus(commit, <Task>[]);
-      expect(SerializableCommitTasksStatus(commitTasksStatus).toJson(), <String, dynamic>{
+      expect(commitTasksStatus.toJson(), <String, dynamic>{
         'Commit': <String, dynamic>{
           'DocumentName': 'sha1',
           'RepositoryPath': 'flutter/flutter',
@@ -26,6 +26,112 @@ void main() {
           'Branch': 'master',
         },
         'Tasks': [],
+      });
+    });
+
+    test('generates json when a task does not have a build number', () async {
+      final Commit commit = generateFirestoreCommit(1, sha: 'sha1');
+      final Task task = generateFirestoreTask(1);
+      final CommitTasksStatus commitTasksStatus = CommitTasksStatus(commit, <Task>[task]);
+      expect(commitTasksStatus.toJson(), <String, dynamic>{
+        'Commit': <String, dynamic>{
+          'DocumentName': 'sha1',
+          'RepositoryPath': 'flutter/flutter',
+          'CreateTimestamp': 1,
+          'Sha': 'sha1',
+          'Message': 'test message',
+          'Author': 'author',
+          'Avatar': 'avatar',
+          'Branch': 'master',
+        },
+        'Tasks': [
+          <String, dynamic>{
+            'Task': <String, dynamic>{
+              'DocumentName': 'testSha_task1_1',
+              'CreateTimestamp': 0,
+              'StartTimestamp': 0,
+              'EndTimestamp': 0,
+              'TaskName': 'task1',
+              'Attempts': 1,
+              'Bringup': false,
+              'TestFlaky': false,
+              'BuildNumber': null,
+              'Status': 'New',
+            },
+            'BuildList': '',
+          }
+        ],
+      });
+    });
+
+    test('generates json when a task has a build number', () async {
+      final Commit commit = generateFirestoreCommit(1, sha: 'sha1');
+      final Task task = generateFirestoreTask(1, buildNumber: 123);
+      final CommitTasksStatus commitTasksStatus = CommitTasksStatus(commit, <Task>[task]);
+      expect(commitTasksStatus.toJson(), <String, dynamic>{
+        'Commit': <String, dynamic>{
+          'DocumentName': 'sha1',
+          'RepositoryPath': 'flutter/flutter',
+          'CreateTimestamp': 1,
+          'Sha': 'sha1',
+          'Message': 'test message',
+          'Author': 'author',
+          'Avatar': 'avatar',
+          'Branch': 'master',
+        },
+        'Tasks': [
+          <String, dynamic>{
+            'Task': <String, dynamic>{
+              'DocumentName': 'testSha_task1_1',
+              'CreateTimestamp': 0,
+              'StartTimestamp': 0,
+              'EndTimestamp': 0,
+              'TaskName': 'task1',
+              'Attempts': 1,
+              'Bringup': false,
+              'TestFlaky': false,
+              'BuildNumber': 123,
+              'Status': 'New',
+            },
+            'BuildList': '123',
+          }
+        ],
+      });
+    });
+
+    test('generates json when a task has multiple reruns', () async {
+      final Commit commit = generateFirestoreCommit(1, sha: 'sha1');
+      final Task task1 = generateFirestoreTask(1, buildNumber: 123);
+      final Task task2 = generateFirestoreTask(1, buildNumber: 124);
+      final CommitTasksStatus commitTasksStatus = CommitTasksStatus(commit, <Task>[task2, task1]);
+      expect(commitTasksStatus.toJson(), <String, dynamic>{
+        'Commit': <String, dynamic>{
+          'DocumentName': 'sha1',
+          'RepositoryPath': 'flutter/flutter',
+          'CreateTimestamp': 1,
+          'Sha': 'sha1',
+          'Message': 'test message',
+          'Author': 'author',
+          'Avatar': 'avatar',
+          'Branch': 'master',
+        },
+        'Tasks': [
+          <String, dynamic>{
+            'Task': <String, dynamic>{
+              'DocumentName': 'testSha_task1_1',
+              'CreateTimestamp': 0,
+              'StartTimestamp': 0,
+              'EndTimestamp': 0,
+              'TaskName': 'task1',
+              'Attempts': 1,
+              'Bringup': false,
+              'TestFlaky': false,
+              'BuildNumber': 124,
+              'Status': 'New',
+            },
+            'BuildList': '124,123',
+          }
+        ],
       });
     });
   });


### PR DESCRIPTION
Frontend needs `BuildList` to handle case of multiple reruns. This PR updates the returned results from.

```
statuses:
  commit,
  tasks
```

to 

```
statuses:
  Commit,
  Tasks
    Task
    BuildList
```

Part of https://github.com/flutter/flutter/issues/142951.