### PR TITLE
Add commit sha to Firestore task facade

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -30,6 +30,7 @@ const String kTaskTestFlakyField = 'testFlaky';
 const String kTaskAttempts = 'Attempts';
 const String kTaskBringup = 'Bringup';
 const String kTaskBuildNumber = 'BuildNumber';
+const String kTaskCommitSha = 'CommitSha';
 const String kTaskCreateTimestamp = 'CreateTimestamp';
 const String kTaskDocumentName = 'DocumentName';
 const String kTaskEndTimestamp = 'EndTimestamp';
@@ -267,6 +268,7 @@ class Task extends Document {
   Map<String, dynamic> get facade {
     return <String, dynamic>{
       kTaskDocumentName: name,
+      kTaskCommitSha: commitSha,
       kTaskCreateTimestamp: createTimestamp,
       kTaskStartTimestamp: startTimestamp,
       kTaskEndTimestamp: endTimestamp,

--- a/app_dart/test/model/firestore/commit_tasks_status_test.dart
+++ b/app_dart/test/model/firestore/commit_tasks_status_test.dart
@@ -48,6 +48,7 @@ void main() {
           <String, dynamic>{
             'Task': <String, dynamic>{
               'DocumentName': 'testSha_task1_1',
+              'CommitSha': 'testSha',
               'CreateTimestamp': 0,
               'StartTimestamp': 0,
               'EndTimestamp': 0,
@@ -83,6 +84,7 @@ void main() {
           <String, dynamic>{
             'Task': <String, dynamic>{
               'DocumentName': 'testSha_task1_1',
+              'CommitSha': 'testSha',
               'CreateTimestamp': 0,
               'StartTimestamp': 0,
               'EndTimestamp': 0,
@@ -119,6 +121,7 @@ void main() {
           <String, dynamic>{
             'Task': <String, dynamic>{
               'DocumentName': 'testSha_task1_1',
+              'CommitSha': 'testSha',
               'CreateTimestamp': 0,
               'StartTimestamp': 0,
               'EndTimestamp': 0,

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -207,6 +207,7 @@ void main() {
     final Task taskDocument = generateFirestoreTask(1);
     final Map<String, dynamic> expectedResult = <String, dynamic>{
       kTaskDocumentName: taskDocument.name,
+      kTaskCommitSha: taskDocument.commitSha,
       kTaskCreateTimestamp: taskDocument.createTimestamp,
       kTaskStartTimestamp: taskDocument.startTimestamp,
       kTaskEndTimestamp: taskDocument.endTimestamp,


### PR DESCRIPTION
The `CommitSha` field was missed, and this PR adds it.