### PR TITLE
Clean up Frontend task stages

### DIFF
--- a/dashboard/lib/logic/qualified_task.dart
+++ b/dashboard/lib/logic/qualified_task.dart
@@ -6,57 +6,59 @@ import 'package:flutter/foundation.dart';
 
 import '../model/task.pb.dart';
 
-/// [Task.stageName] that maps to StageName enums.
-// TODO(chillers): Remove these and use StageName enum when available. https://github.com/flutter/cocoon/issues/441
 class StageName {
-  static const String cocoon = 'cocoon';
-  static const String legacyLuci = 'chromebot';
   static const String luci = 'luci';
-  static const String googleTest = 'google_internal';
   static const String dartInternal = 'dart-internal';
 }
 
+/// This is a side effect after deprecating `stage` field from Task model. A
+/// more generic way to detect dart internal targets may be preferred.
+const Set<String> dartInternalTasks = <String>{
+  'Linux engine_release_builder',
+  'Linux flutter_release',
+  'Linux flutter_release_builder',
+  'Linux packaging_release_builder',
+  'Mac engine_release_builder',
+  'Mac packaging_release_builder',
+  'Windows engine_release_builder',
+  'Windows packaging_release_builder',
+};
+
 /// Base URLs for various endpoints that can relate to a [Task].
 const String _luciUrl = 'https://ci.chromium.org/p/flutter';
-const String _googleTestUrl = 'https://flutter-rob.corp.google.com';
 const String _dartInternalUrl = 'https://ci.chromium.org/p/dart-internal';
 
 @immutable
 class QualifiedTask {
-  const QualifiedTask({this.stage, this.task, this.pool});
+  const QualifiedTask({this.task, this.pool});
 
   QualifiedTask.fromTask(Task task)
-      : stage = task.stageName,
-        task = task.builderName,
-        pool = task.isFlaky ? 'luci.flutter.staging' : 'luci.flutter.prod';
+      : task = task.builderName,
+        pool = dartInternalTasks.contains(task.builderName)
+            ? 'flutter'
+            : (task.isFlaky ? 'luci.flutter.staging' : 'luci.flutter.prod');
 
   final String? pool;
-  final String? stage;
   final String? task;
 
   /// Get the URL for the configuration of this task.
   ///
   /// Luci tasks are stored on Luci.
   String get sourceConfigurationUrl {
-    assert(isLuci || isGoogleTest || isDartInternal);
+    assert(isLuci || isDartInternal);
     if (isLuci) {
       return '$_luciUrl/builders/$pool/$task';
-    } else if (isGoogleTest) {
-      return _googleTestUrl;
     } else if (isDartInternal) {
       return '$_dartInternalUrl/builders/$pool/$task';
     }
-    throw Exception('Failed to get source configuration url for $stage.');
+    throw Exception('Failed to get source configuration url for $task.');
   }
 
-  /// Whether this task was run on google test.
-  bool get isGoogleTest => stage == StageName.googleTest;
-
   /// Whether the task was run on the LUCI infrastructure.
-  bool get isLuci => stage == StageName.cocoon || stage == StageName.legacyLuci || stage == StageName.luci;
+  bool get isLuci => !dartInternalTasks.contains(task);
 
   /// Whether this task was run on internal infrastructure (example: luci dart-internal).
-  bool get isDartInternal => stage == StageName.dartInternal;
+  bool get isDartInternal => dartInternalTasks.contains(task);
 
   @override
   bool operator ==(Object other) {
@@ -64,20 +66,16 @@ class QualifiedTask {
       return false;
     }
 
-    if (isLuci) {
-      return other is QualifiedTask && other.task == task;
-    }
-
-    return other is QualifiedTask && other.stage == stage && other.task == task;
+    return other is QualifiedTask && other.task == task;
   }
 
   @override
   int get hashCode {
     // Ensure tasks from Cocoon or LUCI share the same columns.
     if (isLuci) {
-      return StageName.cocoon.hashCode ^ task.hashCode;
+      return StageName.luci.hashCode ^ task.hashCode;
     }
 
-    return stage.hashCode ^ task.hashCode;
+    return StageName.dartInternal.hashCode ^ task.hashCode;
   }
 }

--- a/dashboard/lib/widgets/task_grid.dart
+++ b/dashboard/lib/widgets/task_grid.dart
@@ -258,9 +258,6 @@ class _TaskGridState extends State<TaskGrid> {
         }
         // If the scores are identical, break ties on the name of the task.
         // We do that because otherwise the sort order isn't stable.
-        if (a.stage != b.stage) {
-          return a.stage!.compareTo(b.stage!);
-        }
         return a.task!.compareTo(b.task!);
       });
 
@@ -270,7 +267,7 @@ class _TaskGridState extends State<TaskGrid> {
         const LatticeCell(),
         ...tasks.map<LatticeCell>(
           (QualifiedTask task) =>
-              LatticeCell(builder: (BuildContext context) => TaskIcon(qualifiedTask: task), taskName: task.stage),
+              LatticeCell(builder: (BuildContext context) => TaskIcon(qualifiedTask: task), taskName: task.task),
         ),
       ],
       ...rows.map<List<LatticeCell>>(

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -34,13 +34,6 @@ class TaskIcon extends StatelessWidget {
     // different assets.
     final Color? blendFilter = brightness == Brightness.dark ? Colors.white : null;
 
-    if (qualifiedTask.isGoogleTest) {
-      return Image.asset(
-        'assets/googleLogo.png',
-        color: blendFilter,
-      );
-    }
-
     if (qualifiedTask.task == null || !(qualifiedTask.isLuci || qualifiedTask.isDartInternal)) {
       return Icon(
         Icons.help,
@@ -113,6 +106,8 @@ class TaskIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final Brightness brightness = Theme.of(context).brightness;
     final Widget icon = stageIconForBrightness(brightness);
+    final String tooltipMessage =
+        qualifiedTask.isDartInternal ? '${qualifiedTask.task} (dart-internal)' : qualifiedTask.task!;
 
     return IconTheme.merge(
       data: IconThemeData(size: TaskBox.of(context) - 5),
@@ -121,7 +116,7 @@ class TaskIcon extends StatelessWidget {
           launchUrl(Uri.parse(qualifiedTask.sourceConfigurationUrl));
         },
         child: Tooltip(
-          message: '${qualifiedTask.task} (${qualifiedTask.stage})',
+          message: tooltipMessage,
           child: Align(
             alignment: Alignment.bottomCenter,
             child: icon,

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -107,7 +107,7 @@ class TaskIcon extends StatelessWidget {
     final Brightness brightness = Theme.of(context).brightness;
     final Widget icon = stageIconForBrightness(brightness);
     final String tooltipMessage =
-        qualifiedTask.isDartInternal ? '${qualifiedTask.task} (dart-internal)' : qualifiedTask.task!;
+        qualifiedTask.isDartInternal ? '${qualifiedTask.task} (${StageName.dartInternal})' : qualifiedTask.task!;
 
     return IconTheme.merge(
       data: IconThemeData(size: TaskBox.of(context) - 5),

--- a/dashboard/test/logic/qualified_task_test.dart
+++ b/dashboard/test/logic/qualified_task_test.dart
@@ -20,25 +20,29 @@ void main() {
     );
   });
 
-  test('QualifiedTask.sourceConfigurationUrl for google test', () {
-    final Task googleTestTask = Task()..stageName = 'google_internal';
-
-    expect(QualifiedTask.fromTask(googleTestTask).sourceConfigurationUrl, 'https://flutter-rob.corp.google.com');
-  });
-
   test('QualifiedTask.sourceConfigurationUrl for dart-internal', () {
-    final Task dartInternalTask = Task()..stageName = 'dart-internal';
+    final Task dartInternalTask = Task()..builderName = 'Linux engine_release_builder';
 
     expect(
       QualifiedTask.fromTask(dartInternalTask).sourceConfigurationUrl,
-      'https://ci.chromium.org/p/dart-internal/builders/luci.flutter.prod/',
+      'https://ci.chromium.org/p/dart-internal/builders/flutter/Linux engine_release_builder',
     );
   });
 
   test('QualifiedTask.isLuci', () {
-    expect(const QualifiedTask(stage: 'luci', task: 'abc').isLuci, true);
-    expect(const QualifiedTask(stage: 'chromebot', task: 'abc').isLuci, true);
-    expect(const QualifiedTask(stage: 'cocoon', task: 'abc').isLuci, true);
-    expect(const QualifiedTask(stage: 'google_internal', task: 'abc').isLuci, false);
+    expect(const QualifiedTask(task: 'abc').isLuci, true);
+    expect(const QualifiedTask(task: 'Linux engine_release_builder').isLuci, false);
+  });
+
+  test('QualifiedTask.isDartInternal', () {
+    expect(const QualifiedTask(task: 'abc').isDartInternal, false);
+    expect(const QualifiedTask(task: 'Linux engine_release_builder').isDartInternal, true);
+  });
+
+  test('QualifiedTask.isEqual', () {
+    const QualifiedTask task1 = QualifiedTask(task: 'abc');
+    const QualifiedTask task2 = QualifiedTask(task: 'abc');
+
+    expect(task1, task2);
   });
 }

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -378,7 +378,6 @@ void main() {
         ..tasks.addAll(
           <Task>[
             Task()
-              ..stageName = StageName.cocoon
               ..name = '1'
               ..builderName = '1'
               ..status = TaskBox.statusSucceeded,
@@ -425,14 +424,12 @@ void main() {
         ..tasks.addAll(
           <Task>[
             Task()
-              ..name = 'Task Name'
-              ..builderName = 'Task Name'
-              ..stageName = 'Stage Nome 1'
+              ..name = 'Task Name 1'
+              ..builderName = 'Task Name 1'
               ..status = TaskBox.statusSucceeded,
             Task()
-              ..name = 'Task Name'
-              ..builderName = 'Task Name'
-              ..stageName = 'Stage Nome 2'
+              ..name = 'Task Name 2'
+              ..builderName = 'Task Name 2'
               ..status = TaskBox.statusFailed,
           ],
         ),
@@ -659,8 +656,8 @@ void main() {
     final List<LatticeCell> myCells = cells.first;
     expect(myCells.length, 3);
     myCells.removeAt(0); // the first element is the github author box.
-    expect(myCells[0].taskName, 'A');
-    expect(myCells[1].taskName, 'B');
+    expect(myCells[0].taskName, '1');
+    expect(myCells[1].taskName, '2');
   });
 
   testWidgets('TaskGrid can handle all the various different statuses', (WidgetTester tester) async {

--- a/dashboard/test/widgets/task_icon_test.dart
+++ b/dashboard/test/widgets/task_icon_test.dart
@@ -13,15 +13,39 @@ import '../utils/fake_url_launcher.dart';
 
 void main() {
   testWidgets('TaskIcon tooltip shows task name', (WidgetTester tester) async {
-    const String stageName = 'stagey stage';
     const String taskName = 'tasky task';
-    const String expectedLabel = 'tasky task (stagey stage)';
+    const String expectedLabel = 'tasky task';
 
     await tester.pumpWidget(
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: stageName, task: taskName),
+            qualifiedTask: QualifiedTask(task: taskName),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text(expectedLabel), findsNothing);
+
+    final Finder taskIcon = find.byType(TaskIcon);
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(taskIcon));
+    await tester.pump(kLongPressTimeout);
+
+    expect(find.text(expectedLabel), findsOneWidget);
+
+    await gesture.up();
+  });
+
+  testWidgets('TaskIcon tooltip shows task name and dart-internal stage', (WidgetTester tester) async {
+    const String taskName = 'Linux engine_release_builder';
+    const String expectedLabel = 'Linux engine_release_builder (dart-internal)';
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: TaskIcon(
+            qualifiedTask: QualifiedTask(task: taskName),
           ),
         ),
       ),
@@ -42,7 +66,7 @@ void main() {
     final FakeUrlLauncher urlLauncher = FakeUrlLauncher();
     UrlLauncherPlatform.instance = urlLauncher;
 
-    const QualifiedTask luciTask = QualifiedTask(stage: StageName.luci, task: 'test');
+    const QualifiedTask luciTask = QualifiedTask(task: 'test');
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -62,41 +86,12 @@ void main() {
     expect(urlLauncher.launches.single, luciTask.sourceConfigurationUrl);
   });
 
-  testWidgets('Unknown stage name shows helper icon in TaskIcon', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Material(
-          child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'stage not to be named', task: 'macbeth'),
-          ),
-        ),
-      ),
-    );
-
-    expect(find.byIcon(Icons.help), findsOneWidget);
-  });
-
-  testWidgets('TaskIcon shows the right icon for google test', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Material(
-          child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'google_internal'),
-          ),
-        ),
-      ),
-    );
-
-    expect((tester.widget(find.byType(Image)) as Image).image, isInstanceOf<AssetImage>());
-    expect(((tester.widget(find.byType(Image)) as Image).image as AssetImage).assetName, 'assets/googleLogo.png');
-  });
-
   testWidgets('TaskIcon shows the right icon for web', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_web test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Windows_web test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -111,7 +106,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows something', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Windows something', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -126,8 +121,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask:
-                QualifiedTask(stage: 'chromebot', task: 'Windows_fuchsia something', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Windows_fuchsia something', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -142,7 +136,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_android test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Windows_android test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -157,7 +151,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Mac test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Mac test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -172,7 +166,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Mac_ios test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Mac_ios test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -187,7 +181,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Linux test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Linux test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -202,7 +196,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Unknown', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Unknown', pool: 'luci.flutter.prod'),
           ),
         ),
       ),
@@ -217,8 +211,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: TaskIcon(
-            qualifiedTask:
-                QualifiedTask(stage: 'dart-internal', task: 'Linux dart-internal test', pool: 'luci.flutter.prod'),
+            qualifiedTask: QualifiedTask(task: 'Linux dart-internal test', pool: 'luci.flutter.prod'),
           ),
         ),
       ),


### PR DESCRIPTION
It has been a technical debt to support Task `stages` in both dashboard and backend: we used to support `cirrus`, `travis`, `chrome`, `google`, `LUCI`, `cocoon` as stages. Over past years, we have been refactoring everything in LUCI, and there is no need to maintain stages.

Now the only `stage` tasks we support is `dart-internal` ones, which are still LUCI though. To distinguish these tests, we reuse the concept of `stage`, but this PR simplifies corresponding logics.

This PR prepares for Frontend switch over to Firestore, which doesn't support `stage` any more.

Part of https://github.com/flutter/flutter/issues/142951