### PR TITLE
Remove semantics from the cocoon dashboard.

### DIFF
--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -67,8 +67,6 @@ void main([List<String> args = const <String>[]]) async {
       child: Now(child: const MyApp()),
     ),
   );
-  // Enable extensions like Vimium to traverse the dashboard
-  SemanticsBinding.instance.ensureSemantics();
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/145849.

This was originally added by Casey so he could use some Chrome extension to navigate the dashboard (https://github.com/flutter/cocoon/pull/1729), but it appears to cause serious problems for mouse-users.

I've filed https://github.com/flutter/flutter/issues/147881 for the web team to take a look.