### PR TITLE
Fix presubmit retry of missing builder

### DIFF
--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription_v2.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription_v2.dart
@@ -143,10 +143,16 @@ class PresubmitLuciSubscriptionV2 extends SubscriptionHandlerV2 {
       sha: userData['commit_sha'] as String,
     );
     late CiYaml ciYaml;
-    if (commit.branch == Config.defaultBranch(commit.slug)) {
-      ciYaml = await scheduler.getCiYaml(commit, validate: true);
-    } else {
-      ciYaml = await scheduler.getCiYaml(commit);
+    try {
+      if (commit.branch == Config.defaultBranch(commit.slug)) {
+        ciYaml = await scheduler.getCiYaml(commit, validate: true);
+      } else {
+        ciYaml = await scheduler.getCiYaml(commit);
+      }
+    } on FormatException {
+      // If ci.yaml no longer passes validation (for example, because a builder
+      // has been removed), ensure no retries.
+      return 0;
     }
 
     // Do not block on the target not found.

--- a/app_dart/test/src/service/fake_scheduler_v2.dart
+++ b/app_dart/test/src/service/fake_scheduler_v2.dart
@@ -45,14 +45,22 @@ class FakeSchedulerV2 extends SchedulerV2 {
   /// [CiYaml] value to be injected on [getCiYaml].
   CiYaml? ciYaml;
 
+  /// If true, getCiYaml will throw a [FormatException] when validation is
+  /// enforced, simulating failing validation.
+  bool failCiYamlValidation = false;
+
   @override
   Future<CiYaml> getCiYaml(
     Commit commit, {
     CiYaml? totCiYaml,
     RetryOptions? retryOptions,
     bool validate = false,
-  }) async =>
-      ciYaml ?? _defaultConfig;
+  }) async {
+    if (validate && failCiYamlValidation) {
+      throw const FormatException('Failed validation!');
+    }
+    return ciYaml ?? _defaultConfig;
+  }
 
   @override
   Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {


### PR DESCRIPTION
Currently the presubmit LUCI pubsub handler has a couple of un-ACK'd messages because the PR has a ci.yaml that references a builder that was recently removed. The current code to determine whether to retry the job is throwing an uncaught exception when validating the config, causing the handler to return a 500.

This catches that error, and forces the job not to retry, so that the message can be processed. Not retrying is the correct behavior, since it would fail again anway.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
