### PR TITLE
Add logging of failed GitHub requests in Config

### DIFF
--- a/auto_submit/test/service/config_test.dart
+++ b/auto_submit/test/service/config_test.dart
@@ -25,7 +25,7 @@ void main() {
     late CacheProvider cacheProvider;
     late Config config;
     late MockClient mockClient;
-    final SecretManager secretManager = LocalSecretManager();
+    final LocalSecretManager secretManager = LocalSecretManager();
     final RepositorySlug flutterSlug = RepositorySlug('flutter', 'flutter');
     final RepositorySlug testSlug = RepositorySlug('test', 'test');
     const int kCacheSize = 1024;
@@ -37,6 +37,29 @@ void main() {
         cacheProvider: cacheProvider,
         httpProvider: () => mockClient,
         secretManager: secretManager,
+      );
+    });
+
+    test('verify throws if installations response is unexpected', () async {
+      cacheProvider = Cache.inMemoryCacheProvider(kCacheSize);
+      mockClient = MockClient((_) async => http.Response('[]', HttpStatus.internalServerError));
+      secretManager.put(Config.kGithubKey, _fakeKey);
+      secretManager.put(Config.kGithubAppId, '1');
+      config = Config(
+        cacheProvider: cacheProvider,
+        httpProvider: () => mockClient,
+        secretManager: secretManager,
+      );
+
+      expect(
+        config.getInstallationId(testSlug),
+        throwsA(
+          isA<CocoonGitHubRequestException>().having(
+            (e) => e.message,
+            'message',
+            contains('failed to get ID'),
+          ),
+        ),
       );
     });
 
@@ -84,3 +107,34 @@ void main() {
     });
   });
 }
+
+// This is a throw-away private key created just for Config tests.
+const String _fakeKey = '''
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAtktJeC0vgnAjkV7mvCIXJZTG8IMTj8viMZxFrbDKjbXP5e7Y
+03srbSwHdFCBgRDasSqo7LEglmTWFedmv7hskO89y6whfQCRovklwIGY8pJmLT86
+/zVtrGv7Y513UR1dKJLf7764/RyaCQyZzgcaStHin4DDslrG+VniW7OVfZNpzu52
+hYpJSy/CJ1e/csSL4T5EyYfNf4tAAcrgo2rBrZXFH+i3UL7wQjudv612wqwMMP3h
+1YgOo2M2GXEPR0ktWkVhKwi9dkW4ac+d/rev4D11GgTEtHQd2Vcy+vsXMSTloEec
+6R10WKG0xD25DjmsvFL8gfwxeNjq/fFBKzcFYwIDAQABAoIBABXKZhvhet5ivT2x
+VG+Eu7OYVzeE05/KxV0cyw96JJxP8WwQ4wZUoNpJ+xIiVXiyJRIsgUjZ24VexGCV
+6qhcSU4B6ycfillA6ifLFIIwe7HzYhdiiZDcOCH2PnSn7A1cLzicZfxolgBbnOYc
+BX6lRrVO5YIfiEUXqNVBs1c23lXGR1BhYxVSiFBtNWyle2wFU/POjShx1V+v8xaS
+hcQempU2eZqH/vJfTpyyd2jjGrE4yHwd/ywivtN57xyaJ9VchHRKu+285+K2seKb
+43TChTaX0CTTSv2jcv/V7LAaVVGHDiqi7aDlS+FxviKwzBJel/b0dsLvkXWxRw+R
+skyBF7ECgYEA8mSI/iOiCLHp+BuLw9bZtO24ue4N6dUHG6hoQntA3z724tnkRcdi
+KzhOksmnIoYiQrdYBUlNQkjSBUnOdnoj6SbdGtOTajMacXoG/6DoGDSaSnxUukxS
+6Vs4Imtv7xy4nt82nO1GKPoI7SObif1hcVN0GzoXznzP93yYFV9kO1cCgYEAwIcQ
+lxOfhdhKoWY4V1Ho4T2NvunjLxpMGz9i3kASZhC8EkcCwuSXXKo1lar6pOATkT1O
+9ghHP/YnwIL/D8PrPHZbyNeo50506fUmd8j+6UOOjiHr6bLAhcDzUwbqdvgcjUiU
+SrELGLG9+y3nLM45mg9iUgovZw+NZ0nmzVmZytUCgYEAu/jY//SUKJgIMD70YTgR
+dqzPj2ib45UvQPSVfdDlWvsSLJP64V4gtBGjZVP6R9yrXv+dw+O3hUrBjBZThS9s
+/9cCqlYfQMFGpW+TU9PtiS/p4w+OCTc9KPhzjMWydUTZq2LAkGu09/wGxhfR++3C
+DkdAiAjCA4BpKqy1qAVkzlsCgYEAoH94OxmmwMOg44/9o/2qsCrKQb9lHt1DWOus
+li6/p8qHno0IJkS+UgerCAwzSsNqTIfZjY01KIMifIA39YKUViEtPu9Z5QoouOkf
+mng62WbyLlbk/jt/94D01+BKEcegtb8tsF6LK5jxEbYgo99/cYklo9LN1ZLHhLW8
+7K+nX8kCgYEAqQPFTRoQvov2Tl7WBrw9yyDLicpfBJP6gCdC7ct7ghslvo6aIbLN
+WdOXeDKJ+NfwqsML4B+fxTn9ItT8tTGZK8NOMNi/anS160uIqqQQVAJsQJCAMs6A
+G27hsm/zSHDKon89i7lOTdWdwW3ensD128ILh1vyb37k2TnvgMlIpvM=
+-----END RSA PRIVATE KEY-----
+''';


### PR DESCRIPTION
Current autosubmit failures appear to be related to unexpected responses from GitHub, which currently aren't handled. This adds logging when responses don't have the exepcted data, and a specific exception that higher levels could handle (instead of uninitialized `late` variables).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
