### PR TITLE
Replace installation query with user-specific version

### DIFF
--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -193,20 +193,15 @@ class Config {
       'Accept': 'application/vnd.github.machine-man-preview+json',
     };
     // TODO(KristinBi): Upstream the github package.https://github.com/flutter/flutter/issues/100920
-    final Uri githubInstallationUri = Uri.https('api.github.com', 'app/installations');
+    final Uri githubInstallationUri = Uri.https('api.github.com', 'users/${slug.owner}/installation');
     final http.Client client = httpProvider();
     // TODO(KristinBi): Track the installation id by repo. https://github.com/flutter/flutter/issues/100808
     final http.Response response = await client.get(
       githubInstallationUri,
       headers: headers,
     );
-    final List<Map<String, dynamic>> list = (json.decode(response.body) as List<dynamic>).cast<Map<String, dynamic>>();
-    String? installationId;
-    for (Map<String, dynamic> installData in list) {
-      if (installData['account']!['login']!.toString() == slug.owner) {
-        installationId = installData['id']!.toString();
-      }
-    }
+    final Map<String, dynamic> installData = json.decode(response.body) as Map<String, dynamic>;
+    final String? installationId = installData['id']?.toString();
     if (installationId == null) {
       log.warning('Failed to get ID from Github '
           '(response code ${response.statusCode}):\n${response.body}');

--- a/auto_submit/test/service/config_test.dart
+++ b/auto_submit/test/service/config_test.dart
@@ -32,7 +32,7 @@ void main() {
 
     setUp(() {
       cacheProvider = Cache.inMemoryCacheProvider(kCacheSize);
-      mockClient = MockClient((_) async => http.Response(installations, HttpStatus.ok));
+      mockClient = MockClient((_) async => http.Response(userInstallation, HttpStatus.ok));
       config = Config(
         cacheProvider: cacheProvider,
         httpProvider: () => mockClient,
@@ -42,7 +42,7 @@ void main() {
 
     test('verify throws if installations response is unexpected', () async {
       cacheProvider = Cache.inMemoryCacheProvider(kCacheSize);
-      mockClient = MockClient((_) async => http.Response('[]', HttpStatus.internalServerError));
+      mockClient = MockClient((_) async => http.Response('{}', HttpStatus.internalServerError));
       secretManager.put(Config.kGithubKey, _fakeKey);
       secretManager.put(Config.kGithubAppId, '1');
       config = Config(
@@ -64,12 +64,10 @@ void main() {
     });
 
     test('verify github App Installation Id ', () async {
-      final Uri githubInstallationUri = Uri.https('api.github.com', 'app/installations');
+      final Uri githubInstallationUri = Uri.https('api.github.com', 'users/flutter/installation');
       final http.Response response = await mockClient.get(githubInstallationUri);
-      final List<dynamic> list =
-          (json.decode(response.body).map((dynamic data) => (data) as Map<String, dynamic>)).toList() as List<dynamic>;
-      expect(list[0]['id'].toString(), '24369313');
-      expect(list[1]['id'].toString(), '23587612');
+      final Map<String, dynamic> map = json.decode(response.body) as Map<String, dynamic>;
+      expect(map['id'].toString(), '24369313');
     });
 
     test('generateGithubToken pulls from cache', () async {

--- a/auto_submit/test/service/config_test_data.dart
+++ b/auto_submit/test/service/config_test_data.dart
@@ -2,68 +2,63 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-const String installations = '''
-      [
-  {
-    "id": 24369313,
-    "account": {
-      "login": "flutter",
-      "id": 14101776,
-      "node_id": "MDEyOk9yZ2FuaXphdGlvbjE0MTAxNzc2",
-      "avatar_url": "https://avatars.githubusercontent.com/u/14101776?v=4"
-    },
-    "repository_selection": "selected",
-    "app_id": 168178,
-    "app_slug": "auto-submit",
-    "target_id": 14101776,
-    "target_type": "Organization",
-    "permissions": {
-      "checks": "read",
-      "metadata": "read",
-      "single_file": "read",
-      "pull_requests": "read"
-    },
-    "events": [
-      "label",
-      "pull_request"
-    ],
-    "created_at": "2022-03-23T23:00:37.000Z",
-    "updated_at": "2022-03-23T23:00:37.000Z",
-    "single_file_name": ".github/autosubmit.yml",
-    "has_multiple_single_files": false,
-    "single_file_paths": [
-      ".github/autosubmit.yml"
-    ]
+const String userInstallation = '''
+{
+  "id": 24369313,
+  "account": {
+    "login": "flutter",
+    "id": 14101776,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjE0MTAxNzc2",
+    "avatar_url": "https://avatars.githubusercontent.com/u/14101776?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/flutter",
+    "html_url": "https://github.com/flutter",
+    "followers_url": "https://api.github.com/users/flutter/followers",
+    "following_url": "https://api.github.com/users/flutter/following{/other_user}",
+    "gists_url": "https://api.github.com/users/flutter/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/flutter/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/flutter/subscriptions",
+    "organizations_url": "https://api.github.com/users/flutter/orgs",
+    "repos_url": "https://api.github.com/users/flutter/repos",
+    "events_url": "https://api.github.com/users/flutter/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/flutter/received_events",
+    "type": "Organization",
+    "site_admin": false
   },
-  {
-    "id": 23587612,
-    "account": {
-      "login": "CaseyHillers",
-      "id": 2148558,
-      "node_id": "MDQ6VXNlcjIxNDg1NTg=",
-      "avatar_url": "https://avatars.githubusercontent.com/u/2148558?v=4"
-    },
-    "repository_selection": "selected",
-    "app_id": 168178,
-    "app_slug": "auto-submit",
-    "target_id": 2148558,
-    "target_type": "User",
-    "permissions": {
-      "checks": "read",
-      "metadata": "read",
-      "single_file": "read",
-      "pull_requests": "read"
-    },
-    "events": [
-      "label",
-      "pull_request"
-    ],
-    "created_at": "2022-02-24T18:29:28.000Z",
-    "updated_at": "2022-03-23T22:18:46.000Z",
-    "single_file_name": ".github/autosubmit.yml",
-    "has_multiple_single_files": false,
-    "single_file_paths": [
-      ".github/autosubmit.yml"
-    ]
-  }
-]''';
+  "repository_selection": "selected",
+  "access_tokens_url": "https://api.github.com/app/installations/24369313/access_tokens",
+  "repositories_url": "https://api.github.com/installation/repositories",
+  "html_url": "https://github.com/organizations/flutter/settings/installations/24369313",
+  "app_id": 168178,
+  "app_slug": "auto-submit",
+  "target_id": 14101776,
+  "target_type": "Organization",
+  "permissions": {
+    "checks": "read",
+    "issues": "write",
+    "members": "read",
+    "contents": "write",
+    "metadata": "read",
+    "statuses": "read",
+    "workflows": "write",
+    "single_file": "read",
+    "pull_requests": "write",
+    "organization_administration": "read"
+  },
+  "events": [
+    "issue_comment",
+    "label",
+    "pull_request",
+    "push"
+  ],
+  "created_at": "2022-03-23T23:00:37.000Z",
+  "updated_at": "2024-04-01T15:13:03.000Z",
+  "single_file_name": ".github/autosubmit/autosubmit.yml",
+  "has_multiple_single_files": false,
+  "single_file_paths": [
+    ".github/autosubmit/autosubmit.yml"
+  ],
+  "suspended_by": null,
+  "suspended_at": null
+}
+''';


### PR DESCRIPTION
Instead of querying all installations and looking for the one owned by a specific user, use the endpoint that allows requesting the installation for a specific user. This avoids issues with pagination, as well as making the logic for processing the result simpler.

Fixes https://github.com/flutter/flutter/issues/148092

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
