### PR TITLE
Remove team-google-testing from triage

### DIFF
--- a/triage_bot/lib/engine.dart
+++ b/triage_bot/lib/engine.dart
@@ -58,7 +58,6 @@ sealed class GitHubSettings {
     'framework',
     'games',
     'go_router',
-    'google-testing',
     'infra',
     'ios',
     'news',


### PR DESCRIPTION
We are retiring this team. The triage page has already been updated: https://github.com/flutter/flutter/wiki/Triage/_compare/b3c2e735f20bffbe7c8446d64aa5402d01b66aa3...109352c79d1e9b8e837983c55f16f5352e3d4445
