### PR TITLE
Fixed regex for identifying release branches.

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -69,7 +69,7 @@ class Config {
 
   static bool doesSkiaGoldRunOnBranch(gh.RepositorySlug slug, String? branch) {
     if (slug == engineSlug) {
-      final RegExp releaseRegex = RegExp(r'flutter-\d?\.\d?-candidate\.\d?');
+      final RegExp releaseRegex = RegExp(r'flutter-\d+\.\d+-candidate\.\d+');
       return defaultBranch(slug) == branch || (branch != null && releaseRegex.hasMatch(branch));
     } else {
       return defaultBranch(slug) == branch;

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -548,7 +548,7 @@ void main() {
 
         test('runs on engine release branches', () async {
           // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'flutter-3.8-candidate.8');
+          final PullRequest pr = newPullRequest(123, 'abc', 'flutter-3.28-candidate.8');
           enginePrsFromGitHub = <PullRequest>[pr];
           final GithubGoldStatusUpdate status = newStatusUpdate(engineSlug, pr, '', '', '');
           db.values[status.key] = status;


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/149670

This will fix the part of the issue where the golden tests weren't run on the release branch.  There is still setup that needs to add GOLDCTL for the release bot.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
