### PR TITLE
Add macos, linux, windows teams

### DIFF
--- a/triage_bot/lib/engine.dart
+++ b/triage_bot/lib/engine.dart
@@ -60,11 +60,14 @@ sealed class GitHubSettings {
     'go_router',
     'infra',
     'ios',
+    'linux',
+    'macos',
     'news',
     'release',
     'text-input',
     'tool',
     'web',
+    'windows',
   };
   static const int thumbsMinimum = 100; // an issue needs at least this many thumbs up to trigger retriage
   static const double thumbsThreshold = 2.0; // and the count must have increased by this factor since last triage

--- a/triage_bot/lib/engine.dart
+++ b/triage_bot/lib/engine.dart
@@ -52,7 +52,6 @@ sealed class GitHubSettings {
     'android',
     'codelabs',
     'design',
-    'desktop',
     'ecosystem',
     'engine',
     'framework',


### PR DESCRIPTION
The team-desktop label is being replaced by the team-linux, team-macos, team-windows labels in triage. This provides a more granular breakdown for issues and makes it easier for a combined iOS/macOS team to triage both, without also needing to wade through Windows and Linux issues.

As per instructions:
https://github.com/flutter/flutter/blob/master/docs/triage/README.md#adding-a-new-team

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I have no idea who the current maintainers of Cocoon are.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
