### PR TITLE
exclude sky/tools python scripts from needing tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -363,17 +363,19 @@ class GithubWebhookSubscription extends SubscriptionHandler {
   /// Returns true if changes to [filename] are exempt from the testing
   /// requirement, across repositories.
   bool _isTestExempt(String filename) {
+    final bool isBuildPythonScript = (filename.startsWith('sky/tools') && filename.endsWith('.py'));
     return filename.contains('.ci.yaml') ||
-        filename.contains('analysis_options.yaml') ||
-        filename.contains('AUTHORS') ||
-        filename.contains('CODEOWNERS') ||
+        filename.endsWith('analysis_options.yaml') ||
+        filename.endsWith('AUTHORS') ||
+        filename.endsWith('CODEOWNERS') ||
         filename == 'DEPS' ||
-        filename.contains('TESTOWNERS') ||
-        filename.contains('pubspec.yaml') ||
+        filename.endsWith('TESTOWNERS') ||
+        filename.endsWith('pubspec.yaml') ||
         // Exempt categories.
         filename.contains('.github/') ||
         filename.endsWith('.md') ||
         // Exempt paths.
+        isBuildPythonScript ||
         filename.startsWith('dev/devicelab/lib/versions/gallery.dart') ||
         filename.startsWith('dev/integration_tests') ||
         filename.startsWith('docs/') ||

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1499,6 +1499,8 @@ void foo() {
         (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           PullRequestFile()..filename = 'shell/config.gni',
           PullRequestFile()..filename = 'shell/BUILD.gn',
+          PullRequestFile()..filename = 'sky/tools/create_ios_framework.py',
+          PullRequestFile()..filename = 'ci/builders/mac_host_engine.json',
         ]),
       );
 


### PR DESCRIPTION
The sky/tools/*.py files are essentially extensions of our *.gn build files.