### PR TITLE
Add mac_unopt to the list of engine builders that push gold status

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -127,8 +127,9 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           if (const <String>[
             'linux_android_emulator',
             'linux_host_engine',
-            'mac_host_engine',
             'linux_web_engine',
+            'mac_host_engine',
+            'mac_unopt',
           ].any((String shardSubString) => name.contains(shardSubString))) {
             runsGoldenFileTests = true;
           }


### PR DESCRIPTION
Prerequisite for https://github.com/flutter/engine/pull/53571

