### PR TITLE
increase the go docker image version

### DIFF
--- a/app_dart/cloudbuild_app_dart_deploy.yaml
+++ b/app_dart/cloudbuild_app_dart_deploy.yaml
@@ -17,7 +17,8 @@ steps:
           unverified_provenance.json
 
   # Verify provenance is valid before proceeding with deployment.
-  - name: 'golang:1.20'
+  # This name is a dockerhub tag
+  - name: 'golang:1.22.5-bookworm'
     entrypoint: '/bin/bash'
     args:
       - '-c'


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/152394
Because the slsa-verifier transitively depends on at least go sdk version 1.21