### PR TITLE
Add tools/clangd_check to test exempt paths

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -383,7 +383,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('impeller/golden_tests') ||
         filename.startsWith('impeller/playground') ||
         filename.startsWith('shell/platform/embedder/tests') ||
-        filename.startsWith('shell/platform/embedder/fixtures');
+        filename.startsWith('shell/platform/embedder/fixtures') ||
+        filename.startsWith('tools/clangd_check');
   }
 
   Future<void> _applyEngineRepoLabels(GitHub gitHubClient, String? eventAction, PullRequest pr) async {

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -665,6 +665,7 @@ void main() {
           PullRequestFile()..filename = 'impeller/playground/playground.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/tests/embedder_test_context.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/fixtures/main.dart',
+          PullRequestFile()..filename = 'tools/clangd_check/bin/main.dart',
         ]),
       );
 


### PR DESCRIPTION
This tool is used as a test to verify that clangd workds correctly with compile_commands.json.

This is currently run as a test in these shards:
* [ci/builders/linux_unopt_debug_no_rbe.json](https://github.com/flutter/engine/blob/b192a52072812804f88b4dd1cb75dec418f025af/ci/builders/linux_unopt_debug_no_rbe.json#L30-L40)
* [ci/builders/mac_unopt_debug_no_rbe.json](https://github.com/flutter/engine/blob/b192a52072812804f88b4dd1cb75dec418f025af/ci/builders/mac_unopt_debug_no_rbe.json#L41-L51)


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
