### PR TITLE
Signal `flutter-gold` when `flutter_driver_android_test` runs.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -135,6 +135,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           }
         } else if (slug == Config.flutterSlug) {
           if (const <String>[
+            'flutter_driver_android_test',
             'framework',
             'misc',
           ].any((String shardSubString) => name.contains(shardSubString))) {


### PR DESCRIPTION
I [added this task a few weeks ago](https://github.com/flutter/flutter/blob/309ae21448521b18a4cc90e3db435089a6dbc3cb/.ci.yaml#L1346-L1356) but forgot to update this allow list.