### PR TITLE
iOS,macOS: Refactor code-signing code, fix logging

### DIFF
--- a/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
+++ b/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
@@ -81,8 +81,10 @@ class FileCodesignVisitor {
   late String appSpecificPassword;
   // Team-id is used by notary service for xcode version 13+.
   late String codesignTeamId;
+
   /// Files that require codesigning that use APIs requiring entitlements.
   Set<String> withEntitlementsFiles = <String>{};
+
   /// Files that require codesigning that DO NOT use APIs requiring entitlements.
   Set<String> withoutEntitlementsFiles = <String>{};
   Set<String> fileConsumed = <String>{};

--- a/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
+++ b/cipd_packages/codesign/lib/src/file_codesign_visitor.dart
@@ -23,6 +23,19 @@ enum NotaryStatus {
   succeeded,
 }
 
+/// Types of codesigning configuration file.
+enum CodesignType {
+  /// Binaries requiring codesigning that do not use APIs requiring entitlements.
+  withEntitlements(filename: 'entitlements.txt'),
+
+  /// Binaries requiring codesigning that DO NOT use APIs requiring entitlements.
+  withoutEntitlements(filename: 'without_entitlements.txt');
+
+  const CodesignType({required this.filename});
+
+  final String filename;
+}
+
 /// Codesign and notarize all files within a [RemoteArchive].
 class FileCodesignVisitor {
   FileCodesignVisitor({
@@ -68,9 +81,10 @@ class FileCodesignVisitor {
   late String appSpecificPassword;
   // Team-id is used by notary service for xcode version 13+.
   late String codesignTeamId;
-
-  Set<String> fileWithEntitlements = <String>{};
-  Set<String> fileWithoutEntitlements = <String>{};
+  /// Files that require codesigning that use APIs requiring entitlements.
+  Set<String> withEntitlementsFiles = <String>{};
+  /// Files that require codesigning that DO NOT use APIs requiring entitlements.
+  Set<String> withoutEntitlementsFiles = <String>{};
   Set<String> fileConsumed = <String>{};
   Set<String> directoriesVisited = <String>{};
   Map<String, String> availablePasswords = {
@@ -183,11 +197,11 @@ update these file paths accordingly.
       processManager: processManager,
     );
 
-    //extract entitlements file.
-    fileWithEntitlements = await parseEntitlements(parentDirectory, true);
-    fileWithoutEntitlements = await parseEntitlements(parentDirectory, false);
-    log.info('parsed binaries with entitlements are $fileWithEntitlements');
-    log.info('parsed binaries without entitlements are $fileWithEntitlements');
+    // Read codesigning configuration files.
+    withEntitlementsFiles = await parseCodesignConfig(parentDirectory, CodesignType.withEntitlements);
+    withoutEntitlementsFiles = await parseCodesignConfig(parentDirectory, CodesignType.withoutEntitlements);
+    log.info('parsed binaries with entitlements are $withEntitlementsFiles');
+    log.info('parsed binaries without entitlements are $withoutEntitlementsFiles');
 
     // recursively visit extracted files
     await visitDirectory(directory: parentDirectory, parentVirtualPath: '');
@@ -222,7 +236,7 @@ update these file paths accordingly.
     }
     directoriesVisited.add(directory.absolute.path);
 
-    await cleanupEntitlements(directory);
+    await cleanupCodesignConfig(directory);
 
     final List<FileSystemEntity> entities = await directory.list(followLinks: false).toList();
     for (FileSystemEntity entity in entities) {
@@ -293,7 +307,7 @@ update these file paths accordingly.
   /// Visit and codesign a binary with / without entitlement.
   ///
   /// At this stage, the virtual [entitlementCurrentPath] accumulated through the recursive visit, is compared
-  /// against the paths extracted from [fileWithEntitlements], to help determine if this file should be signed
+  /// against the paths extracted from [withEntitlementsFiles], to help determine if this file should be signed
   /// with entitlements.
   Future<void> visitBinaryFile({
     required File binaryFile,
@@ -302,8 +316,8 @@ update these file paths accordingly.
     final String currentFileName = binaryFile.basename;
     final String entitlementCurrentPath = joinEntitlementPaths(parentVirtualPath, currentFileName);
 
-    if (!fileWithEntitlements.contains(entitlementCurrentPath) &&
-        !fileWithoutEntitlements.contains(entitlementCurrentPath)) {
+    if (!withEntitlementsFiles.contains(entitlementCurrentPath) &&
+        !withoutEntitlementsFiles.contains(entitlementCurrentPath)) {
       log.severe('the binary file $currentFileName is causing an issue. \n'
           'This file is located at $entitlementCurrentPath in the flutter engine artifact.');
       log.severe('The system has detected a binary file at $entitlementCurrentPath. '
@@ -313,7 +327,7 @@ update these file paths accordingly.
     }
     log.info('signing file at path ${binaryFile.absolute.path}');
     log.info('the virtual entitlement path associated with file is $entitlementCurrentPath');
-    log.info('the decision to sign with entitlement is ${fileWithEntitlements.contains(entitlementCurrentPath)}');
+    log.info('the decision to sign with entitlement is ${withEntitlementsFiles.contains(entitlementCurrentPath)}');
     fileConsumed.add(entitlementCurrentPath);
     if (dryrun) {
       return;
@@ -335,7 +349,7 @@ update these file paths accordingly.
       binaryOrBundlePath,
       '--timestamp', // add a secure timestamp
       '--options=runtime', // hardened runtime
-      if (entitlementCurrentPath != '' && fileWithEntitlements.contains(entitlementCurrentPath)) ...<String>[
+      if (entitlementCurrentPath != '' && withEntitlementsFiles.contains(entitlementCurrentPath)) ...<String>[
         '--entitlements',
         entitlementsFile.absolute.path,
       ],
@@ -360,7 +374,7 @@ update these file paths accordingly.
   ///
   /// Context: https://github.com/flutter/flutter/issues/126705. This is a temporary workaround.
   /// Once flutter tools is ready we can remove this logic.
-  Future<void> cleanupEntitlements(Directory parent) async {
+  Future<void> cleanupCodesignConfig(Directory parent) async {
     final String metadataEntitlements = fileSystem.path.join(parent.path, 'entitlements.txt');
     final String metadataWithoutEntitlements = fileSystem.path.join(parent.path, 'without_entitlements.txt');
     for (String metadataPath in [metadataEntitlements, metadataWithoutEntitlements]) {
@@ -374,14 +388,12 @@ update these file paths accordingly.
   /// Extract entitlements configurations from downloaded zip files.
   ///
   /// Parse and store codesign configurations detailed in configuration files.
-  /// File paths of entilement files and non entitlement files will be parsed and stored in [fileWithEntitlements].
-  Future<Set<String>> parseEntitlements(Directory parent, bool entitlements) async {
-    final String entitlementFilePath = entitlements
-        ? fileSystem.path.join(parent.path, 'entitlements.txt')
-        : fileSystem.path.join(parent.path, 'without_entitlements.txt');
-    if (!(await fileSystem.file(entitlementFilePath).exists())) {
-      log.warning('$entitlementFilePath not found. '
-          'by default, system will assume there is no ${entitlements ? '' : 'without_'}entitlements file. '
+  /// File paths of entitlement files and non entitlement files will be parsed and stored in [withEntitlementsFiles].
+  Future<Set<String>> parseCodesignConfig(Directory parent, CodesignType codesignType) async {
+    final String codesignConfigPath = fileSystem.path.join(parent.path, codesignType.filename);
+    if (!(await fileSystem.file(codesignConfigPath).exists())) {
+      log.warning('$codesignConfigPath not found. '
+          'by default, system will assume there is no ${codesignType.filename} file. '
           'As a result, no binary will be codesigned.'
           'if this is not intended, please provide them along with the engine artifacts.');
       return <String>{};
@@ -389,10 +401,10 @@ update these file paths accordingly.
 
     final Set<String> fileWithEntitlements = <String>{};
 
-    fileWithEntitlements.addAll(await fileSystem.file(entitlementFilePath).readAsLines());
+    fileWithEntitlements.addAll(await fileSystem.file(codesignConfigPath).readAsLines());
     // TODO(xilaizhang) : add back metadata information after https://github.com/flutter/flutter/issues/126705
     // is resolved.
-    await fileSystem.file(entitlementFilePath).delete();
+    await fileSystem.file(codesignConfigPath).delete();
 
     return fileWithEntitlements;
   }

--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -660,8 +660,8 @@ void main() {
       codesignVisitor.appSpecificPassword = randomString;
       codesignVisitor.codesignAppstoreId = randomString;
       codesignVisitor.codesignTeamId = randomString;
-      codesignVisitor.fileWithEntitlements = <String>{'root/folder_a/file_a'};
-      codesignVisitor.fileWithoutEntitlements = <String>{'root/folder_b/file_b'};
+      codesignVisitor.withEntitlementsFiles = <String>{'root/folder_a/file_a'};
+      codesignVisitor.withoutEntitlementsFiles = <String>{'root/folder_b/file_b'};
       fileSystem
         ..file('${rootDirectory.path}/remote_zip_6/folder_a/file_a').createSync(recursive: true)
         ..file('${rootDirectory.path}/remote_zip_6/folder_b/file_b').createSync(recursive: true);
@@ -771,13 +771,13 @@ file_e''',
           mode: FileMode.append,
           encoding: utf8,
         );
-      final Set<String> fileWithEntitlements = await codesignVisitor.parseEntitlements(
+      final Set<String> fileWithEntitlements = await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement'),
-        true,
+        cs.CodesignType.withEntitlements,
       );
-      final Set<String> fileWithoutEntitlements = await codesignVisitor.parseEntitlements(
+      final Set<String> fileWithoutEntitlements = await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement'),
-        false,
+        cs.CodesignType.withoutEntitlements,
       );
       expect(fileWithEntitlements.length, 3);
       expect(
@@ -809,9 +809,9 @@ file_c''',
           encoding: utf8,
         );
 
-      final Set<String> fileWithEntitlements = await codesignVisitor.parseEntitlements(
+      final Set<String> fileWithEntitlements = await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement_2'),
-        true,
+        cs.CodesignType.withEntitlements,
       );
       expect(fileWithEntitlements.length, 3);
       expect(
@@ -822,9 +822,9 @@ file_c''',
           'file_c',
         ]),
       );
-      await codesignVisitor.parseEntitlements(
+      await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement_2'),
-        false,
+        cs.CodesignType.withoutEntitlements,
       );
       final List<String> messages = records
           .where((LogRecord record) => record.level == Level.WARNING)
@@ -833,7 +833,7 @@ file_c''',
       expect(
         messages,
         contains('${rootDirectory.absolute.path}/test_entitlement_2/without_entitlements.txt not found. '
-            'by default, system will assume there is no without_entitlements file. '
+            'by default, system will assume there is no without_entitlements.txt file. '
             'As a result, no binary will be codesigned.'
             'if this is not intended, please provide them along with the engine artifacts.'),
       );


### PR DESCRIPTION
This patch:
* Fixes incorrect logging of the without_entitlements.txt content.
* extracts an enum of code-signing types rather than passing as a boolean, which will allow us to add `CodesignType.unsigned` in a followup patch.
* Renames some identifiers to focus on code-signing rather than entitlements, for readability.
* Improves doc comments.

Issue: https://github.com/flutter/flutter/issues/154571

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
