### PR TITLE
dart_test_runner: output expected dart format args

### DIFF
--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -8,17 +8,25 @@
 
 set -e
 
-# Build and analyze
 echo "###### dart_test_runner #######"
 echo "Directory: $1"
+
+if [ -z "$1" ]; then
+  echo "ERROR: no package directory supplied."
+  echo "usage: $0 PACKAGE_DIR_TO_TEST"
+  exit 1
+fi
+
+# Setup.
 pushd "$1" > /dev/null
 flutter clean
 dart pub get
 
 # TODO(drewroengoogle): Validate proto code has been generated. https://github.com/flutter/flutter/issues/115473
 
-echo "######### dart format #########"
-dart format --set-exit-if-changed --line-length=120 .
+FORMAT_ARGS=--line-length=120
+echo "######### dart format $FORMAT_ARGS #########"
+dart format --set-exit-if-changed $FORMAT_ARGS .
 
 echo "########### analyze ###########"
 dart analyze --fatal-infos

--- a/test_utilities/bin/dart_test_runner.sh
+++ b/test_utilities/bin/dart_test_runner.sh
@@ -6,7 +6,7 @@
 # Runner for dart tests. It expects a single parameter with the full
 # path to the start folder where tests will be run.
 
-set -e
+set -euo pipefail
 
 echo "###### dart_test_runner #######"
 echo "Directory: $1"


### PR DESCRIPTION
Currently on a failed run due to unformatted dart code, the output looks like:

    ######### dart format #########
    Formatted lib/src/file_codesign_visitor.dart
    Formatted 10 files (1 changed) in 0.65 seconds.

In the face of this output, my natural inclination would be to run

    dart format path/to/file

but that would be incorrect. What would be correct would be to locate our CI test script, read the code, and discover that we format to a width of 120 characters, then format with those args. 

Instead, we now inform the user of the args directly in the test output to save them some digging.

Also checks to see the user actually supplied an argument to the script and if not, emits an error message and usage info then fails, rather than silently running  `pushd ""`, resulting in no change to PWD, then failing when it realises that the top level of the repo is not a pub package.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I do not like it Sam-I-Am, I do not like cocoon log spam.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
