### PR TITLE
iOS,macOS: Skip codesigning files in unsigned_binaries.txt

### DIFF
--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -662,9 +662,11 @@ void main() {
       codesignVisitor.codesignTeamId = randomString;
       codesignVisitor.withEntitlementsFiles = <String>{'root/folder_a/file_a'};
       codesignVisitor.withoutEntitlementsFiles = <String>{'root/folder_b/file_b'};
+      codesignVisitor.unsignedBinaryFiles = <String>{'root/folder_c/file_c'};
       fileSystem
         ..file('${rootDirectory.path}/remote_zip_6/folder_a/file_a').createSync(recursive: true)
-        ..file('${rootDirectory.path}/remote_zip_6/folder_b/file_b').createSync(recursive: true);
+        ..file('${rootDirectory.path}/remote_zip_6/folder_b/file_b').createSync(recursive: true)
+        ..file('${rootDirectory.path}/remote_zip_6/folder_c/file_c').createSync(recursive: true);
       final Directory testDirectory = fileSystem.directory('${rootDirectory.path}/remote_zip_6');
       processManager.addCommands(<FakeCommand>[
         FakeCommand(
@@ -713,6 +715,15 @@ void main() {
             '--options=runtime',
           ],
         ),
+        FakeCommand(
+          command: <String>[
+            'file',
+            '--mime-type',
+            '-b',
+            '${rootDirectory.absolute.path}/remote_zip_6/folder_c/file_c',
+          ],
+          stdout: 'application/x-mach-binary',
+        ),
       ]);
       await codesignVisitor.visitDirectory(
         directory: testDirectory,
@@ -722,13 +733,18 @@ void main() {
           .where((LogRecord record) => record.level == Level.INFO)
           .map((LogRecord record) => record.message)
           .toList();
-      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a'));
-      expect(messages, contains('the virtual entitlement path associated with file is root/folder_a/file_a'));
-      expect(messages, contains('the decision to sign with entitlement is true'));
+      expect(messages, contains('Signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_a/file_a'));
+      expect(messages, contains('The virtual entitlement path associated with file is root/folder_a/file_a'));
+      expect(messages, contains('The decision to sign with entitlement is true'));
 
-      expect(messages, contains('signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b'));
-      expect(messages, contains('the virtual entitlement path associated with file is root/folder_b/file_b'));
-      expect(messages, contains('the decision to sign with entitlement is false'));
+      expect(messages, contains('Signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_b/file_b'));
+      expect(messages, contains('The virtual entitlement path associated with file is root/folder_b/file_b'));
+      expect(messages, contains('The decision to sign with entitlement is false'));
+
+      expect(
+        messages,
+        contains('Not signing file at path ${rootDirectory.absolute.path}/remote_zip_6/folder_c/file_c'),
+      );
     });
   });
 


### PR DESCRIPTION
This updates the code-signing workflow to account for iOS and macOS binaries in the artifact cache that are _expected_ to not be codesigned.

In https://github.com/flutter/engine/pull/54414 we started bundling dSYM (debugging symbols) within Flutter.xcframework, a requirement for App Store verification using Xcode 16.

We did the same for macOS in https://github.com/flutter/engine/pull/54696.

Unlike the framework dylib, dSYM contents are not directly codesigned (though the xcframework containing them is). This skips code-signing for files found in `unsigned_binaries.txt`, which will be added in a followup patch to the framework artifact archive creation scripts in engine:
* `sky/tools/create_ios_framework.py`
* `sky/tools/create_macos_framework.py`

Issue: https://github.com/flutter/flutter/issues/154571


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
