### PR TITLE
iOS,macOS: Clean up unsigned_binaries.txt

### DIFF
--- a/cipd_packages/codesign/test/file_codesign_visitor_test.dart
+++ b/cipd_packages/codesign/test/file_codesign_visitor_test.dart
@@ -136,7 +136,8 @@ void main() {
           ],
           onRun: () => fileSystem
             ..file('${rootDirectory.path}/single_artifact/entitlements.txt').createSync(recursive: true)
-            ..file('${rootDirectory.path}/single_artifact/without_entitlements.txt').createSync(recursive: true),
+            ..file('${rootDirectory.path}/single_artifact/without_entitlements.txt').createSync(recursive: true)
+            ..file('${rootDirectory.path}/single_artifact/unsigned_binaries.txt').createSync(recursive: true),
         ),
         FakeCommand(
           command: <String>[
@@ -787,6 +788,15 @@ file_e''',
           mode: FileMode.append,
           encoding: utf8,
         );
+
+      fileSystem.file('${rootDirectory.absolute.path}/test_entitlement/unsigned_binaries.txt')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(
+          '''file_f
+file_g''',
+          mode: FileMode.append,
+          encoding: utf8,
+        );
       final Set<String> fileWithEntitlements = await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement'),
         cs.CodesignType.withEntitlements,
@@ -794,6 +804,10 @@ file_e''',
       final Set<String> fileWithoutEntitlements = await codesignVisitor.parseCodesignConfig(
         fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement'),
         cs.CodesignType.withoutEntitlements,
+      );
+      final Set<String> fileUnsigned = await codesignVisitor.parseCodesignConfig(
+        fileSystem.directory('${rootDirectory.absolute.path}/test_entitlement'),
+        cs.CodesignType.unsigned,
       );
       expect(fileWithEntitlements.length, 3);
       expect(
@@ -810,6 +824,15 @@ file_e''',
         containsAll(<String>[
           'file_d',
           'file_e',
+        ]),
+      );
+
+      expect(fileUnsigned.length, 2);
+      expect(
+        fileUnsigned,
+        containsAll(<String>[
+          'file_f',
+          'file_g',
         ]),
       );
     });


### PR DESCRIPTION
Also cleans up a few more hard-coded filenames and adds more tests.

Also clarified `entitlementsPlist` rather than `entitlementsFile` since we have several things that could legitimately be called entitlements files.

Issue: https://github.com/flutter/flutter/issues/154571

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
