### PR TITLE
Filtered Android tasks should include mokey and pixel 7 pro in dashboard

### DIFF
--- a/dashboard/lib/logic/task_grid_filter.dart
+++ b/dashboard/lib/logic/task_grid_filter.dart
@@ -177,6 +177,7 @@ class TaskGridFilter extends FilterPropertySource {
       'ios': _allProperties['showiOS']?.value ?? false,
       'android': showAndroid,
       'mokey': showAndroid,
+      'pixel_7pro': showAndroid,
       'mac': _allProperties['showMac']?.value ?? false,
       'windows': _allProperties['showWindows']?.value ?? false,
       'linux': _allProperties['showLinux']?.value ?? false,

--- a/dashboard/lib/logic/task_grid_filter.dart
+++ b/dashboard/lib/logic/task_grid_filter.dart
@@ -172,9 +172,11 @@ class TaskGridFilter extends FilterPropertySource {
       return false;
     }
 
+    final bool showAndroid = _allProperties['showAndroid']?.value ?? false;
     final LinkedHashMap<String, bool> orderedOSFilter = LinkedHashMap<String, bool>.of({
       'ios': _allProperties['showiOS']?.value ?? false,
-      'android': _allProperties['showAndroid']?.value ?? false,
+      'android': showAndroid,
+      'mokey': showAndroid,
       'mac': _allProperties['showMac']?.value ?? false,
       'windows': _allProperties['showWindows']?.value ?? false,
       'linux': _allProperties['showLinux']?.value ?? false,

--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 import 'build_dashboard_page.dart';

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -51,9 +51,8 @@ class TaskIcon extends StatelessWidget {
     final String matchedName = qualifiedTask.task!.toLowerCase();
     final bool isWebTest = matchedName.contains('_web') || matchedName.contains('web_');
     final bool isToolTest = matchedName.contains('_tool') || matchedName.contains('tool_');
-    final bool isAndroidTest = matchedName.contains('_android') ||
-        matchedName.contains('_mokey') ||
-        matchedName.contains('_pixel_7pro');
+    final bool isAndroidTest =
+        matchedName.contains('_android') || matchedName.contains('_mokey') || matchedName.contains('_pixel_7pro');
 
     if (matchedName.contains('_fuchsia')) {
       return Padding(

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -51,7 +51,9 @@ class TaskIcon extends StatelessWidget {
     final String matchedName = qualifiedTask.task!.toLowerCase();
     final bool isWebTest = matchedName.contains('_web') || matchedName.contains('web_');
     final bool isToolTest = matchedName.contains('_tool') || matchedName.contains('tool_');
-    final bool isAndroidTest = matchedName.contains('_android') || matchedName.contains('_mokey');
+    final bool isAndroidTest = matchedName.contains('_android') ||
+        matchedName.contains('_mokey') ||
+        matchedName.contains('_pixel_7pro');
 
     if (matchedName.contains('_fuchsia')) {
       return Padding(

--- a/dashboard/lib/widgets/task_icon.dart
+++ b/dashboard/lib/widgets/task_icon.dart
@@ -51,6 +51,7 @@ class TaskIcon extends StatelessWidget {
     final String matchedName = qualifiedTask.task!.toLowerCase();
     final bool isWebTest = matchedName.contains('_web') || matchedName.contains('web_');
     final bool isToolTest = matchedName.contains('_tool') || matchedName.contains('tool_');
+    final bool isAndroidTest = matchedName.contains('_android') || matchedName.contains('_mokey');
 
     if (matchedName.contains('_fuchsia')) {
       return Padding(
@@ -68,7 +69,7 @@ class TaskIcon extends StatelessWidget {
           color: blendFilter,
         ),
       );
-    } else if (matchedName.contains('_android')) {
+    } else if (isAndroidTest) {
       return Icon(
         Icons.android,
         color: blendFilter,

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -232,12 +232,15 @@ void main() {
     expect(macIosBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Mac_ios')), true);
     expect(macIosBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Mac')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
+    expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux')), false);
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), false);
+    expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), false);
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux')), true);
     expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
-    expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
+    expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_android')), true);
+    expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_mokey')), true);
     expect(androidFalseFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Anything_android')), false);
   });
 

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -242,7 +242,8 @@ void main() {
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux')), true);
     expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
     expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), true);
-    expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_pixel_7pro')), true);
+    expect(
+        linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_pixel_7pro')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_android')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_mokey')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_pixel_7pro')), true);

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -233,14 +233,19 @@ void main() {
     expect(macIosBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Mac')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), true);
+    expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_pixel_7pro')), true);
+    expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux pixel_test')), false);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux')), false);
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), false);
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), false);
+    expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_pixel_7pro')), false);
     expect(linuxAndroidFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux')), true);
     expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_android')), true);
     expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_mokey')), true);
+    expect(linuxAndroidBothTrueFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Linux_pixel_7pro')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_android')), true);
     expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_mokey')), true);
+    expect(androidLinuxFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Windows_pixel_7pro')), true);
     expect(androidFalseFilter.matchesTask(QualifiedTask.fromTask(Task()..builderName = 'Anything_android')), false);
   });
 

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -878,5 +878,10 @@ Future<void> expectTaskBoxColorWithMessage(WidgetTester tester, String message, 
   expect(pixels!.lengthInBytes, (cellPixelArea * 4).round());
   const double padding = 4.0;
   final int rgba = pixels.getUint32((((cellPixelSize * (cellSize + padding)) + cellSize + padding).ceil()) * 4);
-  expect((rgba >> 8) | (rgba << 24) & 0xFFFFFFFF, expectedColor.value);
+  final Color actualColor = Color((rgba >> 8) | (rgba << 24) & 0xFFFFFFFF);
+  if (expectedColor is MaterialColor) {
+    expect(actualColor, expectedColor.shade500);
+  } else {
+    expect(actualColor, expectedColor);
+  }
 }

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -879,9 +879,5 @@ Future<void> expectTaskBoxColorWithMessage(WidgetTester tester, String message, 
   const double padding = 4.0;
   final int rgba = pixels.getUint32((((cellPixelSize * (cellSize + padding)) + cellSize + padding).ceil()) * 4);
   final Color actualColor = Color((rgba >> 8) | (rgba << 24) & 0xFFFFFFFF);
-  if (expectedColor is MaterialColor) {
-    expect(actualColor, expectedColor.shade500);
-  } else {
-    expect(actualColor, expectedColor);
-  }
+  expect(actualColor, isSameColorAs(expectedColor));
 }

--- a/dashboard/test/widgets/task_icon_test.dart
+++ b/dashboard/test/widgets/task_icon_test.dart
@@ -141,15 +141,23 @@ void main() {
     await tester.pumpWidget(
       const MaterialApp(
         home: Material(
-          child: TaskIcon(
-            qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_android test', pool: 'luci.flutter.prod'),
+          child: Column(
+            children: <Widget>[
+              TaskIcon(
+                qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_android test'),
+              ),
+              TaskIcon(
+                qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_pixel_7pro test'),
+              ),
+              TaskIcon(
+                qualifiedTask: QualifiedTask(stage: 'chromebot', task: 'Windows_mokey test'),
+              ),
+            ],
           ),
         ),
       ),
     );
-
-    expect(tester.widget(find.byType(Icon)) as Icon, isInstanceOf<Icon>());
-    expect((tester.widget(find.byType(Icon)) as Icon).icon!.codePoint, const Icon(Icons.android).icon!.codePoint);
+    expect(find.byIcon(Icons.android), findsExactly(3));
   });
 
   testWidgets('TaskIcon shows the right icon for LUCI mac', (WidgetTester tester) async {


### PR DESCRIPTION
Update the dashboard so "mokey" and "pixel_7pro"  tasks are filtered/iconed as Android.  https://github.com/flutter/flutter/issues/148085

For example, `Linux_mokey old_gallery__transition_perf` should show up in the dashboard as an Android test, but its icon and filtering counts it as a Linux test:

![Screenshot 2024-09-12 at 9 57 52 AM](https://github.com/user-attachments/assets/b2a090aa-28e3-4495-b781-0717723d318f)
![Screenshot 2024-09-12 at 9 57 48 AM](https://github.com/user-attachments/assets/1aa929d1-045d-49e1-93b4-6cc1fe2f24d9)

Also fix two unrelated warnings.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
