### PR TITLE
Mark `flutter create` pubspec templates as test exempt

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -371,6 +371,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename == 'DEPS' ||
         filename.endsWith('TESTOWNERS') ||
         filename.endsWith('pubspec.yaml') ||
+        filename.endsWith('pubspec.yaml.tmpl') ||
         // Exempt categories.
         filename.contains('.github/') ||
         filename.endsWith('.md') ||


### PR DESCRIPTION
The templates are tested in https://github.com/flutter/flutter/blob/main/packages/flutter_tools/test/commands.shard/permeable/create_test.dart by creating and analyzing them, so any issue with changed dependencies or pubspec format would be caught.