### PR TITLE
explain Github token TTL value

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -401,7 +401,8 @@ class Config {
       configCacheName,
       'githubToken-${slug.fullName}',
       createFn: () => _generateGithubToken(slug),
-      // Tokens are minted for 10 minutes
+      // Tokens are minted for 10 minutes, so expire them earlier (in 8 min),
+      // before the token becomes unusable.
       ttl: const Duration(minutes: 8),
     );
 


### PR DESCRIPTION
Without an explanation it's not clear why we pass 8 minutes right after mentioning 10 minutes in the comment.