### PR TITLE
add a required "CI tasks" check that locks the merge queue

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -463,9 +463,7 @@ class Scheduler {
       slug,
       headSha,
       lock,
-      conclusion == CheckRunConclusion.success
-        ? null
-        : 'Some checks failed',
+      conclusion == CheckRunConclusion.success ? null : 'Some checks failed',
     );
 
     log.info('Finished Simulating merge group checks for @ $headSha');

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2458,7 +2458,7 @@ void foo() {
           status: CheckRunStatus.completed,
           conclusion: CheckRunConclusion.success,
         ),
-      ).called(1);
+      ).called(2);
 
       expect(
         records,
@@ -2467,6 +2467,7 @@ void foo() {
           'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'All required CI tasks passed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );
@@ -2516,6 +2517,8 @@ void foo() {
           'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Some required CI tasks failed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Some checks failed',
           'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );


### PR DESCRIPTION
Because the MQ only waits for "required" checks to pass before merging PRs and merge groups, at least one required check is needed that stays in pending state while all other (non-required) checks pass. Required checks cannot be added dynamically. They are pre-configured in the repositories settings. The "CI tasks" check is that one pre-configured required check whose status is used as a proxy for "the status of all other checks".