### PR TITLE
apply the "CI tasks" check to all repos

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -242,10 +242,10 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     // https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group
     log.fine('Processing $action for merge queue @ $headSha');
     switch (action) {
-      // A merge group (a group of PRs to be tested a merged together) was
+      // A merge group (a group of PRs to be tested and merged together) was
       // created and Github is requesting checks to be performed before merging
       // into the main branch. Cocoon should kick off CI jobs needed to verify
-      // the PR group.
+      // the PR group against the `head_sha` of the merge group.
       case 'checks_requested':
         log.fine('Simulating checks requests for merge queue @ $headSha');
         await scheduler.triggerMergeGroupTargets(mergeGroupEvent: mergeGroupEvent);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -959,7 +959,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kCiTasksName,
+            const CheckRunOutput(
+              title: Scheduler.kCiTasksName,
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -983,7 +988,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object>[
+            Scheduler.kCiTasksName,
+            const CheckRunOutput(
+              title: Scheduler.kCiTasksName,
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+            ),
             Scheduler.kCiYamlCheckName,
             // No other targets should be created.
             const CheckRunOutput(
@@ -1089,7 +1099,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kCiTasksName,
+            const CheckRunOutput(
+              title: Scheduler.kCiTasksName,
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -1112,7 +1127,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kCiTasksName,
+            const CheckRunOutput(
+              title: Scheduler.kCiTasksName,
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -1141,7 +1161,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.success],
+          <Object>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.success,
+            CheckRunStatus.completed,
+            CheckRunConclusion.success,
+          ],
         );
       });
 
@@ -1164,7 +1189,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.failure],
+          <Object>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+          ],
         );
       });
 
@@ -1182,7 +1212,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.failure],
+          <Object>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+          ],
         );
       });
 

--- a/auto_submit/lib/requests/github_webhook.dart
+++ b/auto_submit/lib/requests/github_webhook.dart
@@ -53,8 +53,6 @@ class GithubWebhook extends RequestHandler {
       throw const Forbidden();
     }
 
-    bool hasAutosubmit = false;
-    bool hasRevertLabel = false;
     final String rawBody = utf8.decode(requestBytes);
     final Map<String, dynamic> body = json.decode(rawBody) as Map<String, dynamic>;
 
@@ -67,8 +65,8 @@ class GithubWebhook extends RequestHandler {
     final String action = body[GithubWebhook.action];
     final User sender = User.fromJson(body[GithubWebhook.sender] as Map<String, dynamic>);
 
-    hasAutosubmit = pullRequest.labels!.any((label) => label.name == Config.kAutosubmitLabel);
-    hasRevertLabel =
+    final bool hasAutosubmit = pullRequest.labels!.any((label) => label.name == Config.kAutosubmitLabel);
+    final bool hasRevertLabel =
         pullRequest.labels!.any((label) => label.name == Config.kRevertLabel || label.name == Config.kRevertOfLabel);
 
     // Check for revert label first.


### PR DESCRIPTION
It should be safe to apply the "CI tasks" to all repos.

In repos that are not yet configured to use MQ, it will simply appear as an extra check on every PR that completes together with "ci.yaml validation", which shouldn't be disruptive.

Repos that are configured to use MQ will have this check configured as required, and this code will simply complete it as normal both in the PR and in the merge queue.