### PR TITLE
Scheduler ci yaml merge

### DIFF
--- a/app_dart/.vscode/settings.json
+++ b/app_dart/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dart.lineLength": 120
+}

--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -39,12 +39,15 @@ Future<void> main() async {
     // Gerrit service class to communicate with GoB.
     final GerritService gerritService = GerritService(config: config);
 
+    final fusionTester = FusionTester();
+
     /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
     final Scheduler scheduler = Scheduler(
       cache: cache,
       config: config,
       githubChecksService: githubChecksService,
       luciBuildService: luciBuildService,
+      fusionTester: fusionTester,
     );
 
     final BranchService branchService = BranchService(

--- a/app_dart/bin/local_server.dart
+++ b/app_dart/bin/local_server.dart
@@ -46,12 +46,15 @@ Future<void> main() async {
   // Gerrit service class to communicate with GoB.
   final GerritService gerritService = GerritService(config: config);
 
+  final fusionTester = FusionTester();
+
   /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
   final Scheduler scheduler = Scheduler(
     cache: cache,
     config: config,
     githubChecksService: githubChecksService,
     luciBuildService: luciBuildService,
+    fusionTester: fusionTester,
   );
 
   final BranchService branchService = BranchService(

--- a/app_dart/bin/validate_scheduler_config.dart
+++ b/app_dart/bin/validate_scheduler_config.dart
@@ -24,7 +24,7 @@ void main(List<String> args) async {
   final YamlMap configYaml = loadYaml(configFile.readAsStringSync()) as YamlMap;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
   print(
-    CiYamlInner(
+    CiYaml(
       type: CiType.any,
       slug: Config.flutterSlug,
       branch: Config.defaultBranch(Config.flutterSlug),

--- a/app_dart/bin/validate_scheduler_config.dart
+++ b/app_dart/bin/validate_scheduler_config.dart
@@ -24,7 +24,8 @@ void main(List<String> args) async {
   final YamlMap configYaml = loadYaml(configFile.readAsStringSync()) as YamlMap;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
   print(
-    CiYaml(
+    CiYamlInner(
+      type: CiType.any,
       slug: Config.flutterSlug,
       branch: Config.defaultBranch(Config.flutterSlug),
       config: unCheckedSchedulerConfig,

--- a/app_dart/integration_test/validate_all_ci_configs_test.dart
+++ b/app_dart/integration_test/validate_all_ci_configs_test.dart
@@ -36,7 +36,8 @@ Future<void> main() async {
       final YamlMap configYaml = loadYaml(configContent) as YamlMap;
       final pb.SchedulerConfig currentSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
       try {
-        CiYaml(
+        CiYamlInner(
+          type: CiType.any,
           slug: config.slug,
           branch: Config.defaultBranch(config.slug),
           config: currentSchedulerConfig,
@@ -58,7 +59,8 @@ Future<void> main() async {
         final YamlMap configYaml = loadYaml(configContent) as YamlMap;
         final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
         // Validate using the existing CiYaml logic.
-        CiYaml(
+        CiYamlInner(
+          type: CiType.any,
           slug: config.slug,
           branch: config.branch,
           config: schedulerConfig,
@@ -82,7 +84,7 @@ Future<void> main() async {
         // N^2 scan to verify all enabled branch patterns match an exist branch on the repo.
         for (String enabledBranch in validEnabledBranches.keys) {
           for (String githubBranch in githubBranches) {
-            if (CiYaml.enabledBranchesMatchesCurrentBranch(<String>[enabledBranch], githubBranch)) {
+            if (CiYamlInner.enabledBranchesMatchesCurrentBranch(<String>[enabledBranch], githubBranch)) {
               validEnabledBranches[enabledBranch] = true;
             }
           }

--- a/app_dart/integration_test/validate_all_ci_configs_test.dart
+++ b/app_dart/integration_test/validate_all_ci_configs_test.dart
@@ -36,7 +36,7 @@ Future<void> main() async {
       final YamlMap configYaml = loadYaml(configContent) as YamlMap;
       final pb.SchedulerConfig currentSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
       try {
-        CiYamlInner(
+        CiYaml(
           type: CiType.any,
           slug: config.slug,
           branch: Config.defaultBranch(config.slug),
@@ -59,7 +59,7 @@ Future<void> main() async {
         final YamlMap configYaml = loadYaml(configContent) as YamlMap;
         final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
         // Validate using the existing CiYaml logic.
-        CiYamlInner(
+        CiYaml(
           type: CiType.any,
           slug: config.slug,
           branch: config.branch,
@@ -84,7 +84,7 @@ Future<void> main() async {
         // N^2 scan to verify all enabled branch patterns match an exist branch on the repo.
         for (String enabledBranch in validEnabledBranches.keys) {
           for (String githubBranch in githubBranches) {
-            if (CiYamlInner.enabledBranchesMatchesCurrentBranch(<String>[enabledBranch], githubBranch)) {
+            if (CiYaml.enabledBranchesMatchesCurrentBranch(<String>[enabledBranch], githubBranch)) {
               validEnabledBranches[enabledBranch] = true;
             }
           }

--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -23,7 +23,9 @@ Server createServer({
   required CommitService commitService,
   required GerritService gerritService,
   required Scheduler scheduler,
+  FusionTester? fusionTester,
 }) {
+  fusionTester ??= FusionTester();
   final Map<String, RequestHandler<dynamic>> handlers = <String, RequestHandler<dynamic>>{
     '/api/check_flaky_builders': CheckFlakyBuilders(
       config: config,
@@ -67,7 +69,7 @@ Server createServer({
       gerritService: gerritService,
       scheduler: scheduler,
       commitService: commitService,
-      fusionTester: FusionTester(),
+      fusionTester: fusionTester,
     ),
     '/api/v2/presubmit-luci-subscription': PresubmitLuciSubscription(
       cache: cache,

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -294,14 +294,13 @@ List<String> validateOwnership(
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
 
-  final CiYamlInner ciYamlFromProto = CiYamlInner(
-    type: CiType.any,
+  final CiYaml ciYamlFromProto = CiYaml(
     slug: Config.flutterSlug,
     branch: Config.defaultBranch(Config.flutterSlug),
-    config: unCheckedSchedulerConfig,
+    yamls: {CiType.any: unCheckedSchedulerConfig},
   );
 
-  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.config;
+  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.configForInner(CiType.any);
 
   for (pb.Target target in schedulerConfig.targets) {
     final String builder = target.name;

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -22,6 +22,7 @@ import '../request_handling/exceptions.dart';
 import '../service/logging.dart';
 
 const String kCiYamlPath = '.ci.yaml';
+const String kCiYamlFusionPath = 'engine/src/flutter/$kCiYamlPath';
 const String kTestOwnerPath = 'TESTOWNERS';
 
 /// Signature for a function that calculates the backoff duration to wait in
@@ -293,7 +294,8 @@ List<String> validateOwnership(
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
 
-  final CiYaml ciYamlFromProto = CiYaml(
+  final CiYamlInner ciYamlFromProto = CiYamlInner(
+    type: CiType.any,
     slug: Config.flutterSlug,
     branch: Config.defaultBranch(Config.flutterSlug),
     config: unCheckedSchedulerConfig,

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -294,13 +294,13 @@ List<String> validateOwnership(
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
   final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
 
-  final CiYaml ciYamlFromProto = CiYaml(
+  final CiYamlSet ciYamlFromProto = CiYamlSet(
     slug: Config.flutterSlug,
     branch: Config.defaultBranch(Config.flutterSlug),
     yamls: {CiType.any: unCheckedSchedulerConfig},
   );
 
-  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.configForInner(CiType.any);
+  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.configFor(CiType.any);
 
   for (pb.Target target in schedulerConfig.targets) {
     final String builder = target.name;

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -22,7 +22,7 @@ import '../request_handling/exceptions.dart';
 import '../service/logging.dart';
 
 const String kCiYamlPath = '.ci.yaml';
-const String kCiYamlFusionPath = 'engine/src/flutter/$kCiYamlPath';
+const String kCiYamlFusionEnginePath = 'engine/src/flutter/$kCiYamlPath';
 const String kTestOwnerPath = 'TESTOWNERS';
 
 /// Signature for a function that calculates the backoff duration to wait in

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -52,10 +52,15 @@ class CiYaml {
 
   final configs = <CiType, CiYamlInner>{};
 
+  /// Get's the [pb.SchedulerConfig] for the requested [type].
+  ///
+  /// The type is expected to exist and will fail otherwise.
+  pb.SchedulerConfig configForInner(CiType type) => configs[type]!.config;
+
   /// Get's the [CiYamlInner] for the requested [type].
   ///
   /// The type is expected to exist and will fail otherwise.
-  CiYamlInner configInnerFor(CiType type) => configs[type]!;
+  CiYamlInner innerFor(CiType type) => configs[type]!;
 
   /// The [RepositorySlug] that [config] is from.
   final RepositorySlug slug;

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -41,6 +41,8 @@ class CiYaml {
         branch: branch,
         config: config,
         type: type,
+        validate: validate,
+        isFusion: isFusion,
         totConfig: totConfig?.configs[type],
       );
     }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -87,7 +87,6 @@ class CiYaml {
 
   /// List of postsubmit target names used to filter target from release candidate branches
   /// that were already removed from main.
-
   List<String>? totPostsubmitTargetNames({CiType type = CiType.any}) => configs[type]!.totPostsubmitTargetNames;
 
   /// Filters post submit targets to remove targets we do not want backfilled.

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -27,7 +27,7 @@ message SchedulerConfig {
 }
 
 // A unit of work for infrastructure to run.
-// Next ID: 18
+// Next ID: 17
 message Target {
     // Unique, human readable identifier.
     optional string name = 1;

--- a/app_dart/lib/src/model/proto/internal/scheduler.proto
+++ b/app_dart/lib/src/model/proto/internal/scheduler.proto
@@ -27,7 +27,7 @@ message SchedulerConfig {
 }
 
 // A unit of work for infrastructure to run.
-// Next ID: 17
+// Next ID: 18
 message Target {
     // Unique, human readable identifier.
     optional string name = 1;

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -60,7 +60,8 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     );
     final YamlMap? ci = loadYaml(ciContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYaml ciYaml = CiYaml(
+    final CiYamlInner ciYaml = CiYamlInner(
+      type: CiType.any,
       slug: slug,
       branch: Config.defaultBranch(slug),
       config: unCheckedSchedulerConfig,
@@ -116,7 +117,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     GithubService gitHub,
     RepositorySlug slug, {
     required String content,
-    required CiYaml ciYaml,
+    required CiYamlInner ciYaml,
   }) async {
     final YamlMap ci = loadYaml(content) as YamlMap;
     final YamlList targets = ci[kCiYamlTargetsKey] as YamlList;
@@ -164,7 +165,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   }
 
   @visibleForTesting
-  static bool getIgnoreFlakiness(String? builderName, CiYaml ciYaml) {
+  static bool getIgnoreFlakiness(String? builderName, CiYamlInner ciYaml) {
     if (builderName == null) {
       return false;
     }

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -60,13 +60,13 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     );
     final YamlMap? ci = loadYaml(ciContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYaml ciYaml = CiYaml(
+    final CiYamlSet ciYaml = CiYamlSet(
       slug: slug,
       branch: Config.defaultBranch(slug),
       yamls: {CiType.any: unCheckedSchedulerConfig},
     );
 
-    final pb.SchedulerConfig schedulerConfig = ciYaml.configForInner(CiType.any);
+    final pb.SchedulerConfig schedulerConfig = ciYaml.configFor(CiType.any);
     final List<pb.Target> targets = schedulerConfig.targets;
 
     final List<_BuilderInfo> eligibleBuilders =
@@ -116,7 +116,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     GithubService gitHub,
     RepositorySlug slug, {
     required String content,
-    required CiYaml ciYaml,
+    required CiYamlSet ciYaml,
   }) async {
     final YamlMap ci = loadYaml(content) as YamlMap;
     final YamlList targets = ci[kCiYamlTargetsKey] as YamlList;
@@ -164,7 +164,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   }
 
   @visibleForTesting
-  static bool getIgnoreFlakiness(String? builderName, CiYaml ciYaml) {
+  static bool getIgnoreFlakiness(String? builderName, CiYamlSet ciYaml) {
     if (builderName == null) {
       return false;
     }

--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -60,14 +60,13 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     );
     final YamlMap? ci = loadYaml(ciContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYamlInner ciYaml = CiYamlInner(
-      type: CiType.any,
+    final CiYaml ciYaml = CiYaml(
       slug: slug,
       branch: Config.defaultBranch(slug),
-      config: unCheckedSchedulerConfig,
+      yamls: {CiType.any: unCheckedSchedulerConfig},
     );
 
-    final pb.SchedulerConfig schedulerConfig = ciYaml.config;
+    final pb.SchedulerConfig schedulerConfig = ciYaml.configForInner(CiType.any);
     final List<pb.Target> targets = schedulerConfig.targets;
 
     final List<_BuilderInfo> eligibleBuilders =
@@ -117,7 +116,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
     GithubService gitHub,
     RepositorySlug slug, {
     required String content,
-    required CiYamlInner ciYaml,
+    required CiYaml ciYaml,
   }) async {
     final YamlMap ci = loadYaml(content) as YamlMap;
     final YamlList targets = ci[kCiYamlTargetsKey] as YamlList;
@@ -165,7 +164,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   }
 
   @visibleForTesting
-  static bool getIgnoreFlakiness(String? builderName, CiYamlInner ciYaml) {
+  static bool getIgnoreFlakiness(String? builderName, CiYaml ciYaml) {
     if (builderName == null) {
       return false;
     }

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -41,14 +41,13 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     final List<BuilderStatistic> builderStatisticList = await bigquery.listBuilderStatistic(kBigQueryProjectId);
     final YamlMap? ci = loadYaml(await gitHub.getFileContent(slug, kCiYamlPath)) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYamlInner ciYaml = CiYamlInner(
-      type: CiType.any,
+    final CiYaml ciYaml = CiYaml(
       slug: slug,
       branch: Config.defaultBranch(slug),
-      config: unCheckedSchedulerConfig,
+      yamls: {CiType.any: unCheckedSchedulerConfig},
     );
 
-    final pb.SchedulerConfig schedulerConfig = ciYaml.config;
+    final pb.SchedulerConfig schedulerConfig = ciYaml.configForInner(CiType.any);
     final List<pb.Target> targets = schedulerConfig.targets;
 
     final String testOwnerContent = await gitHub.getFileContent(slug, kTestOwnerPath);
@@ -90,7 +89,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     });
   }
 
-  bool shouldSkip(BuilderStatistic statistic, CiYamlInner ciYaml, List<pb.Target> targets) {
+  bool shouldSkip(BuilderStatistic statistic, CiYaml ciYaml, List<pb.Target> targets) {
     // Skips if the target has been removed from .ci.yaml.
     if (!targets.map((e) => e.name).toList().contains(statistic.name)) {
       return true;
@@ -192,9 +191,9 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
   }
 
   @visibleForTesting
-  static bool getIgnoreFlakiness(String builderName, CiYamlInner ciYaml) {
+  static bool getIgnoreFlakiness(String builderName, CiYaml ciYaml) {
     final Target? target =
-        ciYaml.postsubmitTargets.singleWhereOrNull((Target target) => target.value.name == builderName);
+        ciYaml.postsubmitTargets().singleWhereOrNull((Target target) => target.value.name == builderName);
     return target == null ? false : target.getIgnoreFlakiness();
   }
 

--- a/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
+++ b/app_dart/lib/src/request_handlers/file_flaky_issue_and_pr.dart
@@ -41,7 +41,8 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     final List<BuilderStatistic> builderStatisticList = await bigquery.listBuilderStatistic(kBigQueryProjectId);
     final YamlMap? ci = loadYaml(await gitHub.getFileContent(slug, kCiYamlPath)) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYaml ciYaml = CiYaml(
+    final CiYamlInner ciYaml = CiYamlInner(
+      type: CiType.any,
       slug: slug,
       branch: Config.defaultBranch(slug),
       config: unCheckedSchedulerConfig,
@@ -89,7 +90,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
     });
   }
 
-  bool shouldSkip(BuilderStatistic statistic, CiYaml ciYaml, List<pb.Target> targets) {
+  bool shouldSkip(BuilderStatistic statistic, CiYamlInner ciYaml, List<pb.Target> targets) {
     // Skips if the target has been removed from .ci.yaml.
     if (!targets.map((e) => e.name).toList().contains(statistic.name)) {
       return true;
@@ -191,7 +192,7 @@ class FileFlakyIssueAndPR extends ApiRequestHandler<Body> {
   }
 
   @visibleForTesting
-  static bool getIgnoreFlakiness(String builderName, CiYaml ciYaml) {
+  static bool getIgnoreFlakiness(String builderName, CiYamlInner ciYaml) {
     final Target? target =
         ciYaml.postsubmitTargets.singleWhereOrNull((Target target) => target.value.name == builderName);
     return target == null ? false : target.getIgnoreFlakiness();

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -303,7 +303,7 @@ TestOwnership getTestOwnership(pb.Target target, BuilderType type, String testOw
 
 /// Gets the [BuilderType] of the builder by looking up the information in the
 /// ci.yaml.
-BuilderType getTypeForBuilder(String? targetName, CiYamlInner ciYaml, {bool unfilteredTargets = false}) {
+BuilderType getTypeForBuilder(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
   final List<String>? tags = _getTags(targetName, ciYaml, unfilteredTargets: unfilteredTargets);
   if (tags == null || tags.isEmpty) {
     return BuilderType.unknown;
@@ -332,13 +332,13 @@ BuilderType getTypeForBuilder(String? targetName, CiYamlInner ciYaml, {bool unfi
   return hasFrameworkTag && hasHostOnlyTag ? BuilderType.frameworkHostOnly : BuilderType.unknown;
 }
 
-List<String>? _getTags(String? targetName, CiYamlInner ciYaml, {bool unfilteredTargets = false}) {
+List<String>? _getTags(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
   final Set<Target> allUniqueTargets = {};
   if (!unfilteredTargets) {
-    allUniqueTargets.addAll(ciYaml.presubmitTargets);
-    allUniqueTargets.addAll(ciYaml.postsubmitTargets);
+    allUniqueTargets.addAll(ciYaml.presubmitTargets());
+    allUniqueTargets.addAll(ciYaml.postsubmitTargets());
   } else {
-    allUniqueTargets.addAll(ciYaml.targets);
+    allUniqueTargets.addAll(ciYaml.targets(type: CiType.any));
   }
 
   final Target? target = allUniqueTargets.firstWhereOrNull((element) => element.value.name == targetName);

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -303,7 +303,7 @@ TestOwnership getTestOwnership(pb.Target target, BuilderType type, String testOw
 
 /// Gets the [BuilderType] of the builder by looking up the information in the
 /// ci.yaml.
-BuilderType getTypeForBuilder(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
+BuilderType getTypeForBuilder(String? targetName, CiYamlInner ciYaml, {bool unfilteredTargets = false}) {
   final List<String>? tags = _getTags(targetName, ciYaml, unfilteredTargets: unfilteredTargets);
   if (tags == null || tags.isEmpty) {
     return BuilderType.unknown;
@@ -332,7 +332,7 @@ BuilderType getTypeForBuilder(String? targetName, CiYaml ciYaml, {bool unfiltere
   return hasFrameworkTag && hasHostOnlyTag ? BuilderType.frameworkHostOnly : BuilderType.unknown;
 }
 
-List<String>? _getTags(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
+List<String>? _getTags(String? targetName, CiYamlInner ciYaml, {bool unfilteredTargets = false}) {
   final Set<Target> allUniqueTargets = {};
   if (!unfilteredTargets) {
     allUniqueTargets.addAll(ciYaml.presubmitTargets);

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -303,7 +303,7 @@ TestOwnership getTestOwnership(pb.Target target, BuilderType type, String testOw
 
 /// Gets the [BuilderType] of the builder by looking up the information in the
 /// ci.yaml.
-BuilderType getTypeForBuilder(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
+BuilderType getTypeForBuilder(String? targetName, CiYamlSet ciYaml, {bool unfilteredTargets = false}) {
   final List<String>? tags = _getTags(targetName, ciYaml, unfilteredTargets: unfilteredTargets);
   if (tags == null || tags.isEmpty) {
     return BuilderType.unknown;
@@ -332,7 +332,7 @@ BuilderType getTypeForBuilder(String? targetName, CiYaml ciYaml, {bool unfiltere
   return hasFrameworkTag && hasHostOnlyTag ? BuilderType.frameworkHostOnly : BuilderType.unknown;
 }
 
-List<String>? _getTags(String? targetName, CiYaml ciYaml, {bool unfilteredTargets = false}) {
+List<String>? _getTags(String? targetName, CiYamlSet ciYaml, {bool unfilteredTargets = false}) {
   final Set<Target> allUniqueTargets = {};
   if (!unfilteredTargets) {
     allUniqueTargets.addAll(ciYaml.presubmitTargets());

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -130,7 +130,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
 
     // TODO(codefu): handle fusion
-    final CiYaml ciYaml = await scheduler.getCiYaml(commit);
+    final CiYamlSet ciYaml = await scheduler.getCiYaml(commit);
     final List<Target> postsubmitTargets = ciYaml.postsubmitTargets();
     if (!postsubmitTargets.any((element) => element.value.name == firestoreTask!.taskName)) {
       log.warning('Target ${firestoreTask.taskName} has been deleted from TOT. Skip updating.');

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -128,8 +128,10 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     }
 
     final Commit commit = await datastore.lookupByValue<Commit>(commitKey);
+
+    // TODO(codefu): handle fusion
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
-    final List<Target> postsubmitTargets = ciYaml.postsubmitTargets;
+    final List<Target> postsubmitTargets = ciYaml.postsubmitTargets(type: CiType.any);
     if (!postsubmitTargets.any((element) => element.value.name == firestoreTask!.taskName)) {
       log.warning('Target ${firestoreTask.taskName} has been deleted from TOT. Skip updating.');
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -131,7 +131,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
 
     // TODO(codefu): handle fusion
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
-    final List<Target> postsubmitTargets = ciYaml.postsubmitTargets(type: CiType.any);
+    final List<Target> postsubmitTargets = ciYaml.postsubmitTargets();
     if (!postsubmitTargets.any((element) => element.value.name == firestoreTask!.taskName)) {
       log.warning('Target ${firestoreTask.taskName} has been deleted from TOT. Skip updating.');
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -146,7 +146,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       repository: slug.fullName,
       sha: userData['commit_sha'] as String,
     );
-    late CiYaml ciYaml;
+    late CiYamlSet ciYaml;
     try {
       if (commit.branch == Config.defaultBranch(commit.slug)) {
         ciYaml = await scheduler.getCiYaml(commit, validate: true);

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -162,17 +162,17 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     // TODO(codefu): support fusion
 
     // Do not block on the target not found.
-    if (!ciYaml.presubmitTargets(type: CiType.any).any((element) => element.value.name == builderName)) {
+    if (!ciYaml.presubmitTargets().any((element) => element.value.name == builderName)) {
       // do not reschedule
       log.warning('Did not find builder with name: $builderName in ciYaml for ${commit.sha}');
       final List<String> availableBuilderList =
-          ciYaml.presubmitTargets(type: CiType.any).map((Target e) => e.value.name).toList();
+          ciYaml.presubmitTargets().map((Target e) => e.value.name).toList();
       log.warning('ciYaml presubmit targets found: $availableBuilderList');
       return 1;
     }
 
     final Target target =
-        ciYaml.presubmitTargets(type: CiType.any).where((element) => element.value.name == builderName).single;
+        ciYaml.presubmitTargets().where((element) => element.value.name == builderName).single;
     final Map<String, Object> properties = target.getProperties();
     if (!properties.containsKey('presubmit_max_attempts')) {
       return 1;

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -159,16 +159,20 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       return 0;
     }
 
+    // TODO(codefu): support fusion
+
     // Do not block on the target not found.
-    if (!ciYaml.presubmitTargets.any((element) => element.value.name == builderName)) {
+    if (!ciYaml.presubmitTargets(type: CiType.any).any((element) => element.value.name == builderName)) {
       // do not reschedule
       log.warning('Did not find builder with name: $builderName in ciYaml for ${commit.sha}');
-      final List<String> availableBuilderList = ciYaml.presubmitTargets.map((Target e) => e.value.name).toList();
+      final List<String> availableBuilderList =
+          ciYaml.presubmitTargets(type: CiType.any).map((Target e) => e.value.name).toList();
       log.warning('ciYaml presubmit targets found: $availableBuilderList');
       return 1;
     }
 
-    final Target target = ciYaml.presubmitTargets.where((element) => element.value.name == builderName).single;
+    final Target target =
+        ciYaml.presubmitTargets(type: CiType.any).where((element) => element.value.name == builderName).single;
     final Map<String, Object> properties = target.getProperties();
     if (!properties.containsKey('presubmit_max_attempts')) {
       return 1;

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -165,14 +165,12 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     if (!ciYaml.presubmitTargets().any((element) => element.value.name == builderName)) {
       // do not reschedule
       log.warning('Did not find builder with name: $builderName in ciYaml for ${commit.sha}');
-      final List<String> availableBuilderList =
-          ciYaml.presubmitTargets().map((Target e) => e.value.name).toList();
+      final List<String> availableBuilderList = ciYaml.presubmitTargets().map((Target e) => e.value.name).toList();
       log.warning('ciYaml presubmit targets found: $availableBuilderList');
       return 1;
     }
 
-    final Target target =
-        ciYaml.presubmitTargets().where((element) => element.value.name == builderName).single;
+    final Target target = ciYaml.presubmitTargets().where((element) => element.value.name == builderName).single;
     final Map<String, Object> properties = target.getProperties();
     if (!properties.containsKey('presubmit_max_attempts')) {
       return 1;

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -156,7 +156,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     // TODO(codefu): handle fusion
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
     final Target target =
-        ciYaml.postsubmitTargets(type: CiType.any).singleWhere((Target target) => target.value.name == task.name);
+        ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
 
     // Prepares Firestore task.
     firestore.Task? taskDocument;

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -154,7 +154,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     taskName ??= task.name;
 
     // TODO(codefu): handle fusion
-    final CiYaml ciYaml = await scheduler.getCiYaml(commit);
+    final CiYamlSet ciYaml = await scheduler.getCiYaml(commit);
     final Target target = ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
 
     // Prepares Firestore task.

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -153,8 +153,10 @@ class ResetProdTask extends ApiRequestHandler<Body> {
     sha ??= commit.id!.split('/').last;
     taskName ??= task.name;
 
+    // TODO(codefu): handle fusion
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
-    final Target target = ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task.name);
+    final Target target =
+        ciYaml.postsubmitTargets(type: CiType.any).singleWhere((Target target) => target.value.name == task.name);
 
     // Prepares Firestore task.
     firestore.Task? taskDocument;

--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -155,8 +155,7 @@ class ResetProdTask extends ApiRequestHandler<Body> {
 
     // TODO(codefu): handle fusion
     final CiYaml ciYaml = await scheduler.getCiYaml(commit);
-    final Target target =
-        ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
+    final Target target = ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
 
     // Prepares Firestore task.
     firestore.Task? taskDocument;

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -69,7 +69,7 @@ class BatchBackfiller extends RequestHandler {
 
       // TODO(codefu): handle fusion
       final CiYaml ciYaml = await scheduler.getCiYaml(task.commit);
-      final List<Target> ciYamlTargets = ciYaml.backfillTargets(type: CiType.any);
+      final List<Target> ciYamlTargets = ciYaml.backfillTargets();
 
       // Skips scheduling if the task is not in TOT commit anymore.
       final bool taskInToT = ciYamlTargets.map((Target target) => target.value.name).toList().contains(task.task.name);

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -68,7 +68,7 @@ class BatchBackfiller extends RequestHandler {
       final FullTask task = taskColumn.first;
 
       // TODO(codefu): handle fusion
-      final CiYaml ciYaml = await scheduler.getCiYaml(task.commit);
+      final CiYamlSet ciYaml = await scheduler.getCiYaml(task.commit);
       final List<Target> ciYamlTargets = ciYaml.backfillTargets();
 
       // Skips scheduling if the task is not in TOT commit anymore.

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -66,8 +66,11 @@ class BatchBackfiller extends RequestHandler {
     List<Tuple<Target, FullTask, int>> backfill = <Tuple<Target, FullTask, int>>[];
     for (List<FullTask> taskColumn in taskMap.values) {
       final FullTask task = taskColumn.first;
+
+      // TODO(codefu): handle fusion
       final CiYaml ciYaml = await scheduler.getCiYaml(task.commit);
-      final List<Target> ciYamlTargets = ciYaml.backfillTargets;
+      final List<Target> ciYamlTargets = ciYaml.backfillTargets(type: CiType.any);
+
       // Skips scheduling if the task is not in TOT commit anymore.
       final bool taskInToT = ciYamlTargets.map((Target target) => target.value.name).toList().contains(task.task.name);
       if (!taskInToT) {

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -34,7 +34,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   static const String kThresholdKey = 'threshold';
   static const int kFreshPeriodForOpenFlake = 7; // days
 
-  final CiYaml? ciYaml;
+  final CiYamlInner? ciYaml;
 
   @override
   Future<Body> get() async {
@@ -42,7 +42,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     final GithubService gitHub = config.createGithubServiceWithToken(await config.githubOAuthToken);
     final BigqueryService bigquery = await config.createBigQueryService();
 
-    CiYaml? localCiYaml = ciYaml;
+    CiYamlInner? localCiYaml = ciYaml;
     if (localCiYaml == null) {
       final YamlMap? ci = loadYaml(
         await gitHub.getFileContent(
@@ -51,7 +51,8 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
         ),
       ) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      localCiYaml = CiYaml(
+      localCiYaml = CiYamlInner(
+        type: CiType.any,
         slug: slug,
         branch: Config.defaultBranch(slug),
         config: unCheckedSchedulerConfig,
@@ -90,7 +91,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     required bool bringup,
     required BuilderStatistic statistic,
     required Issue existingIssue,
-    required CiYaml ciYaml,
+    required CiYamlInner ciYaml,
   }) async {
     if (DateTime.now().difference(existingIssue.createdAt!) < const Duration(days: kFreshPeriodForOpenFlake)) {
       return;
@@ -128,7 +129,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   Future<void> _updateExistingFlakyIssue(
     GithubService gitHub,
     RepositorySlug slug,
-    CiYaml ciYaml, {
+    CiYamlInner ciYaml, {
     required List<BuilderStatistic> prodBuilderStatisticList,
     required List<BuilderStatistic> stagingBuilderStatisticList,
     required Map<String?, Issue> nameToExistingIssue,

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -34,7 +34,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   static const String kThresholdKey = 'threshold';
   static const int kFreshPeriodForOpenFlake = 7; // days
 
-  final CiYaml? ciYaml;
+  final CiYamlSet? ciYaml;
 
   @override
   Future<Body> get() async {
@@ -42,7 +42,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     final GithubService gitHub = config.createGithubServiceWithToken(await config.githubOAuthToken);
     final BigqueryService bigquery = await config.createBigQueryService();
 
-    CiYaml? localCiYaml = ciYaml;
+    CiYamlSet? localCiYaml = ciYaml;
     if (localCiYaml == null) {
       final YamlMap? ci = loadYaml(
         await gitHub.getFileContent(
@@ -51,7 +51,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
         ),
       ) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      localCiYaml = CiYaml(
+      localCiYaml = CiYamlSet(
         slug: slug,
         branch: Config.defaultBranch(slug),
         yamls: {CiType.any: unCheckedSchedulerConfig},
@@ -90,7 +90,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
     required bool bringup,
     required BuilderStatistic statistic,
     required Issue existingIssue,
-    required CiYaml ciYaml,
+    required CiYamlSet ciYaml,
   }) async {
     if (DateTime.now().difference(existingIssue.createdAt!) < const Duration(days: kFreshPeriodForOpenFlake)) {
       return;
@@ -110,7 +110,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
         kTestOwnerPath,
       );
 
-      final pb.SchedulerConfig schedulerConfig = ciYaml.configForInner(CiType.any);
+      final pb.SchedulerConfig schedulerConfig = ciYaml.configFor(CiType.any);
       final List<pb.Target> targets = schedulerConfig.targets;
 
       final String? testOwner = getTestOwnership(
@@ -128,7 +128,7 @@ class UpdateExistingFlakyIssue extends ApiRequestHandler<Body> {
   Future<void> _updateExistingFlakyIssue(
     GithubService gitHub,
     RepositorySlug slug,
-    CiYaml ciYaml, {
+    CiYamlSet ciYaml, {
     required List<BuilderStatistic> prodBuilderStatisticList,
     required List<BuilderStatistic> stagingBuilderStatisticList,
     required Map<String?, Issue> nameToExistingIssue,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -264,9 +264,11 @@ class Scheduler {
     Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
       final Uint8List ciYamlBytes = (await cache.getOrCreate(
         subcacheName,
-        ciPath,
+        // This is a key for a cache; not a path - so its needs to be 'unique'
+        '${commit.repository}/${commit.sha!}/$ciPath',
         createFn: () async => (await _downloadCiYaml(
           commit,
+          // actual path to go and fetch
           ciPath,
           retryOptions: retryOptions,
         ))

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -287,8 +287,8 @@ class Scheduler {
     pb.SchedulerConfig? engineFusionConfig;
     if (isFusionCommit) {
       // Fetch the engine yaml and mark it up.
-      engineFusionConfig = await getSchedulerConfig(kCiYamlFusionPath);
-      log.fine('fusion .ci.yaml file fetched');
+      engineFusionConfig = await getSchedulerConfig(kCiYamlFusionEnginePath);
+      log.fine('fusion engine .ci.yaml file fetched');
     }
 
     // If totCiYaml is not null, we assume upper level function has verified that current branch is not a release branch.

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -754,9 +754,8 @@ class Scheduler {
                   taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYaml ciYaml = await getCiYaml(commit);
-              final Target target = ciYaml
-                  .postsubmitTargets()
-                  .singleWhere((Target target) => target.value.name == task.name);
+              final Target target =
+                  ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
               await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -699,8 +699,7 @@ class Scheduler {
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
   Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
-    /// Figure out if we're in fusion or not.
-
+    // TODO(codefu): Figure out if we're in fusion or not.
     switch (checkRunEvent.action) {
       case 'rerequested':
         log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -14,6 +14,7 @@ import 'package:github/github.dart';
 import 'package:github/hooks.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:googleapis/firestore/v1.dart';
+import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 import 'package:truncate/truncate.dart';
 import 'package:yaml/yaml.dart';
@@ -50,6 +51,7 @@ class Scheduler {
     required this.config,
     required this.githubChecksService,
     required this.luciBuildService,
+    required this.fusionTester,
     this.datastoreProvider = DatastoreService.defaultProvider,
     this.httpClientProvider = Providers.freshHttpClient,
     this.buildStatusProvider = BuildStatusService.defaultProvider,
@@ -61,7 +63,7 @@ class Scheduler {
   final DatastoreServiceProvider datastoreProvider;
   final GithubChecksService githubChecksService;
   final HttpClientProvider httpClientProvider;
-
+  final FusionTester fusionTester;
   late DatastoreService datastore;
   late FirestoreService firestoreService;
   LuciBuildService luciBuildService;
@@ -146,7 +148,8 @@ class Scheduler {
 
     final CiYaml ciYaml = await getCiYaml(commit);
 
-    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets);
+    // TODO(codefu): support fusion engine
+    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets(type: CiType.any));
     final List<Task> tasks = targetsToTask(commit, initialTargets).toList();
 
     final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
@@ -244,9 +247,10 @@ class Scheduler {
     Commit commit, {
     bool validate = false,
   }) async {
+    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
     final Commit totCommit = await generateTotCommit(slug: commit.slug, branch: Config.defaultBranch(commit.slug));
-    final CiYaml totYaml = await _getCiYaml(totCommit);
-    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate);
+    final CiYaml totYaml = await _getCiYaml(totCommit, isFusionCommit: isFusion);
+    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
   }
 
   /// Load in memory the `.ci.yaml`.
@@ -255,50 +259,66 @@ class Scheduler {
     CiYaml? totCiYaml,
     bool validate = false,
     RetryOptions retryOptions = const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
+    bool isFusionCommit = false,
   }) async {
-    String ciPath;
-    ciPath = '${commit.repository}/${commit.sha!}/$kCiYamlPath';
-    final Uint8List ciYamlBytes = (await cache.getOrCreate(
-      subcacheName,
-      ciPath,
-      createFn: () => _downloadCiYaml(
-        commit,
+    Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
+      final Uint8List ciYamlBytes = (await cache.getOrCreate(
+        subcacheName,
         ciPath,
-        retryOptions: retryOptions,
-      ),
-      ttl: const Duration(hours: 1),
-    ))!;
-    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
-    log.fine('Retrieved .ci.yaml for $ciPath');
+        createFn: () async => (await _downloadCiYaml(
+          commit,
+          ciPath,
+          retryOptions: retryOptions,
+        ))
+            .writeToBuffer(),
+        ttl: const Duration(hours: 1),
+      ))!;
+      final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
+      log.fine('Retrieved .ci.yaml for $ciPath');
+      return schedulerConfig;
+    }
+
+    // First, whatever was asked of us.
+    final schedulerConfig = await getSchedulerConfig(kCiYamlPath);
+
+    // Second - maybe the engine CI
+    pb.SchedulerConfig? engineFusionConfig;
+    if (isFusionCommit) {
+      // Fetch the engine yaml and mark it up.
+      engineFusionConfig = await getSchedulerConfig(kCiYamlFusionPath);
+      log.fine('fusion .ci.yaml file fetched');
+    }
+
     // If totCiYaml is not null, we assume upper level function has verified that current branch is not a release branch.
     return CiYaml(
-      config: schedulerConfig,
+      yamls: {
+        CiType.any: schedulerConfig,
+        if (engineFusionConfig != null) CiType.fusionEngine: engineFusionConfig,
+      },
       slug: commit.slug,
       branch: commit.branch!,
       totConfig: totCiYaml,
       validate: validate,
+      isFusion: isFusionCommit,
     );
   }
 
-  /// Get `.ci.yaml` from GitHub, and store the bytes in redis for future retrieval.
-  ///
-  /// If GitHub returns [HttpStatus.notFound], an empty config will be inserted assuming
-  /// that commit does not support the scheduler config file.
-  Future<Uint8List> _downloadCiYaml(
+  /// Get `.ci.yaml` from GitHub
+  Future<pb.SchedulerConfig> _downloadCiYaml(
     Commit commit,
     String ciPath, {
     RetryOptions retryOptions = const RetryOptions(maxAttempts: 3),
   }) async {
     final String configContent = await githubFileContent(
       commit.slug,
-      '.ci.yaml',
+      ciPath,
       httpClientProvider: httpClientProvider,
       ref: commit.sha!,
       retryOptions: retryOptions,
     );
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
     final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
-    return schedulerConfig.writeToBuffer();
+    return schedulerConfig;
   }
 
   /// Cancel all incomplete targets against a pull request.
@@ -317,7 +337,7 @@ class Scheduler {
   ///
   /// Cancels all existing targets then schedules the targets.
   ///
-  /// Schedules a [kCiYamlCheckName] to validate [CiYaml] is valid and all builds were able to be triggered.
+  /// Schedules a [kCiYamlCheckName] to validate [CiYamlInner] is valid and all builds were able to be triggered.
   /// If [builderTriggerList] is specified, then trigger only those targets.
   Future<void> triggerPresubmitTargets({
     required PullRequest pullRequest,
@@ -585,7 +605,8 @@ class Scheduler {
   /// Filters targets with runIf, matching them to the diff of [pullRequest].
   ///
   /// In the case there is an issue getting the diff from GitHub, all targets are returned.
-  Future<List<Target>> getPresubmitTargets(PullRequest pullRequest) async {
+  @visibleForTesting
+  Future<List<Target>> getPresubmitTargets(PullRequest pullRequest, {CiType type = CiType.any}) async {
     final Commit commit = Commit(
       branch: pullRequest.base!.ref,
       repository: pullRequest.base!.repo!.fullName,
@@ -601,8 +622,10 @@ class Scheduler {
     log.info('ci.yaml loaded successfully.');
     log.info('Collecting presubmit targets for ${pullRequest.number}');
 
+    final inner = ciYaml.configInnerFor(type);
+
     // Filter out schedulers targets with schedulers different than luci or cocoon.
-    final List<Target> presubmitTargets = ciYaml.presubmitTargets
+    final List<Target> presubmitTargets = inner.presubmitTargets
         .where(
           (Target target) =>
               target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
@@ -610,11 +633,11 @@ class Scheduler {
         .toList();
 
     // See https://github.com/flutter/flutter/issues/138430.
-    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(ciYaml, pullRequest);
+    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(inner, pullRequest);
     if (includePostsubmitAsPresubmit) {
       log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
 
-      for (Target target in ciYaml.postsubmitTargets) {
+      for (Target target in inner.postsubmitTargets) {
         // We don't want to include a presubmit twice
         // We don't want to run the builder_cache target as a presubmit
         if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
@@ -654,7 +677,7 @@ class Scheduler {
   };
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+  static bool _includePostsubmitAsPresubmit(CiYamlInner ciYaml, PullRequest pullRequest) {
     if (!_allowTestAll.contains(ciYaml.slug)) {
       return false;
     }
@@ -674,6 +697,8 @@ class Scheduler {
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
   Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
+    /// Figure out if we're in fusion or not.
+
     switch (checkRunEvent.action) {
       case 'rerequested':
         log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
@@ -727,8 +752,9 @@ class Scheduler {
                   taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYaml ciYaml = await getCiYaml(commit);
-              final Target target =
-                  ciYaml.postsubmitTargets.singleWhere((Target target) => target.value.name == task.name);
+              final Target target = ciYaml
+                  .postsubmitTargets(type: CiType.any)
+                  .singleWhere((Target target) => target.value.name == task.name);
               await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,
@@ -799,8 +825,8 @@ class Scheduler {
 
   /// Returns the tip of tree [Commit] using specified [branch] and [RepositorySlug].
   ///
-  /// A tip of tree [Commit] is used to help generate the tip of tree [CiYaml].
-  /// The generated tip of tree [CiYaml] will be compared against Presubmit Targets in current [CiYaml],
+  /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlInner].
+  /// The generated tip of tree [CiYamlInner] will be compared against Presubmit Targets in current [CiYamlInner],
   /// to ensure new targets without `bringup: true` label are not added into the build.
   Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -149,7 +149,7 @@ class Scheduler {
     final CiYaml ciYaml = await getCiYaml(commit);
 
     // TODO(codefu): support fusion engine
-    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets(type: CiType.any));
+    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
     final List<Task> tasks = targetsToTask(commit, initialTargets).toList();
 
     final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
@@ -339,7 +339,7 @@ class Scheduler {
   ///
   /// Cancels all existing targets then schedules the targets.
   ///
-  /// Schedules a [kCiYamlCheckName] to validate [CiYamlInner] is valid and all builds were able to be triggered.
+  /// Schedules a [kCiYamlCheckName] to validate [CiYaml] is valid and all builds were able to be triggered.
   /// If [builderTriggerList] is specified, then trigger only those targets.
   Future<void> triggerPresubmitTargets({
     required PullRequest pullRequest,
@@ -624,7 +624,7 @@ class Scheduler {
     log.info('ci.yaml loaded successfully.');
     log.info('Collecting presubmit targets for ${pullRequest.number}');
 
-    final inner = ciYaml.configInnerFor(type);
+    final inner = ciYaml.innerFor(type);
 
     // Filter out schedulers targets with schedulers different than luci or cocoon.
     final List<Target> presubmitTargets = inner.presubmitTargets
@@ -755,7 +755,7 @@ class Scheduler {
               log.fine('Latest firestore task is $taskDocument');
               final CiYaml ciYaml = await getCiYaml(commit);
               final Target target = ciYaml
-                  .postsubmitTargets(type: CiType.any)
+                  .postsubmitTargets()
                   .singleWhere((Target target) => target.value.name == task.name);
               await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
@@ -827,8 +827,8 @@ class Scheduler {
 
   /// Returns the tip of tree [Commit] using specified [branch] and [RepositorySlug].
   ///
-  /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlInner].
-  /// The generated tip of tree [CiYamlInner] will be compared against Presubmit Targets in current [CiYamlInner],
+  /// A tip of tree [Commit] is used to help generate the tip of tree [CiYaml].
+  /// The generated tip of tree [CiYaml] will be compared against Presubmit Targets in current [CiYaml],
   /// to ensure new targets without `bringup: true` label are not added into the build.
   Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -26,7 +26,7 @@ void main() {
     for (EnabledBranchesRegexTest regexTest in tests) {
       test(regexTest.name, () {
         expect(
-          CiYamlInner.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
+          CiYaml.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
           regexTest.expectation,
         );
       });
@@ -78,7 +78,7 @@ void main() {
     });
 
     test('filter bringup targets on release branches', () {
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlSet ciYaml = CiYamlSet(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         yamls: {
@@ -111,7 +111,7 @@ void main() {
     });
 
     group('validations and filters.', () {
-      final CiYamlInner totCIYaml = CiYamlInner(
+      final CiYaml totCIYaml = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -130,7 +130,7 @@ void main() {
           ],
         ),
       );
-      final CiYamlInner ciYaml = CiYamlInner(
+      final CiYaml ciYaml = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: 'flutter-2.4-candidate.3',
@@ -196,7 +196,7 @@ void main() {
       });
 
       test('filter release_build targets from release candidate branches', () {
-        final CiYamlInner releaseYaml = CiYamlInner(
+        final CiYaml releaseYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: 'flutter-2.4-candidate.3',
@@ -226,7 +226,7 @@ void main() {
       });
 
       test('release_build targets for main are not filtered', () {
-        final CiYamlInner releaseYaml = CiYamlInner(
+        final CiYaml releaseYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: 'main',
@@ -261,7 +261,7 @@ void main() {
 
       test('validates yaml config', () {
         expect(
-          () => CiYamlInner(
+          () => CiYaml(
             type: CiType.any,
             slug: Config.flutterSlug,
             branch: Config.defaultBranch(Config.flutterSlug),
@@ -286,7 +286,7 @@ void main() {
       });
     });
     group('Presubmit validation', () {
-      final CiYamlInner totCIYaml = CiYamlInner(
+      final CiYaml totCIYaml = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -306,7 +306,7 @@ void main() {
           ],
         ),
       );
-      final CiYamlInner ciYaml = CiYamlInner(
+      final CiYaml ciYaml = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: 'flutter-2.4-candidate.3',
@@ -360,7 +360,7 @@ void main() {
   });
 }
 
-/// Wrapper class for table driven design of [CiYamlInner.enabledBranchesMatchesCurrentBranch].
+/// Wrapper class for table driven design of [CiYaml.enabledBranchesMatchesCurrentBranch].
 class EnabledBranchesRegexTest {
   EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches, [this.expectation = true]);
 

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -63,7 +63,7 @@ void main() {
   group('initialTargets', () {
     test('targets without deps', () {
       final ciYaml = exampleConfig;
-      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets(type: CiType.any));
+      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
       final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
@@ -78,26 +78,27 @@ void main() {
     });
 
     test('filter bringup targets on release branches', () {
-      final CiYamlInner ciYaml = CiYamlInner(
-        type: CiType.any,
+      final CiYaml ciYaml = CiYaml(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
-        config: pb.SchedulerConfig(
-          enabledBranches: <String>[
-            Config.defaultBranch(Config.flutterSlug),
-          ],
-          targets: <pb.Target>[
-            pb.Target(
-              name: 'Linux A',
-            ),
-            pb.Target(
-              name: 'Mac A', // Should be ignored on release branches
-              bringup: true,
-            ),
-          ],
-        ),
+        yamls: {
+          CiType.any: pb.SchedulerConfig(
+            enabledBranches: <String>[
+              Config.defaultBranch(Config.flutterSlug),
+            ],
+            targets: <pb.Target>[
+              pb.Target(
+                name: 'Linux A',
+              ),
+              pb.Target(
+                name: 'Mac A', // Should be ignored on release branches
+                bringup: true,
+              ),
+            ],
+          ),
+        },
       );
-      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets);
+      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
       final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
@@ -180,8 +181,8 @@ void main() {
       });
 
       test('Get backfill targets from postsubmit', () {
-        final  ciYaml = exampleBackfillConfig;
-        final List<Target> backfillTargets = ciYaml.backfillTargets(type: CiType.any);
+        final ciYaml = exampleBackfillConfig;
+        final List<Target> backfillTargets = ciYaml.backfillTargets();
         final List<String> backfillTargetNames = backfillTargets.map((Target target) => target.value.name).toList();
         expect(
           backfillTargetNames,
@@ -344,14 +345,14 @@ void main() {
 
   group('flakiness_threshold', () {
     test('is set', () {
-      final  ciYaml = exampleFlakyConfig;
+      final ciYaml = exampleFlakyConfig;
       final flaky1 = ciYaml.getFirstPostsubmitTarget('Flaky 1');
       expect(flaky1, isNotNull);
       expect(flaky1?.flakinessThreshold, 0.04);
     });
 
     test('is missing', () {
-      final  ciYaml = exampleFlakyConfig;
+      final ciYaml = exampleFlakyConfig;
       final flaky1 = ciYaml.getFirstPostsubmitTarget('Flaky Skip');
       expect(flaky1, isNotNull);
       expect(flaky1?.flakinessThreshold, isNull);

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -26,7 +26,7 @@ void main() {
     for (EnabledBranchesRegexTest regexTest in tests) {
       test(regexTest.name, () {
         expect(
-          CiYaml.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
+          CiYamlInner.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
           regexTest.expectation,
         );
       });
@@ -62,8 +62,8 @@ void main() {
 
   group('initialTargets', () {
     test('targets without deps', () {
-      final CiYaml ciYaml = exampleConfig;
-      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets);
+      final ciYaml = exampleConfig;
+      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets(type: CiType.any));
       final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
@@ -78,7 +78,8 @@ void main() {
     });
 
     test('filter bringup targets on release branches', () {
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: pb.SchedulerConfig(
@@ -109,7 +110,8 @@ void main() {
     });
 
     group('validations and filters.', () {
-      final CiYaml totCIYaml = CiYaml(
+      final CiYamlInner totCIYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: pb.SchedulerConfig(
@@ -127,7 +129,8 @@ void main() {
           ],
         ),
       );
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: 'flutter-2.4-candidate.3',
         config: pb.SchedulerConfig(
@@ -177,8 +180,8 @@ void main() {
       });
 
       test('Get backfill targets from postsubmit', () {
-        final CiYaml ciYaml = exampleBackfillConfig;
-        final List<Target> backfillTargets = ciYaml.backfillTargets;
+        final  ciYaml = exampleBackfillConfig;
+        final List<Target> backfillTargets = ciYaml.backfillTargets(type: CiType.any);
         final List<String> backfillTargetNames = backfillTargets.map((Target target) => target.value.name).toList();
         expect(
           backfillTargetNames,
@@ -192,7 +195,8 @@ void main() {
       });
 
       test('filter release_build targets from release candidate branches', () {
-        final CiYaml releaseYaml = CiYaml(
+        final CiYamlInner releaseYaml = CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: 'flutter-2.4-candidate.3',
           config: pb.SchedulerConfig(
@@ -221,7 +225,8 @@ void main() {
       });
 
       test('release_build targets for main are not filtered', () {
-        final CiYaml releaseYaml = CiYaml(
+        final CiYamlInner releaseYaml = CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: 'main',
           config: pb.SchedulerConfig(
@@ -255,7 +260,8 @@ void main() {
 
       test('validates yaml config', () {
         expect(
-          () => CiYaml(
+          () => CiYamlInner(
+            type: CiType.any,
             slug: Config.flutterSlug,
             branch: Config.defaultBranch(Config.flutterSlug),
             config: pb.SchedulerConfig(
@@ -279,7 +285,8 @@ void main() {
       });
     });
     group('Presubmit validation', () {
-      final CiYaml totCIYaml = CiYaml(
+      final CiYamlInner totCIYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: pb.SchedulerConfig(
@@ -298,7 +305,8 @@ void main() {
           ],
         ),
       );
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: 'flutter-2.4-candidate.3',
         config: pb.SchedulerConfig(
@@ -336,14 +344,14 @@ void main() {
 
   group('flakiness_threshold', () {
     test('is set', () {
-      final CiYaml ciYaml = exampleFlakyConfig;
+      final  ciYaml = exampleFlakyConfig;
       final flaky1 = ciYaml.getFirstPostsubmitTarget('Flaky 1');
       expect(flaky1, isNotNull);
       expect(flaky1?.flakinessThreshold, 0.04);
     });
 
     test('is missing', () {
-      final CiYaml ciYaml = exampleFlakyConfig;
+      final  ciYaml = exampleFlakyConfig;
       final flaky1 = ciYaml.getFirstPostsubmitTarget('Flaky Skip');
       expect(flaky1, isNotNull);
       expect(flaky1?.flakinessThreshold, isNull);
@@ -351,7 +359,7 @@ void main() {
   });
 }
 
-/// Wrapper class for table driven design of [CiYaml.enabledBranchesMatchesCurrentBranch].
+/// Wrapper class for table driven design of [CiYamlInner.enabledBranchesMatchesCurrentBranch].
 class EnabledBranchesRegexTest {
   EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches, [this.expectation = true]);
 

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -29,8 +29,6 @@ const String kCurrentUserName = 'Name';
 const String kCurrentUserLogin = 'login';
 const String kCurrentUserEmail = 'login@email.com';
 
-class MockYaml extends Mock implements CiYamlInner {}
-
 void main() {
   group('Deflake', () {
     late CheckFlakyBuilders handler;
@@ -659,11 +657,10 @@ void main() {
     test('getIgnoreFlakiness handles non-existing builderame', () async {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYamlInner ciYaml = CiYamlInner(
-        type: CiType.any,
+      final CiYaml ciYaml = CiYaml(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
-        config: unCheckedSchedulerConfig,
+        yamls: {CiType.any: unCheckedSchedulerConfig},
       );
       CheckFlakyBuilders.getIgnoreFlakiness('Non_existing', ciYaml);
     });

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -29,7 +29,7 @@ const String kCurrentUserName = 'Name';
 const String kCurrentUserLogin = 'login';
 const String kCurrentUserEmail = 'login@email.com';
 
-class MockYaml extends Mock implements CiYaml {}
+class MockYaml extends Mock implements CiYamlInner {}
 
 void main() {
   group('Deflake', () {
@@ -659,7 +659,8 @@ void main() {
     test('getIgnoreFlakiness handles non-existing builderame', () async {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -657,7 +657,7 @@ void main() {
     test('getIgnoreFlakiness handles non-existing builderame', () async {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlSet ciYaml = CiYamlSet(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         yamls: {CiType.any: unCheckedSchedulerConfig},

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -676,7 +676,7 @@ void main() {
     test('skips when the target doesn not exist', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlSet ciYaml = CiYamlSet(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         yamls: {CiType.any: unCheckedSchedulerConfig},
@@ -698,7 +698,7 @@ void main() {
     test('skips if the flakiness_threshold is not met', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlSet ciYaml = CiYamlSet(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         yamls: {CiType.any: unCheckedSchedulerConfig},
@@ -724,7 +724,7 @@ void main() {
     test('honors the flakiness_threshold', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlSet ciYaml = CiYamlSet(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         yamls: {CiType.any: unCheckedSchedulerConfig},
@@ -758,7 +758,7 @@ void main() {
   test('getIgnoreFlakiness handles non-existing builderame', () async {
     final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYaml ciYaml = CiYaml(
+    final CiYamlSet ciYaml = CiYamlSet(
       slug: Config.flutterSlug,
       branch: Config.defaultBranch(Config.flutterSlug),
       yamls: {CiType.any: unCheckedSchedulerConfig},

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -676,11 +676,10 @@ void main() {
     test('skips when the target doesn not exist', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYamlInner ciYaml = CiYamlInner(
-        type: CiType.any,
+      final CiYaml ciYaml = CiYaml(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
-        config: unCheckedSchedulerConfig,
+        yamls: {CiType.any: unCheckedSchedulerConfig},
       );
       final BuilderStatistic builderStatistic = BuilderStatistic(
         name: 'Mac_android test',
@@ -699,11 +698,10 @@ void main() {
     test('skips if the flakiness_threshold is not met', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYamlInner ciYaml = CiYamlInner(
-        type: CiType.any,
+      final CiYaml ciYaml = CiYaml(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
-        config: unCheckedSchedulerConfig,
+        yamls: {CiType.any: unCheckedSchedulerConfig},
       );
       final BuilderStatistic builderStatistic = BuilderStatistic(
         name: 'Mac_android higher_myflakiness',
@@ -726,11 +724,10 @@ void main() {
     test('honors the flakiness_threshold', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYamlInner ciYaml = CiYamlInner(
-        type: CiType.any,
+      final CiYaml ciYaml = CiYaml(
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
-        config: unCheckedSchedulerConfig,
+        yamls: {CiType.any: unCheckedSchedulerConfig},
       );
       final BuilderStatistic builderStatistic = BuilderStatistic(
         name: 'Mac_android higher_myflakiness',
@@ -761,11 +758,10 @@ void main() {
   test('getIgnoreFlakiness handles non-existing builderame', () async {
     final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYamlInner ciYaml = CiYamlInner(
-      type: CiType.any,
+    final CiYaml ciYaml = CiYaml(
       slug: Config.flutterSlug,
       branch: Config.defaultBranch(Config.flutterSlug),
-      config: unCheckedSchedulerConfig,
+      yamls: {CiType.any: unCheckedSchedulerConfig},
     );
     expect(FileFlakyIssueAndPR.getIgnoreFlakiness('Non_existing', ciYaml), false);
   });

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -676,7 +676,8 @@ void main() {
     test('skips when the target doesn not exist', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -698,7 +699,8 @@ void main() {
     test('skips if the flakiness_threshold is not met', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -724,7 +726,8 @@ void main() {
     test('honors the flakiness_threshold', () {
       final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
       final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-      final CiYaml ciYaml = CiYaml(
+      final CiYamlInner ciYaml = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -758,7 +761,8 @@ void main() {
   test('getIgnoreFlakiness handles non-existing builderame', () async {
     final YamlMap? ci = loadYaml(ciYamlContent) as YamlMap?;
     final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ci);
-    final CiYaml ciYaml = CiYaml(
+    final CiYamlInner ciYaml = CiYamlInner(
+      type: CiType.any,
       slug: Config.flutterSlug,
       branch: Config.defaultBranch(Config.flutterSlug),
       config: unCheckedSchedulerConfig,

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -223,85 +223,86 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter
 Please follow https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
-final CiYamlInner testCiYaml = CiYamlInner(
-  type: CiType.any,
+final CiYaml testCiYaml = CiYaml(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
-  config: pb.SchedulerConfig(
-    enabledBranches: <String>[
-      Config.defaultBranch(Config.flutterSlug),
-    ],
-    targets: <pb.Target>[
-      pb.Target(
-        name: 'Mac_android android_semantics_integration_test',
-        scheduler: pb.SchedulerSystem.luci,
-        presubmit: false,
-        properties: <String, String>{
-          'tags': jsonEncode(['devicelab']),
-          'task_name': 'android_semantics_integration_test',
-        },
-      ),
-      pb.Target(
-        name: 'Mac_android ignore_myflakiness',
-        scheduler: pb.SchedulerSystem.luci,
-        presubmit: false,
-        properties: <String, String>{
-          'ignore_flakiness': 'true',
-          'tags': jsonEncode(['devicelab']),
-          'task_name': 'ignore_myflakiness',
-        },
-      ),
-      pb.Target(
-        name: 'Linux ci_yaml flutter roller',
-        scheduler: pb.SchedulerSystem.luci,
-        bringup: true,
-        timeout: 30,
-        runIf: ['.ci.yaml'],
-        recipe: 'infra/ci_yaml',
-        properties: <String, String>{
-          'tags': jsonEncode(['framework', 'hostonly', 'shard']),
-        },
-      ),
-      pb.Target(
-        name: 'Mac build_tests_1_4',
-        scheduler: pb.SchedulerSystem.luci,
-        recipe: 'flutter/flutter_drone',
-        timeout: 60,
-        properties: <String, String>{
-          'add_recipes_cq': 'true',
-          'shard': 'build_tests',
-          'subshard': '1_4',
-          'tags': jsonEncode(['framework', 'hostonly', 'shard']),
-          'dependencies': jsonEncode([
-            {
-              'dependency': 'android_sdk',
-              'version': 'version:29.0',
-            },
-            {
-              'dependency': 'chrome_and_driver',
-              'version': 'version:84',
-            },
-            {
-              'dependency': 'xcode',
-              'version': '13a233',
-            },
-            {
-              'dependency': 'open_jdk',
-              'version': '11',
-            },
-            {
-              'dependency': 'gems',
-              'version': 'v3.3.14',
-            },
-            {
-              'dependency': 'goldctl',
-              'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
-            },
-          ]),
-        },
-      ),
-    ],
-  ),
+  yamls: {
+    CiType.any: pb.SchedulerConfig(
+      enabledBranches: <String>[
+        Config.defaultBranch(Config.flutterSlug),
+      ],
+      targets: <pb.Target>[
+        pb.Target(
+          name: 'Mac_android android_semantics_integration_test',
+          scheduler: pb.SchedulerSystem.luci,
+          presubmit: false,
+          properties: <String, String>{
+            'tags': jsonEncode(['devicelab']),
+            'task_name': 'android_semantics_integration_test',
+          },
+        ),
+        pb.Target(
+          name: 'Mac_android ignore_myflakiness',
+          scheduler: pb.SchedulerSystem.luci,
+          presubmit: false,
+          properties: <String, String>{
+            'ignore_flakiness': 'true',
+            'tags': jsonEncode(['devicelab']),
+            'task_name': 'ignore_myflakiness',
+          },
+        ),
+        pb.Target(
+          name: 'Linux ci_yaml flutter roller',
+          scheduler: pb.SchedulerSystem.luci,
+          bringup: true,
+          timeout: 30,
+          runIf: ['.ci.yaml'],
+          recipe: 'infra/ci_yaml',
+          properties: <String, String>{
+            'tags': jsonEncode(['framework', 'hostonly', 'shard']),
+          },
+        ),
+        pb.Target(
+          name: 'Mac build_tests_1_4',
+          scheduler: pb.SchedulerSystem.luci,
+          recipe: 'flutter/flutter_drone',
+          timeout: 60,
+          properties: <String, String>{
+            'add_recipes_cq': 'true',
+            'shard': 'build_tests',
+            'subshard': '1_4',
+            'tags': jsonEncode(['framework', 'hostonly', 'shard']),
+            'dependencies': jsonEncode([
+              {
+                'dependency': 'android_sdk',
+                'version': 'version:29.0',
+              },
+              {
+                'dependency': 'chrome_and_driver',
+                'version': 'version:84',
+              },
+              {
+                'dependency': 'xcode',
+                'version': '13a233',
+              },
+              {
+                'dependency': 'open_jdk',
+                'version': '11',
+              },
+              {
+                'dependency': 'gems',
+                'version': 'v3.3.14',
+              },
+              {
+                'dependency': 'goldctl',
+                'version': 'git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603',
+              },
+            ]),
+          },
+        ),
+      ],
+    ),
+  },
 );
 
 const String testOwnersContent = '''

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -223,7 +223,7 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter
 Please follow https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
-final CiYaml testCiYaml = CiYaml(
+final CiYamlSet testCiYaml = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -223,7 +223,8 @@ https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter
 Please follow https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
 
-final CiYaml testCiYaml = CiYaml(
+final CiYamlInner testCiYaml = CiYamlInner(
+  type: CiType.any,
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   config: pb.SchedulerConfig(

--- a/app_dart/test/server_test.dart
+++ b/app_dart/test/server_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'src/datastore/fake_config.dart';
 import 'src/request_handling/fake_authentication.dart';
 import 'src/service/fake_build_bucket_client.dart';
+import 'src/service/fake_fusion_tester.dart';
 import 'src/service/fake_gerrit_service.dart';
 import 'src/service/fake_luci_build_service.dart';
 import 'src/service/fake_scheduler.dart';
@@ -30,6 +31,7 @@ void main() {
       commitService: CommitService(config: FakeConfig()),
       gerritService: FakeGerritService(),
       scheduler: FakeScheduler(config: FakeConfig()),
+      fusionTester: FakeFusionTester(),
     );
   });
 }

--- a/app_dart/test/service/scheduler/graph_test.dart
+++ b/app_dart/test/service/scheduler/graph_test.dart
@@ -24,7 +24,7 @@ targets:
       test: abc
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(singleTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYamlInner(
+      final SchedulerConfig schedulerConfig = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -57,7 +57,7 @@ targets:
         () {
           final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
             ..mergeFromProto3Json(targetWithNonexistentScheduler);
-          CiYamlInner(
+          CiYaml(
             type: CiType.any,
             slug: Config.flutterSlug,
             branch: Config.defaultBranch(Config.flutterSlug),
@@ -91,7 +91,7 @@ targets:
       - B
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(dependentTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYamlInner(
+      final SchedulerConfig schedulerConfig = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -123,7 +123,7 @@ targets:
       - A
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(twoDependentTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYamlInner(
+      final SchedulerConfig schedulerConfig = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -155,7 +155,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(configWithCycle);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -183,7 +183,7 @@ targets:
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
         ..mergeFromProto3Json(configWithDuplicateTargets);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -215,7 +215,7 @@ targets:
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
         ..mergeFromProto3Json(configWithMultipleDependencies);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -243,7 +243,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(configWithMissingTarget);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -262,7 +262,7 @@ targets:
   });
 
   group('validate scheduler config and compared with tip of tree targets', () {
-    late CiYamlInner? totConfig;
+    late CiYaml? totConfig;
 
     setUp(() {
       final YamlMap? totYaml = loadYaml('''
@@ -272,7 +272,7 @@ targets:
   - name: A
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(totYaml);
-      totConfig = CiYamlInner(
+      totConfig = CiYaml(
         type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
@@ -290,7 +290,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -313,7 +313,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -335,7 +335,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
@@ -364,7 +364,7 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYamlInner(
+        () => CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),

--- a/app_dart/test/service/scheduler/graph_test.dart
+++ b/app_dart/test/service/scheduler/graph_test.dart
@@ -24,7 +24,8 @@ targets:
       test: abc
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(singleTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYaml(
+      final SchedulerConfig schedulerConfig = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -56,7 +57,8 @@ targets:
         () {
           final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
             ..mergeFromProto3Json(targetWithNonexistentScheduler);
-          CiYaml(
+          CiYamlInner(
+            type: CiType.any,
             slug: Config.flutterSlug,
             branch: Config.defaultBranch(Config.flutterSlug),
             config: unCheckedSchedulerConfig,
@@ -89,7 +91,8 @@ targets:
       - B
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(dependentTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYaml(
+      final SchedulerConfig schedulerConfig = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -120,7 +123,8 @@ targets:
       - A
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(twoDependentTargetConfig);
-      final SchedulerConfig schedulerConfig = CiYaml(
+      final SchedulerConfig schedulerConfig = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -151,7 +155,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(configWithCycle);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -178,7 +183,8 @@ targets:
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
         ..mergeFromProto3Json(configWithDuplicateTargets);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -209,7 +215,8 @@ targets:
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()
         ..mergeFromProto3Json(configWithMultipleDependencies);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -236,7 +243,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(configWithMissingTarget);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -254,7 +262,7 @@ targets:
   });
 
   group('validate scheduler config and compared with tip of tree targets', () {
-    late CiYaml? totConfig;
+    late CiYamlInner? totConfig;
 
     setUp(() {
       final YamlMap? totYaml = loadYaml('''
@@ -264,7 +272,8 @@ targets:
   - name: A
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(totYaml);
-      totConfig = CiYaml(
+      totConfig = CiYamlInner(
+        type: CiType.any,
         slug: Config.flutterSlug,
         branch: Config.defaultBranch(Config.flutterSlug),
         config: unCheckedSchedulerConfig,
@@ -281,7 +290,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -303,7 +313,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -324,7 +335,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,
@@ -352,7 +364,8 @@ targets:
       ''') as YamlMap?;
       final SchedulerConfig unCheckedSchedulerConfig = SchedulerConfig()..mergeFromProto3Json(currentYaml);
       expect(
-        () => CiYaml(
+        () => CiYamlInner(
+          type: CiType.any,
           slug: Config.flutterSlug,
           branch: Config.defaultBranch(Config.flutterSlug),
           config: unCheckedSchedulerConfig,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -80,6 +80,7 @@ targets:
     scheduler: luci
   - name: Linux runIf engine
     runIf:
+      - DEPS
       - engine/src/flutter/.ci.yaml
       - engine/src/flutter/dev/**
 ''';

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -46,7 +46,7 @@ class FakeScheduler extends Scheduler {
 
   final CiYaml _defaultConfig = emptyConfig;
 
-  /// [CiYamlInner] value to be injected on [getCiYaml].
+  /// [CiYaml] value to be injected on [getCiYaml].
   CiYaml? ciYaml;
 
   /// If true, getCiYaml will throw a [FormatException] when validation is

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -44,19 +44,19 @@ class FakeScheduler extends Scheduler {
           fusionTester: fusionTester ?? FakeFusionTester(),
         );
 
-  final CiYaml _defaultConfig = emptyConfig;
+  final CiYamlSet _defaultConfig = emptyConfig;
 
-  /// [CiYaml] value to be injected on [getCiYaml].
-  CiYaml? ciYaml;
+  /// [CiYamlSet] value to be injected on [getCiYaml].
+  CiYamlSet? ciYaml;
 
   /// If true, getCiYaml will throw a [FormatException] when validation is
   /// enforced, simulating failing validation.
   bool failCiYamlValidation = false;
 
   @override
-  Future<CiYaml> getCiYaml(
+  Future<CiYamlSet> getCiYaml(
     Commit commit, {
-    CiYaml? totCiYaml,
+    CiYamlSet? totCiYaml,
     RetryOptions? retryOptions,
     bool validate = false,
   }) async {
@@ -122,7 +122,7 @@ class FakeScheduler extends Scheduler {
   }
 }
 
-final emptyConfig = CiYaml(
+final emptyConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -140,7 +140,7 @@ final emptyConfig = CiYaml(
   },
 );
 
-final exampleConfig = CiYaml(
+final exampleConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -172,7 +172,7 @@ final exampleConfig = CiYaml(
   },
 );
 
-final exampleFlakyConfig = CiYaml(
+final exampleFlakyConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -200,7 +200,7 @@ final exampleFlakyConfig = CiYaml(
   },
 );
 
-final exampleBackfillConfig = CiYaml(
+final exampleBackfillConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -231,7 +231,7 @@ final exampleBackfillConfig = CiYaml(
   },
 );
 
-final examplePresubmitRescheduleConfig = CiYaml(
+final examplePresubmitRescheduleConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -253,7 +253,7 @@ final examplePresubmitRescheduleConfig = CiYaml(
   },
 );
 
-final batchPolicyConfig = CiYaml(
+final batchPolicyConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -276,7 +276,7 @@ final batchPolicyConfig = CiYaml(
   },
 );
 
-final unsupportedPostsubmitCheckrunConfig = CiYaml(
+final unsupportedPostsubmitCheckrunConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -293,7 +293,7 @@ final unsupportedPostsubmitCheckrunConfig = CiYaml(
   },
 );
 
-final nonBringupPackagesConfig = CiYaml(
+final nonBringupPackagesConfig = CiYamlSet(
   slug: Config.packagesSlug,
   branch: Config.defaultBranch(Config.packagesSlug),
   yamls: {
@@ -310,7 +310,7 @@ final nonBringupPackagesConfig = CiYaml(
   },
 );
 
-final bringupPackagesConfig = CiYaml(
+final bringupPackagesConfig = CiYamlSet(
   slug: Config.packagesSlug,
   branch: Config.defaultBranch(Config.packagesSlug),
   yamls: {
@@ -328,7 +328,7 @@ final bringupPackagesConfig = CiYaml(
   },
 );
 
-final totCiYaml = CiYaml(
+final totCiYaml = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {
@@ -348,7 +348,7 @@ final totCiYaml = CiYaml(
   },
 );
 
-final notInToTConfig = CiYaml(
+final notInToTConfig = CiYamlSet(
   slug: Config.flutterSlug,
   branch: Config.defaultBranch(Config.flutterSlug),
   yamls: {

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -10,7 +10,6 @@ import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore_com
 import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
-import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/gerrit/commit.dart';
 import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:fixnum/fixnum.dart';
@@ -220,7 +219,7 @@ Target generateTarget(
   pb.SchedulerSystem? schedulerSystem,
   String recipe = 'devicelab/devicelab',
 }) {
-  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.config;
+  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.configInnerFor(CiType.any).config;
   if (platformProperties != null && platformDimensions != null) {
     config.platformProperties[platform.toLowerCase()] =
         pb.SchedulerConfig_PlatformProperties(properties: platformProperties, dimensions: platformDimensions);

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -219,7 +219,7 @@ Target generateTarget(
   pb.SchedulerSystem? schedulerSystem,
   String recipe = 'devicelab/devicelab',
 }) {
-  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.configInnerFor(CiType.any).config;
+  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.configForInner(CiType.any);
   if (platformProperties != null && platformDimensions != null) {
     config.platformProperties[platform.toLowerCase()] =
         pb.SchedulerConfig_PlatformProperties(properties: platformProperties, dimensions: platformDimensions);

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -219,7 +219,7 @@ Target generateTarget(
   pb.SchedulerSystem? schedulerSystem,
   String recipe = 'devicelab/devicelab',
 }) {
-  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.configForInner(CiType.any);
+  final pb.SchedulerConfig config = schedulerConfig ?? exampleConfig.configFor(CiType.any);
   if (platformProperties != null && platformDimensions != null) {
     config.platformProperties[platform.toLowerCase()] =
         pb.SchedulerConfig_PlatformProperties(properties: platformProperties, dimensions: platformDimensions);


### PR DESCRIPTION
CiYaml now tracks one or more ci.yaml files in a fusion tree

CiYamlInner is the old CiYaml. Instead of merging or updating protobufs to know which target are engine targets and which are framework targets; keep them apart. We'll have to use this information later when scheduling engine builds first and waiting before we can schedule the test runs.

The fusion-engine-ciyaml will need to be updated to include paths; that needs to be added to the merge script.

- Downloading a ci.yaml path should respect the path requested
- Only adding the ability to find targets; scheduling to follow this PR.

The `settings.json` file has only the dart line length specified; which should be a shared setting between all developers as it is enforced by CI.