### PR TITLE
remove output queries unsupported by enqueuePullRequest

### DIFF
--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -225,21 +225,6 @@ mutation EnqueueFlutterPullRequest ($clientMutationId:String!, $pullRequestId:ID
     }
   ) {
     clientMutationId
-    pullRequest {
-      author {
-        login
-      }
-      authorAssociation
-      id
-      title
-      number
-      repository {
-        owner {
-          login
-        }
-        name
-      }
-    }
   }
 }
 ''');


### PR DESCRIPTION
`enqueuePullRequest` does not return a pull request. Remove it from the return schema.