### PR TITLE
make clientMutationId optional

### DIFF
--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -215,7 +215,7 @@ class EnqueuePullRequestMutation extends GraphQLOperation {
 
   @override
   DocumentNode get documentNode => lang.parseString(r'''
-mutation EnqueueFlutterPullRequest ($clientMutationId:String!, $pullRequestId:ID!, $expectedHeadOid:GitObjectID!, $jump:Boolean!) {
+mutation EnqueueFlutterPullRequest ($clientMutationId:String, $pullRequestId:ID!, $expectedHeadOid:GitObjectID!, $jump:Boolean!) {
   enqueuePullRequest (
     input: {
       clientMutationId: $clientMutationId,


### PR DESCRIPTION
`clientMutationId` is optional, and so it should be in the GQL mutation schema.