### PR TITLE
use minimal number of arguments to enqueue PRs

### DIFF
--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -195,37 +195,27 @@ mutation RevertPullFlutterPullRequest ($revertBody:String!, $clientMutationId:St
 class EnqueuePullRequestMutation extends GraphQLOperation {
   EnqueuePullRequestMutation({
     required this.id,
-    required this.expectedHeadOid,
     required this.jump,
-    this.clientMutationId,
   });
 
-  final String? clientMutationId;
   final String id;
-  final String expectedHeadOid;
   final bool jump;
 
   @override
   Map<String, dynamic> get variables => {
-        'clientMutationId': clientMutationId,
         'pullRequestId': id,
-        'expectedHeadOid': expectedHeadOid,
         'jump': jump,
       };
 
   @override
   DocumentNode get documentNode => lang.parseString(r'''
-mutation EnqueueFlutterPullRequest ($clientMutationId:String, $pullRequestId:ID!, $expectedHeadOid:GitObjectID!, $jump:Boolean!) {
+mutation EnqueueFlutterPullRequest ($pullRequestId:ID!, $jump:Boolean!) {
   enqueuePullRequest (
     input: {
-      clientMutationId: $clientMutationId,
-      expectedHeadOid: $expectedHeadOid,
-      jump: $jump,
       pullRequestId: $pullRequestId,
+      jump: $jump,
     }
-  ) {
-    clientMutationId
-  }
+  )
 }
 ''');
 }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -99,11 +99,11 @@ ${messagePullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
 
     final enqueueMutation = EnqueuePullRequestMutation(
       id: pullRequest.id!.toString(),
-      expectedHeadOid: pullRequest.head!.sha!,
       jump: isEmergencyPullRequest,
     );
 
     try {
+      log.info('Attempting to enqueue ${slug.fullName}/${pullRequest.number} with these variables: ${enqueueMutation.variables}');
       await retryOptions.retry(
         () async {
           await graphQlService.mutateGraphQL(

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -104,7 +104,9 @@ ${messagePullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
 
     try {
       log.info(
-          'Attempting to enqueue ${slug.fullName}/${pullRequest.number} with these variables: ${enqueueMutation.variables}');
+        'Attempting to enqueue ${slug.fullName}/${pullRequest.number} '
+        'with these variables: ${enqueueMutation.variables}',
+      );
       await retryOptions.retry(
         () async {
           await graphQlService.mutateGraphQL(

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -103,7 +103,8 @@ ${messagePullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
     );
 
     try {
-      log.info('Attempting to enqueue ${slug.fullName}/${pullRequest.number} with these variables: ${enqueueMutation.variables}');
+      log.info(
+          'Attempting to enqueue ${slug.fullName}/${pullRequest.number} with these variables: ${enqueueMutation.variables}');
       await retryOptions.retry(
         () async {
           await graphQlService.mutateGraphQL(

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -473,9 +473,7 @@ This is the second line in a paragraph.''');
       expect(
         mutationOptions,
         {
-          'clientMutationId': null,
           'pullRequestId': '1',
-          'expectedHeadOid': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           'jump': false,
         },
       );
@@ -512,9 +510,7 @@ This is the second line in a paragraph.''');
       expect(
         mutationOptions,
         {
-          'clientMutationId': null,
           'pullRequestId': '1',
-          'expectedHeadOid': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           'jump': false,
         },
       );
@@ -555,9 +551,7 @@ This is the second line in a paragraph.''');
       expect(
         mutationOptions,
         {
-          'clientMutationId': null,
           'pullRequestId': '1',
-          'expectedHeadOid': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           'jump': true,
         },
       );


### PR DESCRIPTION
This is a speculative fix for `enqueuePullRequest` internal error:

```
OperationException(linkException: null, graphqlErrors: [GraphQLError(message: Could not resolve to a node with the global id of '2157301061', locations: [ErrorLocation(line: 2, column: 3)], path: [enqueuePullRequest], extensions: null)])"
```

It's unclear what "global id of '2157301061'" is and where it comes from (we're not passing it). The hypothesis in this PR is that perhaps Github is failing to lookup the `expectedHeadOid` or something in the return value, and so reducing the argument list to just the essential one and not requesting anything to be returned might fix the issue.
