### PR TITLE
[mq] add a return payload

### DIFF
--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -215,7 +215,9 @@ mutation EnqueueFlutterPullRequest ($pullRequestId:ID!, $jump:Boolean!) {
       pullRequestId: $pullRequestId,
       jump: $jump,
     }
-  )
+  ) {
+    clientMutationId
+  }
 }
 ''');
 }


### PR DESCRIPTION
It looks like Github doesn't like it when the return payload is completely empty:

```
auto_submit: OperationException(linkException: null, graphqlErrors: [GraphQLError(message: Field must have selections (field 'enqueuePullRequest' returns EnqueuePullRequestPayload but has no selections. Did you mean 'enqueuePullRequest { ... }'?), locations: [ErrorLocation(line: 2, column: 3)], path: [mutation EnqueueFlutterPullRequest, enqueuePullRequest], extensions: {code: selectionMismatch, nodeName: field 'enqueuePullRequest', typeName: EnqueuePullRequestPayload}), GraphQLError(message: Variable $pullRequestId is declared by EnqueueFlutterPullRequest but not used, locations: [ErrorLocation(line: 1, column: 1)], path: [mutation EnqueueFlutterPullRequest], extensions: {code: variableNotUsed, variableName: pullRequestId}), GraphQLError(message: Variable $jump is declared by EnqueueFlutterPullRequest but not used, locations: [ErrorLocation(line: 1, column: 1)], path: [mutation EnqueueFlutterPullRequest], extensions: {code: variableNotUsed, variableName: jump})])
```

So let's return at least the `clientMutationId`?