### PR TITLE
[mq] do not enqueue already enqueued PRs

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -358,8 +358,7 @@ class Scheduler {
     // The MQ only waits for "required status checks" before deciding whether to
     // merge the PR into the target branch. This required check added to both
     // the PR and to the merge group, and so it must be completed in both cases.
-    // TODO(yjbanov): unhardcode the repo name when MQ is enabled in production
-    //                repositories, and not just in flutter/flaux.
+    // TODO(yjbanov): find a robust way to detect if a PR is enabled for MQ.
     CheckRun? lock;
     if (slug.fullName == 'flutter/flaux') {
       lock = await lockMergeGroupChecks(slug, pullRequest.head!.sha!);

--- a/auto_submit/lib/model/auto_submit_query_result.dart
+++ b/auto_submit/lib/model/auto_submit_query_result.dart
@@ -138,7 +138,7 @@ class Commit {
   Map<String, dynamic> toJson() => _$CommitToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(fieldRename: FieldRename.none)
 class PullRequest {
   PullRequest({
     this.author,
@@ -148,11 +148,12 @@ class PullRequest {
     this.body,
     this.reviews,
     this.commits,
-    this.mergeable,
     this.number,
+    this.mergeable,
+    this.isInMergeQueue = false,
   });
+
   final Author? author;
-  @JsonKey(name: 'authorAssociation')
   final String? authorAssociation;
   final String? id;
   final String? title;
@@ -162,6 +163,7 @@ class PullRequest {
   final int? number;
   // https://docs.github.com/en/graphql/reference/enums#mergeablestate
   final MergeableState? mergeable;
+  final bool isInMergeQueue;
 
   factory PullRequest.fromJson(Map<String, dynamic> json) => _$PullRequestFromJson(json);
 
@@ -182,6 +184,7 @@ class Repository {
   Map<String, dynamic> toJson() => _$RepositoryToJson(this);
 }
 
+// TODO(yjbanov): rename to AutosubmitQueryResult to avoid name clash with graphql.dart/QueryResult
 @JsonSerializable()
 class QueryResult {
   QueryResult({

--- a/auto_submit/lib/model/auto_submit_query_result.g.dart
+++ b/auto_submit/lib/model/auto_submit_query_result.g.dart
@@ -97,8 +97,9 @@ PullRequest _$PullRequestFromJson(Map<String, dynamic> json) => PullRequest(
       body: json['body'] as String?,
       reviews: json['reviews'] == null ? null : Reviews.fromJson(json['reviews'] as Map<String, dynamic>),
       commits: json['commits'] == null ? null : Commits.fromJson(json['commits'] as Map<String, dynamic>),
-      mergeable: $enumDecodeNullable(_$MergeableStateEnumMap, json['mergeable']),
       number: (json['number'] as num?)?.toInt(),
+      mergeable: $enumDecodeNullable(_$MergeableStateEnumMap, json['mergeable']),
+      isInMergeQueue: json['isInMergeQueue'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$PullRequestToJson(PullRequest instance) => <String, dynamic>{
@@ -111,6 +112,7 @@ Map<String, dynamic> _$PullRequestToJson(PullRequest instance) => <String, dynam
       'commits': instance.commits,
       'number': instance.number,
       'mergeable': _$MergeableStateEnumMap[instance.mergeable],
+      'isInMergeQueue': instance.isInMergeQueue,
     };
 
 const _$MergeableStateEnumMap = {

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -74,7 +74,8 @@ class CheckPullRequest extends CheckRequest {
 
       log.info('Processing message ackId: ${message.ackId}');
       log.info('Processing mesageId: ${message.message!.messageId}');
-      log.info('Processing PR: $rawBody');
+      log.info('Processing PR: ${pullRequest.toJson()}');
+
       if (processingLog.contains(pullRequest.number)) {
         // Ack duplicate.
         log.info('Ack the duplicated message : ${message.ackId!}.');

--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -114,38 +114,6 @@ query FindPullRequestNodeId ($repoOwner:String!, $repoName:String!, $pullRequest
 ''');
 }
 
-/// Queries a pull request out of GraphQL.
-class GetPullRequestQuery extends GraphQLOperation {
-  GetPullRequestQuery({
-    required this.repositoryOwner,
-    required this.repositoryName,
-    required this.pullRequestNumber,
-  });
-
-  final String repositoryOwner;
-  final String repositoryName;
-  final int pullRequestNumber;
-
-  @override
-  Map<String, dynamic> get variables => {
-        'repoOwner': repositoryOwner,
-        'repoName': repositoryName,
-        'pullRequestNumber': pullRequestNumber,
-      };
-
-  @override
-  DocumentNode get documentNode => lang.parseString(r'''
-query GetPullRequestForAutosubmit ($repoOwner:String!, $repoName:String!, $pullRequestNumber:Int!) {
-  repository(owner:$repoOwner, name:$repoName) {
-    pullRequest(number:$pullRequestNumber) {
-      id,
-      isInMergeQueue,
-    }
-  }
-}
-''');
-}
-
 /// [RevertPullRequestMutation] encapsulates the input variables and
 /// [DocumentNode] needed to perform the revert request mutation to revert a
 /// closed pull request.

--- a/auto_submit/lib/requests/graphql_queries.dart
+++ b/auto_submit/lib/requests/graphql_queries.dart
@@ -48,6 +48,7 @@ query LabeledPullRequestWithReviews($sOwner: String!, $sName: String!, $sPrNumbe
       id
       title
       mergeable
+      isInMergeQueue
       commits(last:1) {
         nodes {
           commit {
@@ -107,6 +108,38 @@ query FindPullRequestNodeId ($repoOwner:String!, $repoName:String!, $pullRequest
   repository(owner:$repoOwner, name:$repoName) {
     pullRequest(number:$pullRequestNumber) {
       id
+    }
+  }
+}
+''');
+}
+
+/// Queries a pull request out of GraphQL.
+class GetPullRequestQuery extends GraphQLOperation {
+  GetPullRequestQuery({
+    required this.repositoryOwner,
+    required this.repositoryName,
+    required this.pullRequestNumber,
+  });
+
+  final String repositoryOwner;
+  final String repositoryName;
+  final int pullRequestNumber;
+
+  @override
+  Map<String, dynamic> get variables => {
+        'repoOwner': repositoryOwner,
+        'repoName': repositoryName,
+        'pullRequestNumber': pullRequestNumber,
+      };
+
+  @override
+  DocumentNode get documentNode => lang.parseString(r'''
+query GetPullRequestForAutosubmit ($repoOwner:String!, $repoName:String!, $pullRequestNumber:Int!) {
+  repository(owner:$repoOwner, name:$repoName) {
+    pullRequest(number:$pullRequestNumber) {
+      id,
+      isInMergeQueue,
     }
   }
 }

--- a/auto_submit/lib/service/graphql_service.dart
+++ b/auto_submit/lib/service/graphql_service.dart
@@ -15,7 +15,10 @@ import 'config.dart';
 class GraphQlService {
   GraphQlService._(this._client);
 
-  // TODO(yjbanov): GraphQlService should not be slug-specific (i.e. repo-specific)
+  // TODO(yjbanov): GraphQlService should not be slug-specific (i.e. repo-specific); you
+  //                only need the "owner" (i.e. the Github org or user). Making it
+  //                slug-specific makes it awkward to use for org operations and cross-repo
+  //                operations.
   static Future<GraphQlService> forRepo(Config config, github.RepositorySlug slug) async {
     final client = await config.createGitHubGraphQLClient(slug);
     return GraphQlService._(client);
@@ -24,6 +27,8 @@ class GraphQlService {
   final GraphQLClient _client;
 
   /// Runs a GraphQL query using [slug], [prNumber] and a [GraphQL] client.
+  // TODO(yjbanov): make this private, and instead expose higher-level testable
+  //                and mockable methods that perform specific queries.
   Future<Map<String, dynamic>> queryGraphQL({
     required DocumentNode documentNode,
     required Map<String, dynamic> variables,
@@ -43,6 +48,8 @@ class GraphQlService {
     return queryResult.data!;
   }
 
+  // TODO(yjbanov): make this private, and instead expose higher-level testable
+  //                and mockable methods that perform specific mutations.
   Future<Map<String, dynamic>> mutateGraphQL({
     required DocumentNode documentNode,
     required Map<String, dynamic> variables,

--- a/auto_submit/lib/service/graphql_service.dart
+++ b/auto_submit/lib/service/graphql_service.dart
@@ -3,20 +3,32 @@
 // found in the LICENSE file.
 
 import 'package:auto_submit/service/log.dart';
+import 'package:github/github.dart' as github;
 import 'package:gql/ast.dart';
 import 'package:graphql/client.dart';
 
 import '../requests/exceptions.dart';
+import '../requests/graphql_queries.dart';
+import 'config.dart';
 
 /// Service class used to execute GraphQL queries.
 class GraphQlService {
+  GraphQlService._(this._client);
+
+  // TODO(yjbanov): GraphQlService should not be slug-specific (i.e. repo-specific)
+  static Future<GraphQlService> forRepo(Config config, github.RepositorySlug slug) async {
+    final client = await config.createGitHubGraphQLClient(slug);
+    return GraphQlService._(client);
+  }
+
+  final GraphQLClient _client;
+
   /// Runs a GraphQL query using [slug], [prNumber] and a [GraphQL] client.
   Future<Map<String, dynamic>> queryGraphQL({
     required DocumentNode documentNode,
     required Map<String, dynamic> variables,
-    required GraphQLClient client,
   }) async {
-    final QueryResult queryResult = await client.query(
+    final QueryResult queryResult = await _client.query(
       QueryOptions(
         document: documentNode,
         fetchPolicy: FetchPolicy.noCache,
@@ -34,9 +46,8 @@ class GraphQlService {
   Future<Map<String, dynamic>> mutateGraphQL({
     required DocumentNode documentNode,
     required Map<String, dynamic> variables,
-    required GraphQLClient client,
   }) async {
-    final QueryResult queryResult = await client.mutate(
+    final QueryResult queryResult = await _client.mutate(
       MutationOptions(
         document: documentNode,
         fetchPolicy: FetchPolicy.noCache,
@@ -49,5 +60,55 @@ class GraphQlService {
       throw const BadRequestException('GraphQL mutate failed');
     }
     return queryResult.data!;
+  }
+
+  /// Retrieves the GraphQL ID for a pull request.
+  ///
+  /// The REST pull request ID is not the same as the GraphQL ID, and GraphQL
+  /// mutations only accept the GraphQL variant.
+  Future<String> getPullRequestId(github.RepositorySlug slug, int pullRequestNumber) async {
+    final queryPullRequest = FindPullRequestNodeIdQuery(
+      repositoryOwner: slug.owner,
+      repositoryName: slug.name,
+      pullRequestNumber: pullRequestNumber,
+    );
+
+    final Map<String, dynamic> graphQlPullRequest = await queryGraphQL(
+      documentNode: queryPullRequest.documentNode,
+      variables: queryPullRequest.variables,
+    );
+
+    return graphQlPullRequest['repository']['pullRequest']['id'];
+  }
+
+  /// Puts the given pull request onto the merge queue.
+  ///
+  /// Assumes merge queue is enabled in the respective repository, and that the
+  /// pull request is in a state that allows it to proceed onto the merge queue
+  /// (e.g. all required checks pass).
+  Future<void> enqueuePullRequest(github.RepositorySlug slug, int pullRequestNumber, bool jump) async {
+    final enqueueMutation = EnqueuePullRequestMutation(
+      id: await getPullRequestId(slug, pullRequestNumber),
+      jump: jump,
+    );
+
+    log.info(
+      'Attempting to enqueue ${slug.fullName}/$pullRequestNumber '
+      'with these variables: ${enqueueMutation.variables}',
+    );
+
+    await mutateGraphQL(
+      documentNode: enqueueMutation.documentNode,
+      variables: enqueueMutation.variables,
+    );
+  }
+}
+
+extension QueryOptionsExtension on QueryOptions {
+  String? get operationDefinitionName {
+    return document.definitions
+        .whereType<OperationDefinitionNode>()
+        .map<String?>((operation) => operation.name?.value)
+        .firstOrNull;
   }
 }

--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -142,6 +142,20 @@ class PullRequestValidationService extends ValidationService {
       await githubService.createComment(slug, prNumber, message);
       log.info(message);
     } else {
+      // Remove the autosubmit label post enqueue/merge to avoid infinite loops.
+      // Here's an example of an infinite loop:
+      //
+      // 1. Autosubmit bot is notified that a PR is ready (reviewed, all green, has `autosubmit` label).
+      // 2. Autosubmit bot puts the PR onto the merge queue.
+      // 3. The PR fails some tests in the merge queue.
+      // 4. Github kicks the PR back, removing it fom the merge queue.
+      // 5. GOTO step 1.
+      //
+      // Removing the `autosubmit` label will prevent the autosubmit bot from
+      // repeating the process, until a human looks at the PR, decides that it's
+      // ready again, and manually adds the `autosubmit` label on it.
+      await githubService.removeLabel(slug, prNumber, Config.kAutosubmitLabel);
+
       log.info('Pull Request ${slug.fullName}/$prNumber was merged successfully!');
       log.info('Attempting to insert a pull request record into the database for $prNumber');
       await insertPullRequestRecord(

--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -58,6 +58,18 @@ class PullRequestValidationService extends ValidationService {
   }) async {
     final github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
     final int prNumber = messagePullRequest.number!;
+
+    // TODO(yjbanov): figure out how to determine if the repo is MQ-enabled.
+    final bool isMergeQueueEnabled = slug.fullName == 'flutter/flaux';
+    if (isMergeQueueEnabled) {
+      if (result.repository!.pullRequest!.isInMergeQueue) {
+        log.info(
+          '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',
+        );
+        return;
+      }
+    }
+
     final RepositoryConfiguration repositoryConfiguration = await config.getRepositoryConfiguration(slug);
 
     // filter out validations here

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -132,11 +132,11 @@ void main() {
       pubsub: pubsub,
     );
 
-    // These checks indicate that the pull request has been merged as the label
-    // is not removed and there was no issue coment generated and the message
-    // was acknowledged.
+    // These checks indicate that the pull request has been merged, the label
+    // was removed, there was no issue coment generated, and the message was
+    // acknowledged.
     expect(githubService.issueComment, isNull);
-    expect(githubService.labelRemoved, false);
+    expect(githubService.labelRemoved, isTrue);
     assert(pubsub.messagesQueue.isEmpty);
   });
 
@@ -349,11 +349,11 @@ void main() {
         pubsub: pubsub,
       );
 
-      // These checks indicate that the pull request has been merged as the label
-      // is not removed and there was no issue comment generated and the message
-      // was acknowledged.
+      // These checks indicate that the pull request has been merged, the label
+      // was removed, there was no issue coment generated, and the message was
+      // acknowledged.
       expect(githubService.issueComment, isNull);
-      expect(githubService.labelRemoved, false);
+      expect(githubService.labelRemoved, isTrue);
       assert(pubsub.messagesQueue.isEmpty);
     });
 

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:auto_submit/configuration/repository_configuration.dart';
 import 'package:auto_submit/model/auto_submit_query_result.dart' as auto hide PullRequest;
+import 'package:auto_submit/service/log.dart';
 import 'package:auto_submit/service/pull_request_validation_service.dart';
 import 'package:auto_submit/service/validation_service.dart';
 import 'package:github/github.dart';
@@ -610,6 +611,53 @@ This is the second line in a paragraph.''');
       );
       expect(result.result, isTrue);
       expect(result.message, contains(prTitle));
+    });
+
+    test('Does not enqueue pull requests already in the queue', () async {
+      final logs = <String>[];
+      final logSub = log.onRecord.listen((record) {
+        logs.add(record.toString());
+      });
+
+      slug = RepositorySlug('flutter', 'flaux');
+      final PullRequestHelper flutterRequest = PullRequestHelper(
+        prNumber: 0,
+        lastCommitHash: oid,
+        isInMergeQueue: true,
+        reviews: <PullRequestReviewHelper>[
+          const PullRequestReviewHelper(
+            authorName: 'member',
+            state: ReviewState.APPROVED,
+            memberType: MemberType.OWNER,
+          ),
+        ],
+      );
+      githubService.checkRunsData = checkRunsMock;
+      githubService.checkRunsMock = checkRunsMock;
+      githubService.createCommentData = createCommentMock;
+      githubService.isTeamMemberMockMap['author1'] = true;
+      githubService.isTeamMemberMockMap['member'] = true;
+      final FakePubSub pubsub = FakePubSub();
+      final PullRequest pullRequest = generatePullRequest(
+        prNumber: 0,
+        repoName: slug.name,
+        baseRef: 'feature_a',
+        mergeable: true,
+      );
+
+      await validationService.processPullRequest(
+        config: config,
+        result: createQueryResult(flutterRequest),
+        messagePullRequest: pullRequest,
+        ackId: 'test',
+        pubsub: pubsub,
+      );
+
+      await logSub.cancel();
+      expect(
+        logs,
+        contains('[INFO] auto_submit: flutter/flaux/0 is already in the merge queue. Skipping.'),
+      );
     });
   });
 }

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -133,7 +133,7 @@ void main() {
     );
 
     // These checks indicate that the pull request has been merged, the label
-    // was removed, there was no issue coment generated, and the message was
+    // was removed, there was no issue comment generated, and the message was
     // acknowledged.
     expect(githubService.issueComment, isNull);
     expect(githubService.labelRemoved, isTrue);
@@ -350,7 +350,7 @@ void main() {
       );
 
       // These checks indicate that the pull request has been merged, the label
-      // was removed, there was no issue coment generated, and the message was
+      // was removed, there was no issue comment generated, and the message was
       // acknowledged.
       expect(githubService.issueComment, isNull);
       expect(githubService.labelRemoved, isTrue);

--- a/auto_submit/test/utilities/utils.dart
+++ b/auto_submit/test/utilities/utils.dart
@@ -39,6 +39,7 @@ class PullRequestHelper {
     this.lastCommitMessage = '',
     this.dateTime,
     this.mergedAt,
+    this.isInMergeQueue = false,
   });
 
   final int prNumber;
@@ -53,6 +54,7 @@ class PullRequestHelper {
   final String title;
   final MergeableState mergeableState;
   final DateTime? mergedAt;
+  final bool isInMergeQueue;
 
   RepositorySlug get slug => RepositorySlug('flutter', repo);
 
@@ -65,6 +67,7 @@ class PullRequestHelper {
       'title': title,
       'mergeable': mergeableState.name,
       'mergedAt': (mergedAt ?? DateTime.now().subtract(const Duration(hours: 12))).toUtc().toIso8601String(),
+      'isInMergeQueue': isInMergeQueue,
       'reviews': <String, dynamic>{
         'nodes': reviews.map((PullRequestReviewHelper review) {
           return <String, dynamic>{


### PR DESCRIPTION
A PR stays open while it's in the merge queue because the MQ can eject it back if it doesn't pass tests, so `PullRequestValidationService` can receive pings that would look like a request to validate and merge the PR (it will be all green, reviewed, and have an `autosubmit` label). However, if a PR is already in the merge queue, there's nothing to do. So short-circuit the validation process, do nothing other than print a log message that it happened.