### PR TITLE
rename "CI Tasks" to "Merge Queue Guard"

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -90,11 +90,14 @@ class Scheduler {
   /// workflow.
   static const String kMergeQueueLockName = 'Merge Queue Guard';
 
-  /// Briefly describes what [kMergeQueueLockName] is for.
+  /// Briefly describes what the "Merge Queue Guard" check is for.
+  ///
+  /// Find more details about this check at [kMergeQueueLockName].
   ///
   /// This description appears next to the Github check run in the pull request
   /// and merge queue UI.
-  static const String kMergeQueueLockDescription = 'This is only here to block the merge queue; nothing to see here in PRs';
+  static const String kMergeQueueLockDescription =
+      'This is only here to block the merge queue; nothing to see here in PRs';
 
   /// Ensure [commits] exist in Cocoon.
   ///

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -77,13 +77,24 @@ class Scheduler {
   /// CI checks and the PR/commit should be treated as failing.
   static const String kCiYamlCheckName = 'ci.yaml validation';
 
-  /// A virtual check that stays in pending state until all other CI tasks are
-  /// completed.
+  /// A required check that stays in pending state until a sufficient subset of
+  /// checks pass.
   ///
   /// This check is "required", meaning that it must pass before Github will
   /// allow a PR to land in the merge queue, or a merge group to land on the
   /// target branch (main or master).
-  static const String kCiTasksName = 'CI tasks';
+  ///
+  /// IMPORTANT: the name of this task - "Merge Queue Guard" - must strictly
+  /// match the name of the required check configured in the repo settings.
+  /// Changing the name here or in the settings alone will break the PR
+  /// workflow.
+  static const String kMergeQueueLockName = 'Merge Queue Guard';
+
+  /// Briefly describes what [kMergeQueueLockName] is for.
+  ///
+  /// This description appears next to the Github check run in the pull request
+  /// and merge queue UI.
+  static const String kMergeQueueLockDescription = 'This is only here to block the merge queue; nothing to see here in PRs';
 
   /// Ensure [commits] exist in Cocoon.
   ///
@@ -498,8 +509,8 @@ class Scheduler {
     log.info('Simulating cancellation of merge group CI targets for @ $headSha');
   }
 
-  /// Pushes a required "CI tasks" check to the merge queue, which serves as a
-  /// "lock".
+  /// Pushes the required "Merge Queue Guard" check to the merge queue, which
+  /// serves as a "lock".
   ///
   /// While this check is still in progress, the merge queue will not merge the
   /// respective PR onto the target branch (e.g. main or master), because this
@@ -509,16 +520,16 @@ class Scheduler {
       config,
       slug,
       headSha,
-      kCiTasksName,
+      kMergeQueueLockName,
       output: const CheckRunOutput(
-        title: kCiTasksName,
-        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+        title: kMergeQueueLockName,
+        summary: kMergeQueueLockDescription,
       ),
     );
   }
 
-  /// Completes a "CI tasks" check that was scheduled using [lockMergeGroupChecks]
-  /// with either success or failure.
+  /// Completes the "Merge Queue Guard" check that was scheduled using
+  /// [lockMergeGroupChecks] with either success or failure.
   ///
   /// If [exception] is null completed the check with success. Otherwise,
   /// completes the check with failure.
@@ -529,7 +540,7 @@ class Scheduler {
   Future<void> unlockMergeGroupChecks(RepositorySlug slug, String headSha, CheckRun lock, Object? exception) async {
     if (exception == null) {
       // All checks have passed. Unlocking Github with success.
-      log.info('All required CI tasks passed for $headSha');
+      log.info('All required tests passed for $headSha');
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
         slug,
@@ -539,7 +550,7 @@ class Scheduler {
       );
     } else {
       // Some checks failed. Unlocking Github with failure.
-      log.info('Some required CI tasks failed for $headSha');
+      log.info('Some required tests failed for $headSha');
       log.warning(exception.toString());
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
@@ -549,7 +560,7 @@ class Scheduler {
         conclusion: CheckRunConclusion.failure,
         output: CheckRunOutput(
           title: kCiYamlCheckName,
-          summary: 'Some required CI tasks failed for ${lock.headSha}',
+          summary: 'Some required tests failed for $headSha',
           text: exception.toString(),
         ),
       );

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2539,7 +2539,7 @@ void foo() {
           'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'All required CI tasks passed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'All required tests passed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );
@@ -2589,7 +2589,7 @@ void foo() {
           'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Some required CI tasks failed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Some required tests failed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Some checks failed',
           'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],


### PR DESCRIPTION
New name: "Merge Queue Guard"
New description: "This is only here to block the merge queue; nothing to see here in PRs"