### PR TITLE
[mq] enable merge queue guard check in all repos

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -372,11 +372,7 @@ class Scheduler {
     // The MQ only waits for "required status checks" before deciding whether to
     // merge the PR into the target branch. This required check added to both
     // the PR and to the merge group, and so it must be completed in both cases.
-    // TODO(yjbanov): find a robust way to detect if a PR is enabled for MQ.
-    CheckRun? lock;
-    if (slug.fullName == 'flutter/flaux') {
-      lock = await lockMergeGroupChecks(slug, pullRequest.head!.sha!);
-    }
+    final lock = await lockMergeGroupChecks(slug, pullRequest.head!.sha!);
 
     log.info('Creating ciYaml validation check run for ${pullRequest.number}');
     final CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
@@ -446,9 +442,7 @@ class Scheduler {
       );
     }
 
-    if (lock != null) {
-      await unlockMergeGroupChecks(slug, pullRequest.head!.sha!, lock, exception);
-    }
+    await unlockMergeGroupChecks(slug, pullRequest.head!.sha!, lock, exception);
 
     log.info(
       'Finished triggering builds for: pr ${pullRequest.number}, commit ${pullRequest.base!.sha}, branch ${pullRequest.head!.ref} and slug $slug}',

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -275,7 +275,7 @@ void main() {
         final Commit commit = shaToCommit('1');
         db.values[commit.key] = commit;
 
-        db.onCommit = (List<gcloud_db.Model<dynamic>> inserts, List<gcloud_db.Key<dynamic>> deletes) {
+        db.onCommit = (List<gcloud_db.Model<Object?>> inserts, List<gcloud_db.Key<Object?>> deletes) {
           if (inserts.whereType<Commit>().where((Commit commit) => commit.sha == '3').isNotEmpty) {
             throw StateError('Commit failed');
           }
@@ -304,7 +304,7 @@ void main() {
         final Commit commit = shaToCommit('1');
         db.values[commit.key] = commit;
 
-        db.onCommit = (List<gcloud_db.Model<dynamic>> inserts, List<gcloud_db.Key<dynamic>> deletes) {
+        db.onCommit = (List<gcloud_db.Model<Object?>> inserts, List<gcloud_db.Key<Object?>> deletes) {
           if (inserts.whereType<Task>().where((Task task) => task.createTimestamp == 3).isNotEmpty) {
             throw StateError('Task failed');
           }
@@ -351,13 +351,13 @@ void main() {
         );
 
         await scheduler.addCommits(createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
-        final List<dynamic> captured = verify(
+        final List<Object?> captured = verify(
           luciBuildService.schedulePostsubmitBuilds(
             commit: anyNamed('commit'),
             toBeScheduled: captureAnyNamed('toBeScheduled'),
           ),
         ).captured;
-        final List<dynamic> toBeScheduled = captured.first as List<dynamic>;
+        final List<Object?> toBeScheduled = captured.first as List<Object?>;
         expect(toBeScheduled.length, 2);
         final Iterable<Tuple<Target, Task, int>> tuples =
             toBeScheduled.map((dynamic tuple) => tuple as Tuple<Target, Task, int>);
@@ -440,7 +440,7 @@ void main() {
         expect(commit.authorAvatarUrl, 'dashatar');
         expect(commit.message, 'example message');
 
-        final List<dynamic> captured = verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
+        final List<Object?> captured = verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
         expect(captured.length, 1);
         final List<Write> commitResponse = captured[0] as List<Write>;
         expect(commitResponse.length, 4);
@@ -1024,7 +1024,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kMergeQueueLockName,
+            const CheckRunOutput(
+              title: Scheduler.kMergeQueueLockName,
+              summary: Scheduler.kMergeQueueLockDescription,
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -1048,7 +1053,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kMergeQueueLockName,
+            const CheckRunOutput(
+              title: Scheduler.kMergeQueueLockName,
+              summary: Scheduler.kMergeQueueLockDescription,
+            ),
             Scheduler.kCiYamlCheckName,
             // No other targets should be created.
             const CheckRunOutput(
@@ -1156,7 +1166,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kMergeQueueLockName,
+            const CheckRunOutput(
+              title: Scheduler.kMergeQueueLockName,
+              summary: Scheduler.kMergeQueueLockDescription,
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -1179,7 +1194,12 @@ targets:
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
-          <dynamic>[
+          <Object?>[
+            Scheduler.kMergeQueueLockName,
+            const CheckRunOutput(
+              title: Scheduler.kMergeQueueLockName,
+              summary: Scheduler.kMergeQueueLockDescription,
+            ),
             Scheduler.kCiYamlCheckName,
             const CheckRunOutput(
               title: Scheduler.kCiYamlCheckName,
@@ -1208,7 +1228,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.success],
+          <Object?>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.success,
+            CheckRunStatus.completed,
+            CheckRunConclusion.success,
+          ],
         );
       });
 
@@ -1231,7 +1256,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.failure],
+          <Object?>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+          ],
         );
       });
 
@@ -1249,7 +1279,12 @@ targets:
               output: anyNamed('output'),
             ),
           ).captured,
-          <dynamic>[CheckRunStatus.completed, CheckRunConclusion.failure],
+          <Object?>[
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+            CheckRunStatus.completed,
+            CheckRunConclusion.failure,
+          ],
         );
       });
 


### PR DESCRIPTION
Enables the "Merge Queue Guard" check in all repos. No impact on contribution process is expected. This check should simply pass or fail in tandem with the "ci.yaml validation" check.