### PR TITLE
[mq] flutter/flutter will autosubmit using MQ

### DIFF
--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -59,9 +59,7 @@ class PullRequestValidationService extends ValidationService {
     final github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
     final int prNumber = messagePullRequest.number!;
 
-    // TODO(yjbanov): figure out how to determine if the repo is MQ-enabled.
-    final bool isMergeQueueEnabled = slug.fullName == 'flutter/flaux';
-    if (isMergeQueueEnabled) {
+    if (messagePullRequest.isMergeQueueEnabled) {
       if (result.repository!.pullRequest!.isInMergeQueue) {
         log.info(
           '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -79,10 +79,7 @@ ${messagePullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
     final String prBody = _sanitizePrBody(messagePullRequest.body ?? '');
     final String commitMessage = '$messagePrefix$prBody';
 
-    // TODO(yjbanov): figure out how to determine if the repo is MQ-enabled.
-    final bool isMergeQueueEnabled = slug.fullName == 'flutter/flaux';
-
-    if (isMergeQueueEnabled) {
+    if (messagePullRequest.isMergeQueueEnabled) {
       return _enqueuePullRequest(slug, messagePullRequest);
     } else {
       return _mergePullRequest(number, commitMessage, slug);
@@ -250,4 +247,22 @@ String _sanitizePrBody(String rawPrBody) {
     buffer.writeln(line);
   }
   return buffer.toString().trim();
+}
+
+/// Repos that use MQ-based workflow.
+///
+/// This variable is read-write to allow tests to choose which repos they want
+/// to test in which mode.
+List<String> mqEnabledRepos = const <String>[
+  'flutter/flaux',
+  'flutter/flutter',
+];
+
+/// Convenience extension so one can just do `pullRequest.isMergeQueueEnabled`.
+extension PullRequestExtension on github.PullRequest {
+  /// Whether this pull requests must be merged via a merge queue.
+  bool get isMergeQueueEnabled {
+    final slug = base!.repo!.slug();
+    return mqEnabledRepos.contains(slug.fullName);
+  }
 }

--- a/auto_submit/test/src/service/fake_graphql_client.dart
+++ b/auto_submit/test/src/service/fake_graphql_client.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:gql/ast.dart';
 import 'package:graphql/client.dart';
 import 'package:test/test.dart';
@@ -39,12 +41,24 @@ class FakeGraphQLClient implements GraphQLClient {
   }
 
   void verifyQueries(List<QueryOptions> expected) {
-    expect(queries.length, expected.length);
-    for (int i = 0; i < queries.length; i++) {
-      expect(
-        queries[i].properties,
-        equals(expected[i].properties),
-      );
+    final errorBuffer = StringBuffer();
+
+    if (queries.length != expected.length) {
+      errorBuffer.writeln('queries.length (${queries.length}) != expected.length (${expected.length})');
+    }
+
+    for (int i = 0; i < math.min(queries.length, expected.length); i++) {
+      final matcher = equals(expected[i].properties);
+      final matchState = {};
+      if (!matcher.matches(queries[i].properties, matchState)) {
+        final description = StringDescription();
+        matcher.describeMismatch(expected[i].properties, description, matchState, false);
+        errorBuffer.writeln(description);
+      }
+    }
+
+    if (errorBuffer.isNotEmpty) {
+      fail(errorBuffer.toString());
     }
   }
 


### PR DESCRIPTION
Add flutter/flutter to the list of MQ-enabled repos.

> [!IMPORTANT]  
> Deploying this change to production will cause Cocoon to start merging PRs using the merge queue. Therefore, this change needs to be deployed shortly after merge queue is enabled in flutter/flutter "Settings" tab.