### PR TITLE
Add test exemption for engine code under testing/*

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -465,6 +465,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('${engineBasePath}impeller/playground') ||
         filename.startsWith('${engineBasePath}shell/platform/embedder/tests') ||
         filename.startsWith('${engineBasePath}shell/platform/embedder/fixtures') ||
+        filename.startsWith('${engineBasePath}testing') ||
         filename.startsWith('${engineBasePath}tools/clangd_check');
   }
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -740,6 +740,7 @@ void main() {
           PullRequestFile()..filename = 'impeller/playground/playground.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/tests/embedder_test_context.cc',
           PullRequestFile()..filename = 'shell/platform/embedder/fixtures/main.dart',
+          PullRequestFile()..filename = 'testing/test_gl_surface.h',
           PullRequestFile()..filename = 'tools/clangd_check/bin/main.dart',
         ]),
       );


### PR DESCRIPTION
The top-level `testing/` directory contains unit test support files. Most of these are test-specific OpenGL/Metal/Vulkan/Software context/surface code.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
