### PR TITLE
Handle check_run completions with ci staging

### DIFF
--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -27,17 +27,16 @@ class CiStaging extends Document {
   static const kTotalField = 'total';
   static const kFailedField = 'failed_count';
   static const kCheckRunGuardField = 'check_run_guard';
-  static const kEngineStage = 'engine';
 
   static const kScheduledValue = 'scheduled';
   static final kSuccessValue = CheckRunConclusion.success.value!;
   static final kFailureValue = CheckRunConclusion.failure.value!;
 
-  static String documentIdFor({required RepositorySlug slug, required String sha, required String stage}) =>
+  static String documentIdFor({required RepositorySlug slug, required String sha, required CiStage stage}) =>
       '${slug.owner}_${slug.name}_${sha}_$stage';
 
   /// Returns a firebase documentName used in [fromFirestore].
-  static String documentNameFor({required RepositorySlug slug, required String sha, required String stage}) {
+  static String documentNameFor({required RepositorySlug slug, required String sha, required CiStage stage}) {
     // Document names cannot cannot have '/' in the document id.
     final docId = documentIdFor(slug: slug, sha: sha, stage: stage);
     return '$kDocumentParent/$kCollectionId/$docId';
@@ -85,7 +84,7 @@ class CiStaging extends Document {
     required FirestoreService firestoreService,
     required RepositorySlug slug,
     required String sha,
-    required String stage,
+    required CiStage stage,
     required String checkRun,
     required String conclusion,
   }) async {
@@ -243,7 +242,7 @@ class CiStaging extends Document {
     required FirestoreService firestoreService,
     required RepositorySlug slug,
     required String sha,
-    required String stage,
+    required CiStage stage,
     required List<String> tasks,
     required String checkRunGuard,
   }) async {
@@ -277,6 +276,25 @@ class CiStaging extends Document {
       rethrow;
     }
   }
+}
+
+/// Well-defined stages in the build infrastructure.
+enum CiStage implements Comparable<CiStage> {
+  /// Build engine artifacts
+  fusionEngineBuild('engine'),
+
+  /// All non-engine artifact tests (engine & framework)
+  fusionTests('fusion');
+
+  const CiStage(this.name);
+
+  final String name;
+
+  @override
+  int compareTo(CiStage other) => index - other.index;
+
+  @override
+  String toString() => name;
 }
 
 /// Results from attempting to mark a staging task as completed.

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -21,8 +21,8 @@ void main() {
 
     test('documentNameFor produces expected keys', () {
       expect(
-        CiStaging.documentNameFor(slug: RepositorySlug('code', 'fu'), sha: '12345', stage: 'coconut'),
-        '$kDocumentParent/ciStaging/code_fu_12345_coconut',
+        CiStaging.documentNameFor(slug: RepositorySlug('code', 'fu'), sha: '12345', stage: CiStage.fusionTests),
+        '$kDocumentParent/ciStaging/code_fu_12345_fusion',
       );
     });
 
@@ -33,7 +33,7 @@ void main() {
           name: CiStaging.documentNameFor(
             slug: RepositorySlug('flutter', 'flaux'),
             sha: '12345',
-            stage: 'engine',
+            stage: CiStage.fusionEngineBuild,
           ),
           fields: {
             CiStaging.kRemainingField: Value(integerValue: '1'),
@@ -50,7 +50,7 @@ void main() {
         documentName: CiStaging.documentNameFor(
           slug: RepositorySlug('flutter', 'flaux'),
           sha: '12345',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
         ),
       );
       expect(future, completes);
@@ -62,7 +62,7 @@ void main() {
           CiStaging.documentNameFor(
             slug: RepositorySlug('flutter', 'flaux'),
             sha: '12345',
-            stage: 'engine',
+            stage: CiStage.fusionEngineBuild,
           ),
         ),
       ).called(1);
@@ -77,7 +77,7 @@ void main() {
       final expectedName = CiStaging.documentNameFor(
         slug: RepositorySlug('flutter', 'flaux'),
         sha: '1234',
-        stage: 'engine',
+        stage: CiStage.fusionEngineBuild,
       );
 
       setUp(() {
@@ -93,7 +93,7 @@ void main() {
             firestoreService: firestoreService,
             slug: slug,
             sha: '1234',
-            stage: 'engine',
+            stage: CiStage.fusionEngineBuild,
             checkRun: 'test',
             conclusion: 'mulligan',
           ),
@@ -119,7 +119,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'test',
           conclusion: 'mulligan',
         );
@@ -173,7 +173,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'test',
           conclusion: 'mulligan',
         );
@@ -214,7 +214,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'Linux build_test',
           conclusion: 'mulligan',
         );
@@ -267,7 +267,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'Linux build_test',
           conclusion: 'mulligan',
         );
@@ -321,7 +321,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'MacOS build_test',
           conclusion: 'mulligan',
         );
@@ -375,7 +375,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'MacOS build_test',
           conclusion: CiStaging.kSuccessValue,
         );
@@ -431,7 +431,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'MacOS build_test',
           conclusion: CiStaging.kFailureValue,
         );
@@ -486,7 +486,7 @@ void main() {
           firestoreService: firestoreService,
           slug: slug,
           sha: '1234',
-          stage: 'engine',
+          stage: CiStage.fusionEngineBuild,
           checkRun: 'MacOS build_test',
           conclusion: CiStaging.kFailureValue,
         );
@@ -517,7 +517,7 @@ void main() {
       final tasks = <String>['task1', 'task2'];
       const checkRunGuard = '{"id": "check_run_id"}';
       const sha = '1234abc';
-      const stage = 'unit_test';
+      const stage = CiStage.fusionTests;
 
       late MockProjectsDatabasesDocumentsResource docRes;
 

--- a/app_dart/test/src/utilities/mocks.dart
+++ b/app_dart/test/src/utilities/mocks.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:cocoon_service/src/foundation/github_checks_util.dart';
+import 'package:cocoon_service/src/model/firestore/ci_staging.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/access_client_provider.dart';
 import 'package:cocoon_service/src/service/access_token_provider.dart';
@@ -91,6 +92,7 @@ Future<AutoRefreshingAuthClient> authClientProviderShim({
     UsersService,
     ProjectsDatabasesDocumentsResource,
     BeginTransactionResponse,
+    Callbacks,
   ],
   customMocks: [
     MockSpec<Cache<Uint8List>>(),
@@ -106,4 +108,15 @@ void main() {}
 class ThrowingGitHub implements GitHub {
   @override
   dynamic noSuchMethod(Invocation invocation) => throw AssertionError();
+}
+
+abstract class Callbacks {
+  Future<StagingConclusion> markCheckRunConclusion({
+    required FirestoreService firestoreService,
+    required RepositorySlug slug,
+    required String sha,
+    required CiStage stage,
+    required String checkRun,
+    required String conclusion,
+  });
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -20,6 +20,7 @@ import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i37;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i36;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i42;
+import 'package:cocoon_service/src/model/firestore/ci_staging.dart' as _i47;
 import 'package:cocoon_service/src/model/firestore/commit.dart' as _i40;
 import 'package:cocoon_service/src/model/firestore/github_build_status.dart' as _i23;
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart' as _i22;
@@ -46,7 +47,7 @@ import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i31;
 import 'package:neat_cache/neat_cache.dart' as _i28;
-import 'package:process/src/interface/process_manager.dart' as _i45;
+import 'package:process/process.dart' as _i45;
 import 'package:retry/retry.dart' as _i30;
 
 import '../../service/cache_service_test.dart' as _i38;
@@ -4033,6 +4034,24 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
         ),
         returnValue: _i20.Future<List<_i13.Issue>>.value(<_i13.Issue>[]),
       ) as _i20.Future<List<_i13.Issue>>);
+
+  @override
+  _i20.Future<bool> removeLabel(
+    _i13.RepositorySlug? slug,
+    int? issueNumber,
+    String? label,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #removeLabel,
+          [
+            slug,
+            issueNumber,
+            label,
+          ],
+        ),
+        returnValue: _i20.Future<bool>.value(false),
+      ) as _i20.Future<bool>);
 
   @override
   _i20.Future<_i13.Issue>? getIssue(
@@ -9828,6 +9847,41 @@ class MockBeginTransactionResponse extends _i1.Mock implements _i21.BeginTransac
         ),
         returnValue: <String, dynamic>{},
       ) as Map<String, dynamic>);
+}
+
+/// A class which mocks [Callbacks].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCallbacks extends _i1.Mock implements _i46.Callbacks {
+  MockCallbacks() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i20.Future<({String? checkRunGuard, int failed, int remaining, bool valid})> markCheckRunConclusion({
+    required _i15.FirestoreService? firestoreService,
+    required _i13.RepositorySlug? slug,
+    required String? sha,
+    required _i47.CiStage? stage,
+    required String? checkRun,
+    required String? conclusion,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #markCheckRunConclusion,
+          [],
+          {
+            #firestoreService: firestoreService,
+            #slug: slug,
+            #sha: sha,
+            #stage: stage,
+            #checkRun: checkRun,
+            #conclusion: conclusion,
+          },
+        ),
+        returnValue: _i20.Future<({String? checkRunGuard, int failed, int remaining, bool valid})>.value(
+            (checkRunGuard: null, failed: 0, remaining: 0, valid: false)),
+      ) as _i20.Future<({String? checkRunGuard, int failed, int remaining, bool valid})>);
 }
 
 /// A class which mocks [Cache].


### PR DESCRIPTION
Right now we have "three" stages:
  1. non-monorepo: none (schedule everything)
  2. mono-repo: engine
  3. mono-repo: tests.

To handle monorepo, we need to react to updates from check_run events.
The engine check is hard-coded because to put it somewhere else would be
to either create a new firestore doc or encode it in the tree (e.g. .ci.yaml) - but
we're not interested in building a build-graph right now.

To reduce the QPH quota; we could cache the check-run id to PR lookup in firestore.