### PR TITLE
Query GitHub Less: pull request / check_run map in Firestore

### DIFF
--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -95,7 +95,7 @@ class PrCheckRuns extends Document {
     }
   }
 
-  /// Retrieve the [PullRequest] for a given [checkRun] or throw an error.  
+  /// Retrieve the [PullRequest] for a given [checkRun] or throw an error.
   static Future<PullRequest> findDocumentFor(
     FirestoreService firestoreService,
     CheckRun checkRun,

--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -30,9 +30,8 @@ import 'package:googleapis/firestore/v1.dart' hide Status;
 ///       pullRequest: json string
 ///       slug: json string
 ///       sha: string
-///       [*fields]: <string check_run id>: empty string
+///       [*fields]: "test_name": "check_run id"
 class PrCheckRuns extends Document {
-  /// Firestore collection for the staging documents.
   static const kCollectionId = 'prCheckRuns';
   static const kPullRequestField = 'pull_request';
   static const kSlugField = 'slug';
@@ -72,7 +71,7 @@ class PrCheckRuns extends Document {
       kPullRequestField: Value(stringValue: json.encode(pullRequest.toJson())),
       kSlugField: Value(stringValue: json.encode(pullRequest.head!.repo!.slug().toJson())),
       kShaField: Value(stringValue: pullRequest.head!.sha!),
-      for (final run in checks) '${run.id}': Value(stringValue: run.name),
+      for (final run in checks) run.name!: Value(stringValue: '${run.id}'),
     };
 
     final document = Document(fields: fields);
@@ -101,7 +100,7 @@ class PrCheckRuns extends Document {
     CheckRun checkRun,
   ) async {
     final filterMap = <String, Object>{
-      '${checkRun.id} =': checkRun.name!,
+      '${checkRun.name!} =': '${checkRun.id}',
     };
     log.info('findDocumentFor($filterMap): finding prCheckRuns document');
     final docs = await firestoreService.query(kCollectionId, filterMap);

--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -1,0 +1,111 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_service/src/service/logging.dart';
+import 'package:github/github.dart';
+
+import '../../service/firestore.dart';
+import 'package:googleapis/firestore/v1.dart' hide Status;
+
+/// Pairs the GitHub PR with the check runs associated with it.
+///
+/// The current webhook for check_runs does not include the PR. To reduce quota
+/// on GitHub, we need to be able to look up PRs based on check_run ids. Each
+/// document will be a collection of check_runs scheduled for a PR / sha.
+///
+/// The PR / SHA combo is not unique:
+///   - PR's will have multiple runs and we want this document to represent a
+///     snapshot.
+///   - SHAs can exist in multiple PRs.
+///
+/// Instead of generating some unique key (e.g. check_run+slug) and creating a
+/// large amount of documents, we will rely on querying the fields.
+///
+/// This document layout is currently:
+///  /projects/flutter-dashboard/databases/cocoon/prCheckRuns/
+///     document: <firebase unique id>
+///       pullRequest: json string
+///       slug: json string
+///       sha: string
+///       [*fields]: <string check_run id>: empty string
+class PrCheckRuns extends Document {
+  /// Firestore collection for the staging documents.
+  static const kCollectionId = 'prCheckRuns';
+  static const kPullRequestField = 'pull_request';
+  static const kSlugField = 'slug';
+  static const kShaField = 'sha';
+
+  /// Create [PrCheckRuns] from a Commit Document.
+  static PrCheckRuns fromDocument(Document prCheckRunsDoc) {
+    return PrCheckRuns()
+      ..fields = prCheckRunsDoc.fields!
+      ..name = prCheckRunsDoc.name!;
+  }
+
+  /// The json string of the pullrequest belonging to this document.
+  PullRequest get pullRequest => PullRequest.fromJson(json.decode(fields![kPullRequestField]!.stringValue!));
+
+  /// The head sha at the time this document was created for testing.
+  String get sha => fields![kShaField]!.stringValue!;
+
+  RepositorySlug get slug => RepositorySlug.fromJson(json.decode(fields![kSlugField]!.stringValue!));
+
+  /// Initializes a new document for the list of check_runs in Firestore so we can find it later.
+  ///
+  /// The list of tasks will be written as fields of a document with additional fields for tracking the total
+  /// number of tasks, remaining count. It is required to include [checkRunGuard] as a json encoded [CheckRun] as this
+  /// will be used to unlock any check runs blocking progress.
+  ///
+  /// Returns the created document or throws an error.
+  static Future<Document> initializeDocument({
+    required FirestoreService firestoreService,
+    required PullRequest pullRequest,
+    required List<CheckRun> checks,
+  }) async {
+    final logCrumb =
+        'initializeDocument(${pullRequest.repo?.slug().fullName}/${pullRequest.number}, ${checks.length} check runs)';
+
+    final fields = <String, Value>{
+      kPullRequestField: Value(stringValue: json.encode(pullRequest.toJson())),
+      kSlugField: Value(stringValue: json.encode(pullRequest.head!.repo!.slug().toJson())),
+      kShaField: Value(stringValue: pullRequest.head!.sha!),
+      for (final run in checks) '${run.id}': Value(stringValue: run.name),
+    };
+
+    final document = Document(fields: fields);
+
+    try {
+      // Calling createDocument multiple times for the same documentId will return a 409 - ALREADY_EXISTS error;
+      // this is good because it means we don't have to do any transactions.
+      // curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer <TOKEN>" "https://firestore.googleapis.com/v1beta1/projects/flutter-dashboard/databases/cocoon/documents/prCheckRuns" -d '{"fields": {"test": {"stringValue": "baz"}}}'
+      final databasesDocumentsResource = await firestoreService.documentResource();
+      final newDoc = await databasesDocumentsResource.createDocument(
+        document,
+        kDocumentParent,
+        kCollectionId,
+      );
+      log.info('$logCrumb: document created');
+      return newDoc;
+    } catch (e) {
+      log.warning('$logCrumb: failed to create document: $e');
+      rethrow;
+    }
+  }
+
+  /// Retrieve the [PullRequest] for a given [checkRun] or throw an error.  
+  static Future<PullRequest> findDocumentFor(
+    FirestoreService firestoreService,
+    CheckRun checkRun,
+  ) async {
+    final filterMap = <String, Object>{
+      '${checkRun.id} =': checkRun.name!,
+    };
+    log.info('findDocumentFor($filterMap): finding prCheckRuns document');
+    final docs = await firestoreService.query(kCollectionId, filterMap);
+    log.info('findDocumentFor($filterMap): found: $docs');
+    return PrCheckRuns.fromDocument(docs.first).pullRequest;
+  }
+}

--- a/app_dart/test/model/firestore/pr_check_runs_test.dart
+++ b/app_dart/test/model/firestore/pr_check_runs_test.dart
@@ -72,8 +72,8 @@ void main() {
         expect(document.fields![PrCheckRuns.kPullRequestField]!.stringValue, json.encode(pr.toJson()));
         expect(document.fields![PrCheckRuns.kSlugField]!.stringValue, json.encode(pr.head!.repo!.slug().toJson()));
         expect(document.fields![PrCheckRuns.kShaField]!.stringValue, pr.head!.sha);
-        expect(document.fields!['1']!.stringValue, 'check 1');
-        expect(document.fields!['2']!.stringValue, 'check 2');
+        expect(document.fields!['check 1']!.stringValue, '1');
+        expect(document.fields!['check 2']!.stringValue, '2');
       });
     });
 
@@ -93,7 +93,7 @@ void main() {
       final captured = verify(firestoreService.query(PrCheckRuns.kCollectionId, captureAny)).captured;
       expect(captured, [
         {
-          '1 =': 'testing tesing',
+          'testing tesing =': '1',
         },
       ]);
       expect(pr.id, 1234);

--- a/app_dart/test/model/firestore/pr_check_runs_test.dart
+++ b/app_dart/test/model/firestore/pr_check_runs_test.dart
@@ -1,0 +1,102 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_service/src/model/firestore/pr_check_runs.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
+import 'package:github/github.dart';
+import 'package:googleapis/firestore/v1.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../src/utilities/entity_generators.dart';
+import '../../src/utilities/mocks.dart';
+
+void main() {
+  group('PrCheckRuns', () {
+    late MockFirestoreService firestoreService;
+
+    setUp(() {
+      firestoreService = MockFirestoreService();
+    });
+
+    group('initializeDocument', () {
+      final runs = <CheckRun>[
+        generateCheckRun(1, name: 'check 1'),
+        generateCheckRun(2, name: 'check 2'),
+      ];
+      final pr = generatePullRequest(id: 11252024, repo: 'fluax', sha: '1234abc');
+
+      late MockProjectsDatabasesDocumentsResource docRes;
+
+      setUp(() {
+        docRes = MockProjectsDatabasesDocumentsResource();
+        when(firestoreService.documentResource()).thenAnswer((_) async => docRes);
+      });
+
+      test('creates a document with the correct fields', () async {
+        when(
+          docRes.createDocument(
+            any,
+            any,
+            any,
+            documentId: anyNamed('documentId'),
+            $fields: anyNamed(r'$fields'),
+          ),
+        ).thenAnswer((Invocation inv) async {
+          return Document(name: '$kDocumentParent/${PrCheckRuns.kCollectionId}/867-5309');
+        });
+
+        await PrCheckRuns.initializeDocument(
+          firestoreService: firestoreService,
+          pullRequest: pr,
+          checks: runs,
+        );
+        final result = verify(
+          docRes.createDocument(
+            captureAny,
+            captureAny,
+            captureAny,
+            documentId: anyNamed('documentId'),
+          ),
+        );
+        expect(result.callCount, 1);
+        final captured = result.captured;
+        final Document document = captured[0] as Document;
+        final String parent = captured[1] as String;
+        final String collectionId = captured[2] as String;
+        expect(parent, kDocumentParent);
+        expect(collectionId, PrCheckRuns.kCollectionId);
+        expect(document.fields![PrCheckRuns.kPullRequestField]!.stringValue, json.encode(pr.toJson()));
+        expect(document.fields![PrCheckRuns.kSlugField]!.stringValue, json.encode(pr.head!.repo!.slug().toJson()));
+        expect(document.fields![PrCheckRuns.kShaField]!.stringValue, pr.head!.sha);
+        expect(document.fields!['1']!.stringValue, 'check 1');
+        expect(document.fields!['2']!.stringValue, 'check 2');
+      });
+    });
+
+    test('query for checkrun', () async {
+      when(firestoreService.query(any, any)).thenAnswer(
+        (_) async => [
+          Document(
+            fields: {
+              PrCheckRuns.kPullRequestField: Value(stringValue: json.encode(generatePullRequest(id: 1234).toJson())),
+            },
+            name: 'pr1234',
+          ),
+        ],
+      );
+      final pr = await PrCheckRuns.findDocumentFor(firestoreService, generateCheckRun(1, name: 'testing tesing'));
+
+      final captured = verify(firestoreService.query(PrCheckRuns.kCollectionId, captureAny)).captured;
+      expect(captured, [
+        {
+          '1 =': 'testing tesing',
+        },
+      ]);
+      expect(pr.id, 1234);
+    });
+  });
+}

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -329,6 +329,11 @@ github.PullRequest generatePullRequest({
     head: github.PullRequestHead(
       ref: branch,
       sha: sha,
+      repo: github.Repository(
+        fullName: 'flutter/$repo',
+        name: repo,
+        owner: github.UserInformation('flutter', 1, '', ''),
+      ),
     ),
     user: github.User(
       login: authorLogin,


### PR DESCRIPTION
Problem: we're hitting some quota on github, typically around check_runs Future problem: merging repos and having engine staging requires more check_runs mapping to PRs, which is a query, check suite look up, and comparison.

This PR setups a solution where were record a new document in firestore that can be queried at each check_run update when we need access to the pull request field.

```
/projects/flutter-dashboard/databases/cocoon/prCheckRuns/
   document: <firebase unique id>
     pullRequest: json string
     slug: json string
     sha: string
     [*fields]: <string check_run id>: empty string
```