### PR TITLE
Record & Query PrCheckRuns in luci when scheduling

### DIFF
--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -95,12 +95,13 @@ class PrCheckRuns extends Document {
   }
 
   /// Retrieve the [PullRequest] for a given [checkRun] or throw an error.
-  static Future<PullRequest> findDocumentFor(
+  static Future<PullRequest> findPullRequestFor(
     FirestoreService firestoreService,
-    CheckRun checkRun,
+    int checkRunId,
+    String checkRunName,
   ) async {
     final filterMap = <String, Object>{
-      '${checkRun.name!} =': '${checkRun.id}',
+      '$checkRunName =': '$checkRunId',
     };
     log.info('findDocumentFor($filterMap): finding prCheckRuns document');
     final docs = await firestoreService.query(kCollectionId, filterMap);

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -898,11 +898,13 @@ class Scheduler {
 
     // Look up the PR in our cache first. This reduces github quota and requires less calls.
     PullRequest? pullRequest;
+    final id = checkRunEvent.checkRun!.id!;
+    final name = checkRunEvent.checkRun!.name!;
     try {
       pullRequest = await findPullRequestFor(
         firestoreService,
-        checkRunEvent.checkRun!.id!,
-        checkRunEvent.checkRun!.name!,
+        id,
+        name,
       );
     } catch (e, s) {
       log.warning('$logCrumb: unable to find PR in PrCheckRuns', e, s);
@@ -916,7 +918,7 @@ class Scheduler {
 
     // We cannot make any forward progress. Abandon all hope, Check runs who enter here.
     if (pullRequest == null) {
-      throw 'No PR found matching this check_run';
+      throw 'No PR found matching this check_run($id, $name)';
     }
 
     Object? exception;

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -96,7 +96,7 @@ class Scheduler {
     FirestoreService firestoreService,
     int checkRunId,
     String checkRunName,
-  ) findPullRequestFor;  
+  ) findPullRequestFor;
 
   /// Name of the subcache to store scheduler related values in redis.
   static const String subcacheName = 'scheduler';

--- a/app_dart/test/model/firestore/pr_check_runs_test.dart
+++ b/app_dart/test/model/firestore/pr_check_runs_test.dart
@@ -88,7 +88,7 @@ void main() {
           ),
         ],
       );
-      final pr = await PrCheckRuns.findDocumentFor(firestoreService, generateCheckRun(1, name: 'testing tesing'));
+      final pr = await PrCheckRuns.findPullRequestFor(firestoreService, 1, 'testing tesing');
 
       final captured = verify(firestoreService.query(PrCheckRuns.kCollectionId, captureAny)).captured;
       expect(captured, [

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1109,8 +1109,7 @@ targets:
               isTrue,
             );
 
-            verify(gitHubChecksService.findMatchingPullRequest(Config.flauxSlug, 'testSha', 668083231))
-                .called(1);
+            verify(gitHubChecksService.findMatchingPullRequest(Config.flauxSlug, 'testSha', 668083231)).called(1);
 
             verify(
               callbacks.markCheckRunConclusion(

--- a/app_dart/test/src/utilities/mocks.dart
+++ b/app_dart/test/src/utilities/mocks.dart
@@ -128,4 +128,18 @@ abstract class Callbacks {
     required List<String> tasks,
     required String checkRunGuard,
   });
+
+  /// See [PrCheckRuns.initializeDocument]
+  Future<Document> initializePrCheckRuns({
+    required FirestoreService firestoreService,
+    required PullRequest pullRequest,
+    required List<CheckRun> checks,
+  });
+
+  /// See [PrCheckRuns.findPullRequestFor]
+  Future<PullRequest> findPullRequestFor(
+    FirestoreService firestoreService,
+    int checkRunId,
+    String checkRunName,
+  );
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -3922,6 +3922,22 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
       ) as _i20.Future<List<_i13.RepositoryCommit>>);
 
   @override
+  _i20.Future<bool> deleteBranch(
+    _i13.RepositorySlug? slug,
+    String? branchName,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteBranch,
+          [
+            slug,
+            branchName,
+          ],
+        ),
+        returnValue: _i20.Future<bool>.value(false),
+      ) as _i20.Future<bool>);
+
+  @override
   _i20.Future<List<_i13.PullRequest>> listPullRequests(
     _i13.RepositorySlug? slug,
     String? branch,
@@ -6562,6 +6578,28 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
           Invocation.getter(#pubsub),
         ),
       ) as _i15.PubSub);
+
+  @override
+  _i20.Future<_i21.Document> Function({
+    required List<_i13.CheckRun> checks,
+    required _i15.FirestoreService firestoreService,
+    required _i13.PullRequest pullRequest,
+  }) get initializePrCheckRuns => (super.noSuchMethod(
+        Invocation.getter(#initializePrCheckRuns),
+        returnValue: ({
+          required List<_i13.CheckRun> checks,
+          required _i15.FirestoreService firestoreService,
+          required _i13.PullRequest pullRequest,
+        }) =>
+            _i20.Future<_i21.Document>.value(_FakeDocument_25(
+          this,
+          Invocation.getter(#initializePrCheckRuns),
+        )),
+      ) as _i20.Future<_i21.Document> Function({
+        required List<_i13.CheckRun> checks,
+        required _i15.FirestoreService firestoreService,
+        required _i13.PullRequest pullRequest,
+      }));
 
   @override
   _i20.Future<List<List<_i8.BatchRequest_Request>>> shard({
@@ -9944,6 +9982,64 @@ class MockCallbacks extends _i1.Mock implements _i47.Callbacks {
           ),
         )),
       ) as _i20.Future<_i21.Document>);
+
+  @override
+  _i20.Future<_i21.Document> initializePrCheckRuns({
+    required _i15.FirestoreService? firestoreService,
+    required _i13.PullRequest? pullRequest,
+    required List<_i13.CheckRun>? checks,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #initializePrCheckRuns,
+          [],
+          {
+            #firestoreService: firestoreService,
+            #pullRequest: pullRequest,
+            #checks: checks,
+          },
+        ),
+        returnValue: _i20.Future<_i21.Document>.value(_FakeDocument_25(
+          this,
+          Invocation.method(
+            #initializePrCheckRuns,
+            [],
+            {
+              #firestoreService: firestoreService,
+              #pullRequest: pullRequest,
+              #checks: checks,
+            },
+          ),
+        )),
+      ) as _i20.Future<_i21.Document>);
+
+  @override
+  _i20.Future<_i13.PullRequest> findPullRequestFor(
+    _i15.FirestoreService? firestoreService,
+    int? checkRunId,
+    String? checkRunName,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #findPullRequestFor,
+          [
+            firestoreService,
+            checkRunId,
+            checkRunName,
+          ],
+        ),
+        returnValue: _i20.Future<_i13.PullRequest>.value(_FakePullRequest_41(
+          this,
+          Invocation.method(
+            #findPullRequestFor,
+            [
+              firestoreService,
+              checkRunId,
+              checkRunName,
+            ],
+          ),
+        )),
+      ) as _i20.Future<_i13.PullRequest>);
 }
 
 /// A class which mocks [Cache].


### PR DESCRIPTION
Reduces the need to search for PRs by check suite / check runs in a monorepo