### PR TITLE
Docker fix #2: Docker build requries '.'

### DIFF
--- a/app_dart/cloudbuild_app_dart.yaml
+++ b/app_dart/cloudbuild_app_dart.yaml
@@ -18,7 +18,7 @@ steps:
 
   # Build docker image
   - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
-    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', '-f', 'Dockerfile.app_dart']
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/default.version-$SHORT_SHA', '-f', 'Dockerfile.app_dart', '.']
 
   # Trigger the cloud build that deploys the docker image
   - name: gcr.io/cloud-builders/gcloud

--- a/auto_submit/cloudbuild_auto_submit.yaml
+++ b/auto_submit/cloudbuild_auto_submit.yaml
@@ -10,7 +10,7 @@
 steps:
   # Build docker image
   - name: 'us-docker.pkg.dev/cloud-builders/ga/v1/docker'
-    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA', '-f', 'Dockerfile.auto_submit']
+    args: ['build', '-t', 'us-docker.pkg.dev/$PROJECT_ID/appengine/auto-submit.version-$SHORT_SHA', '-f', 'Dockerfile.auto_submit', '.']
 
   # Trigger the cloud build that deploys the docker image
   - name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
Even with `-f file`, `.` is still required. Podman didn't have a problem with this.