### PR TITLE
Fusion presubmits should specify a realm property

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -302,6 +302,9 @@ class LuciBuildService {
 
       if (isFusion) {
         properties['is_fusion'] = 'true';
+        // When in fusion, we want the recipies to override the engine.realm
+        // if some environment variable (FLUTTER_REALM) is set.
+        properties['flutter_realm'] = 'flutter_archives_v2';
       }
 
       final List<bbv2.RequestedDimension> requestedDimensions = target.getDimensions();

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -420,6 +420,7 @@ void main() {
         'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
         'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
         'is_fusion': bbv2.Value(stringValue: 'true'),
+        'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
       });
       expect(dimensions.length, 1);
       expect(dimensions[0].key, 'os');
@@ -508,6 +509,7 @@ void main() {
         'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
         'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
         'is_fusion': bbv2.Value(stringValue: 'true'),
+        'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
       });
       expect(dimensions.length, 1);
       expect(dimensions[0].key, 'os');


### PR DESCRIPTION
LUCI recipes should set an environment variable to this property if it exists; the Flutter Tool should set the `engine.realm` file as appropriate.