### PR TITLE
Parse github merge queue branches for CI targets

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -29,11 +29,13 @@ const String kTestOwnerPath = 'TESTOWNERS';
 ({bool parsed, String branch, int pullRequestNumber, String sha}) tryParseGitHubMergeQueueBranch(String branch) {
   final match = _githubMqBranch.firstMatch(branch);
   if (match == null) {
-    return (parsed: false, branch: '', pullRequestNumber: -1, sha: '');
+    return notGitHubMergeQueueBranch;
   }
 
   return (parsed: true, branch: match.group(1)!, pullRequestNumber: int.parse(match.group(2)!), sha: match.group(3)!);
 }
+
+const notGitHubMergeQueueBranch = (parsed: false, branch: '', pullRequestNumber: -1, sha: '');
 
 final _githubMqBranch = RegExp(r'^gh-readonly-queue\/([^/]+)\/pr-(\d+)-([a-fA-F0-9]+)$');
 

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -25,6 +25,18 @@ const String kCiYamlPath = '.ci.yaml';
 const String kCiYamlFusionEnginePath = 'engine/src/flutter/$kCiYamlPath';
 const String kTestOwnerPath = 'TESTOWNERS';
 
+/// Attempts to parse the github merge queue branch into its constituent parts to be returned as a record.
+({bool parsed, String branch, int pullRequestNumber, String sha}) tryParseGitHubMergeQueueBranch(String branch) {
+  final match = _githubMqBranch.firstMatch(branch);
+  if (match == null) {
+    return (parsed: false, branch: '', pullRequestNumber: -1, sha: '');
+  }
+
+  return (parsed: true, branch: match.group(1)!, pullRequestNumber: int.parse(match.group(2)!), sha: match.group(3)!);
+}
+
+final _githubMqBranch = RegExp(r'^gh-readonly-queue\/([^/]+)\/pr-(\d+)-([a-fA-F0-9]+)$');
+
 /// Signature for a function that calculates the backoff duration to wait in
 /// between requests when GitHub responds with an error.
 ///

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -288,7 +288,7 @@ class CiYaml {
     final List<Target> filteredTargets = <Target>[];
 
     final ghMqBranch = tryParseGitHubMergeQueueBranch(branch);
-    final realBranch = ghMqBranch.parsed ? ghMqBranch.branch : branch;
+    final realBranch = ghMqBranch == notGitHubMergeQueueBranch ? branch : ghMqBranch.branch;
 
     // 1. Add targets with local definition
     final Iterable<Target> overrideBranchTargets =

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -287,15 +287,18 @@ class CiYaml {
   List<Target> _filterEnabledTargets(Iterable<Target> targets) {
     final List<Target> filteredTargets = <Target>[];
 
+    final ghMqBranch = tryParseGitHubMergeQueueBranch(branch);
+    final realBranch = ghMqBranch.parsed ? ghMqBranch.branch : branch;
+
     // 1. Add targets with local definition
     final Iterable<Target> overrideBranchTargets =
         targets.where((Target target) => target.value.enabledBranches.isNotEmpty);
     final Iterable<Target> enabledTargets = overrideBranchTargets
-        .where((Target target) => enabledBranchesMatchesCurrentBranch(target.value.enabledBranches, branch));
+        .where((Target target) => enabledBranchesMatchesCurrentBranch(target.value.enabledBranches, realBranch));
     filteredTargets.addAll(enabledTargets);
 
     // 2. Add targets with global definition (this is the majority of targets)
-    if (enabledBranchesMatchesCurrentBranch(config.enabledBranches, branch)) {
+    if (enabledBranchesMatchesCurrentBranch(config.enabledBranches, realBranch)) {
       final Iterable<Target> defaultBranchTargets =
           targets.where((Target target) => target.value.enabledBranches.isEmpty);
       filteredTargets.addAll(defaultBranchTargets);

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -46,6 +46,20 @@ void main() {
       delayFactor: Duration.zero,
       maxDelay: Duration.zero,
     );
+
+    test('github merge queue branch parsing', () {
+      expect(
+        tryParseGitHubMergeQueueBranch('gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56'),
+        (parsed: true, branch: 'master', pullRequestNumber: 160481, sha: '1398dc7eecb696d302e4edb19ad79901e615ed56'),
+        reason: 'parses expected magic branch',
+      );
+      expect(
+        tryParseGitHubMergeQueueBranch('master'),
+        (parsed: false, branch: '', pullRequestNumber: -1, sha: ''),
+        reason: 'does not parse regular branch',
+      );
+    });
+
     group('githubFileContent', () {
       late MockClient branchHttpClient;
 

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -55,7 +55,7 @@ void main() {
       );
       expect(
         tryParseGitHubMergeQueueBranch('master'),
-        (parsed: false, branch: '', pullRequestNumber: -1, sha: ''),
+        notGitHubMergeQueueBranch,
         reason: 'does not parse regular branch',
       );
     });

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -167,6 +167,43 @@ void main() {
         );
       });
 
+      test('handles github merge queue branch', () {
+        final ciYaml = CiYaml(
+          type: CiType.any,
+          slug: Config.flutterSlug,
+          branch: 'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56',
+          config: pb.SchedulerConfig(
+            enabledBranches: <String>[
+              'master',
+            ],
+            targets: <pb.Target>[
+              pb.Target(
+                name: 'Linux A',
+              ),
+              pb.Target(
+                name: 'Linux B',
+              ),
+              pb.Target(
+                name: 'Mac A', // Should be ignored on release branches
+                bringup: true,
+              ),
+            ],
+          ),
+          totConfig: totCIYaml,
+        );
+
+        final List<String> initialTargetNames =
+            ciYaml.presubmitTargets.map((Target target) => target.value.name).toList();
+        expect(
+          initialTargetNames,
+          containsAll(
+            <String>[
+              'Linux A',
+            ],
+          ),
+        );
+      });
+
       test('filter targets removed from postsubmit', () {
         final List<Target> initialTargets = ciYaml.postsubmitTargets;
         final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();


### PR DESCRIPTION
The merge queue uses branches like:
  gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56

This parses the branch and returns the <branch name> expected to match enabled branches.