### PR TITLE
Update checks flutter-gold guards for in monorepo land

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -135,9 +135,21 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           }
         } else if (slug == Config.flutterSlug) {
           if (const <String>[
+            // Framework test shards that run golden file tests
             'flutter_driver_android_test',
             'framework',
             'misc',
+
+            // Engine test shards that run golden file tests
+            // Monorepo
+            'linux_android_emulator',
+            'linux_host_engine',
+            'linux_web_engine',
+            'mac_host_engine',
+            'mac_unopt',
+
+            // Integration test shards that run golden file tests
+            // TODO(matanlurey): Add here!
           ].any((String shardSubString) => name.contains(shardSubString))) {
             runsGoldenFileTests = true;
           }
@@ -164,6 +176,9 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
           continue;
         }
 
+        // TODO(Piinks): Check after monorepo settles that this accounts for
+        // framework checks added after engine checks complete, there could be a
+        // hole here.
         if (incompleteChecks.isNotEmpty) {
           // If checks on an open PR are running or failing, the gold status
           // should just be pending. Any draft PRs are skipped

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -136,7 +136,6 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         } else if (slug == Config.flutterSlug) {
           if (const <String>[
             // Framework test shards that run golden file tests
-            'flutter_driver_android_test',
             'framework',
             'misc',
 
@@ -149,7 +148,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             'mac_unopt',
 
             // Integration test shards that run golden file tests
-            // TODO(matanlurey): Add here!
+            'flutter_driver_android_test',
           ].any((String shardSubString) => name.contains(shardSubString))) {
             runsGoldenFileTests = true;
           }

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -1016,7 +1016,7 @@ void main() {
           );
         });
 
-        test('includes linux_android_emulator test shard - monorepo', () async {
+        Future<void> includesEngineShard(String shard) async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');
           prsFromGitHub = <PullRequest>[pr];
@@ -1026,7 +1026,7 @@ void main() {
 
           // Checks completed
           checkRuns = <dynamic>[
-            <String, String>{'name': 'linux_android_emulator', 'status': 'completed', 'conclusion': 'success'},
+            <String, String>{'name': shard, 'status': 'completed', 'conclusion': 'success'},
           ];
 
           // Change detected by Gold
@@ -1086,294 +1086,26 @@ void main() {
               argThat(contains(config.flutterGoldCommentID(pr))),
             ),
           );
+        }
+
+        test('includes linux_android_emulator test shard - monorepo', () async {
+          await includesEngineShard('linux_android_emulator');
         });
 
         test('includes linux_host_engine test shard - monorepo', () async {
-          // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
-          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
-
-          // Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{'name': 'linux_host_engine', 'status': 'completed', 'conclusion': 'success'},
-          ];
-
-          // Change detected by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobEmpty(), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
-            },
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-          );
-
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(status.updates, 1);
-          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
-          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
-
-          final List<dynamic> captured =
-              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
-          expect(captured.length, 2);
-          // The first element corresponds to the `status`.
-          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
-          expect(batchWriteRequest.writes!.length, 1);
-          final GithubGoldStatus updatedDocument =
-              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocument.updates, 1);
-
-          // Should not label or comment
-          verifyNever(
-            issuesService.addLabelsToIssue(
-              slug,
-              pr.number!,
-              <String>[
-                kGoldenFileLabel,
-              ],
-            ),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
+          await includesEngineShard('linux_host_engine');
         });
 
         test('includes linux_web_engine test shard - monorepo', () async {
-          // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
-          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
-
-          // Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{'name': 'linux_web_engine', 'status': 'completed', 'conclusion': 'success'},
-          ];
-
-          // Change detected by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobEmpty(), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
-            },
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-          );
-
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(status.updates, 1);
-          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
-          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
-
-          final List<dynamic> captured =
-              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
-          expect(captured.length, 2);
-          // The first element corresponds to the `status`.
-          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
-          expect(batchWriteRequest.writes!.length, 1);
-          final GithubGoldStatus updatedDocument =
-              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocument.updates, 1);
-
-          // Should not label or comment
-          verifyNever(
-            issuesService.addLabelsToIssue(
-              slug,
-              pr.number!,
-              <String>[
-                kGoldenFileLabel,
-              ],
-            ),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
+          await includesEngineShard('linux_web_engine');
         });
 
         test('includes mac_host_engine test shard - monorepo', () async {
-          // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
-          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
-
-          // Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{'name': 'mac_host_engine', 'status': 'completed', 'conclusion': 'success'},
-          ];
-
-          // Change detected by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobEmpty(), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
-            },
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-          );
-
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(status.updates, 1);
-          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
-          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
-
-          final List<dynamic> captured =
-              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
-          expect(captured.length, 2);
-          // The first element corresponds to the `status`.
-          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
-          expect(batchWriteRequest.writes!.length, 1);
-          final GithubGoldStatus updatedDocument =
-              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocument.updates, 1);
-
-          // Should not label or comment
-          verifyNever(
-            issuesService.addLabelsToIssue(
-              slug,
-              pr.number!,
-              <String>[
-                kGoldenFileLabel,
-              ],
-            ),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
+          await includesEngineShard('mac_host_engine');
         });
 
         test('includes mac_unopt test shard - monorepo', () async {
-          // New commit
-          final PullRequest pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
-          db.values[status.key] = status;
-          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
-
-          // Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{'name': 'mac_host_engine', 'status': 'completed', 'conclusion': 'success'},
-          ];
-
-          // Change detected by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobEmpty(), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            datastoreProvider: (DatastoreDB db) {
-              return DatastoreService(
-                config.db,
-                5,
-                retryOptions: retryOptions,
-              );
-            },
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-          );
-
-          final Body body = await tester.get<Body>(handler);
-          expect(body, same(Body.empty));
-          expect(status.updates, 1);
-          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
-          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
-
-          final List<dynamic> captured =
-              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
-          expect(captured.length, 2);
-          // The first element corresponds to the `status`.
-          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
-          expect(batchWriteRequest.writes!.length, 1);
-          final GithubGoldStatus updatedDocument =
-              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
-          expect(updatedDocument.updates, 1);
-
-          // Should not label or comment
-          verifyNever(
-            issuesService.addLabelsToIssue(
-              slug,
-              pr.number!,
-              <String>[
-                kGoldenFileLabel,
-              ],
-            ),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
+          await includesEngineShard('mac_unopt');
         });
 
         test('new commit, checks complete, no changes detected', () async {

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -1016,6 +1016,366 @@ void main() {
           );
         });
 
+        test('includes linux_android_emulator test shard - monorepo', () async {
+          // New commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
+          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'linux_android_emulator', 'status': 'completed', 'conclusion': 'success'},
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            datastoreProvider: (DatastoreDB db) {
+              return DatastoreService(
+                config.db,
+                5,
+                retryOptions: retryOptions,
+              );
+            },
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
+          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(
+              slug,
+              pr.number!,
+              <String>[
+                kGoldenFileLabel,
+              ],
+            ),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        });
+
+        test('includes linux_host_engine test shard - monorepo', () async {
+          // New commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
+          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'linux_host_engine', 'status': 'completed', 'conclusion': 'success'},
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            datastoreProvider: (DatastoreDB db) {
+              return DatastoreService(
+                config.db,
+                5,
+                retryOptions: retryOptions,
+              );
+            },
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
+          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(
+              slug,
+              pr.number!,
+              <String>[
+                kGoldenFileLabel,
+              ],
+            ),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        });
+
+        test('includes linux_web_engine test shard - monorepo', () async {
+          // New commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
+          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'linux_web_engine', 'status': 'completed', 'conclusion': 'success'},
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            datastoreProvider: (DatastoreDB db) {
+              return DatastoreService(
+                config.db,
+                5,
+                retryOptions: retryOptions,
+              );
+            },
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
+          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(
+              slug,
+              pr.number!,
+              <String>[
+                kGoldenFileLabel,
+              ],
+            ),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        });
+
+        test('includes mac_host_engine test shard - monorepo', () async {
+          // New commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
+          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'mac_host_engine', 'status': 'completed', 'conclusion': 'success'},
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            datastoreProvider: (DatastoreDB db) {
+              return DatastoreService(
+                config.db,
+                5,
+                retryOptions: retryOptions,
+              );
+            },
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
+          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(
+              slug,
+              pr.number!,
+              <String>[
+                kGoldenFileLabel,
+              ],
+            ),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        });
+
+        test('includes mac_unopt test shard - monorepo', () async {
+          // New commit
+          final PullRequest pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+          final GithubGoldStatusUpdate status = newStatusUpdate(slug, pr, '', '', '');
+          db.values[status.key] = status;
+          githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
+
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{'name': 'mac_host_engine', 'status': 'completed', 'conclusion': 'success'},
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            datastoreProvider: (DatastoreDB db) {
+              return DatastoreService(
+                config.db,
+                5,
+                retryOptions: retryOptions,
+              );
+            },
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+          );
+
+          final Body body = await tester.get<Body>(handler);
+          expect(body, same(Body.empty));
+          expect(status.updates, 1);
+          expect(status.status, GithubGoldStatusUpdate.statusCompleted);
+          expect(records.where((LogRecord record) => record.level == Level.WARNING), isEmpty);
+          expect(records.where((LogRecord record) => record.level == Level.SEVERE), isEmpty);
+
+          final List<dynamic> captured =
+              verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+          expect(captured.length, 2);
+          // The first element corresponds to the `status`.
+          final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+          expect(batchWriteRequest.writes!.length, 1);
+          final GithubGoldStatus updatedDocument =
+              GithubGoldStatus.fromDocument(githubGoldStatus: batchWriteRequest.writes![0].update!);
+          expect(updatedDocument.updates, 1);
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(
+              slug,
+              pr.number!,
+              <String>[
+                kGoldenFileLabel,
+              ],
+            ),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        });
+
         test('new commit, checks complete, no changes detected', () async {
           // New commit
           final PullRequest pr = newPullRequest(123, 'abc', 'master');


### PR DESCRIPTION
The flutter-gold check prevents PRs from landing in flutter/flutter or flutter/engine if there are new images that need triage.

It currently does this by having awareness of what checks run golden file tests in these repos. In monorepo world, flutter-gold needs to now cover engine checks in flutter/flutter.

Added a spot for newly added integration test coverage as well.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
