### PR TITLE
[tech debt] remove the MQ simulation

### DIFF
--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2663,60 +2663,9 @@ void foo() {
           'Checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf was found on GoB mirror. Scheduling merge group tasks',
           'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): Scheduling merge group checks',
+          'Updating ci.yaml validation check for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'ci.yaml validation check was successful for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'All required tests passed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-        ],
-      );
-    });
-
-    test('checks_requested failure', () async {
-      final records = <String>[];
-      final subscription = log.onRecord.listen((record) {
-        if (record.level >= Level.FINE) {
-          records.add(record.message);
-        }
-      });
-
-      tester.message = generateMergeGroupMessage(
-        repository: 'flutter/flutter',
-        action: 'checks_requested',
-        message: 'Implement a buggy feature (MQ_FAIL)',
-      );
-
-      await tester.post(webhook);
-      await subscription.cancel();
-
-      verify(
-        mockGithubChecksUtil.createCheckRun(
-          any,
-          any,
-          'c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Merge queue check',
-          output: anyNamed('output'),
-        ),
-      ).called(1);
-
-      verify(
-        mockGithubChecksUtil.updateCheckRun(
-          any,
-          any,
-          any,
-          status: CheckRunStatus.completed,
-          conclusion: CheckRunConclusion.failure,
-        ),
-      ).called(1);
-
-      expect(
-        records,
-        <String>[
-          'Processing merge_group',
-          'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf was found on GoB mirror. Scheduling merge group tasks',
-          'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): Scheduling merge group checks',
-          'Some required tests failed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Some checks failed',
-          'Finished Simulating merge group checks for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );
     });


### PR DESCRIPTION
It was there for testing MQ functionality. We don't need it anymore.