### PR TITLE
[monorepo] cancel builds after merge group is destroyed

### DIFF
--- a/app_dart/lib/src/model/github/checks.dart
+++ b/app_dart/lib/src/model/github/checks.dart
@@ -68,6 +68,7 @@ class MergeGroupEvent extends HookEvent {
   MergeGroupEvent({
     required this.action,
     required this.mergeGroup,
+    this.reason,
     this.repository,
     this.sender,
   });
@@ -75,6 +76,23 @@ class MergeGroupEvent extends HookEvent {
   factory MergeGroupEvent.fromJson(Map<String, dynamic> input) => _$MergeGroupEventFromJson(input);
 
   String action;
+
+  /// Possible reasons for the 'destroyed' event.
+  static const String merged = 'merged';
+  static const String invalidated = 'invalidated';
+  static const String dequeued = 'dequeued';
+  static const destroyReasons = <String>[merged, invalidated, dequeued];
+
+  /// If [action] is "destroyed", explains why the merge group is being destroyed.
+  ///
+  /// The group could have been merged, removed from the queue (dequeued), or
+  /// invalidated by an earlier queue entry being dequeued (invalidated).
+  ///
+  /// Can be one of: merged, invalidated, dequeued.
+  ///
+  /// If [action] is not "destroyed", this field is null.
+  String? reason;
+
   MergeGroup mergeGroup;
   Repository? repository;
   User? sender;

--- a/app_dart/lib/src/model/github/checks.g.dart
+++ b/app_dart/lib/src/model/github/checks.g.dart
@@ -46,12 +46,14 @@ Map<String, dynamic> _$CheckRunToJson(CheckRun instance) => <String, dynamic>{
 MergeGroupEvent _$MergeGroupEventFromJson(Map<String, dynamic> json) => MergeGroupEvent(
       action: json['action'] as String,
       mergeGroup: MergeGroup.fromJson(json['merge_group'] as Map<String, dynamic>),
+      reason: json['reason'] as String?,
       repository: json['repository'] == null ? null : Repository.fromJson(json['repository'] as Map<String, dynamic>),
       sender: json['sender'] == null ? null : User.fromJson(json['sender'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$MergeGroupEventToJson(MergeGroupEvent instance) => <String, dynamic>{
       'action': instance.action,
+      'reason': instance.reason,
       'merge_group': instance.mergeGroup,
       'repository': instance.repository,
       'sender': instance.sender,

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -251,7 +251,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       // into the main branch.
       case 'destroyed':
         log.info('Merge group destroyed for $slug/$headSha');
-        await scheduler.cancelMergeGroupTargets(headSha: headSha);
+        await scheduler.cancelDestroyedMergeGroupTargets(headSha: headSha);
     }
   }
 

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -222,7 +222,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     }
 
     final mergeGroupEvent = MergeGroupEvent.fromJson(request);
-    final MergeGroupEvent(:mergeGroup, :action) = mergeGroupEvent;
+    final MergeGroupEvent(:mergeGroup, :action, :reason) = mergeGroupEvent;
     final headSha = mergeGroup.headSha;
     final slug = mergeGroupEvent.repository!.slug();
 
@@ -250,8 +250,14 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       // stopped to save CI resources, as Github will no longer merge this group
       // into the main branch.
       case 'destroyed':
-        log.info('Merge group destroyed for $slug/$headSha');
-        await scheduler.cancelDestroyedMergeGroupTargets(headSha: headSha);
+        log.info('Merge group destroyed for $slug/$headSha because it was $reason.');
+        if (reason == 'invalidated' || reason == 'dequeued') {
+          await scheduler.cancelDestroyedMergeGroupTargets(headSha: headSha);
+        } else if (reason == 'merged') {
+          log.info('Merge group for $slug/$headSha was merged successfully.');
+        } else {
+          log.warning('Unrecognized reason for merge group destroyed event: $reason');
+        }
     }
   }
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -366,8 +366,6 @@ class LuciBuildService {
   }
 
   /// Cancels all the current builds on [pullRequest] with [reason].
-  ///
-  /// Builds are queried based on the [RepositorySlug] and pull request number.
   Future<void> cancelBuilds({
     required github.PullRequest pullRequest,
     required String reason,
@@ -408,24 +406,23 @@ class LuciBuildService {
   }
 
   /// Cancels all the current builds against the give [sha] with [reason].
-  ///
-  /// Builds are queried based on the [RepositorySlug] and git SHA.
   Future<void> cancelBuildsBySha({
     required String sha,
     required String reason,
   }) async {
-    log.info('Attempting to cancel builds (v2) for git SHA $sha');
+    log.info('Attempting to cancel builds (v2) for git SHA $sha because $reason');
 
-    final Iterable<bbv2.Build> builds = await getProdBuilds(sha: sha);
-    log.info('Found ${builds.length} builds.');
+    final builds = await getProdBuilds(sha: sha);
 
     if (builds.isEmpty) {
-      log.warning('No builds were found for SHA $sha.');
+      log.warning('Will not request cancellation from LUCI.');
       return;
     }
 
-    final List<bbv2.BatchRequest_Request> requests = <bbv2.BatchRequest_Request>[];
-    for (bbv2.Build build in builds) {
+    log.info('Found ${builds.length} builds.');
+
+    final requests = <bbv2.BatchRequest_Request>[];
+    for (final build in builds) {
       if (build.status == bbv2.Status.SCHEDULED || build.status == bbv2.Status.STARTED) {
         // Scheduled status includes scheduled and pending tasks.
         log.info('Cancelling build with build id ${build.id}.');

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -679,12 +679,15 @@ class Scheduler {
     return [...inner.presubmitTargets.where(filter)];
   }
 
-  Future<void> cancelMergeGroupTargets({
+  /// Cancels builds for a destroyed merge group.
+  Future<void> cancelDestroyedMergeGroupTargets({
     required String headSha,
   }) async {
-    // TODO(yjbanov): there's no actual LUCI jobs to cancel, so for now just log
-    //                and move on.
-    log.info('Simulating cancellation of merge group CI targets for @ $headSha');
+    log.info('Cancelling merge group targets.');
+    await luciBuildService.cancelBuildsBySha(
+      sha: headSha,
+      reason: 'Merge group was destroyed',
+    );
   }
 
   /// Pushes the required "Merge Queue Guard" check to the merge queue, which

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -683,7 +683,7 @@ class Scheduler {
   Future<void> cancelDestroyedMergeGroupTargets({
     required String headSha,
   }) async {
-    log.info('Cancelling merge group targets.');
+    log.info('Cancelling merge group targets for $headSha');
     await luciBuildService.cancelBuildsBySha(
       sha: headSha,
       reason: 'Merge group was destroyed',

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -12,6 +12,7 @@ import 'package:cocoon_service/src/service/cache_service.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
+import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart' hide Branch;
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:logging/logging.dart';
@@ -432,7 +433,7 @@ void main() {
       );
       bool batchRequestCalled = false;
 
-      Future<bbv2.BatchResponse> getBatchResponse() async {
+      Future<bbv2.BatchResponse> getBatchResponse(_, __) async {
         batchRequestCalled = true;
         fail('Marking a draft ready for review should not trigger new builds');
       }
@@ -455,7 +456,7 @@ void main() {
 
       bool batchRequestCalled = false;
 
-      Future<bbv2.BatchResponse> getBatchResponse() async {
+      Future<bbv2.BatchResponse> getBatchResponse(_, __) async {
         batchRequestCalled = true;
         return bbv2.BatchResponse(
           responses: <bbv2.BatchResponse_Response>[
@@ -2347,7 +2348,7 @@ void foo() {
       const int issueNumber = 12345;
       bool batchRequestCalled = false;
 
-      Future<bbv2.BatchResponse> getBatchResponse() async {
+      Future<bbv2.BatchResponse> getBatchResponse(_, __) async {
         batchRequestCalled = true;
         return bbv2.BatchResponse(
           responses: <bbv2.BatchResponse_Response>[
@@ -2424,7 +2425,7 @@ void foo() {
           ]);
         });
 
-        fakeBuildBucketClient.batchResponse = () => Future<bbv2.BatchResponse>.value(
+        fakeBuildBucketClient.batchResponse = (_, __) => Future<bbv2.BatchResponse>.value(
               bbv2.BatchResponse(
                 responses: <bbv2.BatchResponse_Response>[
                   bbv2.BatchResponse_Response(
@@ -2492,7 +2493,7 @@ void foo() {
       });
 
       test('When synchronized, cancels existing builds and schedules new ones', () async {
-        fakeBuildBucketClient.batchResponse = () => Future<bbv2.BatchResponse>.value(
+        fakeBuildBucketClient.batchResponse = (_, __) => Future<bbv2.BatchResponse>.value(
               bbv2.BatchResponse(
                 responses: <bbv2.BatchResponse_Response>[
                   bbv2.BatchResponse_Response(
@@ -2682,48 +2683,149 @@ void foo() {
         action: 'destroyed',
         message: 'test message',
       );
+
+      final luciLog = <String>[];
+
+      fakeBuildBucketClient.batchResponse = (batchRequest, uri) async {
+        final batchResponseRc = bbv2.BatchResponse.create();
+        final batchResponseResponses = batchResponseRc.responses;
+
+        for (final request in batchRequest.requests) {
+          if (request.hasSearchBuilds()) {
+            final requestSha = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'buildset').value;
+            luciLog.add('search builds for $requestSha');
+            batchResponseResponses.add(
+              bbv2.BatchResponse_Response(
+                searchBuilds: bbv2.SearchBuildsResponse(
+                  builds: <bbv2.Build>[
+                    for (final status in bbv2.Status.values)
+                      bbv2.Build(
+                        id: Int64(status.value),
+                        status: status,
+                        builder: bbv2.BuilderID(
+                          builder: 'builder_abc',
+                          bucket: 'try',
+                          project: 'flutter',
+                        ),
+                        tags: <bbv2.StringPair>[
+                          bbv2.StringPair(key: 'buildset', value: 'pr/git/12345'),
+                          bbv2.StringPair(key: 'cipd_version', value: 'refs/heads/main'),
+                          bbv2.StringPair(key: 'github_link', value: 'https://github/flutter/flutter/pull/1'),
+                        ],
+                        input: bbv2.Build_Input(
+                          properties: bbv2.Struct(fields: {'bringup': bbv2.Value(stringValue: 'false')}),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            );
+          } else if (request.hasCancelBuild()) {
+            final bbv2.CancelBuildRequest cancelBuildRequest = request.cancelBuild;
+            luciLog.add('cancel ${cancelBuildRequest.id}');
+            batchResponseResponses.add(
+              bbv2.BatchResponse_Response(
+                cancelBuild: bbv2.Build(
+                  id: cancelBuildRequest.id,
+                ),
+              ),
+            );
+          } else {
+            throw UnimplementedError();
+          }
+        }
+        return batchResponseRc;
+      };
+
       await tester.post(webhook);
       await subscription.cancel();
 
       expect(
-        records,
+        luciLog,
         <String>[
+          'search builds for sha/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          // Even though there are 8 builds in total, only 2 of them are eligible
+          // for cancellation.
+          'cancel ${bbv2.Status.SCHEDULED.value}',
+          'cancel ${bbv2.Status.STARTED.value}',
+        ],
+      );
+
+      expect(
+        records,
+        [
           'Processing merge_group',
           'Processing destroyed for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Merge group destroyed for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Cancelling merge group targets.',
-          'Attempting to cancel builds (v2) for git SHA c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Cancelling merge group targets for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Attempting to cancel builds (v2) for git SHA c9affbbb12aa40cb3afbe94b9ea6b119a256bebf because Merge group was destroyed',
           'Responses from get builds batch request = 1',
-          'Found a response: searchBuilds: {\n'
-              '  builds: {\n'
-              '    id: 123\n'
-              '    builder: {\n'
-              '      project: flutter\n'
-              '      bucket: try\n'
-              '      builder: builder_abc\n'
-              '    }\n'
-              '    input: {\n'
-              '      properties: {\n'
-              '        fields: {bringup : stringValue: true\n'
-              '} \n'
-              '      }\n'
-              '    }\n'
-              '    tags: {\n'
-              '      key: buildset\n'
-              '      value: pr/git/12345\n'
-              '    }\n'
-              '    tags: {\n'
-              '      key: cipd_version\n'
-              '      value: refs/heads/main\n'
-              '    }\n'
-              '    tags: {\n'
-              '      key: github_link\n'
-              '      value: https://github/flutter/flutter/pull/1\n'
-              '    }\n'
-              '  }\n'
-              '}\n'
-              '',
-          'Found 1 builds.',
+          contains('Found a response: searchBuilds:'),
+          'Found 8 builds.',
+          'Cancelling build with build id 1.',
+          'Cancelling build with build id 2.',
+        ],
+      );
+    });
+
+    test('destroyed with no builds', () async {
+      final records = <String>[];
+      final subscription = log.onRecord.listen((record) {
+        if (record.level >= Level.FINE) {
+          records.add(record.message);
+        }
+      });
+      tester.message = generateMergeGroupMessage(
+        repository: 'flutter/flutter',
+        action: 'destroyed',
+        message: 'test message',
+      );
+
+      final luciLog = <String>[];
+
+      fakeBuildBucketClient.batchResponse = (batchRequest, uri) async {
+        final batchResponseRc = bbv2.BatchResponse.create();
+        final batchResponseResponses = batchResponseRc.responses;
+
+        for (final request in batchRequest.requests) {
+          if (request.hasSearchBuilds()) {
+            final requestSha = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'buildset').value;
+            luciLog.add('search builds for $requestSha');
+            batchResponseResponses.add(
+              bbv2.BatchResponse_Response(
+                searchBuilds: bbv2.SearchBuildsResponse(
+                  builds: <bbv2.Build>[],
+                ),
+              ),
+            );
+          } else {
+            throw UnimplementedError();
+          }
+        }
+        return batchResponseRc;
+      };
+
+      await tester.post(webhook);
+      await subscription.cancel();
+
+      expect(
+        luciLog,
+        <String>[
+          'search builds for sha/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+        ],
+      );
+
+      expect(
+        records,
+        [
+          'Processing merge_group',
+          'Processing destroyed for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Merge group destroyed for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Cancelling merge group targets for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Attempting to cancel builds (v2) for git SHA c9affbbb12aa40cb3afbe94b9ea6b119a256bebf because Merge group was destroyed',
+          'Responses from get builds batch request = 1',
+          contains('Found a response: searchBuilds:'),
+          'Will not request cancellation from LUCI.',
         ],
       );
     });

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2691,7 +2691,39 @@ void foo() {
           'Processing merge_group',
           'Processing destroyed for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Merge group destroyed for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Simulating cancellation of merge group CI targets for @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Cancelling merge group targets.',
+          'Attempting to cancel builds (v2) for git SHA c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Responses from get builds batch request = 1',
+          'Found a response: searchBuilds: {\n'
+              '  builds: {\n'
+              '    id: 123\n'
+              '    builder: {\n'
+              '      project: flutter\n'
+              '      bucket: try\n'
+              '      builder: builder_abc\n'
+              '    }\n'
+              '    input: {\n'
+              '      properties: {\n'
+              '        fields: {bringup : stringValue: true\n'
+              '} \n'
+              '      }\n'
+              '    }\n'
+              '    tags: {\n'
+              '      key: buildset\n'
+              '      value: pr/git/12345\n'
+              '    }\n'
+              '    tags: {\n'
+              '      key: cipd_version\n'
+              '      value: refs/heads/main\n'
+              '    }\n'
+              '    tags: {\n'
+              '      key: github_link\n'
+              '      value: https://github/flutter/flutter/pull/1\n'
+              '    }\n'
+              '  }\n'
+              '}\n'
+              '',
+          'Found 1 builds.',
         ],
       );
     });

--- a/app_dart/test/src/service/fake_build_bucket_client.dart
+++ b/app_dart/test/src/service/fake_build_bucket_client.dart
@@ -24,7 +24,12 @@ class FakeBuildBucketClient extends BuildBucketClient {
 
   Future<bbv2.Build>? scheduleBuildResponse;
   Future<bbv2.SearchBuildsResponse>? searchBuildsResponse;
-  Future<bbv2.BatchResponse> Function()? batchResponse;
+
+  Future<bbv2.BatchResponse>? Function(
+    bbv2.BatchRequest request,
+    String buildBucketUri,
+  )? batchResponse;
+
   Future<bbv2.Build>? cancelBuildResponse;
   Future<bbv2.Build>? getBuildResponse;
   Future<bbv2.ListBuildersResponse>? listBuildersResponse;
@@ -101,8 +106,9 @@ class FakeBuildBucketClient extends BuildBucketClient {
     bbv2.BatchRequest request, {
     String buildBucketUri = 'https://localhost/builds',
   }) async {
-    if (batchResponse != null) {
-      return batchResponse!();
+    final customResponse = batchResponse?.call(request, buildBucketUri);
+    if (customResponse != null) {
+      return customResponse;
     }
 
     final bbv2.BatchResponse batchResponseRc = bbv2.BatchResponse.create();

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -677,8 +677,8 @@ class _FakeStreamSubscription_60<T> extends _i1.SmartFake implements _i20.Stream
         );
 }
 
-class _FakeBuildBucketClient_61 extends _i1.SmartFake implements _i15.BuildBucketClient {
-  _FakeBuildBucketClient_61(
+class _FakeFusionTester_61 extends _i1.SmartFake implements _i15.FusionTester {
+  _FakeFusionTester_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -687,8 +687,8 @@ class _FakeBuildBucketClient_61 extends _i1.SmartFake implements _i15.BuildBucke
         );
 }
 
-class _FakeCacheService_62 extends _i1.SmartFake implements _i15.CacheService {
-  _FakeCacheService_62(
+class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
+  _FakeBuildBucketClient_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,8 +697,8 @@ class _FakeCacheService_62 extends _i1.SmartFake implements _i15.CacheService {
         );
 }
 
-class _FakePubSub_63 extends _i1.SmartFake implements _i15.PubSub {
-  _FakePubSub_63(
+class _FakeCacheService_63 extends _i1.SmartFake implements _i15.CacheService {
+  _FakeCacheService_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -707,8 +707,8 @@ class _FakePubSub_63 extends _i1.SmartFake implements _i15.PubSub {
         );
 }
 
-class _FakeProcess_64 extends _i1.SmartFake implements _i25.Process {
-  _FakeProcess_64(
+class _FakePubSub_64 extends _i1.SmartFake implements _i15.PubSub {
+  _FakePubSub_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -717,8 +717,8 @@ class _FakeProcess_64 extends _i1.SmartFake implements _i25.Process {
         );
 }
 
-class _FakeTableDataInsertAllResponse_65 extends _i1.SmartFake implements _i5.TableDataInsertAllResponse {
-  _FakeTableDataInsertAllResponse_65(
+class _FakeProcess_65 extends _i1.SmartFake implements _i25.Process {
+  _FakeProcess_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +727,8 @@ class _FakeTableDataInsertAllResponse_65 extends _i1.SmartFake implements _i5.Ta
         );
 }
 
-class _FakeTableDataList_66 extends _i1.SmartFake implements _i5.TableDataList {
-  _FakeTableDataList_66(
+class _FakeTableDataInsertAllResponse_66 extends _i1.SmartFake implements _i5.TableDataInsertAllResponse {
+  _FakeTableDataInsertAllResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,8 +737,8 @@ class _FakeTableDataList_66 extends _i1.SmartFake implements _i5.TableDataList {
         );
 }
 
-class _FakeUser_67 extends _i1.SmartFake implements _i13.User {
-  _FakeUser_67(
+class _FakeTableDataList_67 extends _i1.SmartFake implements _i5.TableDataList {
+  _FakeTableDataList_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -747,8 +747,8 @@ class _FakeUser_67 extends _i1.SmartFake implements _i13.User {
         );
 }
 
-class _FakeCurrentUser_68 extends _i1.SmartFake implements _i13.CurrentUser {
-  _FakeCurrentUser_68(
+class _FakeUser_68 extends _i1.SmartFake implements _i13.User {
+  _FakeUser_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -757,8 +757,8 @@ class _FakeCurrentUser_68 extends _i1.SmartFake implements _i13.CurrentUser {
         );
 }
 
-class _FakePublicKey_69 extends _i1.SmartFake implements _i13.PublicKey {
-  _FakePublicKey_69(
+class _FakeCurrentUser_69 extends _i1.SmartFake implements _i13.CurrentUser {
+  _FakeCurrentUser_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,8 +767,8 @@ class _FakePublicKey_69 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeBeginTransactionResponse_70 extends _i1.SmartFake implements _i21.BeginTransactionResponse {
-  _FakeBeginTransactionResponse_70(
+class _FakePublicKey_70 extends _i1.SmartFake implements _i13.PublicKey {
+  _FakePublicKey_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,8 +777,8 @@ class _FakeBeginTransactionResponse_70 extends _i1.SmartFake implements _i21.Beg
         );
 }
 
-class _Fake$Empty_71 extends _i1.SmartFake implements _i27.$Empty {
-  _Fake$Empty_71(
+class _FakeBeginTransactionResponse_71 extends _i1.SmartFake implements _i21.BeginTransactionResponse {
+  _FakeBeginTransactionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +787,8 @@ class _Fake$Empty_71 extends _i1.SmartFake implements _i27.$Empty {
         );
 }
 
-class _FakeListDocumentsResponse_72 extends _i1.SmartFake implements _i21.ListDocumentsResponse {
-  _FakeListDocumentsResponse_72(
+class _Fake$Empty_72 extends _i1.SmartFake implements _i27.$Empty {
+  _Fake$Empty_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,8 +797,8 @@ class _FakeListDocumentsResponse_72 extends _i1.SmartFake implements _i21.ListDo
         );
 }
 
-class _FakeListCollectionIdsResponse_73 extends _i1.SmartFake implements _i21.ListCollectionIdsResponse {
-  _FakeListCollectionIdsResponse_73(
+class _FakeListDocumentsResponse_73 extends _i1.SmartFake implements _i21.ListDocumentsResponse {
+  _FakeListDocumentsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,8 +807,8 @@ class _FakeListCollectionIdsResponse_73 extends _i1.SmartFake implements _i21.Li
         );
 }
 
-class _FakePartitionQueryResponse_74 extends _i1.SmartFake implements _i21.PartitionQueryResponse {
-  _FakePartitionQueryResponse_74(
+class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake implements _i21.ListCollectionIdsResponse {
+  _FakeListCollectionIdsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -817,8 +817,8 @@ class _FakePartitionQueryResponse_74 extends _i1.SmartFake implements _i21.Parti
         );
 }
 
-class _FakeWriteResponse_75 extends _i1.SmartFake implements _i21.WriteResponse {
-  _FakeWriteResponse_75(
+class _FakePartitionQueryResponse_75 extends _i1.SmartFake implements _i21.PartitionQueryResponse {
+  _FakePartitionQueryResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,8 +827,8 @@ class _FakeWriteResponse_75 extends _i1.SmartFake implements _i21.WriteResponse 
         );
 }
 
-class _FakeStagingConclusion_76 extends _i1.SmartFake implements _i28.StagingConclusion {
-  _FakeStagingConclusion_76(
+class _FakeWriteResponse_76 extends _i1.SmartFake implements _i21.WriteResponse {
+  _FakeWriteResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,8 +837,8 @@ class _FakeStagingConclusion_76 extends _i1.SmartFake implements _i28.StagingCon
         );
 }
 
-class _FakeEntry_77<T> extends _i1.SmartFake implements _i29.Entry<T> {
-  _FakeEntry_77(
+class _FakeStagingConclusion_77 extends _i1.SmartFake implements _i28.StagingConclusion {
+  _FakeStagingConclusion_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -847,8 +847,18 @@ class _FakeEntry_77<T> extends _i1.SmartFake implements _i29.Entry<T> {
         );
 }
 
-class _FakeCache_78<T> extends _i1.SmartFake implements _i29.Cache<T> {
-  _FakeCache_78(
+class _FakeEntry_78<T> extends _i1.SmartFake implements _i29.Entry<T> {
+  _FakeEntry_78(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCache_79<T> extends _i1.SmartFake implements _i29.Cache<T> {
+  _FakeCache_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -5770,9 +5780,18 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   }
 
   @override
+  _i15.FusionTester get fusionTester => (super.noSuchMethod(
+        Invocation.getter(#fusionTester),
+        returnValue: _FakeFusionTester_61(
+          this,
+          Invocation.getter(#fusionTester),
+        ),
+      ) as _i15.FusionTester);
+
+  @override
   _i15.BuildBucketClient get buildBucketClient => (super.noSuchMethod(
         Invocation.getter(#buildBucketClient),
-        returnValue: _FakeBuildBucketClient_61(
+        returnValue: _FakeBuildBucketClient_62(
           this,
           Invocation.getter(#buildBucketClient),
         ),
@@ -5790,7 +5809,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.CacheService get cache => (super.noSuchMethod(
         Invocation.getter(#cache),
-        returnValue: _FakeCacheService_62(
+        returnValue: _FakeCacheService_63(
           this,
           Invocation.getter(#cache),
         ),
@@ -5853,7 +5872,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   @override
   _i15.PubSub get pubsub => (super.noSuchMethod(
         Invocation.getter(#pubsub),
-        returnValue: _FakePubSub_63(
+        returnValue: _FakePubSub_64(
           this,
           Invocation.getter(#pubsub),
         ),
@@ -5949,11 +5968,18 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<Iterable<_i8.Build>> getProdBuilds({String? builderName}) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i8.Build>> getProdBuilds({
+    String? builderName,
+    String? sha,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getProdBuilds,
           [],
-          {#builderName: builderName},
+          {
+            #builderName: builderName,
+            #sha: sha,
+          },
         ),
         returnValue: _i20.Future<Iterable<_i8.Build>>.value(<_i8.Build>[]),
       ) as _i20.Future<Iterable<_i8.Build>>);
@@ -6007,6 +6033,24 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
           [],
           {
             #pullRequest: pullRequest,
+            #reason: reason,
+          },
+        ),
+        returnValue: _i20.Future<void>.value(),
+        returnValueForMissingStub: _i20.Future<void>.value(),
+      ) as _i20.Future<void>);
+
+  @override
+  _i20.Future<void> cancelBuildsBySha({
+    required String? sha,
+    required String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #cancelBuildsBySha,
+          [],
+          {
+            #sha: sha,
             #reason: reason,
           },
         ),
@@ -6275,7 +6319,7 @@ class MockProcessManager extends _i1.Mock implements _i46.ProcessManager {
             #mode: mode,
           },
         ),
-        returnValue: _i20.Future<_i25.Process>.value(_FakeProcess_64(
+        returnValue: _i20.Future<_i25.Process>.value(_FakeProcess_65(
           this,
           Invocation.method(
             #start,
@@ -6543,7 +6587,7 @@ class MockTabledataResource extends _i1.Mock implements _i5.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_65(
+        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_66(
           this,
           Invocation.method(
             #insertAll,
@@ -6587,7 +6631,7 @@ class MockTabledataResource extends _i1.Mock implements _i5.TabledataResource {
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i5.TableDataList>.value(_FakeTableDataList_66(
+        returnValue: _i20.Future<_i5.TableDataList>.value(_FakeTableDataList_67(
           this,
           Invocation.method(
             #list,
@@ -6632,7 +6676,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getUser,
           [name],
         ),
-        returnValue: _i20.Future<_i13.User>.value(_FakeUser_67(
+        returnValue: _i20.Future<_i13.User>.value(_FakeUser_68(
           this,
           Invocation.method(
             #getUser,
@@ -6665,7 +6709,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
             #bio: bio,
           },
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_68(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_69(
           this,
           Invocation.method(
             #editCurrentUser,
@@ -6703,7 +6747,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #getCurrentUser,
           [],
         ),
-        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_68(
+        returnValue: _i20.Future<_i13.CurrentUser>.value(_FakeCurrentUser_69(
           this,
           Invocation.method(
             #getCurrentUser,
@@ -6850,7 +6894,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
           #createPublicKey,
           [key],
         ),
-        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_69(
+        returnValue: _i20.Future<_i13.PublicKey>.value(_FakePublicKey_70(
           this,
           Invocation.method(
             #createPublicKey,
@@ -6930,7 +6974,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(_FakeBeginTransactionResponse_70(
+        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(_FakeBeginTransactionResponse_71(
           this,
           Invocation.method(
             #beginTransaction,
@@ -7029,7 +7073,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i27.$Empty>.value(_Fake$Empty_71(
+        returnValue: _i20.Future<_i27.$Empty>.value(_Fake$Empty_72(
           this,
           Invocation.method(
             #delete,
@@ -7108,7 +7152,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_72(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #list,
@@ -7145,7 +7189,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(_FakeListCollectionIdsResponse_73(
+        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(_FakeListCollectionIdsResponse_74(
           this,
           Invocation.method(
             #listCollectionIds,
@@ -7189,7 +7233,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_72(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #listDocuments,
@@ -7226,7 +7270,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(_FakePartitionQueryResponse_74(
+        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(_FakePartitionQueryResponse_75(
           this,
           Invocation.method(
             #partitionQuery,
@@ -7298,7 +7342,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i27.$Empty>.value(_Fake$Empty_71(
+        returnValue: _i20.Future<_i27.$Empty>.value(_Fake$Empty_72(
           this,
           Invocation.method(
             #rollback,
@@ -7363,7 +7407,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_75(
+        returnValue: _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_76(
           this,
           Invocation.method(
             #write,
@@ -7449,7 +7493,7 @@ class MockCallbacks extends _i1.Mock implements _i47.Callbacks {
             #conclusion: conclusion,
           },
         ),
-        returnValue: _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_76(
+        returnValue: _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_77(
           this,
           Invocation.method(
             #markCheckRunConclusion,
@@ -7578,7 +7622,7 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
           #[],
           [key],
         ),
-        returnValue: _FakeEntry_77<_i40.Uint8List>(
+        returnValue: _FakeEntry_78<_i40.Uint8List>(
           this,
           Invocation.method(
             #[],
@@ -7593,7 +7637,7 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
           #withPrefix,
           [prefix],
         ),
-        returnValue: _FakeCache_78<_i40.Uint8List>(
+        returnValue: _FakeCache_79<_i40.Uint8List>(
           this,
           Invocation.method(
             #withPrefix,
@@ -7608,7 +7652,7 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
           #withCodec,
           [codec],
         ),
-        returnValue: _FakeCache_78<S>(
+        returnValue: _FakeCache_79<S>(
           this,
           Invocation.method(
             #withCodec,
@@ -7623,7 +7667,7 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
           #withTTL,
           [ttl],
         ),
-        returnValue: _FakeCache_78<_i40.Uint8List>(
+        returnValue: _FakeCache_79<_i40.Uint8List>(
           this,
           Invocation.method(
             #withTTL,

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -1133,8 +1133,12 @@ PushMessage generateMergeGroupMessage({
   return PushMessage(data: webhookMessage.writeToJson(), messageId: 'abc123');
 }
 
-String generateMergeGroupEventString(
-    {required String action, required String message, required String repository, String? reason}) {
+String generateMergeGroupEventString({
+  required String action,
+  required String message,
+  required String repository,
+  String? reason,
+}) {
   return '''
 {
 "action": "$action",


### PR DESCRIPTION
When a PR gets kicked out of the queue, Cocoon will cancel any remaining LUCI builds to free up resources.