### PR TITLE
Add an optional third argument for a relative path from the root directory.

### DIFF
--- a/app_dart/test/generate_jspb_test.dart
+++ b/app_dart/test/generate_jspb_test.dart
@@ -8,8 +8,7 @@ import 'package:test/test.dart';
 
 import '../bin/generate_jspb.dart' as gen_jspb show main, debugHttpClientFactory;
 
-const String fakeCiYaml =
-'''
+const String fakeCiYaml = '''
 enabled_branches:
   - main
 ''';
@@ -30,7 +29,8 @@ void main() {
 
   test('generate with three args', () async {
     mockClient = MockClient((request) async {
-      expect(request.url, Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'));
+      expect(request.url,
+          Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'));
       return http.Response(fakeCiYaml, 200);
     });
     await gen_jspb.main(['flutter/flutter', 'abcde', 'engine/src/.ci.yaml']);

--- a/app_dart/test/generate_jspb_test.dart
+++ b/app_dart/test/generate_jspb_test.dart
@@ -29,8 +29,10 @@ void main() {
 
   test('generate with three args', () async {
     mockClient = MockClient((request) async {
-      expect(request.url,
-          Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'));
+      expect(
+        request.url,
+        Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'),
+      );
       return http.Response(fakeCiYaml, 200);
     });
     await gen_jspb.main(['flutter/flutter', 'abcde', 'engine/src/.ci.yaml']);

--- a/app_dart/test/generate_jspb_test.dart
+++ b/app_dart/test/generate_jspb_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import '../bin/generate_jspb.dart' as gen_jspb show main, debugHttpClientFactory;
+
+const String fakeCiYaml =
+'''
+enabled_branches:
+  - main
+''';
+void main() {
+  late MockClient mockClient;
+
+  setUp(() {
+    gen_jspb.debugHttpClientFactory = () => mockClient;
+  });
+
+  test('generate with two args', () async {
+    mockClient = MockClient((request) async {
+      expect(request.url, Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/.ci.yaml'));
+      return http.Response(fakeCiYaml, 200);
+    });
+    await gen_jspb.main(['flutter/flutter', 'abcde']);
+  });
+
+  test('generate with three args', () async {
+    mockClient = MockClient((request) async {
+      expect(request.url, Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'));
+      return http.Response(fakeCiYaml, 200);
+    });
+    await gen_jspb.main(['flutter/flutter', 'abcde', 'engine/src/.ci.yaml']);
+  });
+}

--- a/app_dart/test/generate_jspb_test.dart
+++ b/app_dart/test/generate_jspb_test.dart
@@ -21,20 +21,20 @@ void main() {
 
   test('generate with two args', () async {
     mockClient = MockClient((request) async {
-      expect(request.url, Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/.ci.yaml'));
+      expect(request.url, Uri.parse('https://raw.githubusercontent.com/flutter/flutter/abcde/.ci.yaml'));
       return http.Response(fakeCiYaml, 200);
     });
-    await gen_jspb.main(['flutter/flutter', 'abcde']);
+    await gen_jspb.main(['flutter', 'abcde']);
   });
 
   test('generate with three args', () async {
     mockClient = MockClient((request) async {
       expect(
         request.url,
-        Uri.parse('https://raw.githubusercontent.com/flutter/flutter/flutter/abcde/engine/src/.ci.yaml'),
+        Uri.parse('https://raw.githubusercontent.com/flutter/flutter/abcde/engine/src/.ci.yaml'),
       );
       return http.Response(fakeCiYaml, 200);
     });
-    await gen_jspb.main(['flutter/flutter', 'abcde', 'engine/src/.ci.yaml']);
+    await gen_jspb.main(['flutter', 'abcde', 'engine/src/.ci.yaml']);
   });
 }


### PR DESCRIPTION
This is to support .ci.yaml roller in the monorepo. This is to prepare for this recipe change: https://flutter-review.googlesource.com/c/recipes/+/61680