### PR TITLE
shout less and explain better empty build list

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -415,7 +415,7 @@ class LuciBuildService {
     final builds = await getProdBuilds(sha: sha);
 
     if (builds.isEmpty) {
-      log.warning('Will not request cancellation from LUCI.');
+      log.info('No builds found. Will not request cancellation from LUCI.');
       return;
     }
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2828,7 +2828,7 @@ void foo() {
           'Attempting to cancel builds (v2) for git SHA c9affbbb12aa40cb3afbe94b9ea6b119a256bebf because Merge group was destroyed',
           'Responses from get builds batch request = 1',
           contains('Found a response: searchBuilds:'),
-          'Will not request cancellation from LUCI.',
+          'No builds found. Will not request cancellation from LUCI.',
         ],
       );
     });


### PR DESCRIPTION
It's totally OK that when we attempt to cancel merge group builds, there aren't any. Some merge groups may still be waiting to be scheduled when the "destroy" message comes in, and there's nothing wrong with that. Warnings would make it seem like something is wrong. So I'm downgrading this to info.