### PR TITLE
Rescheduled merge queue builds must include gitiles

### DIFF
--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -84,7 +84,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       return Body.empty;
     }
 
-    log.fine('Setting status (${build.status}) for $builderName');
+    log.info('Setting status (${build.status}) for $builderName');
 
     if (!pubSubCallBack.hasUserData()) {
       log.info('No user data was found in this request');
@@ -115,7 +115,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
         );
         if (currentAttempt < maxAttempt) {
           rescheduled = true;
-          log.fine('Rerunning failed task: $builderName');
+          log.info('Rerunning failed task: $builderName');
           await luciBuildService.rescheduleBuild(
             builderName: builderName,
             build: build,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -496,6 +496,7 @@ class LuciBuildService {
         builder: build.builder,
         tags: tags,
         properties: build.input.properties,
+        gitilesCommit: build.input.gitilesCommit,
         notify: bbv2.NotificationConfig(
           pubsubTopic: 'projects/flutter-dashboard/topics/build-bucket-presubmit',
           userData: UserData.encodeUserDataToBytes(userDataMap),


### PR DESCRIPTION
See flutter/flutter#160704 - Merge Queue builds are postsubmit, they are missing the git_ref but have the gitiles passed along with them. Since MQ uses the presubmit callback for Luci, this wasn't passed along on retries, leading to incorred checkouts and corrupt builds.

Changed logging levels since `fine` doesn't show up.

Added test that failed before and now shows the gitiles passed through.

Extra commas for the dart analyzer.