### PR TITLE
Fix `.ci.yaml` validation for Fusion (the monorepo)

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -76,12 +76,10 @@ class CiYamlSet {
   final String branch;
 
   /// Gets all [Target] that run on presubmit for this config.
-  List<Target> presubmitTargets({CiType type = CiType.any}) =>
-      configs[type]!.presubmitTargets;
+  List<Target> presubmitTargets({CiType type = CiType.any}) => configs[type]!.presubmitTargets;
 
   /// Gets all [Target] that run on postsubmit for this config.
-  List<Target> postsubmitTargets({CiType type = CiType.any}) =>
-      configs[type]!.postsubmitTargets;
+  List<Target> postsubmitTargets({CiType type = CiType.any}) => configs[type]!.postsubmitTargets;
 
   /// Gets the first [Target] matching [builderName] or null.
   Target? getFirstPostsubmitTarget(
@@ -92,17 +90,14 @@ class CiYamlSet {
 
   /// List of target names used to filter target from release candidate branches
   /// that were already removed from main.
-  List<String>? totTargetNames({CiType type = CiType.any}) =>
-      configs[type]!.totTargetNames;
+  List<String>? totTargetNames({CiType type = CiType.any}) => configs[type]!.totTargetNames;
 
   /// List of postsubmit target names used to filter target from release candidate branches
   /// that were already removed from main.
-  List<String>? totPostsubmitTargetNames({CiType type = CiType.any}) =>
-      configs[type]!.totPostsubmitTargetNames;
+  List<String>? totPostsubmitTargetNames({CiType type = CiType.any}) => configs[type]!.totPostsubmitTargetNames;
 
   /// Filters post submit targets to remove targets we do not want backfilled.
-  List<Target> backfillTargets({CiType type = CiType.any}) =>
-      configs[type]!.backfillTargets;
+  List<Target> backfillTargets({CiType type = CiType.any}) => configs[type]!.backfillTargets;
 
   /// Filters targets that were removed from main. [slug] is the gihub
   /// slug for branch under test, [targets] is the list of targets from
@@ -154,12 +149,9 @@ class CiYaml {
     // with release candidate branches.
     final Iterable<Target> totTargets = totConfig?._targets ?? <Target>[];
     final List<Target> totEnabledTargets = _filterEnabledTargets(totTargets);
-    totTargetNames =
-        totEnabledTargets.map((Target target) => target.value.name).toList();
-    totPostsubmitTargetNames = totConfig?.postsubmitTargets
-            .map((Target target) => target.value.name)
-            .toList() ??
-        <String>[];
+    totTargetNames = totEnabledTargets.map((Target target) => target.value.name).toList();
+    totPostsubmitTargetNames =
+        totConfig?.postsubmitTargets.map((Target target) => target.value.name).toList() ?? <String>[];
   }
 
   final CiType type;
@@ -185,32 +177,28 @@ class CiYaml {
 
   /// Gets all [Target] that run on presubmit for this config.
   List<Target> get presubmitTargets {
-    final Iterable<Target> presubmitTargets = _targets.where(
-        (Target target) => target.value.presubmit && !target.value.bringup);
+    final Iterable<Target> presubmitTargets =
+        _targets.where((Target target) => target.value.presubmit && !target.value.bringup);
     List<Target> enabledTargets = _filterEnabledTargets(presubmitTargets);
 
     if (enabledTargets.isEmpty) {
-      throw Exception(
-          '$branch is not enabled for this .ci.yaml.\nAdd it to run tests against this PR.');
+      throw Exception('$branch is not enabled for this .ci.yaml.\nAdd it to run tests against this PR.');
     }
     // Filter targets removed from main.
     if (totTargetNames!.isNotEmpty) {
-      enabledTargets =
-          filterOutdatedTargets(slug, enabledTargets, totTargetNames);
+      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totTargetNames);
     }
     return enabledTargets;
   }
 
   /// Gets all [Target] that run on postsubmit for this config.
   List<Target> get postsubmitTargets {
-    final Iterable<Target> postsubmitTargets =
-        _targets.where((Target target) => target.value.postsubmit);
+    final Iterable<Target> postsubmitTargets = _targets.where((Target target) => target.value.postsubmit);
 
     List<Target> enabledTargets = _filterEnabledTargets(postsubmitTargets);
     // Filter targets removed from main.
     if (totPostsubmitTargetNames!.isNotEmpty) {
-      enabledTargets =
-          filterOutdatedTargets(slug, enabledTargets, totPostsubmitTargetNames);
+      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totPostsubmitTargetNames);
     }
     // filter if release_build true if current branch is a release candidate branch, or a fusion tree.
     enabledTargets = _selectTargetsForBranch(enabledTargets);
@@ -219,8 +207,7 @@ class CiYaml {
 
   /// Gets the first [Target] matching [builderName] or null.
   Target? getFirstPostsubmitTarget(String builderName) {
-    return postsubmitTargets
-        .singleWhereOrNull((Target target) => target.value.name == builderName);
+    return postsubmitTargets.singleWhereOrNull((Target target) => target.value.name == builderName);
   }
 
   /// Filters post submit targets to remove targets we do not want backfilled.
@@ -228,8 +215,7 @@ class CiYaml {
     final List<Target> filteredTargets = <Target>[];
     for (Target target in postsubmitTargets) {
       final Map<String, Object> properties = target.getProperties();
-      if (!properties.containsKey('backfill') ||
-          properties['backfill'] as bool) {
+      if (!properties.containsKey('backfill') || properties['backfill'] as bool) {
         filteredTargets.add(target);
       }
     }
@@ -245,10 +231,7 @@ class CiYaml {
       // For release branches we don't want to run release targets or bringup
       // targets because they are built outside of Cocoon. This applies in both
       // fusion and non-fusion repos.
-      return [
-        ...targets.where(
-            (target) => !target.isReleaseBuildTarget && !target.isBringupTarget)
-      ];
+      return [...targets.where((target) => !target.isReleaseBuildTarget && !target.isBringupTarget)];
     } else {
       // For non-release branches we also want to include bringup targets.
       // However, there's a difference between fusion and non-fusion repos.
@@ -273,8 +256,7 @@ class CiYaml {
     return targets
         .where(
           (Target target) =>
-              (target.value.enabledBranches.isNotEmpty &&
-                  !target.value.enabledBranches.contains(defaultBranch)) ||
+              (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
               totTargetNames!.contains(target.value.name),
         )
         .toList();
@@ -286,13 +268,10 @@ class CiYaml {
   /// This shouldn't be confused for targets that have the property named dependency, which is used by the
   /// flutter_deps recipe module on LUCI.
   List<Target> getInitialTargets(List<Target> targets) {
-    Iterable<Target> initialTargets = targets
-        .where((Target target) => target.value.dependencies.isEmpty)
-        .toList();
+    Iterable<Target> initialTargets = targets.where((Target target) => target.value.dependencies.isEmpty).toList();
     if (branch != Config.defaultBranch(slug)) {
       // Filter out bringup targets for release branches
-      initialTargets =
-          initialTargets.where((Target target) => !target.value.bringup);
+      initialTargets = initialTargets.where((Target target) => !target.value.bringup);
     }
 
     return initialTargets.toList();
@@ -318,22 +297,19 @@ class CiYaml {
     final List<Target> filteredTargets = <Target>[];
 
     final ghMqBranch = tryParseGitHubMergeQueueBranch(branch);
-    final realBranch =
-        ghMqBranch == notGitHubMergeQueueBranch ? branch : ghMqBranch.branch;
+    final realBranch = ghMqBranch == notGitHubMergeQueueBranch ? branch : ghMqBranch.branch;
 
     // 1. Add targets with local definition
-    final Iterable<Target> overrideBranchTargets = targets
-        .where((Target target) => target.value.enabledBranches.isNotEmpty);
-    final Iterable<Target> enabledTargets = overrideBranchTargets.where(
-        (Target target) => enabledBranchesMatchesCurrentBranch(
-            target.value.enabledBranches, realBranch));
+    final Iterable<Target> overrideBranchTargets =
+        targets.where((Target target) => target.value.enabledBranches.isNotEmpty);
+    final Iterable<Target> enabledTargets = overrideBranchTargets
+        .where((Target target) => enabledBranchesMatchesCurrentBranch(target.value.enabledBranches, realBranch));
     filteredTargets.addAll(enabledTargets);
 
     // 2. Add targets with global definition (this is the majority of targets)
-    if (enabledBranchesMatchesCurrentBranch(
-        config.enabledBranches, realBranch)) {
-      final Iterable<Target> defaultBranchTargets = targets
-          .where((Target target) => target.value.enabledBranches.isEmpty);
+    if (enabledBranchesMatchesCurrentBranch(config.enabledBranches, realBranch)) {
+      final Iterable<Target> defaultBranchTargets =
+          targets.where((Target target) => target.value.enabledBranches.isEmpty);
       filteredTargets.addAll(defaultBranchTargets);
     }
 
@@ -341,8 +317,7 @@ class CiYaml {
   }
 
   /// Whether any of the possible [RegExp] in [enabledBranches] match [branch].
-  static bool enabledBranchesMatchesCurrentBranch(
-      List<String> enabledBranches, String branch) {
+  static bool enabledBranchesMatchesCurrentBranch(List<String> enabledBranches, String branch) {
     final List<String> regexes = <String>[];
     for (String enabledBranch in enabledBranches) {
       // Prefix with start of line and suffix with end of line
@@ -369,20 +344,16 @@ class CiYaml {
   ///   6. [pb.Target] cannot have more than 1 dependency
   ///   7. [pb.Target] should depend on target that already exist in depedency graph, and already recorded in map [targetGraph]
   ///   8. [pb.Target] has an empty runIf or the runIf includes `.ci.yaml` `DEPS`, and `engine/**` if validating the framework.
-  void _validate(pb.SchedulerConfig schedulerConfig, String branch,
-      {pb.SchedulerConfig? totSchedulerConfig}) {
+  void _validate(pb.SchedulerConfig schedulerConfig, String branch, {pb.SchedulerConfig? totSchedulerConfig}) {
     if (schedulerConfig.targets.isEmpty) {
-      throw const FormatException(
-          'Scheduler config must have at least 1 target');
+      throw const FormatException('Scheduler config must have at least 1 target');
     }
 
     if (schedulerConfig.enabledBranches.isEmpty) {
-      throw const FormatException(
-          'Scheduler config must have at least 1 enabled branch');
+      throw const FormatException('Scheduler config must have at least 1 enabled branch');
     }
 
-    final Map<String, List<pb.Target>> targetGraph =
-        <String, List<pb.Target>>{};
+    final Map<String, List<pb.Target>> targetGraph = <String, List<pb.Target>>{};
     final List<String> exceptions = <String>[];
     final Set<String> totTargets = <String>{};
     if (totSchedulerConfig != null) {
@@ -398,9 +369,7 @@ class CiYaml {
       } else {
         // a new build without "bringup: true"
         // link to wiki - https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#adding-a-new-devicelab-test
-        if (totTargets.isNotEmpty &&
-            !totTargets.contains(target.name) &&
-            target.bringup != true) {
+        if (totTargets.isNotEmpty && !totTargets.contains(target.name) && target.bringup != true) {
           exceptions.add(
             'ERROR: ${target.name} is a new builder added. it needs to be marked bringup: true\nIf ci.yaml wasn\'t changed, try `git fetch upstream && git merge upstream/master`',
           );
@@ -410,16 +379,15 @@ class CiYaml {
         // Add edges
         if (target.dependencies.isNotEmpty) {
           if (target.dependencies.length != 1) {
-            exceptions.add(
-                'ERROR: ${target.name} has multiple dependencies which is not supported. Use only one dependency');
+            exceptions
+                .add('ERROR: ${target.name} has multiple dependencies which is not supported. Use only one dependency');
           } else {
             if (target.dependencies.first == target.name) {
               exceptions.add('ERROR: ${target.name} cannot depend on itself');
             } else if (targetGraph.containsKey(target.dependencies.first)) {
               targetGraph[target.dependencies.first]!.add(target);
             } else {
-              exceptions.add(
-                  'ERROR: ${target.name} depends on ${target.dependencies.first} which does not exist');
+              exceptions.add('ERROR: ${target.name} depends on ${target.dependencies.first} which does not exist');
             }
           }
         }
@@ -501,8 +469,7 @@ class CiYaml {
 
   void _checkExceptions(List<String> exceptions) {
     if (exceptions.isNotEmpty) {
-      final String fullException =
-          exceptions.reduce((String exception, _) => '$exception\n');
+      final String fullException = exceptions.reduce((String exception, _) => '$exception\n');
       throw FormatException(fullException);
     }
   }
@@ -520,25 +487,22 @@ class DependencyValidator {
     final List<String> exceptions = <String>[];
 
     /// Decoded will contain a list of maps for the dependencies found.
-    final List<dynamic> decoded =
-        json.decode(dependencyJsonString) as List<dynamic>;
+    final List<dynamic> decoded = json.decode(dependencyJsonString) as List<dynamic>;
 
     for (Map<String, dynamic> depMap in decoded) {
       if (!depMap.containsKey('version')) {
-        exceptions.add(
-            'ERROR: dependency ${depMap['dependency']} must have a version.');
+        exceptions.add('ERROR: dependency ${depMap['dependency']} must have a version.');
       } else {
         final String version = depMap['version'] as String;
         if (version.isEmpty || version == 'latest') {
-          exceptions.add(
-              'ERROR: dependency ${depMap['dependency']} must have a non empty, non "latest" version supplied.');
+          exceptions
+              .add('ERROR: dependency ${depMap['dependency']} must have a non empty, non "latest" version supplied.');
         }
       }
     }
 
     if (exceptions.isNotEmpty) {
-      final String fullException =
-          exceptions.reduce((String exception, _) => '$exception\n');
+      final String fullException = exceptions.reduce((String exception, _) => '$exception\n');
       throw FormatException(fullException);
     }
   }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -427,11 +427,15 @@ class CiYaml {
     assert(target.runIf.isNotEmpty, 'Expected to be called when non-empty');
 
     // 1. Every target must depend on .ci.yaml at the root of the repo.
+    // TODO(matanlurey): Can this be inferred instead in the .ci.yaml parser?
+    // See https://github.com/flutter/flutter/issues/160874.
     if (!target.runIf.contains('.ci.yaml')) {
       exceptions.add('ERROR: ${target.name} is missing `.ci.yaml` in runIf');
     }
 
     // 2. The engine repo must additionally depend on DEPS.
+    // TODO(matanlurey): Can this be inferred instead in the .ci.yaml parser?
+    // See https://github.com/flutter/flutter/issues/160874.
     if (slug == Config.engineSlug && !target.runIf.contains('DEPS')) {
       exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
     }
@@ -447,6 +451,9 @@ class CiYaml {
     // The path depends on whether the framework or engine are being validated;
     // while both belong in the same (mono)repo, they have separate .ci.yaml
     // files located in different paths.
+    //
+    // TODO(matanlurey): Can this be inferred instead in the .ci.yaml parser?
+    // See https://github.com/flutter/flutter/issues/160874.
     final ciYamlPath = switch (type) {
       CiType.fusionEngine => 'engine/src/flutter/.ci.yaml',
       _ => '.ci.yaml',
@@ -456,6 +463,8 @@ class CiYaml {
     }
 
     // 2. Every target must depend on DEPS.
+    // TODO(matanlurey): Can this be inferred instead in the .ci.yaml parser?
+    // See https://github.com/flutter/flutter/issues/160874.
     if (!target.runIf.contains('DEPS')) {
       exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
     }

--- a/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
+++ b/app_dart/lib/src/model/ci_yaml/ci_yaml.dart
@@ -76,10 +76,12 @@ class CiYamlSet {
   final String branch;
 
   /// Gets all [Target] that run on presubmit for this config.
-  List<Target> presubmitTargets({CiType type = CiType.any}) => configs[type]!.presubmitTargets;
+  List<Target> presubmitTargets({CiType type = CiType.any}) =>
+      configs[type]!.presubmitTargets;
 
   /// Gets all [Target] that run on postsubmit for this config.
-  List<Target> postsubmitTargets({CiType type = CiType.any}) => configs[type]!.postsubmitTargets;
+  List<Target> postsubmitTargets({CiType type = CiType.any}) =>
+      configs[type]!.postsubmitTargets;
 
   /// Gets the first [Target] matching [builderName] or null.
   Target? getFirstPostsubmitTarget(
@@ -90,14 +92,17 @@ class CiYamlSet {
 
   /// List of target names used to filter target from release candidate branches
   /// that were already removed from main.
-  List<String>? totTargetNames({CiType type = CiType.any}) => configs[type]!.totTargetNames;
+  List<String>? totTargetNames({CiType type = CiType.any}) =>
+      configs[type]!.totTargetNames;
 
   /// List of postsubmit target names used to filter target from release candidate branches
   /// that were already removed from main.
-  List<String>? totPostsubmitTargetNames({CiType type = CiType.any}) => configs[type]!.totPostsubmitTargetNames;
+  List<String>? totPostsubmitTargetNames({CiType type = CiType.any}) =>
+      configs[type]!.totPostsubmitTargetNames;
 
   /// Filters post submit targets to remove targets we do not want backfilled.
-  List<Target> backfillTargets({CiType type = CiType.any}) => configs[type]!.backfillTargets;
+  List<Target> backfillTargets({CiType type = CiType.any}) =>
+      configs[type]!.backfillTargets;
 
   /// Filters targets that were removed from main. [slug] is the gihub
   /// slug for branch under test, [targets] is the list of targets from
@@ -149,9 +154,12 @@ class CiYaml {
     // with release candidate branches.
     final Iterable<Target> totTargets = totConfig?._targets ?? <Target>[];
     final List<Target> totEnabledTargets = _filterEnabledTargets(totTargets);
-    totTargetNames = totEnabledTargets.map((Target target) => target.value.name).toList();
-    totPostsubmitTargetNames =
-        totConfig?.postsubmitTargets.map((Target target) => target.value.name).toList() ?? <String>[];
+    totTargetNames =
+        totEnabledTargets.map((Target target) => target.value.name).toList();
+    totPostsubmitTargetNames = totConfig?.postsubmitTargets
+            .map((Target target) => target.value.name)
+            .toList() ??
+        <String>[];
   }
 
   final CiType type;
@@ -177,28 +185,32 @@ class CiYaml {
 
   /// Gets all [Target] that run on presubmit for this config.
   List<Target> get presubmitTargets {
-    final Iterable<Target> presubmitTargets =
-        _targets.where((Target target) => target.value.presubmit && !target.value.bringup);
+    final Iterable<Target> presubmitTargets = _targets.where(
+        (Target target) => target.value.presubmit && !target.value.bringup);
     List<Target> enabledTargets = _filterEnabledTargets(presubmitTargets);
 
     if (enabledTargets.isEmpty) {
-      throw Exception('$branch is not enabled for this .ci.yaml.\nAdd it to run tests against this PR.');
+      throw Exception(
+          '$branch is not enabled for this .ci.yaml.\nAdd it to run tests against this PR.');
     }
     // Filter targets removed from main.
     if (totTargetNames!.isNotEmpty) {
-      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totTargetNames);
+      enabledTargets =
+          filterOutdatedTargets(slug, enabledTargets, totTargetNames);
     }
     return enabledTargets;
   }
 
   /// Gets all [Target] that run on postsubmit for this config.
   List<Target> get postsubmitTargets {
-    final Iterable<Target> postsubmitTargets = _targets.where((Target target) => target.value.postsubmit);
+    final Iterable<Target> postsubmitTargets =
+        _targets.where((Target target) => target.value.postsubmit);
 
     List<Target> enabledTargets = _filterEnabledTargets(postsubmitTargets);
     // Filter targets removed from main.
     if (totPostsubmitTargetNames!.isNotEmpty) {
-      enabledTargets = filterOutdatedTargets(slug, enabledTargets, totPostsubmitTargetNames);
+      enabledTargets =
+          filterOutdatedTargets(slug, enabledTargets, totPostsubmitTargetNames);
     }
     // filter if release_build true if current branch is a release candidate branch, or a fusion tree.
     enabledTargets = _selectTargetsForBranch(enabledTargets);
@@ -207,7 +219,8 @@ class CiYaml {
 
   /// Gets the first [Target] matching [builderName] or null.
   Target? getFirstPostsubmitTarget(String builderName) {
-    return postsubmitTargets.singleWhereOrNull((Target target) => target.value.name == builderName);
+    return postsubmitTargets
+        .singleWhereOrNull((Target target) => target.value.name == builderName);
   }
 
   /// Filters post submit targets to remove targets we do not want backfilled.
@@ -215,7 +228,8 @@ class CiYaml {
     final List<Target> filteredTargets = <Target>[];
     for (Target target in postsubmitTargets) {
       final Map<String, Object> properties = target.getProperties();
-      if (!properties.containsKey('backfill') || properties['backfill'] as bool) {
+      if (!properties.containsKey('backfill') ||
+          properties['backfill'] as bool) {
         filteredTargets.add(target);
       }
     }
@@ -231,7 +245,10 @@ class CiYaml {
       // For release branches we don't want to run release targets or bringup
       // targets because they are built outside of Cocoon. This applies in both
       // fusion and non-fusion repos.
-      return [...targets.where((target) => !target.isReleaseBuildTarget && !target.isBringupTarget)];
+      return [
+        ...targets.where(
+            (target) => !target.isReleaseBuildTarget && !target.isBringupTarget)
+      ];
     } else {
       // For non-release branches we also want to include bringup targets.
       // However, there's a difference between fusion and non-fusion repos.
@@ -256,7 +273,8 @@ class CiYaml {
     return targets
         .where(
           (Target target) =>
-              (target.value.enabledBranches.isNotEmpty && !target.value.enabledBranches.contains(defaultBranch)) ||
+              (target.value.enabledBranches.isNotEmpty &&
+                  !target.value.enabledBranches.contains(defaultBranch)) ||
               totTargetNames!.contains(target.value.name),
         )
         .toList();
@@ -268,10 +286,13 @@ class CiYaml {
   /// This shouldn't be confused for targets that have the property named dependency, which is used by the
   /// flutter_deps recipe module on LUCI.
   List<Target> getInitialTargets(List<Target> targets) {
-    Iterable<Target> initialTargets = targets.where((Target target) => target.value.dependencies.isEmpty).toList();
+    Iterable<Target> initialTargets = targets
+        .where((Target target) => target.value.dependencies.isEmpty)
+        .toList();
     if (branch != Config.defaultBranch(slug)) {
       // Filter out bringup targets for release branches
-      initialTargets = initialTargets.where((Target target) => !target.value.bringup);
+      initialTargets =
+          initialTargets.where((Target target) => !target.value.bringup);
     }
 
     return initialTargets.toList();
@@ -297,19 +318,22 @@ class CiYaml {
     final List<Target> filteredTargets = <Target>[];
 
     final ghMqBranch = tryParseGitHubMergeQueueBranch(branch);
-    final realBranch = ghMqBranch == notGitHubMergeQueueBranch ? branch : ghMqBranch.branch;
+    final realBranch =
+        ghMqBranch == notGitHubMergeQueueBranch ? branch : ghMqBranch.branch;
 
     // 1. Add targets with local definition
-    final Iterable<Target> overrideBranchTargets =
-        targets.where((Target target) => target.value.enabledBranches.isNotEmpty);
-    final Iterable<Target> enabledTargets = overrideBranchTargets
-        .where((Target target) => enabledBranchesMatchesCurrentBranch(target.value.enabledBranches, realBranch));
+    final Iterable<Target> overrideBranchTargets = targets
+        .where((Target target) => target.value.enabledBranches.isNotEmpty);
+    final Iterable<Target> enabledTargets = overrideBranchTargets.where(
+        (Target target) => enabledBranchesMatchesCurrentBranch(
+            target.value.enabledBranches, realBranch));
     filteredTargets.addAll(enabledTargets);
 
     // 2. Add targets with global definition (this is the majority of targets)
-    if (enabledBranchesMatchesCurrentBranch(config.enabledBranches, realBranch)) {
-      final Iterable<Target> defaultBranchTargets =
-          targets.where((Target target) => target.value.enabledBranches.isEmpty);
+    if (enabledBranchesMatchesCurrentBranch(
+        config.enabledBranches, realBranch)) {
+      final Iterable<Target> defaultBranchTargets = targets
+          .where((Target target) => target.value.enabledBranches.isEmpty);
       filteredTargets.addAll(defaultBranchTargets);
     }
 
@@ -317,7 +341,8 @@ class CiYaml {
   }
 
   /// Whether any of the possible [RegExp] in [enabledBranches] match [branch].
-  static bool enabledBranchesMatchesCurrentBranch(List<String> enabledBranches, String branch) {
+  static bool enabledBranchesMatchesCurrentBranch(
+      List<String> enabledBranches, String branch) {
     final List<String> regexes = <String>[];
     for (String enabledBranch in enabledBranches) {
       // Prefix with start of line and suffix with end of line
@@ -343,17 +368,21 @@ class CiYaml {
   ///   5. [pb.Target] should not depend on self
   ///   6. [pb.Target] cannot have more than 1 dependency
   ///   7. [pb.Target] should depend on target that already exist in depedency graph, and already recorded in map [targetGraph]
-  ///   8. [pb.Target] has an empty runIf or the runIf includes `.ci.yaml` and `DEPS if on the engine repo.
-  void _validate(pb.SchedulerConfig schedulerConfig, String branch, {pb.SchedulerConfig? totSchedulerConfig}) {
+  ///   8. [pb.Target] has an empty runIf or the runIf includes `.ci.yaml` `DEPS`, and `engine/**` if validating the framework.
+  void _validate(pb.SchedulerConfig schedulerConfig, String branch,
+      {pb.SchedulerConfig? totSchedulerConfig}) {
     if (schedulerConfig.targets.isEmpty) {
-      throw const FormatException('Scheduler config must have at least 1 target');
+      throw const FormatException(
+          'Scheduler config must have at least 1 target');
     }
 
     if (schedulerConfig.enabledBranches.isEmpty) {
-      throw const FormatException('Scheduler config must have at least 1 enabled branch');
+      throw const FormatException(
+          'Scheduler config must have at least 1 enabled branch');
     }
 
-    final Map<String, List<pb.Target>> targetGraph = <String, List<pb.Target>>{};
+    final Map<String, List<pb.Target>> targetGraph =
+        <String, List<pb.Target>>{};
     final List<String> exceptions = <String>[];
     final Set<String> totTargets = <String>{};
     if (totSchedulerConfig != null) {
@@ -369,7 +398,9 @@ class CiYaml {
       } else {
         // a new build without "bringup: true"
         // link to wiki - https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#adding-a-new-devicelab-test
-        if (totTargets.isNotEmpty && !totTargets.contains(target.name) && target.bringup != true) {
+        if (totTargets.isNotEmpty &&
+            !totTargets.contains(target.name) &&
+            target.bringup != true) {
           exceptions.add(
             'ERROR: ${target.name} is a new builder added. it needs to be marked bringup: true\nIf ci.yaml wasn\'t changed, try `git fetch upstream && git merge upstream/master`',
           );
@@ -379,40 +410,33 @@ class CiYaml {
         // Add edges
         if (target.dependencies.isNotEmpty) {
           if (target.dependencies.length != 1) {
-            exceptions
-                .add('ERROR: ${target.name} has multiple dependencies which is not supported. Use only one dependency');
+            exceptions.add(
+                'ERROR: ${target.name} has multiple dependencies which is not supported. Use only one dependency');
           } else {
             if (target.dependencies.first == target.name) {
               exceptions.add('ERROR: ${target.name} cannot depend on itself');
             } else if (targetGraph.containsKey(target.dependencies.first)) {
               targetGraph[target.dependencies.first]!.add(target);
             } else {
-              exceptions.add('ERROR: ${target.name} depends on ${target.dependencies.first} which does not exist');
+              exceptions.add(
+                  'ERROR: ${target.name} depends on ${target.dependencies.first} which does not exist');
             }
           }
         }
 
         // Verify runIf includes foundational files.
         if (target.runIf.isNotEmpty) {
-          if (isFusion && type == CiType.fusionEngine) {
-            // Look in different locations if fusion && engine ci.yaml
-            if (!target.runIf.contains('engine/src/flutter/.ci.yaml')) {
-              exceptions.add(
-                'ERROR: ${target.name} is missing `engine/src/flutter/.ci.yaml` in runIf',
-              );
-            }
-            if (!target.runIf.contains('DEPS')) {
-              exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
-            }
+          if (isFusion) {
+            _verifyTargetFusionRepo(target, exceptions);
           } else {
-            // not fusion or not engine in fusion.
-            if (!target.runIf.contains('.ci.yaml')) {
-              exceptions.add('ERROR: ${target.name} is missing `.ci.yaml` in runIf');
-            }
-            if (slug == Config.engineSlug && !target.runIf.contains('DEPS')) {
-              exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
-            }
+            _verifyTargetClassicRepo(target, exceptions);
           }
+        }
+
+        // Verify runIfNot is never used, as it is a very confusing feature.
+        // https://github.com/flutter/flutter/issues/147182
+        if (target.runIfNot.isNotEmpty) {
+          exceptions.add('ERROR: ${target.name}: Do not use runIfNot.');
         }
       }
 
@@ -429,9 +453,56 @@ class CiYaml {
     _checkExceptions(exceptions);
   }
 
+  void _verifyTargetClassicRepo(pb.Target target, List<String> exceptions) {
+    // These serve mostly as documentation.
+    assert(!isFusion, 'Expected to be called in a non-monorepo');
+    assert(target.runIf.isNotEmpty, 'Expected to be called when non-empty');
+
+    // 1. Every target must depend on .ci.yaml at the root of the repo.
+    if (!target.runIf.contains('.ci.yaml')) {
+      exceptions.add('ERROR: ${target.name} is missing `.ci.yaml` in runIf');
+    }
+
+    // 2. The engine repo must additionally depend on DEPS.
+    if (slug == Config.engineSlug && !target.runIf.contains('DEPS')) {
+      exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
+    }
+  }
+
+  void _verifyTargetFusionRepo(pb.Target target, List<String> exceptions) {
+    // These serve mostly as documentation.
+    assert(isFusion, 'Expected to be called in a fusion monorepo');
+    assert(target.runIf.isNotEmpty, 'Expected to be called when non-empty');
+    assert(slug == Config.flutterSlug, 'Expected to be in the combined repo');
+
+    // 1. Every target must depend on .ci.yaml.
+    // The path depends on whether the framework or engine are being validated;
+    // while both belong in the same (mono)repo, they have separate .ci.yaml
+    // files located in different paths.
+    final ciYamlPath = switch (type) {
+      CiType.fusionEngine => 'engine/src/flutter/.ci.yaml',
+      _ => '.ci.yaml',
+    };
+    if (!target.runIf.contains(ciYamlPath)) {
+      exceptions.add('ERROR: ${target.name} is missing `$ciYamlPath` in runIf');
+    }
+
+    // 2. Every target must depend on DEPS.
+    if (!target.runIf.contains('DEPS')) {
+      exceptions.add('ERROR: ${target.name} is missing `DEPS` in runIf');
+    }
+
+    // 3. The framework tree must depend on engine/**.
+    final isFrameworkCiYaml = type != CiType.fusionEngine;
+    if (isFrameworkCiYaml && !target.runIf.contains('engine/**')) {
+      exceptions.add('ERROR: ${target.name} is missing `engine/**` in runIf');
+    }
+  }
+
   void _checkExceptions(List<String> exceptions) {
     if (exceptions.isNotEmpty) {
-      final String fullException = exceptions.reduce((String exception, _) => '$exception\n');
+      final String fullException =
+          exceptions.reduce((String exception, _) => '$exception\n');
       throw FormatException(fullException);
     }
   }
@@ -449,22 +520,25 @@ class DependencyValidator {
     final List<String> exceptions = <String>[];
 
     /// Decoded will contain a list of maps for the dependencies found.
-    final List<dynamic> decoded = json.decode(dependencyJsonString) as List<dynamic>;
+    final List<dynamic> decoded =
+        json.decode(dependencyJsonString) as List<dynamic>;
 
     for (Map<String, dynamic> depMap in decoded) {
       if (!depMap.containsKey('version')) {
-        exceptions.add('ERROR: dependency ${depMap['dependency']} must have a version.');
+        exceptions.add(
+            'ERROR: dependency ${depMap['dependency']} must have a version.');
       } else {
         final String version = depMap['version'] as String;
         if (version.isEmpty || version == 'latest') {
-          exceptions
-              .add('ERROR: dependency ${depMap['dependency']} must have a non empty, non "latest" version supplied.');
+          exceptions.add(
+              'ERROR: dependency ${depMap['dependency']} must have a non empty, non "latest" version supplied.');
         }
       }
     }
 
     if (exceptions.isNotEmpty) {
-      final String fullException = exceptions.reduce((String exception, _) => '$exception\n');
+      final String fullException =
+          exceptions.reduce((String exception, _) => '$exception\n');
       throw FormatException(fullException);
     }
   }

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_service/protos.dart' as pb;
 import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/service/config.dart';
+import 'package:github/github.dart';
 import 'package:test/test.dart';
 
 import '../../src/service/fake_scheduler.dart';
@@ -19,14 +20,17 @@ void main() {
         'flutter-2.4-candidate.3',
         <String>['flutter-\\d+\\.\\d+-candidate\\.\\d+'],
       ),
-      EnabledBranchesRegexTest('matches main when not first pattern', 'main', <String>['dev', 'main']),
-      EnabledBranchesRegexTest('does not do partial matches', 'super-main', <String>['main'], false),
+      EnabledBranchesRegexTest('matches main when not first pattern', 'main',
+          <String>['dev', 'main']),
+      EnabledBranchesRegexTest(
+          'does not do partial matches', 'super-main', <String>['main'], false),
     ];
 
     for (EnabledBranchesRegexTest regexTest in tests) {
       test(regexTest.name, () {
         expect(
-          CiYaml.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
+          CiYaml.enabledBranchesMatchesCurrentBranch(
+              regexTest.enabledBranches, regexTest.branch),
           regexTest.expectation,
         );
       });
@@ -40,9 +44,11 @@ void main() {
       });
     }
 
-    validatePinnedVersion('[{"dependency": "chrome_and_driver", "version": "version:96.2"}]');
+    validatePinnedVersion(
+        '[{"dependency": "chrome_and_driver", "version": "version:96.2"}]');
     validatePinnedVersion('[{"dependency": "open_jdk", "version": "11"}]');
-    validatePinnedVersion('[{"dependency": "android_sdk", "version": "version:31v8"}]');
+    validatePinnedVersion(
+        '[{"dependency": "android_sdk", "version": "version:31v8"}]');
     validatePinnedVersion(
       '[{"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}]',
     );
@@ -51,20 +57,25 @@ void main() {
   group('Validate un-pinned version operation.', () {
     void validateUnPinnedVersion(String input) {
       test('$input -> returns normally', () {
-        expect(() => DependencyValidator.hasVersion(dependencyJsonString: input), throwsException);
+        expect(
+            () => DependencyValidator.hasVersion(dependencyJsonString: input),
+            throwsException);
       });
     }
 
     validateUnPinnedVersion('[{"dependency": "some_sdk", "version": ""}]');
     validateUnPinnedVersion('[{"dependency": "another_sdk"}]');
-    validateUnPinnedVersion('[{"dependency": "yet_another_sdk", "version": "latest"}]');
+    validateUnPinnedVersion(
+        '[{"dependency": "yet_another_sdk", "version": "latest"}]');
   });
 
   group('initialTargets', () {
     test('targets without deps', () {
       final ciYaml = exampleConfig;
-      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-      final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+      final List<Target> initialTargets =
+          ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+      final List<String> initialTargetNames =
+          initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
         containsAll(
@@ -98,8 +109,10 @@ void main() {
           ),
         },
       );
-      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-      final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+      final List<Target> initialTargets =
+          ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+      final List<String> initialTargetNames =
+          initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
         containsAll(
@@ -156,7 +169,8 @@ void main() {
 
       test('filter targets removed from presubmit', () {
         final List<Target> initialTargets = ciYaml.presubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -171,7 +185,8 @@ void main() {
         final ciYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
-          branch: 'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56',
+          branch:
+              'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56',
           config: pb.SchedulerConfig(
             enabledBranches: <String>[
               'master',
@@ -192,8 +207,9 @@ void main() {
           totConfig: totCIYaml,
         );
 
-        final List<String> initialTargetNames =
-            ciYaml.presubmitTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = ciYaml.presubmitTargets
+            .map((Target target) => target.value.name)
+            .toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -206,7 +222,8 @@ void main() {
 
       test('filter targets removed from postsubmit', () {
         final List<Target> initialTargets = ciYaml.postsubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -220,7 +237,8 @@ void main() {
       test('Get backfill targets from postsubmit', () {
         final ciYaml = exampleBackfillConfig;
         final List<Target> backfillTargets = ciYaml.backfillTargets();
-        final List<String> backfillTargetNames = backfillTargets.map((Target target) => target.value.name).toList();
+        final List<String> backfillTargetNames =
+            backfillTargets.map((Target target) => target.value.name).toList();
         expect(
           backfillTargetNames,
           containsAll(
@@ -258,7 +276,8 @@ void main() {
           totConfig: totCIYaml,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(initialTargetNames, isEmpty);
       });
 
@@ -285,7 +304,8 @@ void main() {
           totConfig: totCIYaml,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -296,7 +316,9 @@ void main() {
         );
       });
 
-      test('release_build and bringup targets are correctly filtered for postsubmit in fusion mode', () {
+      test(
+          'release_build and bringup targets are correctly filtered for postsubmit in fusion mode',
+          () {
         final CiYaml releaseYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
@@ -319,7 +341,8 @@ void main() {
           isFusion: true,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           <String>[
@@ -357,6 +380,7 @@ void main() {
         );
       });
     });
+
     group('Presubmit validation', () {
       final CiYaml totCIYaml = CiYaml(
         type: CiType.any,
@@ -400,15 +424,351 @@ void main() {
         totConfig: totCIYaml,
       );
 
-      test('presubmit true target is scheduled though TOT is with presubmit false', () {
+      test(
+          'presubmit true target is scheduled though TOT is with presubmit false',
+          () {
         final List<Target> initialTargets = ciYaml.presubmitTargets;
-        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames =
+            initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
             <String>[
               'Linux A',
             ],
+          ),
+        );
+      });
+    });
+  });
+
+  group('validates runIf blocks', () {
+    test('never use runIfNot', () {
+      expect(
+        () => CiYaml(
+          slug: Config.flutterSlug,
+          branch: Config.defaultBranch(Config.flutterSlug),
+          config: pb.SchedulerConfig(
+            enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+            targets: [
+              pb.Target(
+                name: 'Target.Uses.runIfNot',
+                runIfNot: ['some-file'],
+              ),
+            ],
+          ),
+          type: CiType.any,
+          validate: true,
+        ),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            stringContainsInOrder([
+              'Target.Uses.runIfNot',
+              'Do not use runIfNot',
+            ]),
+          ),
+        ),
+      );
+    });
+
+    group('classic repo', () {
+      test('must include .ci.yaml', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.ciYaml',
+                  runIf: [
+                    'some-file',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.ciYaml',
+                'is missing `.ci.yaml` in runIf',
+              ]),
+            ),
+          ),
+        );
+      });
+
+      test('framework is valid with .ci.yaml', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.OK',
+                  runIf: [
+                    '.ci.yaml',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+          ),
+          returnsNormally,
+        );
+      });
+
+      test('engine is valid with DEPS and .ci.yaml', () {
+        expect(
+          () => CiYaml(
+            slug: Config.engineSlug,
+            branch: Config.defaultBranch(Config.engineSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.engineSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.OK',
+                  runIf: [
+                    '.ci.yaml',
+                    'DEPS',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+          ),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('fusion repo', () {
+      test('framework is valid with DEPS, root .ci.yaml, and engine/**', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.OK',
+                  runIf: [
+                    '.ci.yaml',
+                    'DEPS',
+                    'engine/**',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            isFusion: true,
+            validate: true,
+          ),
+          returnsNormally,
+        );
+      });
+
+      test('engine is valid with DEPS and engine .ci.yaml', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.OK',
+                  runIf: [
+                    'engine/src/flutter/.ci.yaml',
+                    'DEPS',
+                    'engine/**',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.fusionEngine,
+            isFusion: true,
+            validate: true,
+          ),
+          returnsNormally,
+        );
+      });
+
+      test('must include DEPS for the framework builds/tests', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.DEPS',
+                  runIf: [
+                    '.ci.yaml',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+            isFusion: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.DEPS',
+                'is missing `DEPS` in runIf',
+              ]),
+            ),
+          ),
+        );
+      });
+
+      test('must include root .ci.yaml for the framework builds/tests', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.ciYaml',
+                  runIf: [
+                    'some-file',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+            isFusion: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.ciYaml',
+                'is missing `.ci.yaml` in runIf',
+              ]),
+            ),
+          ),
+        );
+      });
+
+      test('must include engine .ci.yaml for the engine builds/tests', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.ciYaml',
+                  runIf: [
+                    'some-file',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.fusionEngine,
+            validate: true,
+            isFusion: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.ciYaml',
+                'is missing `engine/src/flutter/.ci.yaml` in runIf',
+              ]),
+            ),
+          ),
+        );
+      });
+
+      test('must include engine sources for the framework builds/tests', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.engineSources',
+                  runIf: [
+                    '.ci.yaml',
+                    'DEPS',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.any,
+            validate: true,
+            isFusion: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.engineSources',
+                'is missing `engine/**` in runIf',
+              ]),
+            ),
+          ),
+        );
+      });
+
+      test('must include DEPS for the engine builds/tests', () {
+        expect(
+          () => CiYaml(
+            slug: Config.flutterSlug,
+            branch: Config.defaultBranch(Config.flutterSlug),
+            config: pb.SchedulerConfig(
+              enabledBranches: [Config.defaultBranch(Config.flutterSlug)],
+              targets: [
+                pb.Target(
+                  name: 'Target.Missing.DEPS',
+                  runIf: [
+                    'engine/src/flutter/.ci.yaml',
+                  ],
+                ),
+              ],
+            ),
+            type: CiType.fusionEngine,
+            validate: true,
+            isFusion: true,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              stringContainsInOrder([
+                'Target.Missing.DEPS',
+                'is missing `DEPS` in runIf',
+              ]),
+            ),
           ),
         );
       });
@@ -434,7 +794,8 @@ void main() {
 
 /// Wrapper class for table driven design of [CiYaml.enabledBranchesMatchesCurrentBranch].
 class EnabledBranchesRegexTest {
-  EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches, [this.expectation = true]);
+  EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches,
+      [this.expectation = true]);
 
   final String branch;
   final List<String> enabledBranches;

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -20,17 +20,14 @@ void main() {
         'flutter-2.4-candidate.3',
         <String>['flutter-\\d+\\.\\d+-candidate\\.\\d+'],
       ),
-      EnabledBranchesRegexTest('matches main when not first pattern', 'main',
-          <String>['dev', 'main']),
-      EnabledBranchesRegexTest(
-          'does not do partial matches', 'super-main', <String>['main'], false),
+      EnabledBranchesRegexTest('matches main when not first pattern', 'main', <String>['dev', 'main']),
+      EnabledBranchesRegexTest('does not do partial matches', 'super-main', <String>['main'], false),
     ];
 
     for (EnabledBranchesRegexTest regexTest in tests) {
       test(regexTest.name, () {
         expect(
-          CiYaml.enabledBranchesMatchesCurrentBranch(
-              regexTest.enabledBranches, regexTest.branch),
+          CiYaml.enabledBranchesMatchesCurrentBranch(regexTest.enabledBranches, regexTest.branch),
           regexTest.expectation,
         );
       });
@@ -44,11 +41,9 @@ void main() {
       });
     }
 
-    validatePinnedVersion(
-        '[{"dependency": "chrome_and_driver", "version": "version:96.2"}]');
+    validatePinnedVersion('[{"dependency": "chrome_and_driver", "version": "version:96.2"}]');
     validatePinnedVersion('[{"dependency": "open_jdk", "version": "11"}]');
-    validatePinnedVersion(
-        '[{"dependency": "android_sdk", "version": "version:31v8"}]');
+    validatePinnedVersion('[{"dependency": "android_sdk", "version": "version:31v8"}]');
     validatePinnedVersion(
       '[{"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}]',
     );
@@ -57,25 +52,20 @@ void main() {
   group('Validate un-pinned version operation.', () {
     void validateUnPinnedVersion(String input) {
       test('$input -> returns normally', () {
-        expect(
-            () => DependencyValidator.hasVersion(dependencyJsonString: input),
-            throwsException);
+        expect(() => DependencyValidator.hasVersion(dependencyJsonString: input), throwsException);
       });
     }
 
     validateUnPinnedVersion('[{"dependency": "some_sdk", "version": ""}]');
     validateUnPinnedVersion('[{"dependency": "another_sdk"}]');
-    validateUnPinnedVersion(
-        '[{"dependency": "yet_another_sdk", "version": "latest"}]');
+    validateUnPinnedVersion('[{"dependency": "yet_another_sdk", "version": "latest"}]');
   });
 
   group('initialTargets', () {
     test('targets without deps', () {
       final ciYaml = exampleConfig;
-      final List<Target> initialTargets =
-          ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-      final List<String> initialTargetNames =
-          initialTargets.map((Target target) => target.value.name).toList();
+      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+      final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
         containsAll(
@@ -109,10 +99,8 @@ void main() {
           ),
         },
       );
-      final List<Target> initialTargets =
-          ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-      final List<String> initialTargetNames =
-          initialTargets.map((Target target) => target.value.name).toList();
+      final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+      final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
       expect(
         initialTargetNames,
         containsAll(
@@ -169,8 +157,7 @@ void main() {
 
       test('filter targets removed from presubmit', () {
         final List<Target> initialTargets = ciYaml.presubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -185,8 +172,7 @@ void main() {
         final ciYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
-          branch:
-              'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56',
+          branch: 'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56',
           config: pb.SchedulerConfig(
             enabledBranches: <String>[
               'master',
@@ -207,9 +193,8 @@ void main() {
           totConfig: totCIYaml,
         );
 
-        final List<String> initialTargetNames = ciYaml.presubmitTargets
-            .map((Target target) => target.value.name)
-            .toList();
+        final List<String> initialTargetNames =
+            ciYaml.presubmitTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -222,8 +207,7 @@ void main() {
 
       test('filter targets removed from postsubmit', () {
         final List<Target> initialTargets = ciYaml.postsubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -237,8 +221,7 @@ void main() {
       test('Get backfill targets from postsubmit', () {
         final ciYaml = exampleBackfillConfig;
         final List<Target> backfillTargets = ciYaml.backfillTargets();
-        final List<String> backfillTargetNames =
-            backfillTargets.map((Target target) => target.value.name).toList();
+        final List<String> backfillTargetNames = backfillTargets.map((Target target) => target.value.name).toList();
         expect(
           backfillTargetNames,
           containsAll(
@@ -276,8 +259,7 @@ void main() {
           totConfig: totCIYaml,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(initialTargetNames, isEmpty);
       });
 
@@ -304,8 +286,7 @@ void main() {
           totConfig: totCIYaml,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -316,9 +297,7 @@ void main() {
         );
       });
 
-      test(
-          'release_build and bringup targets are correctly filtered for postsubmit in fusion mode',
-          () {
+      test('release_build and bringup targets are correctly filtered for postsubmit in fusion mode', () {
         final CiYaml releaseYaml = CiYaml(
           type: CiType.any,
           slug: Config.flutterSlug,
@@ -341,8 +320,7 @@ void main() {
           isFusion: true,
         );
         final List<Target> initialTargets = releaseYaml.postsubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           <String>[
@@ -424,12 +402,9 @@ void main() {
         totConfig: totCIYaml,
       );
 
-      test(
-          'presubmit true target is scheduled though TOT is with presubmit false',
-          () {
+      test('presubmit true target is scheduled though TOT is with presubmit false', () {
         final List<Target> initialTargets = ciYaml.presubmitTargets;
-        final List<String> initialTargetNames =
-            initialTargets.map((Target target) => target.value.name).toList();
+        final List<String> initialTargetNames = initialTargets.map((Target target) => target.value.name).toList();
         expect(
           initialTargetNames,
           containsAll(
@@ -794,8 +769,7 @@ void main() {
 
 /// Wrapper class for table driven design of [CiYaml.enabledBranchesMatchesCurrentBranch].
 class EnabledBranchesRegexTest {
-  EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches,
-      [this.expectation = true]);
+  EnabledBranchesRegexTest(this.name, this.branch, this.enabledBranches, [this.expectation = true]);
 
   final String branch;
   final List<String> enabledBranches;

--- a/app_dart/test/model/ci_yaml/ci_yaml_test.dart
+++ b/app_dart/test/model/ci_yaml/ci_yaml_test.dart
@@ -6,7 +6,6 @@ import 'package:cocoon_service/protos.dart' as pb;
 import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/service/config.dart';
-import 'package:github/github.dart';
 import 'package:test/test.dart';
 
 import '../../src/service/fake_scheduler.dart';

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -60,7 +60,9 @@ targets:
   - name: Linux runIf
     runIf:
       - .ci.yaml
+      - DEPS
       - dev/**
+      - engine/**
   - name: Google Internal Roll
     postsubmit: true
     presubmit: false
@@ -1481,11 +1483,6 @@ targets:
         - .ci.yaml
         - DEPS
         - dev/run_if/**
-    - name: Linux Conditional Presubmit (runIfNot)
-      presubmit: true
-      scheduler: luci
-      runIfNot:
-        - dev/run_if_not/**
     - name: Linux Postsubmit
       presubmit: false
       scheduler: luci
@@ -1516,7 +1513,6 @@ targets:
               'Linux Presubmit',
               // test: all label is present, so runIf is skipped.
               'Linux Conditional Presubmit (runIf)',
-              'Linux Conditional Presubmit (runIfNot)',
               // test: all label is present, so postsubmit is treated as presubmit.
               'Linux Postsubmit',
             ],
@@ -1537,7 +1533,6 @@ targets:
               'Linux Presubmit',
               // test: all label is present, so runIf is skipped.
               'Linux Conditional Presubmit (runIf)',
-              'Linux Conditional Presubmit (runIfNot)',
               // test: all label is present, so postsubmit is treated as presubmit.
               'Linux Postsubmit',
             ],
@@ -1556,7 +1551,6 @@ targets:
             (<String>[
               // Always runs.
               'Linux Presubmit',
-              'Linux Conditional Presubmit (runIfNot)',
             ]),
           );
         });

--- a/cloud_build/dashboard_build.sh
+++ b/cloud_build/dashboard_build.sh
@@ -8,7 +8,7 @@
 pushd dashboard > /dev/null
 set -e
 rm -rf build
-flutter channel stable 
+flutter channel stable
 flutter upgrade
 flutter doctor
 flutter pub get


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160707.

Fixes a bug where `DEPS` was accidentally (or purposefully, there were no tests to verify) not checked for framework builds, and then expands on the validation by adding a check for `engine/**` for framework builds, adding a check nobody uses `runIfNot`, which is extremely broken and should not be used, and then lastly refactors the code and adds tests for the next shmuck to want to change this.