### PR TITLE
remove dangerously unused SHA from parsed MQ branch

### DIFF
--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -26,16 +26,16 @@ const String kCiYamlFusionEnginePath = 'engine/src/flutter/$kCiYamlPath';
 const String kTestOwnerPath = 'TESTOWNERS';
 
 /// Attempts to parse the github merge queue branch into its constituent parts to be returned as a record.
-({bool parsed, String branch, int pullRequestNumber, String sha}) tryParseGitHubMergeQueueBranch(String branch) {
+({bool parsed, String branch, int pullRequestNumber}) tryParseGitHubMergeQueueBranch(String branch) {
   final match = _githubMqBranch.firstMatch(branch);
   if (match == null) {
     return notGitHubMergeQueueBranch;
   }
 
-  return (parsed: true, branch: match.group(1)!, pullRequestNumber: int.parse(match.group(2)!), sha: match.group(3)!);
+  return (parsed: true, branch: match.group(1)!, pullRequestNumber: int.parse(match.group(2)!));
 }
 
-const notGitHubMergeQueueBranch = (parsed: false, branch: '', pullRequestNumber: -1, sha: '');
+const notGitHubMergeQueueBranch = (parsed: false, branch: '', pullRequestNumber: -1);
 
 final _githubMqBranch = RegExp(r'^gh-readonly-queue\/([^/]+)\/pr-(\d+)-([a-fA-F0-9]+)$');
 

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -50,7 +50,7 @@ void main() {
     test('github merge queue branch parsing', () {
       expect(
         tryParseGitHubMergeQueueBranch('gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56'),
-        (parsed: true, branch: 'master', pullRequestNumber: 160481, sha: '1398dc7eecb696d302e4edb19ad79901e615ed56'),
+        (parsed: true, branch: 'master', pullRequestNumber: 160481),
         reason: 'parses expected magic branch',
       );
       expect(


### PR DESCRIPTION
The SHA in the branch name could be accidentally used, and this logic's presence already confused me while I was investigating https://github.com/flutter/flutter/issues/160704. The branch name is not meant to be the source of truth for the actual head SHA that's being tested (that should be the `headSha` of the `merge_group` request). In the spirit of "better safe than sorry", let's remove it for now.