### PR TITLE
[monorepo] fix prod job look-up

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -174,9 +174,18 @@ class LuciBuildService {
   }) async {
     final List<bbv2.StringPair> tags = [
       if (sha != null)
+        // Unlike try tasks, which use the "sha/git/" prefix, prod tasks use the
+        // "commit/git/" prefix.
         bbv2.StringPair(
           key: 'buildset',
-          value: 'sha/git/$sha',
+          value: 'commit/git/$sha',
+        ),
+
+        // Only cancel jobs automatically kicked off by Cocoon. For example, do
+        // not cancel manual jobs.
+        bbv2.StringPair(
+          key: 'user_agent',
+          value: 'flutter-cocoon',
         ),
     ];
     return getBuilds(

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -181,12 +181,12 @@ class LuciBuildService {
           value: 'commit/git/$sha',
         ),
 
-        // Only cancel jobs automatically kicked off by Cocoon. For example, do
-        // not cancel manual jobs.
-        bbv2.StringPair(
-          key: 'user_agent',
-          value: 'flutter-cocoon',
-        ),
+      // Only cancel jobs automatically kicked off by Cocoon. For example, do
+      // not cancel manual jobs.
+      bbv2.StringPair(
+        key: 'user_agent',
+        value: 'flutter-cocoon',
+      ),
     ];
     return getBuilds(
       builderName: builderName,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -181,8 +181,8 @@ class LuciBuildService {
           value: 'commit/git/$sha',
         ),
 
-      // Only cancel jobs automatically kicked off by Cocoon. For example, do
-      // not cancel manual jobs.
+      // Only process jobs automatically kicked off by Cocoon. For example, we
+      // do not want to cancel or retry manually started jobs.
       bbv2.StringPair(
         key: 'user_agent',
         value: 'flutter-cocoon',

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2695,7 +2695,8 @@ void foo() {
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
             final requestSha = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'buildset').value;
-            luciLog.add('search builds for $requestSha');
+            final userAgent = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'user_agent').value;
+            luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
                 searchBuilds: bbv2.SearchBuildsResponse(
@@ -2745,7 +2746,7 @@ void foo() {
       expect(
         luciLog,
         <String>[
-          'search builds for sha/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'search builds for commit/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf by flutter-cocoon',
           // Even though there are 8 builds in total, only 2 of them are eligible
           // for cancellation.
           'cancel ${bbv2.Status.SCHEDULED.value}',
@@ -2793,7 +2794,8 @@ void foo() {
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
             final requestSha = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'buildset').value;
-            luciLog.add('search builds for $requestSha');
+            final userAgent = request.searchBuilds.predicate.tags.singleWhere((tag) => tag.key == 'user_agent').value;
+            luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
                 searchBuilds: bbv2.SearchBuildsResponse(
@@ -2814,7 +2816,7 @@ void foo() {
       expect(
         luciLog,
         <String>[
-          'search builds for sha/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'search builds for commit/git/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf by flutter-cocoon',
         ],
       );
 


### PR DESCRIPTION
The old logic was using the presubmit LUCI tags. Prod tags look like this:

![Screenshot 2024-12-26 at 3 29 02 PM](https://github.com/user-attachments/assets/d9e882d8-5818-410e-ac25-dde8fa7609af)

We also don't want to grep non-Cocoon jobs, as that would include jobs started manually.

Fixes https://github.com/flutter/flutter/issues/160887