### PR TITLE
Remove filter query parameters that are now default values.

### DIFF
--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -87,13 +87,14 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
   ///
   /// This enables bookmarking state specific values, like [repo].
   void _updateNavigation(BuildContext context) {
-    final Map<String, String> queryParameters = <String, String>{};
+    Map<String, String> queryParameters = <String, String>{};
     if (widget.queryParameters != null) {
       queryParameters.addAll(widget.queryParameters!);
     }
     if (_filter != null) {
-      queryParameters.addAll(_filter!.toMap());
+      queryParameters = _filter!.toMap(initialMap: queryParameters);
     }
+
     queryParameters['repo'] = repo!;
 
     queryParameters['branch'] = branch!;

--- a/dashboard/test/logic/task_grid_filter_test.dart
+++ b/dashboard/test/logic/task_grid_filter_test.dart
@@ -332,4 +332,26 @@ void main() {
       expect(filter.matchesCommit(CommitStatus()..commit = (Commit()..sha = 'foo')), false);
     }
   });
+
+  group('filter.toMap()', () {
+    test('adds key-value pairs that are non-default', () {
+      final showAndroidFalseNonDefault = TaskGridFilter()..showAndroid = false;
+      expect(showAndroidFalseNonDefault.toMap(), {'showAndroid': 'false'});
+    });
+
+    test('ignores key-value pairs that are default', () {
+      final showAndroidTrueIsDefault = TaskGridFilter()..showAndroid = true;
+      expect(showAndroidTrueIsDefault.toMap(), isEmpty);
+    });
+
+    test('ignores existing key-value pairs that are not filter keys', () {
+      final showAndroidTrueIsDefault = TaskGridFilter()..showAndroid = true;
+      expect(showAndroidTrueIsDefault.toMap(initialMap: {'foo': 'bar'}), {'foo': 'bar'});
+    });
+
+    test('removes existing key-value pairs that are now default values', () {
+      final showAndroidTrueIsDefault = TaskGridFilter()..showAndroid = true;
+      expect(showAndroidTrueIsDefault.toMap(initialMap: {'showAndroid': 'false'}), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/160926.

The test explains things better than I can in the PR description.