### PR TITLE
[monorepo] add CI stage document for tests

### DIFF
--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -153,7 +153,11 @@ class CiStaging extends Document {
         log.info('$logCrumb: $checkRun not present in doc for $transaction / $doc');
         await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
         return StagingConclusion(
-            result: StagingConclusionResult.missing, remaining: remaining, checkRunGuard: null, failed: failed,);
+          result: StagingConclusionResult.missing,
+          remaining: remaining,
+          checkRunGuard: null,
+          failed: failed,
+        );
       }
 
       // GitHub sends us 3 "action" messages for check_runs: created, completed, or rerequested.
@@ -209,7 +213,11 @@ class CiStaging extends Document {
         log.info('$logCrumb: staging document not found for $transaction');
         await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
         return StagingConclusion(
-            result: StagingConclusionResult.failed, remaining: -1, checkRunGuard: null, failed: failed,);
+          result: StagingConclusionResult.failed,
+          remaining: -1,
+          checkRunGuard: null,
+          failed: failed,
+        );
       }
       // All other errors should bubble up and be retried.
       await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -308,6 +308,8 @@ enum CiStage implements Comparable<CiStage> {
   String toString() => name;
 }
 
+/// Explains what happened when attempting to mark the conclusion of a check run
+/// using [CiStaging.markConclusion].
 enum StagingConclusionResult {
   /// Check run update recorded successfully in the respective CI stage.
   ok,

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -312,6 +312,8 @@ enum CiStage implements Comparable<CiStage> {
 /// using [CiStaging.markConclusion].
 enum StagingConclusionResult {
   /// Check run update recorded successfully in the respective CI stage.
+  ///
+  /// It is OK to evaluate returned results for stage completeness.
   ok,
 
   /// The check run is not in the specified CI stage.

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -152,7 +152,8 @@ class CiStaging extends Document {
       if (recordedConclusion == null) {
         log.info('$logCrumb: $checkRun not present in doc for $transaction / $doc');
         await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
-        return StagingConclusion(valid: false, remaining: remaining, checkRunGuard: null, failed: failed);
+        return StagingConclusion(
+            result: StagingConclusionResult.missing, remaining: remaining, checkRunGuard: null, failed: failed,);
       }
 
       // GitHub sends us 3 "action" messages for check_runs: created, completed, or rerequested.
@@ -207,7 +208,8 @@ class CiStaging extends Document {
         // An attempt to read a document not in firestore should not be retried.
         log.info('$logCrumb: staging document not found for $transaction');
         await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
-        return StagingConclusion(valid: false, remaining: -1, checkRunGuard: null, failed: failed);
+        return StagingConclusion(
+            result: StagingConclusionResult.failed, remaining: -1, checkRunGuard: null, failed: failed,);
       }
       // All other errors should bubble up and be retried.
       await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
@@ -224,7 +226,12 @@ class CiStaging extends Document {
     final commitRequest = CommitRequest(transaction: transaction, writes: documentsToWrites([doc], exists: true));
     final response = await docRes.commit(commitRequest, kDatabase);
     log.info('$logCrumb: results = ${response.writeResults?.map((e) => e.toJson())}');
-    return StagingConclusion(valid: valid, remaining: remaining, checkRunGuard: checkRunGuard, failed: failed);
+    return StagingConclusion(
+      result: valid ? StagingConclusionResult.ok : StagingConclusionResult.failed,
+      remaining: remaining,
+      checkRunGuard: checkRunGuard,
+      failed: failed,
+    );
   }
 
   /// Initializes a new document for the given [tasks] in Firestore so that stage-tracking can succeed.
@@ -293,37 +300,52 @@ enum CiStage implements Comparable<CiStage> {
   String toString() => name;
 }
 
+enum StagingConclusionResult {
+  /// Check run update recorded successfully in the respective CI stage.
+  ok,
+
+  /// The check run is not in the specified CI stage.
+  ///
+  /// Perhaps it's from a different CI stage.
+  missing,
+
+  /// The check run was found in the specified CI stage but the update failed.
+  failed,
+}
+
 /// Results from attempting to mark a staging task as completed.
 ///
 /// See: [CiStaging.markConclusion]
 class StagingConclusion {
-  final bool valid;
+  final StagingConclusionResult result;
   final int remaining;
   final String? checkRunGuard;
   final int failed;
 
   const StagingConclusion({
-    required this.valid,
+    required this.result,
     required this.remaining,
     required this.checkRunGuard,
     required this.failed,
   });
 
-  bool get isPending => valid && remaining > 0;
+  bool get isOk => result == StagingConclusionResult.ok;
 
-  bool get isFailed => valid && !isPending && failed > 0;
+  bool get isPending => isOk && remaining > 0;
 
-  bool get isComplete => valid && !isPending && !isFailed;
+  bool get isFailed => isOk && !isPending && failed > 0;
+
+  bool get isComplete => isOk && !isPending && !isFailed;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is StagingConclusion &&
-          other.valid == valid &&
+          other.result == result &&
           other.remaining == remaining &&
           other.checkRunGuard == checkRunGuard &&
           other.failed == failed);
 
   @override
-  int get hashCode => Object.hashAll([valid, remaining, checkRunGuard, failed]);
+  int get hashCode => Object.hashAll([result, remaining, checkRunGuard, failed]);
 }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -1013,7 +1013,8 @@ class Scheduler {
     // TODO: Unlock the guarding check_run after confirming that the test stage
     //       document is tracking all check runs correctly.
     // IMPORTANT: when moving the unlock here, REMEMBER to remove the unlock in
-    //            _proceedToCiTestingStage !!!
+    //            _proceedToCiTestingStage for non-MQ runs. MQ should unlock the
+    //            guard right after the build stage.
     // await unlockMergeGroupChecks(slug, sha, checkRunGuard, exception);
 
     return true;

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -1163,13 +1163,13 @@ class Scheduler {
     return r.retry(
       () {
         return markCheckRunConclusion(
-        firestoreService: firestoreService,
-        slug: slug,
-        sha: sha,
-        stage: stage,
-        checkRun: name,
-        conclusion: conclusion,
-      );
+          firestoreService: firestoreService,
+          slug: slug,
+          sha: sha,
+          stage: stage,
+          checkRun: name,
+          conclusion: conclusion,
+        );
       },
     );
   }

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -179,7 +179,7 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, valid: false, failed: 0, checkRunGuard: null));
+        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.missing, failed: 0, checkRunGuard: null));
         verify(docRes.rollback(argThat(predicate((RollbackRequest t) => t.transaction == kTransaction)), kDatabase))
             .called(1);
       });
@@ -273,7 +273,7 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 0, valid: true, failed: 0, checkRunGuard: '{}'));
+        expect(result, const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -327,7 +327,7 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, valid: false, failed: 0, checkRunGuard: '{}'));
+        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.failed, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -382,7 +382,7 @@ void main() {
 
         final result = await future;
         // Remaining == 1 because our test was already concluded.
-        expect(result, const StagingConclusion(remaining: 1, valid: true, failed: 0, checkRunGuard: '{}'));
+        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -437,7 +437,7 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, valid: false, failed: 1, checkRunGuard: '{}'));
+        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.failed, failed: 1, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -492,7 +492,7 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, valid: true, failed: 1, checkRunGuard: '{}'));
+        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -180,9 +180,14 @@ void main() {
 
         final result = await future;
         expect(
-            result,
-            const StagingConclusion(
-                remaining: 1, result: StagingConclusionResult.missing, failed: 0, checkRunGuard: null));
+          result,
+          const StagingConclusion(
+            remaining: 1,
+            result: StagingConclusionResult.missing,
+            failed: 0,
+            checkRunGuard: null,
+          ),
+        );
         verify(docRes.rollback(argThat(predicate((RollbackRequest t) => t.transaction == kTransaction)), kDatabase))
             .called(1);
       });
@@ -276,8 +281,10 @@ void main() {
         );
 
         final result = await future;
-        expect(result,
-            const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
+        expect(
+          result,
+          const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'),
+        );
         verify(
           docRes.commit(
             argThat(
@@ -332,9 +339,14 @@ void main() {
 
         final result = await future;
         expect(
-            result,
-            const StagingConclusion(
-                remaining: 1, result: StagingConclusionResult.failed, failed: 0, checkRunGuard: '{}'));
+          result,
+          const StagingConclusion(
+            remaining: 1,
+            result: StagingConclusionResult.failed,
+            failed: 0,
+            checkRunGuard: '{}',
+          ),
+        );
         verify(
           docRes.commit(
             argThat(
@@ -389,8 +401,10 @@ void main() {
 
         final result = await future;
         // Remaining == 1 because our test was already concluded.
-        expect(result,
-            const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
+        expect(
+          result,
+          const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'),
+        );
         verify(
           docRes.commit(
             argThat(
@@ -446,9 +460,14 @@ void main() {
 
         final result = await future;
         expect(
-            result,
-            const StagingConclusion(
-                remaining: 1, result: StagingConclusionResult.failed, failed: 1, checkRunGuard: '{}'));
+          result,
+          const StagingConclusion(
+            remaining: 1,
+            result: StagingConclusionResult.failed,
+            failed: 1,
+            checkRunGuard: '{}',
+          ),
+        );
         verify(
           docRes.commit(
             argThat(
@@ -503,8 +522,10 @@ void main() {
         );
 
         final result = await future;
-        expect(result,
-            const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'));
+        expect(
+          result,
+          const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'),
+        );
         verify(
           docRes.commit(
             argThat(

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -179,7 +179,10 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.missing, failed: 0, checkRunGuard: null));
+        expect(
+            result,
+            const StagingConclusion(
+                remaining: 1, result: StagingConclusionResult.missing, failed: 0, checkRunGuard: null));
         verify(docRes.rollback(argThat(predicate((RollbackRequest t) => t.transaction == kTransaction)), kDatabase))
             .called(1);
       });
@@ -273,7 +276,8 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
+        expect(result,
+            const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -327,7 +331,10 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.failed, failed: 0, checkRunGuard: '{}'));
+        expect(
+            result,
+            const StagingConclusion(
+                remaining: 1, result: StagingConclusionResult.failed, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -382,7 +389,8 @@ void main() {
 
         final result = await future;
         // Remaining == 1 because our test was already concluded.
-        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
+        expect(result,
+            const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -437,7 +445,10 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.failed, failed: 1, checkRunGuard: '{}'));
+        expect(
+            result,
+            const StagingConclusion(
+                remaining: 1, result: StagingConclusionResult.failed, failed: 1, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(
@@ -492,7 +503,8 @@ void main() {
         );
 
         final result = await future;
-        expect(result, const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'));
+        expect(result,
+            const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'));
         verify(
           docRes.commit(
             argThat(

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -342,7 +342,7 @@ void main() {
           result,
           const StagingConclusion(
             remaining: 1,
-            result: StagingConclusionResult.failed,
+            result: StagingConclusionResult.internalError,
             failed: 0,
             checkRunGuard: '{}',
           ),
@@ -463,7 +463,7 @@ void main() {
           result,
           const StagingConclusion(
             remaining: 1,
-            result: StagingConclusionResult.failed,
+            result: StagingConclusionResult.internalError,
             failed: 1,
             checkRunGuard: '{}',
           ),

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1043,7 +1043,7 @@ targets:
               ),
             ).thenAnswer((_) async {
               return const StagingConclusion(
-                result: StagingConclusionResult.failed,
+                result: StagingConclusionResult.internalError,
                 remaining: 1,
                 checkRunGuard: '{}',
                 failed: 0,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1001,7 +1001,11 @@ targets:
               ),
             ).thenAnswer((_) async {
               return const StagingConclusion(
-                  result: StagingConclusionResult.missing, remaining: 1, checkRunGuard: '{}', failed: 0);
+                result: StagingConclusionResult.missing,
+                remaining: 1,
+                checkRunGuard: '{}',
+                failed: 0,
+              );
             });
 
             for (final ignored in Scheduler.kCheckRunsToIgnore) {
@@ -1039,7 +1043,11 @@ targets:
               ),
             ).thenAnswer((_) async {
               return const StagingConclusion(
-                  result: StagingConclusionResult.failed, remaining: 1, checkRunGuard: '{}', failed: 0);
+                result: StagingConclusionResult.failed,
+                remaining: 1,
+                checkRunGuard: '{}',
+                failed: 0,
+              );
             });
 
             expect(
@@ -1085,7 +1093,11 @@ targets:
               ),
             ).thenAnswer((inv) async {
               return const StagingConclusion(
-                  result: StagingConclusionResult.ok, remaining: 1, checkRunGuard: '{}', failed: 0);
+                result: StagingConclusionResult.ok,
+                remaining: 1,
+                checkRunGuard: '{}',
+                failed: 0,
+              );
             });
 
             expect(

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1000,7 +1000,8 @@ targets:
                 conclusion: anyNamed('conclusion'),
               ),
             ).thenAnswer((_) async {
-              return const StagingConclusion(result: StagingConclusionResult.missing, remaining: 1, checkRunGuard: '{}', failed: 0);
+              return const StagingConclusion(
+                  result: StagingConclusionResult.missing, remaining: 1, checkRunGuard: '{}', failed: 0);
             });
 
             for (final ignored in Scheduler.kCheckRunsToIgnore) {
@@ -1037,7 +1038,8 @@ targets:
                 conclusion: anyNamed('conclusion'),
               ),
             ).thenAnswer((_) async {
-              return const StagingConclusion(result: StagingConclusionResult.failed, remaining: 1, checkRunGuard: '{}', failed: 0);
+              return const StagingConclusion(
+                  result: StagingConclusionResult.failed, remaining: 1, checkRunGuard: '{}', failed: 0);
             });
 
             expect(
@@ -1082,7 +1084,8 @@ targets:
                 conclusion: anyNamed('conclusion'),
               ),
             ).thenAnswer((inv) async {
-              return const StagingConclusion(result: StagingConclusionResult.ok, remaining: 1, checkRunGuard: '{}', failed: 0);
+              return const StagingConclusion(
+                  result: StagingConclusionResult.ok, remaining: 1, checkRunGuard: '{}', failed: 0);
             });
 
             expect(


### PR DESCRIPTION
- When `fusionEngineBuild` completes, create a firestore document for the `fusionTests` CI stage tasks.
- When receiving a status update for a test check run, update the respective document.

This PR does not yet alter the MQ guard behavior. I'd like to debug the document behavior first.

Progress towards https://github.com/flutter/flutter/issues/159898
