### PR TITLE
[monorepo] do not fail merge queue guard on failed fusionTests stage

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -944,7 +944,10 @@ class Scheduler {
       return false;
     }
 
-    if (stagingConclusion.isFailed) {
+    // Only report failure into the merge queue guard for engine build stage.
+    // Until https://github.com/flutter/flutter/issues/159898 is fixed, the
+    // merge queue guard ignores the `fusionTests` stage.
+    if (stage == CiStage.fusionEngineBuild && stagingConclusion.isFailed) {
       await _reportCiStageFailure(
         conclusion: stagingConclusion,
         slug: slug,


### PR DESCRIPTION
Today if a test check run fails (i.e. one of the post engine build check runs), Cocoon also fails the merge queue guard. This is wrong according to the current semantics of the guard, which is only meant to watch engine build check runs.

Fixes: flutter/flutter#161779