### PR TITLE
Make `Test.kt` files count as tests for the purpose of calculating if a PR has tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -664,7 +664,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
           filename.contains('android/src/test/') ||
           filename.contains('androidTest/') ||
           // Kotlin source tests, used in the Flutter Gradle Plugin.
-          filename.contains('Test.kt') ||
+          filename.endsWith('Test.kt') ||
           // Native Linux tests.
           filename.endsWith('_test.cc') ||
           // Native Windows tests.

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -663,6 +663,8 @@ class GithubWebhookSubscription extends SubscriptionHandler {
           // Native Android tests.
           filename.contains('android/src/test/') ||
           filename.contains('androidTest/') ||
+          // Kotlin source tests, used in the Flutter Gradle Plugin.
+          filename.contains('Test.kt') ||
           // Native Linux tests.
           filename.endsWith('_test.cc') ||
           // Native Windows tests.


### PR DESCRIPTION
Makes `Test.kt` files count as tests for the purpose of calculating if a PR has tests.

Context: https://github.com/flutter/flutter/pull/161835

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
