### PR TITLE
AllowedList has been broken for 3 years...

### DIFF
--- a/app_dart/lib/src/model/appengine/allowed_account.dart
+++ b/app_dart/lib/src/model/appengine/allowed_account.dart
@@ -16,7 +16,6 @@ class AllowedAccount extends Model<int> {
   /// Creates a new [AllowedAccount].
   AllowedAccount({
     Key<int>? key,
-    required this.email,
   }) {
     parentKey = key?.parent;
     id = key?.id;
@@ -24,7 +23,7 @@ class AllowedAccount extends Model<int> {
 
   /// The email address of the account that has been allowlisted.
   @StringProperty(propertyName: 'Email', required: true)
-  String email;
+  String email = '';
 
   @override
   String toString() {

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -156,8 +156,7 @@ void main() {
       test('succeeds for allowed non-Google auth users', () async {
         final AllowedAccount account = AllowedAccount(
           key: config.db.emptyKey.append<int>(AllowedAccount, id: 123),
-          email: 'test@gmail.com',
-        );
+        )..email = 'test@gmail.com';
         config.db.values[account.key] = account;
         final TokenInfo token = TokenInfo(
           audience: 'client-id',


### PR DESCRIPTION
The `required` parameter causes mirrors to fail to create the class, giving the user a 500 error. Fun!