### PR TITLE
Break glass v2

### DIFF
--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -88,7 +88,8 @@ class CiStaging extends Document {
     required String checkRun,
     required String conclusion,
   }) async {
-    final logCrumb = 'markConclusion(${slug.owner}_${slug.name}_${sha}_$stage, $checkRun, $conclusion)';
+    final changeCrumb = '${slug.owner}_${slug.name}_$sha';
+    final logCrumb = 'markConclusion(${changeCrumb}_$stage, $checkRun, $conclusion)';
 
     // Marking needs to happen while in a transaction to ensure `remaining` is
     // updated correctly. For that to happen correctly; we need to perform a
@@ -110,8 +111,10 @@ class CiStaging extends Document {
 
     var remaining = -1;
     var failed = -1;
+    var total = -1;
     bool valid = false;
     String? checkRunGuard;
+    String? recordedConclusion;
 
     late final Document doc;
 
@@ -146,9 +149,15 @@ class CiStaging extends Document {
       }
       failed = maybeFailed;
 
+      final maybeTotal = int.tryParse(fields[kTotalField]?.integerValue ?? '');
+      if (maybeTotal == null) {
+        throw '$logCrumb: missing field "$kTotalField" for $transaction / ${doc.fields}';
+      }
+      total = maybeTotal;
+
       // We will have check_runs scheduled after the engine was built successfully, so missing the checkRun field
       // is an OK response to have. All fields should have been written at creation time.
-      final recordedConclusion = fields[checkRun]?.stringValue;
+      recordedConclusion = fields[checkRun]?.stringValue;
       if (recordedConclusion == null) {
         log.info('$logCrumb: $checkRun not present in doc for $transaction / $doc');
         await docRes.rollback(RollbackRequest(transaction: transaction), kDatabase);
@@ -157,6 +166,8 @@ class CiStaging extends Document {
           remaining: remaining,
           checkRunGuard: null,
           failed: failed,
+          summary: 'Check run "$checkRun" not present in $stage CI stage',
+          details: 'Change $changeCrumb',
         );
       }
 
@@ -207,7 +218,7 @@ class CiStaging extends Document {
       fields[checkRun] = Value(stringValue: conclusion);
       fields[kRemainingField] = Value(integerValue: '$remaining');
       fields[kFailedField] = Value(integerValue: '$failed');
-    } on DetailedApiRequestError catch (e) {
+    } on DetailedApiRequestError catch (e, stack) {
       if (e.status == 404) {
         // An attempt to read a document not in firestore should not be retried.
         log.info('$logCrumb: staging document not found for $transaction');
@@ -217,6 +228,15 @@ class CiStaging extends Document {
           remaining: -1,
           checkRunGuard: null,
           failed: failed,
+          summary: 'Internal server error',
+          details: '''
+Staging document not found for CI stage "$stage" for $changeCrumb. Got 404 from
+Firestore.
+
+Error:
+${e.toString()}
+$stack
+''',
         );
       }
       // All other errors should bubble up and be retried.
@@ -239,6 +259,15 @@ class CiStaging extends Document {
       remaining: remaining,
       checkRunGuard: checkRunGuard,
       failed: failed,
+      summary: valid ? 'All tests passed' : 'Not a valid state transition for $checkRun',
+      details: valid
+          ? '''
+For CI stage $stage:
+  Total check runs scheduled: $total
+  Pending: $remaining
+  Failed: $failed
+'''
+          : 'Attempted to transition the state of check run $checkRun from "$recordedConclusion" to "$conclusion".',
     );
   }
 
@@ -343,12 +372,16 @@ class StagingConclusion {
   final int remaining;
   final String? checkRunGuard;
   final int failed;
+  final String summary;
+  final String details;
 
   const StagingConclusion({
     required this.result,
     required this.remaining,
     required this.checkRunGuard,
     required this.failed,
+    required this.summary,
+    required this.details,
   });
 
   bool get isOk => result == StagingConclusionResult.ok;
@@ -366,8 +399,21 @@ class StagingConclusion {
           other.result == result &&
           other.remaining == remaining &&
           other.checkRunGuard == checkRunGuard &&
-          other.failed == failed);
+          other.failed == failed &&
+          other.summary == summary &&
+          other.details == details);
 
   @override
-  int get hashCode => Object.hashAll([result, remaining, checkRunGuard, failed]);
+  int get hashCode => Object.hashAll([
+        result,
+        remaining,
+        checkRunGuard,
+        failed,
+        summary,
+        details,
+      ]);
+
+  @override
+  String toString() =>
+      'StagingConclusion("$result", "$remaining", "$checkRunGuard", "$failed", "$summary", "$details")';
 }

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -32,10 +32,17 @@ const String kDefaultBranchName = 'master';
 class Config {
   Config(this._db, this._cache);
 
-  /// Labels autosubmit looks for on pull requests
+  /// When present on a pull request, instructs Cocoon to land it automatically
+  /// as soon as all the required checks pass.
   ///
   /// Keep this in sync with the similar `Config` class in `auto_submit`.
   static const String kAutosubmitLabel = 'autosubmit';
+
+  /// When present on a pull request, allows it to land without passing all the
+  /// checks, and jumps the merge queue.
+  ///
+  /// Keep this in sync with the similar `Config` class in `auto_submit`.
+  static const String kEmergencyLabel = 'emergency';
 
   final DatastoreDB _db;
 

--- a/app_dart/test/model/firestore/ci_staging_test.dart
+++ b/app_dart/test/model/firestore/ci_staging_test.dart
@@ -186,6 +186,8 @@ void main() {
             result: StagingConclusionResult.missing,
             failed: 0,
             checkRunGuard: null,
+            summary: 'Check run "test" not present in engine CI stage',
+            details: 'Change flutter_flutter_1234',
           ),
         );
         verify(docRes.rollback(argThat(predicate((RollbackRequest t) => t.transaction == kTransaction)), kDatabase))
@@ -208,6 +210,7 @@ void main() {
           (_) async => Document(
             name: expectedName,
             fields: {
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '0'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
@@ -234,7 +237,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['Linux build_test']!.stringValue == 'mulligan' &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '0';
               }),
@@ -263,6 +266,7 @@ void main() {
             fields: {
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '0'),
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
               'Linux build_test': Value(stringValue: CiStaging.kScheduledValue),
             },
@@ -283,7 +287,19 @@ void main() {
         final result = await future;
         expect(
           result,
-          const StagingConclusion(remaining: 0, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'),
+          const StagingConclusion(
+            remaining: 0,
+            result: StagingConclusionResult.ok,
+            failed: 0,
+            checkRunGuard: '{}',
+            summary: 'All tests passed',
+            details: '''
+For CI stage engine:
+  Total check runs scheduled: 1
+  Pending: 0
+  Failed: 0
+''',
+          ),
         );
         verify(
           docRes.commit(
@@ -291,7 +307,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['Linux build_test']!.stringValue == 'mulligan' &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '0';
               }),
@@ -320,6 +336,7 @@ void main() {
             fields: {
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '0'),
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
               'MacOS build_test': Value(stringValue: CiStaging.kSuccessValue),
             },
@@ -345,6 +362,8 @@ void main() {
             result: StagingConclusionResult.internalError,
             failed: 0,
             checkRunGuard: '{}',
+            summary: 'Not a valid state transition for MacOS build_test',
+            details: 'Attempted to transition the state of check run MacOS build_test from "success" to "mulligan".',
           ),
         );
         verify(
@@ -353,7 +372,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['MacOS build_test']!.stringValue == 'mulligan' &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '1';
               }),
@@ -382,6 +401,7 @@ void main() {
             fields: {
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '1'),
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
               'MacOS build_test': Value(stringValue: CiStaging.kFailureValue),
             },
@@ -403,7 +423,19 @@ void main() {
         // Remaining == 1 because our test was already concluded.
         expect(
           result,
-          const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 0, checkRunGuard: '{}'),
+          const StagingConclusion(
+            remaining: 1,
+            result: StagingConclusionResult.ok,
+            failed: 0,
+            checkRunGuard: '{}',
+            summary: 'All tests passed',
+            details: '''
+For CI stage engine:
+  Total check runs scheduled: 1
+  Pending: 1
+  Failed: 0
+''',
+          ),
         );
         verify(
           docRes.commit(
@@ -411,7 +443,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['MacOS build_test']!.stringValue == CiStaging.kSuccessValue &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '1' &&
                     t.writes!.first.update!.fields![CiStaging.kFailedField]!.integerValue == '0';
@@ -441,6 +473,7 @@ void main() {
             fields: {
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '1'),
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
               'MacOS build_test': Value(stringValue: CiStaging.kFailureValue),
             },
@@ -466,6 +499,8 @@ void main() {
             result: StagingConclusionResult.internalError,
             failed: 1,
             checkRunGuard: '{}',
+            summary: 'Not a valid state transition for MacOS build_test',
+            details: 'Attempted to transition the state of check run MacOS build_test from "failure" to "failure".',
           ),
         );
         verify(
@@ -474,7 +509,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['MacOS build_test']!.stringValue == CiStaging.kFailureValue &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '1' &&
                     t.writes!.first.update!.fields![CiStaging.kFailedField]!.integerValue == '1';
@@ -504,6 +539,7 @@ void main() {
             fields: {
               CiStaging.kRemainingField: Value(integerValue: '1'),
               CiStaging.kFailedField: Value(integerValue: '0'),
+              CiStaging.kTotalField: Value(integerValue: '1'),
               CiStaging.kCheckRunGuardField: Value(stringValue: '{}'),
               'MacOS build_test': Value(stringValue: CiStaging.kSuccessValue),
             },
@@ -524,7 +560,19 @@ void main() {
         final result = await future;
         expect(
           result,
-          const StagingConclusion(remaining: 1, result: StagingConclusionResult.ok, failed: 1, checkRunGuard: '{}'),
+          const StagingConclusion(
+            remaining: 1,
+            result: StagingConclusionResult.ok,
+            failed: 1,
+            checkRunGuard: '{}',
+            summary: 'All tests passed',
+            details: '''
+For CI stage engine:
+  Total check runs scheduled: 1
+  Pending: 1
+  Failed: 1
+''',
+          ),
         );
         verify(
           docRes.commit(
@@ -532,7 +580,7 @@ void main() {
               predicate((CommitRequest t) {
                 return t.transaction == kTransaction &&
                     t.writes!.length == 1 &&
-                    t.writes!.first.update!.fields!.length == 4 &&
+                    t.writes!.first.update!.fields!.length == 5 &&
                     t.writes!.first.update!.fields!['MacOS build_test']!.stringValue == CiStaging.kFailureValue &&
                     t.writes!.first.update!.fields![CiStaging.kRemainingField]!.integerValue == '1' &&
                     t.writes!.first.update!.fields![CiStaging.kFailedField]!.integerValue == '1';

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2669,7 +2669,7 @@ void foo() {
           'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): Scheduling merge group checks',
           'Updating ci.yaml validation check for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'ci.yaml validation check was successful for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'All required tests passed for c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
+          'Unlocking Merge Queue Guard for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );
     });

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1010,6 +1010,8 @@ targets:
                 remaining: 1,
                 checkRunGuard: '{}',
                 failed: 0,
+                summary: 'Field missing',
+                details: 'Some details',
               );
             });
 
@@ -1052,6 +1054,8 @@ targets:
                 remaining: 1,
                 checkRunGuard: '{}',
                 failed: 0,
+                summary: 'Internal error',
+                details: 'Some details',
               );
             });
 
@@ -1102,6 +1106,8 @@ targets:
                 remaining: 1,
                 checkRunGuard: '{}',
                 failed: 0,
+                summary: 'OK',
+                details: 'Some details',
               );
             });
 
@@ -1156,6 +1162,8 @@ targets:
                 remaining: 0,
                 checkRunGuard: checkRunFor(name: 'GUARD TEST'),
                 failed: 1,
+                summary: 'OK',
+                details: 'Some details',
               );
             });
 
@@ -1268,6 +1276,8 @@ targets:
                 remaining: 0,
                 checkRunGuard: checkRunFor(name: 'GUARD TEST'),
                 failed: 0,
+                summary: 'OK',
+                details: 'Some details',
               );
             });
 
@@ -1359,6 +1369,8 @@ targets:
                 remaining: 0,
                 checkRunGuard: checkRunFor(name: 'GUARD TEST'),
                 failed: 0,
+                summary: 'Field missing or OK',
+                details: 'Some details',
               );
             });
 
@@ -1459,6 +1471,8 @@ targets:
                   CiStage.fusionEngineBuild => 0,
                   CiStage.fusionTests => 1,
                 },
+                summary: 'Field missing or OK',
+                details: 'Some details',
               );
             });
 
@@ -1591,6 +1605,8 @@ targets:
                 remaining: 0,
                 checkRunGuard: checkRunFor(name: 'GUARD TEST'),
                 failed: 0,
+                summary: 'OK',
+                details: 'Some details',
               );
             });
 

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -731,12 +731,12 @@ targets:
           return CheckRun.fromJson(const <String, dynamic>{
             'id': 1,
             'started_at': '2020-05-10T02:49:31Z',
-            'name': Scheduler.kCiYamlCheckName,
+            'name': Config.kCiYamlCheckName,
             'check_suite': <String, dynamic>{'id': 2},
           });
         });
         final Map<String, dynamic> checkRunEventJson = jsonDecode(checkRunString) as Map<String, dynamic>;
-        checkRunEventJson['check_run']['name'] = Scheduler.kCiYamlCheckName;
+        checkRunEventJson['check_run']['name'] = Config.kCiYamlCheckName;
         final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
         expect(await scheduler.processCheckRun(checkRunEvent), true);
         verify(
@@ -744,7 +744,7 @@ targets:
             any,
             any,
             any,
-            Scheduler.kCiYamlCheckName,
+            Config.kCiYamlCheckName,
             output: anyNamed('output'),
           ),
         );
@@ -796,12 +796,12 @@ targets:
           return CheckRun.fromJson(const <String, dynamic>{
             'id': 1,
             'started_at': '2020-05-10T02:49:31Z',
-            'name': Scheduler.kCiYamlCheckName,
+            'name': Config.kCiYamlCheckName,
             'check_suite': <String, dynamic>{'id': 2},
           });
         });
         final Map<String, dynamic> checkRunEventJson = jsonDecode(checkRunString) as Map<String, dynamic>;
-        checkRunEventJson['check_run']['name'] = Scheduler.kMergeQueueLockName;
+        checkRunEventJson['check_run']['name'] = Config.kMergeQueueLockName;
         final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
         expect(await scheduler.processCheckRun(checkRunEvent), true);
         verifyNever(
@@ -809,7 +809,7 @@ targets:
             any,
             any,
             any,
-            Scheduler.kMergeQueueLockName,
+            Config.kMergeQueueLockName,
             output: anyNamed('output'),
           ),
         );
@@ -1838,14 +1838,14 @@ targets:
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
-            Scheduler.kMergeQueueLockName,
+            Config.kMergeQueueLockName,
             const CheckRunOutput(
-              title: Scheduler.kMergeQueueLockName,
+              title: Config.kMergeQueueLockName,
               summary: Scheduler.kMergeQueueLockDescription,
             ),
-            Scheduler.kCiYamlCheckName,
+            Config.kCiYamlCheckName,
             const CheckRunOutput(
-              title: Scheduler.kCiYamlCheckName,
+              title: Config.kCiYamlCheckName,
               summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',
@@ -1867,15 +1867,15 @@ targets:
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
-            Scheduler.kMergeQueueLockName,
+            Config.kMergeQueueLockName,
             const CheckRunOutput(
-              title: Scheduler.kMergeQueueLockName,
+              title: Config.kMergeQueueLockName,
               summary: Scheduler.kMergeQueueLockDescription,
             ),
-            Scheduler.kCiYamlCheckName,
+            Config.kCiYamlCheckName,
             // No other targets should be created.
             const CheckRunOutput(
-              title: Scheduler.kCiYamlCheckName,
+              title: Config.kCiYamlCheckName,
               summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
           ],
@@ -2012,14 +2012,14 @@ targets:
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
-            Scheduler.kMergeQueueLockName,
+            Config.kMergeQueueLockName,
             const CheckRunOutput(
-              title: Scheduler.kMergeQueueLockName,
+              title: Config.kMergeQueueLockName,
               summary: Scheduler.kMergeQueueLockDescription,
             ),
-            Scheduler.kCiYamlCheckName,
+            Config.kCiYamlCheckName,
             const CheckRunOutput(
-              title: Scheduler.kCiYamlCheckName,
+              title: Config.kCiYamlCheckName,
               summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',
@@ -2040,14 +2040,14 @@ targets:
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
-            Scheduler.kMergeQueueLockName,
+            Config.kMergeQueueLockName,
             const CheckRunOutput(
-              title: Scheduler.kMergeQueueLockName,
+              title: Config.kMergeQueueLockName,
               summary: Scheduler.kMergeQueueLockDescription,
             ),
-            Scheduler.kCiYamlCheckName,
+            Config.kCiYamlCheckName,
             const CheckRunOutput(
-              title: Scheduler.kCiYamlCheckName,
+              title: Config.kCiYamlCheckName,
               summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -185,11 +185,11 @@ void main() {
       // Generate check runs based on the name hash code
       when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
           .thenAnswer((Invocation invocation) async {
-            return generateCheckRun(
-              invocation.positionalArguments[2].hashCode,
-              name: invocation.positionalArguments[3],
-            );
-          });
+        return generateCheckRun(
+          invocation.positionalArguments[2].hashCode,
+          name: invocation.positionalArguments[3],
+        );
+      });
 
       fakeFusion = FakeFusionTester();
       callbacks = MockCallbacks();
@@ -2103,11 +2103,13 @@ targets:
           ),
         ).thenAnswer((inv) async {
           final CheckRun checkRun = inv.positionalArguments[2];
-          capturedUpdates.add((
-            checkRun.name!,
-            inv.namedArguments[#status],
-            inv.namedArguments[#conclusion],
-          ),);
+          capturedUpdates.add(
+            (
+              checkRun.name!,
+              inv.namedArguments[#status],
+              inv.namedArguments[#conclusion],
+            ),
+          );
         });
 
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -101,7 +101,6 @@ class FakeConfig implements Config {
   String? flutterGoldDraftChangeValue;
   String? flutterGoldStalePRValue;
   List<String>? supportedBranchesValue;
-  String? overrideTreeStatusLabelValue;
   Set<gh.RepositorySlug>? supportedReposValue;
   Set<gh.RepositorySlug>? postsubmitSupportedReposValue;
   Duration? githubRequestDelayValue;
@@ -260,9 +259,6 @@ class FakeConfig implements Config {
 
   @override
   Future<GithubService> createDefaultGitHubService() async => githubService!;
-
-  @override
-  Future<String> get overrideTreeStatusLabel async => overrideTreeStatusLabelValue!;
 
   @override
   String get defaultRecipeBundleRef => 'refs/heads/main';

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -56,8 +56,6 @@ class CheckPullRequest extends CheckRequest {
 
     log.info('Processing ${messageList.length} messages');
 
-    final PullRequestValidationService validationService = PullRequestValidationService(config);
-
     final List<Future<void>> futures = <Future<void>>[];
 
     for (pub.ReceivedMessage message in messageList) {
@@ -92,6 +90,7 @@ class CheckPullRequest extends CheckRequest {
         processingLog.add(pullRequest.number!);
       }
 
+      final PullRequestValidationService validationService = PullRequestValidationService(config);
       futures.add(
         validationService.processMessage(pullRequest, message.ackId!, pubsub),
       );

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -59,10 +59,17 @@ class Config {
   static const String kFlutterGitHubBotKey = 'AUTO_SUBMIT_FLUTTER_GITHUB_TOKEN';
   static const String kTreeStatusDiscordUrl = 'TREE_STATUS_DISCORD_WEBHOOK_URL';
 
-  /// Labels autosubmit looks for on pull requests
+  /// When present on a pull request, instructs Cocoon to land it automatically
+  /// as soon as all the required checks pass.
   ///
   /// Keep this in sync with the similar `Config` class in `app_dart`.
   static const String kAutosubmitLabel = 'autosubmit';
+
+  /// When present on a pull request, allows it to land without passing all the
+  /// checks, and jumps the merge queue.
+  ///
+  /// Keep this in sync with the similar `Config` class in `app_dart`.
+  static const String kEmergencyLabel = 'emergency';
 
   /// GitHub check stale threshold.
   static const int kGitHubCheckStaleThreshold = 2; // hours

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -59,8 +59,8 @@ class Config {
   static const String kFlutterGitHubBotKey = 'AUTO_SUBMIT_FLUTTER_GITHUB_TOKEN';
   static const String kTreeStatusDiscordUrl = 'TREE_STATUS_DISCORD_WEBHOOK_URL';
 
-  /// When present on a pull request, instructs Cocoon to land it automatically
-  /// as soon as all the required checks pass.
+  /// When present on a pull request, instructs Cocoon to submit it
+  /// automatically as soon as all the required checks pass.
   ///
   /// Keep this in sync with the similar `Config` class in `app_dart`.
   static const String kAutosubmitLabel = 'autosubmit';
@@ -70,6 +70,25 @@ class Config {
   ///
   /// Keep this in sync with the similar `Config` class in `app_dart`.
   static const String kEmergencyLabel = 'emergency';
+
+  /// Validates that CI tasks were successfully created from the .ci.yaml file.
+  ///
+  /// If this check fails, it means Cocoon failed to fully populate the list of
+  /// CI checks and the PR/commit should be treated as failing.
+  static const String kCiYamlCheckName = 'ci.yaml validation';
+
+  /// A required check that stays in pending state until a sufficient subset of
+  /// checks pass.
+  ///
+  /// This check is "required", meaning that it must pass before Github will
+  /// allow a PR to land in the merge queue, or a merge group to land on the
+  /// target branch (main or master).
+  ///
+  /// IMPORTANT: the name of this task - "Merge Queue Guard" - must strictly
+  /// match the name of the required check configured in the repo settings.
+  /// Changing the name here or in the settings alone will break the PR
+  /// workflow.
+  static const String kMergeQueueLockName = 'Merge Queue Guard';
 
   /// GitHub check stale threshold.
   static const int kGitHubCheckStaleThreshold = 2; // hours
@@ -88,9 +107,6 @@ class Config {
   /// it adds this label to signify that it should then validate and merge this
   /// as a revert.
   static const String kRevertOfLabel = 'revert of';
-
-  /// The label which shows the overrideTree    Status.
-  String get overrideTreeStatusLabel => 'warning: land on red to fix tree breakage';
 
   /// Repository Slug data
   /// GitHub repositories that use CI status to determine if pull requests can be submitted.

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -43,6 +43,34 @@ class GithubService {
         .toList();
   }
 
+  Future<CheckRun> updateCheckRun({
+    required RepositorySlug slug,
+    required CheckRun checkRun,
+    String? name,
+    String? detailsUrl,
+    String? externalId,
+    DateTime? startedAt,
+    CheckRunStatus status = CheckRunStatus.queued,
+    CheckRunConclusion? conclusion,
+    DateTime? completedAt,
+    CheckRunOutput? output,
+    List<CheckRunAction>? actions,
+  }) async {
+    return github.checks.checkRuns.updateCheckRun(
+      slug,
+      checkRun,
+      name: name,
+      detailsUrl: detailsUrl,
+      externalId: externalId,
+      startedAt: startedAt,
+      status: status,
+      conclusion: conclusion,
+      completedAt: completedAt,
+      output: output,
+      actions: actions,
+    );
+  }
+
   /// Fetches the specified commit.
   Future<RepositoryCommit> getCommit(
     RepositorySlug slug,

--- a/auto_submit/lib/service/process_method.dart
+++ b/auto_submit/lib/service/process_method.dart
@@ -6,6 +6,7 @@
 /// found.
 enum ProcessMethod {
   processAutosubmit,
+  processEmergency,
   processRevert,
   doNotProcess,
 }

--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -174,9 +174,9 @@ class _PullRequestValidationProcessor {
 
     /// If there is at least one action that requires to remove label do so and add comments for all the failures.
     bool shouldReturn = false;
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.REMOVE_LABEL) {
-        final String commmentMessage = result.value.message.isEmpty ? 'Validations Fail.' : result.value.message;
+    for (final MapEntry(key: _, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.REMOVE_LABEL) {
+        final String commmentMessage = value.message.isEmpty ? 'Validations Fail.' : value.message;
         final String message =
             '${Config.kEmergencyLabel} label is removed for ${slug.fullName}/$prNumber, due to $commmentMessage';
         await githubService.removeLabel(slug, prNumber, Config.kEmergencyLabel);
@@ -192,10 +192,10 @@ class _PullRequestValidationProcessor {
     }
 
     // If PR has some failures to ignore temporarily do nothing and continue.
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.IGNORE_TEMPORARILY) {
+    for (final MapEntry(:key, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.IGNORE_TEMPORARILY) {
         log.info(
-          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to ${result.key} failing validation.',
+          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to $key failing validation.',
         );
         return true;
       }
@@ -255,9 +255,9 @@ class _PullRequestValidationProcessor {
 
     /// If there is at least one action that requires to remove label do so and add comments for all the failures.
     bool shouldReturn = false;
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.REMOVE_LABEL) {
-        final String commentMessage = result.value.message.isEmpty ? 'Validations Fail.' : result.value.message;
+    for (final MapEntry(key: _, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.REMOVE_LABEL) {
+        final String commentMessage = value.message.isEmpty ? 'Validations Fail.' : value.message;
         await _removeAutosubmitLabel(commentMessage);
         shouldReturn = true;
       }
@@ -273,10 +273,10 @@ class _PullRequestValidationProcessor {
     }
 
     // If PR has some failures to ignore temporarily do nothing and continue.
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.IGNORE_TEMPORARILY) {
+    for (final MapEntry(:key, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.IGNORE_TEMPORARILY) {
         log.info(
-          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to ${result.key} failing validation.',
+          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to $key failing validation.',
         );
         return;
       }

--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -17,6 +17,21 @@ import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart' as github;
 import 'package:retry/retry.dart';
 
+/// A required check that stays in pending state until a sufficient subset of
+/// checks pass.
+///
+/// This check is "required", meaning that it must pass before Github will
+/// allow a PR to land in the merge queue, or a merge group to land on the
+/// target branch (main or master).
+///
+/// IMPORTANT: the name of this task - "Merge Queue Guard" - must strictly
+/// match the name of the required check configured in the repo settings.
+/// Changing the name here or in the settings alone will break the PR
+/// workflow.
+///
+/// Keep this in sync with the identical constant defined in `scheduler.dart`.
+const String kMergeQueueLockName = 'Merge Queue Guard';
+
 class PullRequestValidationService extends ValidationService {
   PullRequestValidationService(Config config, {RetryOptions? retryOptions})
       : super(config, retryOptions: retryOptions) {
@@ -28,11 +43,13 @@ class PullRequestValidationService extends ValidationService {
 
   /// Processes a pub/sub message associated with PullRequest event.
   Future<void> processMessage(github.PullRequest messagePullRequest, String ackId, PubSub pubsub) async {
-    if (await shouldProcess(messagePullRequest)) {
+    final slug = messagePullRequest.base!.repo!.slug();
+    final fullPullRequest = await getFullPullRequest(slug, messagePullRequest.number!);
+    if (shouldProcess(fullPullRequest)) {
       await processPullRequest(
         config: config,
         result: await getNewestPullRequestInfo(config, messagePullRequest),
-        messagePullRequest: messagePullRequest,
+        pullRequest: fullPullRequest,
         ackId: ackId,
         pubsub: pubsub,
       );
@@ -42,9 +59,11 @@ class PullRequestValidationService extends ValidationService {
     }
   }
 
-  Future<bool> shouldProcess(github.PullRequest pullRequest) async {
-    final (currentPullRequest, labelNames) = await getPrWithLabels(pullRequest);
-    return (currentPullRequest.state == 'open' && labelNames.contains(Config.kAutosubmitLabel));
+  bool shouldProcess(github.PullRequest pullRequest) {
+    final labelNames = pullRequest.labelNames;
+    final containsLabelsNeedingValidation =
+        labelNames.contains(Config.kAutosubmitLabel) || labelNames.contains(Config.kEmergencyLabel);
+    return pullRequest.state == 'open' && containsLabelsNeedingValidation;
   }
 
   /// Processes a PullRequest running several validations to decide whether to
@@ -52,16 +71,16 @@ class PullRequestValidationService extends ValidationService {
   Future<void> processPullRequest({
     required Config config,
     required QueryResult result,
-    required github.PullRequest messagePullRequest,
+    required github.PullRequest pullRequest,
     required String ackId,
     required PubSub pubsub,
   }) async {
-    final github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
-    final int prNumber = messagePullRequest.number!;
+    final github.RepositorySlug slug = pullRequest.base!.repo!.slug();
+    final int prNumber = pullRequest.number!;
 
     // If a pull request is currently in the merge queue do not touch it. Let
     // the merge queue merge it, or kick it out of the merge queue.
-    if (messagePullRequest.isMergeQueueEnabled) {
+    if (pullRequest.isMergeQueueEnabled) {
       if (result.repository!.pullRequest!.isInMergeQueue) {
         log.info(
           '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',
@@ -71,6 +90,140 @@ class PullRequestValidationService extends ValidationService {
       }
     }
 
+    final processor = _PullRequestValidationProcessor(
+      validationService: this,
+      config: config,
+      result: result,
+      pullRequest: pullRequest,
+      ackId: ackId,
+      pubsub: pubsub,
+    );
+
+    final hasEmergencyLabel = pullRequest.labelNames.contains(Config.kEmergencyLabel);
+
+    if (hasEmergencyLabel) {
+      await processor.processEmergency();
+    }
+
+    final hasAutosubmitLabel = pullRequest.labelNames.contains(Config.kAutosubmitLabel);
+
+    if (hasAutosubmitLabel) {
+      return processor.processAutosubmit();
+    } else {
+      log.info('Ack the processed message : $ackId.');
+      await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+    }
+  }
+}
+
+class _PullRequestValidationProcessor {
+  _PullRequestValidationProcessor({
+    required this.validationService,
+    required this.config,
+    required this.result,
+    required this.pullRequest,
+    required this.ackId,
+    required this.pubsub,
+  })  : slug = pullRequest.base!.repo!.slug(),
+        prNumber = pullRequest.number!;
+
+  final PullRequestValidationService validationService;
+  final Config config;
+  final QueryResult result;
+  final github.PullRequest pullRequest;
+  final String ackId;
+  final PubSub pubsub;
+  final github.RepositorySlug slug;
+  final int prNumber;
+
+  Future<void> processEmergency() async {
+    final RepositoryConfiguration repositoryConfiguration = await config.getRepositoryConfiguration(slug);
+
+    // filter out validations here
+    final ValidationFilter validationFilter = ValidationFilter(
+      config: config,
+      processMethod: ProcessMethod.processEmergency,
+      repositoryConfiguration: repositoryConfiguration,
+    );
+    final Set<Validation> validations = validationFilter.getValidations();
+
+    final Map<String, ValidationResult> validationsMap = <String, ValidationResult>{};
+    final GithubService githubService = await config.createGithubService(slug);
+
+    /// Runs all the validation defined in the service.
+    /// If the runCi flag is false then we need a way to not run the ciSuccessful validation.
+    for (Validation validation in validations) {
+      log.info('${slug.fullName}/$prNumber running validation ${validation.name}');
+      final ValidationResult validationResult = await validation.validate(
+        result,
+        pullRequest,
+      );
+      validationsMap[validation.name] = validationResult;
+    }
+
+    /// If there is at least one action that requires to remove label do so and add comments for all the failures.
+    bool shouldReturn = false;
+    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
+      if (!result.value.result && result.value.action == Action.REMOVE_LABEL) {
+        final String commmentMessage = result.value.message.isEmpty ? 'Validations Fail.' : result.value.message;
+        final String message =
+            '${Config.kEmergencyLabel} label is removed for ${slug.fullName}/$prNumber, due to $commmentMessage';
+        await githubService.removeLabel(slug, prNumber, Config.kEmergencyLabel);
+        await githubService.createComment(slug, prNumber, message);
+        log.info(message);
+        shouldReturn = true;
+      }
+    }
+
+    if (shouldReturn) {
+      log.info(
+        'The pr ${slug.fullName}/$prNumber with message: $ackId should be acknowledged due to validation failure.',
+      );
+      await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+      log.info('The pr ${slug.fullName}/$prNumber is not eligible for emergency landing: $ackId is acknowledged.');
+      return;
+    }
+
+    // If PR has some failures to ignore temporarily do nothing and continue.
+    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
+      if (!result.value.result && result.value.action == Action.IGNORE_TEMPORARILY) {
+        log.info(
+          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to ${result.key} failing validation.',
+        );
+        return;
+      }
+    }
+
+    // At this point all validations passed, and the PR can proceed to landing
+    // as an emergency.
+    final guard = (await githubService.getCheckRunsFiltered(
+      slug: slug,
+      ref: pullRequest.base!.ref!,
+      checkName: kMergeQueueLockName,
+    ))
+        .singleOrNull;
+
+    if (guard == null) {
+      log.severe(
+        'Failed to process the emergency label in ${slug.fullName}/$prNumber. '
+        '"kMergeQueueLockName" check run is missing.',
+      );
+      await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+      return;
+    }
+
+    await githubService.updateCheckRun(
+      slug: slug,
+      checkRun: guard,
+      status: github.CheckRunStatus.completed,
+      conclusion: github.CheckRunConclusion.success,
+    );
+
+    log.info('Unlocked merge guard for ${slug.fullName}/$prNumber to allow it to land as an emergency.');
+    await pubsub.acknowledge('auto-submit-queue-sub', ackId);
+  }
+
+  Future<void> processAutosubmit() async {
     final RepositoryConfiguration repositoryConfiguration = await config.getRepositoryConfiguration(slug);
 
     // filter out validations here
@@ -84,17 +237,13 @@ class PullRequestValidationService extends ValidationService {
     final Map<String, ValidationResult> validationsMap = <String, ValidationResult>{};
     final GithubService githubService = await config.createGithubService(slug);
 
-    // get the labels before validation so that we can detect all labels.
-    // TODO (https://github.com/flutter/flutter/issues/132811) remove this after graphql is removed.
-    final github.PullRequest updatedPullRequest = await githubService.getPullRequest(slug, messagePullRequest.number!);
-
     /// Runs all the validation defined in the service.
     /// If the runCi flag is false then we need a way to not run the ciSuccessful validation.
     for (Validation validation in validations) {
       log.info('${slug.fullName}/$prNumber running validation ${validation.name}');
       final ValidationResult validationResult = await validation.validate(
         result,
-        updatedPullRequest,
+        pullRequest,
       );
       validationsMap[validation.name] = validationResult;
     }
@@ -132,9 +281,9 @@ class PullRequestValidationService extends ValidationService {
     }
 
     // If we got to this point it means we are ready to submit the PR.
-    final MergeResult processed = await submitPullRequest(
+    final MergeResult processed = await validationService.submitPullRequest(
       config: config,
-      messagePullRequest: messagePullRequest,
+      pullRequest: pullRequest,
     );
 
     if (!processed.result) {
@@ -145,9 +294,9 @@ class PullRequestValidationService extends ValidationService {
     } else {
       log.info('Pull Request ${slug.fullName}/$prNumber was ${processed.method.pastTenseLabel} successfully!');
       log.info('Attempting to insert a pull request record into the database for $prNumber');
-      await insertPullRequestRecord(
+      await validationService.insertPullRequestRecord(
         config: config,
-        pullRequest: messagePullRequest,
+        pullRequest: pullRequest,
         pullRequestType: PullRequestChangeType.change,
       );
     }

--- a/auto_submit/lib/service/revert_request_validation_service.dart
+++ b/auto_submit/lib/service/revert_request_validation_service.dart
@@ -57,11 +57,12 @@ class RevertRequestValidationService extends ValidationService {
   ) async {
     // Make sure the pull request still contains the labels.
     final github.PullRequest messagePullRequest = githubPullRequestEvent.pullRequest!;
-    final (currentPullRequest, labelNames) = await getPrWithLabels(messagePullRequest);
-    final RevertProcessMethod revertProcessMethod = await shouldProcess(currentPullRequest, labelNames);
+    final slug = messagePullRequest.base!.repo!.slug();
+    final fullPullRequest = await getFullPullRequest(slug, messagePullRequest.number!);
+    final revertProcessMethod = await shouldProcess(fullPullRequest);
 
-    final GithubPullRequestEvent updatedGithubPullRequestEvent = GithubPullRequestEvent(
-      pullRequest: currentPullRequest,
+    final updatedGithubPullRequestEvent = GithubPullRequestEvent(
+      pullRequest: fullPullRequest,
       action: githubPullRequestEvent.action,
       sender: githubPullRequestEvent.sender,
     );
@@ -80,7 +81,7 @@ class RevertRequestValidationService extends ValidationService {
       case RevertProcessMethod.revertOf:
         await processRevertOfRequest(
           result: await getNewestPullRequestInfo(config, messagePullRequest),
-          githubPullRequestEvent: updatedGithubPullRequestEvent,
+          githubPullRequestEvent: githubPullRequestEvent,
           ackId: ackId,
           pubsub: pubsub,
         );
@@ -126,10 +127,8 @@ class RevertRequestValidationService extends ValidationService {
   }
 
   /// Determine if we should process the incoming pull request webhook event.
-  Future<RevertProcessMethod> shouldProcess(
-    github.PullRequest pullRequest,
-    List<String> labelNames,
-  ) async {
+  Future<RevertProcessMethod> shouldProcess(github.PullRequest pullRequest) async {
+    final labelNames = pullRequest.labelNames;
     // This is the initial revert request state.
     if (pullRequest.state == 'closed' && labelNames.contains(Config.kRevertLabel) && pullRequest.mergedAt != null) {
       return RevertProcessMethod.revert;
@@ -214,14 +213,14 @@ class RevertRequestValidationService extends ValidationService {
     required String ackId,
     required PubSub pubsub,
   }) async {
-    final github.PullRequest messagePullRequest = githubPullRequestEvent.pullRequest!;
-    final github.RepositorySlug slug = messagePullRequest.base!.repo!.slug();
+    final pullRequest = githubPullRequestEvent.pullRequest!;
+    final github.RepositorySlug slug = pullRequest.base!.repo!.slug();
     final GithubService githubService = await config.createGithubService(slug);
-    final int prNumber = messagePullRequest.number!;
+    final int prNumber = pullRequest.number!;
 
     // If a pull request is currently in the merge queue do not touch it. Let
     // the merge queue merge it, or kick it out of the merge queue.
-    if (messagePullRequest.isMergeQueueEnabled) {
+    if (pullRequest.isMergeQueueEnabled) {
       if (result.repository!.pullRequest!.isInMergeQueue) {
         log.info(
           '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',
@@ -264,7 +263,7 @@ class RevertRequestValidationService extends ValidationService {
       validationsMap[validation.name] = await validation.validate(
         result,
         // this needs to be the newly opened pull request.
-        messagePullRequest,
+        pullRequest,
       );
     }
 
@@ -303,7 +302,7 @@ class RevertRequestValidationService extends ValidationService {
     // If we got to this point it means we are ready to submit the PR.
     final MergeResult processed = await submitPullRequest(
       config: config,
-      messagePullRequest: messagePullRequest,
+      pullRequest: pullRequest,
     );
 
     if (!processed.result) {
@@ -314,14 +313,14 @@ class RevertRequestValidationService extends ValidationService {
     } else {
       // Need to add the discord notification here.
       final DiscordNotification discordNotification = await discordNotificationClient;
-      final Message discordMessage = craftDiscordRevertMessage(messagePullRequest);
+      final Message discordMessage = craftDiscordRevertMessage(pullRequest);
       discordNotification.notifyDiscordChannelWebhook(jsonEncode(discordMessage.toJson()));
 
       log.info('Pull Request ${slug.fullName}/$prNumber was ${processed.method.pastTenseLabel} successfully!');
       log.info('Attempting to insert a pull request record into the database for $prNumber');
       await insertPullRequestRecord(
         config: config,
-        pullRequest: messagePullRequest,
+        pullRequest: pullRequest,
         pullRequestType: PullRequestChangeType.revert,
       );
     }

--- a/auto_submit/lib/service/revert_request_validation_service.dart
+++ b/auto_submit/lib/service/revert_request_validation_service.dart
@@ -269,9 +269,9 @@ class RevertRequestValidationService extends ValidationService {
 
     /// If there is at least one action that requires to remove label do so and add comments for all the failures.
     bool shouldReturn = false;
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.REMOVE_LABEL) {
-        final String commmentMessage = result.value.message.isEmpty ? 'Validations Fail.' : result.value.message;
+    for (final MapEntry(key: _, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.REMOVE_LABEL) {
+        final String commmentMessage = value.message.isEmpty ? 'Validations Fail.' : value.message;
         final String message = 'auto label is removed for ${slug.fullName}/$prNumber, due to $commmentMessage';
         await githubService.removeLabel(slug, prNumber, Config.kRevertOfLabel);
         await githubService.createComment(slug, prNumber, message);
@@ -290,10 +290,10 @@ class RevertRequestValidationService extends ValidationService {
     }
 
     // If PR has some failures to ignore temporarily do nothing and continue.
-    for (MapEntry<String, ValidationResult> result in validationsMap.entries) {
-      if (!result.value.result && result.value.action == Action.IGNORE_TEMPORARILY) {
+    for (final MapEntry(:key, :value) in validationsMap.entries) {
+      if (!value.result && value.action == Action.IGNORE_TEMPORARILY) {
         log.info(
-          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to ${result.key} failing validation.',
+          'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to $key failing validation.',
         );
         return;
       }

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -125,9 +125,6 @@ ${pullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
         return (result: false, message: message, method: SubmitMethod.merge);
       }
     } catch (e) {
-      if ('$e'.contains('Null check operator used')) {
-        rethrow;
-      }
       // Catch graphql client init exceptions.
       final String message = 'Failed to merge ${slug.fullName}/$number with $e';
       log.severe(message);

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -290,6 +290,6 @@ extension PullRequestExtension on github.PullRequest {
       return const <String>[];
     }
 
-    return labels.map<String>((github.IssueLabel labelMap) => labelMap.name).toList();
+    return labels.map<String>((label) => label.name).toList();
   }
 }

--- a/auto_submit/lib/validations/validation_filter.dart
+++ b/auto_submit/lib/validations/validation_filter.dart
@@ -68,12 +68,10 @@ class EmergencyValidationFilter implements ValidationFilter {
   final RepositoryConfiguration repositoryConfiguration;
 
   @override
-  Set<Validation> getValidations() {
-    final Set<Validation> validationsToRun = {};
-    validationsToRun.add(Approval(config: config));
-    validationsToRun.add(Mergeable(config: config));
-    return validationsToRun;
-  }
+  Set<Validation> getValidations() => {
+        Approval(config: config),
+        Mergeable(config: config),
+      };
 }
 
 /// [RevertRequestValidationFilter] returns a Set of validations that we run on
@@ -85,13 +83,9 @@ class RevertRequestValidationFilter implements ValidationFilter {
   final RepositoryConfiguration repositoryConfiguration;
 
   @override
-  Set<Validation> getValidations() {
-    final Set<Validation> validationsToRun = {};
-
-    validationsToRun.add(Approval(config: config));
-    validationsToRun.add(RequiredCheckRuns(config: config));
-    validationsToRun.add(Mergeable(config: config));
-
-    return validationsToRun;
-  }
+  Set<Validation> getValidations() => {
+        Approval(config: config),
+        RequiredCheckRuns(config: config),
+        Mergeable(config: config),
+      };
 }

--- a/auto_submit/lib/validations/validation_filter.dart
+++ b/auto_submit/lib/validations/validation_filter.dart
@@ -23,6 +23,8 @@ abstract class ValidationFilter {
     switch (processMethod) {
       case ProcessMethod.processAutosubmit:
         return PullRequestValidationFilter(config, repositoryConfiguration);
+      case ProcessMethod.processEmergency:
+        return EmergencyValidationFilter(config, repositoryConfiguration);
       case ProcessMethod.processRevert:
         return RevertRequestValidationFilter(config, repositoryConfiguration);
       default:
@@ -54,6 +56,22 @@ class PullRequestValidationFilter implements ValidationFilter {
     }
     validationsToRun.add(Mergeable(config: config));
 
+    return validationsToRun;
+  }
+}
+
+/// Provides validations for applying the `emergency` label.
+class EmergencyValidationFilter implements ValidationFilter {
+  EmergencyValidationFilter(this.config, this.repositoryConfiguration);
+
+  final Config config;
+  final RepositoryConfiguration repositoryConfiguration;
+
+  @override
+  Set<Validation> getValidations() {
+    final Set<Validation> validationsToRun = {};
+    validationsToRun.add(Approval(config: config));
+    validationsToRun.add(Mergeable(config: config));
     return validationsToRun;
   }
 }

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -55,7 +55,6 @@ void main() {
     const String testSubscription = 'test-sub';
     const String testTopic = 'test-topic';
     const String rollorAuthor = 'engine-flutter-autoroll';
-    const String labelName = 'warning: land on red to fix tree breakage';
     const String cocoonRepo = 'cocoon';
     const String noAutosubmitLabel = 'no_autosubmit';
 
@@ -421,10 +420,10 @@ void main() {
       assert(pubsub.messagesQueue.isEmpty);
     });
 
-    test('Merges PR with failed tree status if override tree status label is provided', () async {
+    test('Merges PR with failed tree status if the "emergency" label is provided', () async {
       final PullRequest pullRequest = generatePullRequest(
         prNumber: 0,
-        labelName: labelName,
+        labelName: Config.kEmergencyLabel,
       );
       // 'member' is in the review nodes and 'author1' is the pr author.
       githubService.isTeamMemberMockMap['member'] = true;
@@ -436,6 +435,37 @@ void main() {
           pullRequest,
         ),
       );
+
+      githubService.checkRunsData = '''{
+  "total_count": 2,
+  "check_runs": [
+    {
+      "id": 1,
+      "head_sha": "be6ff099a4ee56e152a5fa2f37edd10f79d1269a",
+      "external_id": "",
+      "details_url": "https://example.com",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2018-05-04T01:14:52Z",
+      "name": "mighty_readme",
+      "check_suite": {
+        "id": 5
+      }
+    },
+    {
+      "id": 2,
+      "head_sha": "be6ff099a4ee56e152a5fa2f37edd10f79d1269a",
+      "external_id": "",
+      "details_url": "https://example.com",
+      "status": "in_progress",
+      "started_at": "2018-05-04T01:14:52Z",
+      "name": "Merge Queue Guard",
+      "check_suite": {
+        "id": 5
+      }
+    }
+  ]
+}''';
 
       checkPullRequest = CheckPullRequest(
         config: config,
@@ -456,18 +486,18 @@ void main() {
       verifyQueries(expectedOptions);
 
       final Map<int, RepositorySlug> expectedMergeRequestMap = {};
-      expectedMergeRequestMap[0] = RepositorySlug(
-        'flutter',
-        'flutter',
-      );
-
-      githubService.mergeRequestMock = PullRequestMerge(
-        merged: true,
-        sha: 'sha1',
-        message: 'Pull request merged successfully',
-      );
+      expectedMergeRequestMap[0] = RepositorySlug('flutter', 'flutter');
 
       githubService.verifyMergePullRequests(expectedMergeRequestMap);
+
+      // Verify that the "Merge Queue Guard" was unlocked.
+      expect(githubService.checkRunUpdates, hasLength(1));
+      final checkRunUpdate = githubService.checkRunUpdates.single;
+      expect(checkRunUpdate.slug, RepositorySlug('flutter', 'flutter'));
+      expect(checkRunUpdate.checkRun.id, 2);
+      expect(checkRunUpdate.checkRun.name, 'Merge Queue Guard');
+      expect(checkRunUpdate.status, CheckRunStatus.completed);
+      expect(checkRunUpdate.conclusion, CheckRunConclusion.success);
 
       assert(pubsub.messagesQueue.isEmpty);
     });

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -320,7 +320,10 @@ void main() {
         prNumber: 1,
         repoName: cocoonRepo,
       );
-      githubService.pullRequestData = pullRequest1;
+
+      githubService.usePullRequestList = true;
+      githubService.pullRequestMockList = [pullRequest1, pullRequest2];
+
       // 'octocat' is the pr author from generatePullRequest calls.
       // 'member' is in the review nodes and 'author1' is the pr author.
       githubService.isTeamMemberMockMap['member'] = true;

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -187,21 +187,21 @@ void main() {
     test('Should process message when autosubmit label exists and pr is open', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       githubService.pullRequestData = pullRequest;
-      expect(await validationService.shouldProcess(pullRequest), true);
+      expect(validationService.shouldProcess(pullRequest), true);
     });
 
     test('Skip processing message when autosubmit label does not exist anymore', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.labels = <IssueLabel>[];
       githubService.pullRequestData = pullRequest;
-      expect(await validationService.shouldProcess(pullRequest), false);
+      expect(validationService.shouldProcess(pullRequest), false);
     });
 
     test('Skip processing message when the pull request is closed', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name);
       pullRequest.state = 'closed';
       githubService.pullRequestData = pullRequest;
-      expect(await validationService.shouldProcess(pullRequest), false);
+      expect(validationService.shouldProcess(pullRequest), false);
     });
 
     test('Should not process message when revert label exists and pr is open', () async {
@@ -209,7 +209,7 @@ void main() {
       final IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      expect(await validationService.shouldProcess(pullRequest), false);
+      expect(validationService.shouldProcess(pullRequest), false);
     });
 
     test('Skip processing message when revert label exists and pr is closed', () async {
@@ -218,7 +218,7 @@ void main() {
       final IssueLabel issueLabel = IssueLabel(name: 'revert');
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      expect(await validationService.shouldProcess(pullRequest), false);
+      expect(validationService.shouldProcess(pullRequest), false);
     });
   });
 

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -83,7 +83,7 @@ void main() {
     await validationService.processPullRequest(
       config: config,
       result: queryResult,
-      messagePullRequest: pullRequest,
+      pullRequest: pullRequest,
       ackId: 'test',
       pubsub: pubsub,
     );
@@ -131,7 +131,7 @@ void main() {
     await validationService.processPullRequest(
       config: config,
       result: queryResult,
-      messagePullRequest: pullRequest,
+      pullRequest: pullRequest,
       ackId: 'test',
       pubsub: pubsub,
     );
@@ -173,7 +173,7 @@ void main() {
     await validationService.processPullRequest(
       config: config,
       result: queryResult,
-      messagePullRequest: pullRequest,
+      pullRequest: pullRequest,
       ackId: 'test',
       pubsub: pubsub,
     );
@@ -238,7 +238,7 @@ void main() {
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.message, contains('Reland "My first PR!"'));
@@ -263,7 +263,7 @@ void main() {
       await validationService.processPullRequest(
         config: config,
         result: queryResult,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
         ackId: 'test',
         pubsub: pubsub,
       );
@@ -302,7 +302,7 @@ void main() {
       await validationService.processPullRequest(
         config: config,
         result: queryResult,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
         ackId: 'test',
         pubsub: pubsub,
       );
@@ -348,7 +348,7 @@ void main() {
       await validationService.processPullRequest(
         config: config,
         result: queryResult,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
         ackId: 'test',
         pubsub: pubsub,
       );
@@ -379,7 +379,7 @@ void main() {
       );
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.message, '''
@@ -438,7 +438,7 @@ If you need help, consider asking for advice on the #hackers-new channel on [Dis
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.result, isTrue);
@@ -488,7 +488,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.method, SubmitMethod.enqueue);
@@ -522,7 +522,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.method, SubmitMethod.merge);
@@ -537,7 +537,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.method, SubmitMethod.enqueue);
@@ -552,7 +552,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.method, SubmitMethod.enqueue);
@@ -595,7 +595,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(
@@ -650,7 +650,7 @@ This is the second line in a paragraph.''');
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(
@@ -700,7 +700,7 @@ This is the second line in a paragraph.''');
       await validationService.processPullRequest(
         config: config,
         result: createQueryResult(flutterRequest),
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
         ackId: 'test',
         pubsub: pubsub,
       );

--- a/auto_submit/test/service/revert_request_validation_service_test.dart
+++ b/auto_submit/test/service/revert_request_validation_service_test.dart
@@ -124,10 +124,9 @@ void main() {
     test('Process revert from closed as "revert"', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name, state: 'closed');
       final IssueLabel issueLabel = IssueLabel(name: 'revert');
-      final List<String> labelNames = ['revert'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.revert);
     });
@@ -136,10 +135,9 @@ void main() {
       final PullRequest pullRequest =
           generatePullRequest(prNumber: 0, repoName: slug.name, state: 'open', author: config.autosubmitBot);
       final IssueLabel issueLabel = IssueLabel(name: 'revert of');
-      final List<String> labelNames = ['revert of'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.revertOf);
 
@@ -152,10 +150,9 @@ void main() {
     test('Pull request state is open with revert label is not processed', () async {
       final PullRequest pullRequest = generatePullRequest(prNumber: 0, repoName: slug.name, state: 'open');
       final IssueLabel issueLabel = IssueLabel(name: 'revert');
-      final List<String> labelNames = ['revert'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.none);
     });
@@ -164,10 +161,9 @@ void main() {
       final PullRequest pullRequest =
           generatePullRequest(prNumber: 0, repoName: slug.name, state: 'closed', author: config.autosubmitBot);
       final IssueLabel issueLabel = IssueLabel(name: 'revert of');
-      final List<String> labelNames = ['revert of'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.none);
     });
@@ -176,10 +172,9 @@ void main() {
       final PullRequest pullRequest =
           generatePullRequest(prNumber: 0, repoName: slug.name, state: 'open', author: 'octocat');
       final IssueLabel issueLabel = IssueLabel(name: 'revert of');
-      final List<String> labelNames = ['revert of'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.none);
     });
@@ -192,10 +187,9 @@ void main() {
         mergedAt: null,
       );
       final IssueLabel issueLabel = IssueLabel(name: 'revert');
-      final List<String> labelNames = ['revert'];
       pullRequest.labels = <IssueLabel>[issueLabel];
       githubService.pullRequestData = pullRequest;
-      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest, labelNames);
+      final RevertProcessMethod revertProcessMethod = await validationService.shouldProcess(pullRequest);
 
       expect(revertProcessMethod, RevertProcessMethod.none);
     });
@@ -1332,7 +1326,7 @@ Reason for reverting: comment was added by mistake.''';
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.message, contains('Reland "My first PR!"'));
@@ -1356,7 +1350,7 @@ Reason for reverting: comment was added by mistake.''';
       );
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.message, '''
@@ -1415,7 +1409,7 @@ If you need help, consider asking for advice on the #hackers-new channel on [Dis
 
       final MergeResult result = await validationService.submitPullRequest(
         config: config,
-        messagePullRequest: pullRequest,
+        pullRequest: pullRequest,
       );
 
       expect(result.result, isTrue);

--- a/auto_submit/test/src/service/fake_config.dart
+++ b/auto_submit/test/src/service/fake_config.dart
@@ -22,7 +22,6 @@ class FakeConfig extends Config {
     this.githubGraphQLClient,
     this.githubService,
     this.rollerAccountsValue,
-    this.overrideTreeStatusLabelValue,
     this.webhookKey,
     this.kPubsubPullNumberValue,
     this.bigqueryService,
@@ -35,7 +34,6 @@ class FakeConfig extends Config {
   GraphQLClient? githubGraphQLClient;
   GithubService? githubService = FakeGithubService();
   Set<String>? rollerAccountsValue;
-  String? overrideTreeStatusLabelValue;
   String? webhookKey;
   int? kPubsubPullNumberValue;
   BigqueryService? bigqueryService;
@@ -74,9 +72,6 @@ class FakeConfig extends Config {
         'dependabot[bot]',
         'dependabot',
       };
-
-  @override
-  String get overrideTreeStatusLabel => overrideTreeStatusLabelValue ?? 'warning: land on red to fix tree breakage';
 
   @override
   Future<String> getWebhookKey() async {

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -8,6 +8,7 @@ import 'package:auto_submit/service/github_service.dart';
 import 'package:cocoon_server/testing/mocks.dart';
 import 'package:github/github.dart';
 import 'package:shelf/src/response.dart';
+import 'package:test/test.dart';
 
 /// A fake GithubService implementation.
 class FakeGithubService implements GithubService {
@@ -135,6 +136,21 @@ class FakeGithubService implements GithubService {
     return checkRuns;
   }
 
+  final List<
+      ({
+        RepositorySlug slug,
+        CheckRun checkRun,
+        String? name,
+        String? detailsUrl,
+        String? externalId,
+        DateTime? startedAt,
+        CheckRunStatus status,
+        CheckRunConclusion? conclusion,
+        DateTime? completedAt,
+        CheckRunOutput? output,
+        List<CheckRunAction>? actions,
+      })> checkRunUpdates = [];
+
   @override
   Future<CheckRun> updateCheckRun({
     required RepositorySlug slug,
@@ -151,12 +167,28 @@ class FakeGithubService implements GithubService {
   }) async {
     final Map<String, Object?> json = checkRun.toJson();
 
+    checkRunUpdates.add(
+      (
+        slug: slug,
+        checkRun: checkRun,
+        name: name,
+        detailsUrl: detailsUrl,
+        externalId: externalId,
+        startedAt: startedAt,
+        status: status,
+        conclusion: conclusion,
+        completedAt: completedAt,
+        output: output,
+        actions: actions,
+      ),
+    );
+
     if (conclusion != null) {
-      json['conclusion'] = conclusion;
+      json['conclusion'] = conclusion.value;
     }
 
     if (status != checkRun.status) {
-      json['status'] = status;
+      json['status'] = status.value;
     }
 
     return CheckRun.fromJson(json);
@@ -296,10 +328,13 @@ class FakeGithubService implements GithubService {
   }
 
   void verifyMergePullRequests(Map<int, RepositorySlug> expected) {
-    assert(verifyPullRequestMergeCallMap.length == expected.length);
+    expect(
+      reason: 'Pull request numbers in mergePullRequest invocations do not match',
+      verifyPullRequestMergeCallMap.keys.toList(),
+      expected.keys.toList(),
+    );
     verifyPullRequestMergeCallMap.forEach((key, value) {
-      assert(expected.containsKey(key));
-      assert(expected[key] == value);
+      expect(value, expected[key]);
     });
   }
 

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -136,6 +136,33 @@ class FakeGithubService implements GithubService {
   }
 
   @override
+  Future<CheckRun> updateCheckRun({
+    required RepositorySlug slug,
+    required CheckRun checkRun,
+    String? name,
+    String? detailsUrl,
+    String? externalId,
+    DateTime? startedAt,
+    CheckRunStatus status = CheckRunStatus.queued,
+    CheckRunConclusion? conclusion,
+    DateTime? completedAt,
+    CheckRunOutput? output,
+    List<CheckRunAction>? actions,
+  }) async {
+    final Map<String, Object?> json = checkRun.toJson();
+
+    if (conclusion != null) {
+      json['conclusion'] = conclusion;
+    }
+
+    if (status != checkRun.status) {
+      json['status'] = status;
+    }
+
+    return CheckRun.fromJson(json);
+  }
+
+  @override
   Future<RepositoryCommit> getCommit(RepositorySlug slug, String sha) async {
     final RepositoryCommit commit = RepositoryCommit.fromJson(jsonDecode(commitMock!) as Map<String, dynamic>);
     return commit;

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -9,6 +9,7 @@ import 'dart:core';
 import 'package:auto_submit/configuration/repository_configuration.dart';
 import 'package:auto_submit/model/auto_submit_query_result.dart';
 import 'package:auto_submit/model/pull_request_data_types.dart';
+import 'package:auto_submit/service/config.dart';
 import 'package:auto_submit/validations/ci_successful.dart';
 import 'package:auto_submit/validations/validation.dart';
 import 'package:cocoon_server/logging.dart';
@@ -277,7 +278,7 @@ void main() {
       final Author author = Author(login: 'ricardoamador');
 
       final List<String> labelNames = [];
-      labelNames.add('warning: land on red to fix tree breakage');
+      labelNames.add(Config.kEmergencyLabel);
       labelNames.add('Other label');
 
       convertContextNodeStatuses(contextNodeList);
@@ -519,7 +520,7 @@ void main() {
 
       /// The status must be uppercase as the original code is expecting this.
       convertContextNodeStatuses(contextNodeList);
-      final bool treeStatusFlag = ciSuccessful.treeStatusCheck(slug, prNumber, contextNodeList);
+      final bool treeStatusFlag = ciSuccessful.isTreeStatusReporting(slug, prNumber, contextNodeList);
       expect(treeStatusFlag, true);
     });
 
@@ -530,7 +531,7 @@ void main() {
 
       /// The status must be uppercase as the original code is expecting this.
       convertContextNodeStatuses(contextNodeList);
-      final bool treeStatusFlag = ciSuccessful.treeStatusCheck(slug, prNumber, contextNodeList);
+      final bool treeStatusFlag = ciSuccessful.isTreeStatusReporting(slug, prNumber, contextNodeList);
       expect(treeStatusFlag, true);
     });
 
@@ -540,7 +541,7 @@ void main() {
 
       /// The status must be uppercase as the original code is expecting this.
       convertContextNodeStatuses(contextNodeList);
-      final bool treeStatusFlag = ciSuccessful.treeStatusCheck(slug, prNumber, contextNodeList);
+      final bool treeStatusFlag = ciSuccessful.isTreeStatusReporting(slug, prNumber, contextNodeList);
       expect(treeStatusFlag, false);
     });
   });
@@ -663,7 +664,7 @@ void main() {
       expect(commit, isNotNull);
       expect(commit.status, isNotNull);
 
-      final github.PullRequest npr = generatePullRequest(labelName: 'warning: land on red to fix tree breakage');
+      final github.PullRequest npr = generatePullRequest(labelName: Config.kEmergencyLabel);
       githubService.checkRunsData = checkRunsMock;
 
       ciSuccessful.validate(queryResult, npr).then((value) {


### PR DESCRIPTION
Implement the new break glass behavior for the monorepo world.

Fixes https://github.com/flutter/flutter/issues/159898
Fixes https://github.com/flutter/flutter/issues/132811

Below is an updated copy of https://github.com/flutter/flutter/issues/159898#issuecomment-2597209435:

# Pull request

## Two-state Merge Queue Guard

The guard can only be in two states:

- **Pending** (yellow): this is the initial state, and the guard stays in this state for as long as the pull request is not allowed to enter the merge queue.
- **Success** (green): the guard enters this state when the infra decides that the PR is allowed to enter the merge queue.

The state can only go from pending to success. There are no other state transitions.

## Deciding when the guard goes green

Going from pending to green is the only transition we need to worry about. This is how we decide it:

- **Normal case**: the normal workflow for landing a PR is for all the checks to go green. Once this happens, Cocoon closes the guard (by making it green). This will allow the `autosubmit` label to enqueue the PR, and it will allow the author to press "Merge When Ready".
- **Emergency case**: the a PR must be landed despite failing checks (typically on a red tree status). The author adds the `emergency` label. Cocoon immediately unlocks the guard, ignoring any pending or failed checks. In conjunction with the `autosubmit` label, Cocoon will also automatically enqueue the PR after all tests pass even if the tree status is red. With an `emergency` Cocoon will also let the PR to jump the queue. However, if the PR must be landed right away, the author can use the "Merge When Ready" button manually as soon as Cocoon unlocks the merge guard.

## Explainer

The above system makes everything simpler. There are fewer states (just pending and success), fewer transitions (just pending => success), and fewer situations to consider (normal and emergency). We don't need to do anything special w.r.t. the guard for the purposes of retrying failed flaky tests. It simply stays pending while the author is doing whatever is necessary to make the PR green enough to land: push fixes, retry check runs, rebase, get approvals, etc.

Importantly, it covers all situations we need to handle in PR management.

### Why not have a third "failed" state?

The guard's job is not to tell you whether any tests are failing. You can already tell which tests are failing by looking at the status of respective check runs (this may change in the future, but when that time comes we'll find a new visual cue). The guard's job is only to tell you whether your PR is allowed to be enqueued. Permission to proceed never "fails". It's either granted (green), or not yet granted (pending). Once granted the PR is typically enqueued or landed immediately, so performing any other state transitions after green is mostly meaningless. Green is the final state of the guard, that's all.

The other reason for keeping the guard in two states is for simpler state management. Once green, the PR can immediately be enqueued. There's no transition from pending to failed, from failed to pending, or from failed to green. We can remove some of the existing Cocoon code around this, and we don't have to add anything new to support normal and emergency PR landing.

# Merge group

There are two possible outcomes for a merge group:

- **Land**: all check runs are green => Cocoon completes the merge guard as success and GitHub lands the merge group.
- **Fail**: some check runs failed => Cocoon fails the merge guard and GitHub pulls the merge group (and the corresponding PR) out of the queue.
