### PR TITLE
Add new gold shard names to Flutter Gold.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -148,6 +148,8 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
             'mac_unopt',
 
             // Integration test shards that run golden file tests
+            'android_engine_vulkan_tests',
+            'android_engine_opengles_tests',
             'flutter_driver_android_test',
           ].any((String shardSubString) => name.contains(shardSubString))) {
             runsGoldenFileTests = true;


### PR DESCRIPTION
Shard was renamed in https://github.com/flutter/flutter/pull/162020.