### PR TITLE
fail merge queue guard when failing to schedule merge group

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -547,21 +547,9 @@ class Scheduler {
 
     final lock = await lockMergeGroupChecks(slug, headSha);
 
-    final ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
-      config,
-      slug,
-      headSha,
-      'Merge queue check',
-      output: const CheckRunOutput(
-        title: 'Merge queue check',
-        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
-      ),
-    );
-
     // If the repo is not fusion, it doesn't run anything in the MQ, so just
-    // close the ci.yaml validation and merge group guard.
+    // close the merge group guard.
     if (!isFusion) {
-      await closeCiYamlCheckRun('MQ $slug/$headSha', null, slug, ciValidationCheckRun);
       await unlockMergeQueueGuard(slug, headSha, lock);
       return;
     }
@@ -575,7 +563,6 @@ class Scheduler {
       ),
     };
 
-    Object? exception;
     try {
       // Filter out targets missing builders - we cannot wait to complete the merge group if we will never complete.
       final availableBuilders = await luciBuildService.getAvailableBuilderSet(
@@ -609,16 +596,27 @@ class Scheduler {
         targets: [...availableTargets],
         commit: commit,
       );
-    } catch (e, s) {
-      log.warning('$logCrumb: error encountered when scheduling presubmit targets', e, s);
-      exception = e;
+
+      // Do not unlock the merge group guard in successful case - that will be done by staging checks.
+      log.info('$logCrumb: Finished merge group checks');
+    } catch (error, stackTrace) {
+      log.warning('$logCrumb: error encountered when scheduling presubmit targets', error, stackTrace);
+      // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
+      // of the queue. To do that, the merge queue guard must fail as it's the
+      // only required GitHub check.
+      await failGuardForMergeGroup(
+        slug,
+        headSha,
+        'Failed to schedule checks for merge group',
+        '''
+$logCrumb
+
+ERROR: $error
+$stackTrace
+''',
+        lock,
+      );
     }
-
-    await closeCiYamlCheckRun('MQ $slug/$headSha', exception, slug, ciValidationCheckRun);
-
-    // Do not unlock the merge group `lock` - that will be done by staging checks.
-
-    log.info('$logCrumb: Finished merge group checks');
   }
 
   Future<List<Target>> getMergeGroupTargetsForStage(

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -543,7 +543,7 @@ class Scheduler {
 
     final logCrumb = 'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
 
-    log.info('$logCrumb: Scheduling merge group checks');
+    log.info('$logCrumb: scheduling merge group checks');
 
     final lock = await lockMergeGroupChecks(slug, headSha);
 
@@ -598,9 +598,9 @@ class Scheduler {
       );
 
       // Do not unlock the merge group guard in successful case - that will be done by staging checks.
-      log.info('$logCrumb: Finished merge group checks');
+      log.info('$logCrumb: successfully scheduled merge group checks');
     } catch (error, stackTrace) {
-      log.warning('$logCrumb: error encountered when scheduling presubmit targets', error, stackTrace);
+      log.warning('$logCrumb: error encountered when scheduling merge group checks', error, stackTrace);
       // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
       // of the queue. To do that, the merge queue guard must fail as it's the
       // only required GitHub check.

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2664,16 +2664,6 @@ void foo() {
       await subscription.cancel();
 
       verify(
-        mockGithubChecksUtil.createCheckRun(
-          any,
-          any,
-          'c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'Merge queue check',
-          output: anyNamed('output'),
-        ),
-      ).called(1);
-
-      verify(
         mockGithubChecksUtil.updateCheckRun(
           any,
           any,
@@ -2681,7 +2671,7 @@ void foo() {
           status: CheckRunStatus.completed,
           conclusion: CheckRunConclusion.success,
         ),
-      ).called(2);
+      ).called(1);
 
       expect(
         records,
@@ -2691,8 +2681,6 @@ void foo() {
           'Checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf was found on GoB mirror. Scheduling merge group tasks',
           'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): Scheduling merge group checks',
-          'Updating ci.yaml validation check for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
-          'ci.yaml validation check was successful for MQ flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Unlocking Merge Queue Guard for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2680,7 +2680,7 @@ void foo() {
           'Processing checks_requested for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'Checks requests for merge queue @ c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
           'flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf was found on GoB mirror. Scheduling merge group tasks',
-          'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): Scheduling merge group checks',
+          'triggerMergeGroupTargets(flutter/flutter, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): scheduling merge group checks',
           'Unlocking Merge Queue Guard for flutter/flutter/c9affbbb12aa40cb3afbe94b9ea6b119a256bebf',
         ],
       );


### PR DESCRIPTION
1. Remove the fake "Merge queue check" that was used for testing flutter/flaux.
2. Fail the "Merge Queue Guard" when failing to schedule LUCI builds for the merge group (instead of failing the fake).