### PR TITLE
Inject a `GetFilesChanged` shim instead of using `GithubService` directly.

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -20,10 +20,8 @@ Future<void> main() async {
 
     final CacheService cache = CacheService(inMemory: false);
     final Config config = Config(dbService, cache);
-    final AuthenticationProvider authProvider =
-        AuthenticationProvider(config: config);
-    final AuthenticationProvider swarmingAuthProvider =
-        SwarmingAuthenticationProvider(config: config);
+    final AuthenticationProvider authProvider = AuthenticationProvider(config: config);
+    final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config: config);
 
     final BuildBucketClient buildBucketClient = BuildBucketClient(
       accessTokenService: AccessTokenService.defaultProvider(config),

--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/server.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
+import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:gcloud/db.dart';
 import 'package:logging/logging.dart';
 
@@ -19,8 +20,10 @@ Future<void> main() async {
 
     final CacheService cache = CacheService(inMemory: false);
     final Config config = Config(dbService, cache);
-    final AuthenticationProvider authProvider = AuthenticationProvider(config: config);
-    final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config: config);
+    final AuthenticationProvider authProvider =
+        AuthenticationProvider(config: config);
+    final AuthenticationProvider swarmingAuthProvider =
+        SwarmingAuthenticationProvider(config: config);
 
     final BuildBucketClient buildBucketClient = BuildBucketClient(
       accessTokenService: AccessTokenService.defaultProvider(config),
@@ -50,6 +53,9 @@ Future<void> main() async {
       cache: cache,
       config: config,
       githubChecksService: githubChecksService,
+      getFilesChanged: GithubApiGetFilesChanged(
+        await config.createDefaultGitHubService(),
+      ),
       luciBuildService: luciBuildService,
       fusionTester: fusionTester,
     );

--- a/app_dart/bin/local_server.dart
+++ b/app_dart/bin/local_server.dart
@@ -18,20 +18,14 @@ import '../test/src/datastore/fake_datastore.dart';
 Future<void> main() async {
   final CacheService cache = CacheService(inMemory: false);
   final DatastoreDB dbService = FakeDatastoreDB();
-  final DatastoreService datastoreService =
-      DatastoreService(dbService, defaultMaxEntityGroups);
+  final DatastoreService datastoreService = DatastoreService(dbService, defaultMaxEntityGroups);
   await datastoreService.insert(<CocoonConfig>[
-    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'WebhookKey'),
-        'fake-secret'),
-    CocoonConfig.fake(
-        dbService.emptyKey.append(CocoonConfig, id: 'FrobWebhookKey'),
-        'fake-secret'),
+    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'WebhookKey'), 'fake-secret'),
+    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'FrobWebhookKey'), 'fake-secret'),
   ]);
   final Config config = Config(dbService, cache);
-  final AuthenticationProvider authProvider =
-      AuthenticationProvider(config: config);
-  final AuthenticationProvider swarmingAuthProvider =
-      SwarmingAuthenticationProvider(config: config);
+  final AuthenticationProvider authProvider = AuthenticationProvider(config: config);
+  final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config: config);
 
   final BuildBucketClient buildBucketClient = BuildBucketClient(
     accessTokenService: AccessTokenService.defaultProvider(config),

--- a/app_dart/bin/local_server.dart
+++ b/app_dart/bin/local_server.dart
@@ -10,6 +10,7 @@ import 'package:cocoon_service/server.dart';
 import 'package:cocoon_service/src/model/appengine/cocoon_config.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:gcloud/db.dart';
 
 import '../test/src/datastore/fake_datastore.dart';
@@ -17,14 +18,20 @@ import '../test/src/datastore/fake_datastore.dart';
 Future<void> main() async {
   final CacheService cache = CacheService(inMemory: false);
   final DatastoreDB dbService = FakeDatastoreDB();
-  final DatastoreService datastoreService = DatastoreService(dbService, defaultMaxEntityGroups);
+  final DatastoreService datastoreService =
+      DatastoreService(dbService, defaultMaxEntityGroups);
   await datastoreService.insert(<CocoonConfig>[
-    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'WebhookKey'), 'fake-secret'),
-    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'FrobWebhookKey'), 'fake-secret'),
+    CocoonConfig.fake(dbService.emptyKey.append(CocoonConfig, id: 'WebhookKey'),
+        'fake-secret'),
+    CocoonConfig.fake(
+        dbService.emptyKey.append(CocoonConfig, id: 'FrobWebhookKey'),
+        'fake-secret'),
   ]);
   final Config config = Config(dbService, cache);
-  final AuthenticationProvider authProvider = AuthenticationProvider(config: config);
-  final AuthenticationProvider swarmingAuthProvider = SwarmingAuthenticationProvider(config: config);
+  final AuthenticationProvider authProvider =
+      AuthenticationProvider(config: config);
+  final AuthenticationProvider swarmingAuthProvider =
+      SwarmingAuthenticationProvider(config: config);
 
   final BuildBucketClient buildBucketClient = BuildBucketClient(
     accessTokenService: AccessTokenService.defaultProvider(config),
@@ -54,6 +61,9 @@ Future<void> main() async {
     cache: cache,
     config: config,
     githubChecksService: githubChecksService,
+    getFilesChanged: GithubApiGetFilesChanged(
+      await config.createDefaultGitHubService(),
+    ),
     luciBuildService: luciBuildService,
     fusionTester: fusionTester,
   );

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -235,7 +235,7 @@ Future<List<Target>> getTargetsToRun(
   switch (filesChanged) {
     case InconclusiveFilesChanged(:final pullRequestNumber, :final reason):
       log.info('Running all targets on PR#$pullRequestNumber: $reason');
-      return targets.toList();
+      return [...targets];
     case SuccessfulFilesChanged(:final pullRequestNumber, :final filesChanged):
       final targetsToRun = <Target>[];
       for (final target in targets) {

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -27,25 +27,18 @@ const String kCiYamlFusionEnginePath = 'engine/src/flutter/$kCiYamlPath';
 const String kTestOwnerPath = 'TESTOWNERS';
 
 /// Attempts to parse the github merge queue branch into its constituent parts to be returned as a record.
-({bool parsed, String branch, int pullRequestNumber})
-    tryParseGitHubMergeQueueBranch(String branch) {
+({bool parsed, String branch, int pullRequestNumber}) tryParseGitHubMergeQueueBranch(String branch) {
   final match = _githubMqBranch.firstMatch(branch);
   if (match == null) {
     return notGitHubMergeQueueBranch;
   }
 
-  return (
-    parsed: true,
-    branch: match.group(1)!,
-    pullRequestNumber: int.parse(match.group(2)!)
-  );
+  return (parsed: true, branch: match.group(1)!, pullRequestNumber: int.parse(match.group(2)!));
 }
 
-const notGitHubMergeQueueBranch =
-    (parsed: false, branch: '', pullRequestNumber: -1);
+const notGitHubMergeQueueBranch = (parsed: false, branch: '', pullRequestNumber: -1);
 
-final _githubMqBranch =
-    RegExp(r'^gh-readonly-queue\/([^/]+)\/pr-(\d+)-([a-fA-F0-9]+)$');
+final _githubMqBranch = RegExp(r'^gh-readonly-queue\/([^/]+)\/pr-(\d+)-([a-fA-F0-9]+)$');
 
 /// Signature for a function that calculates the backoff duration to wait in
 /// between requests when GitHub responds with an error.
@@ -85,8 +78,7 @@ class FusionTester {
       log.info('isFusionRef: cache hit for $cacheKey = $cacheHit');
       return cacheHit;
     }
-    final isFusion = _isFusionMap[cacheKey] =
-        await _isFusionBasedRefReal(slug, sha, timeout, retryOptions);
+    final isFusion = _isFusionMap[cacheKey] = await _isFusionBasedRefReal(slug, sha, timeout, retryOptions);
     return isFusion;
   }
 
@@ -141,8 +133,7 @@ class FusionTester {
 }
 
 const _githubTimeout = Duration(seconds: 5);
-const _githubRetryOptions =
-    RetryOptions(maxAttempts: 3, delayFactor: Duration(seconds: 3));
+const _githubRetryOptions = RetryOptions(maxAttempts: 3, delayFactor: Duration(seconds: 3));
 
 /// Get content of [filePath] from GitHub CDN.
 Future<String> githubFileContent(
@@ -153,8 +144,7 @@ Future<String> githubFileContent(
   Duration timeout = _githubTimeout,
   RetryOptions retryOptions = _githubRetryOptions,
 }) async {
-  final Uri githubUrl =
-      Uri.https('raw.githubusercontent.com', '${slug.fullName}/$ref/$filePath');
+  final Uri githubUrl = Uri.https('raw.githubusercontent.com', '${slug.fullName}/$ref/$filePath');
   // git-on-borg has a different path for shas and refs to github
   final String gobRef = (ref.length < 40) ? 'refs/heads/$ref' : ref;
   final Uri gobUrl = Uri.https(
@@ -167,8 +157,7 @@ Future<String> githubFileContent(
   late String content;
   try {
     await retryOptions.retry(
-      () async => content =
-          await getUrl(githubUrl, httpClientProvider, timeout: timeout),
+      () async => content = await getUrl(githubUrl, httpClientProvider, timeout: timeout),
       retryIf: (Exception e) => e is HttpException || e is NotFoundException,
     );
   } catch (e) {
@@ -258,8 +247,7 @@ Future<List<Target>> getTargetsToRun(
           for (final glob in globs) {
             // If a file is found within a pre-set dir, the builder needs to run. No need to check further.
             final regExp = _convertGlobToRegExp(glob);
-            if (glob.isEmpty ||
-                filesChanged.any((file) => regExp.hasMatch(file))) {
+            if (glob.isEmpty || filesChanged.any((file) => regExp.hasMatch(file))) {
               targetsToRun.add(target);
               break;
             }
@@ -317,8 +305,7 @@ List<String> validateOwnership(
 }) {
   final List<String> noOwnerBuilders = <String>[];
   final YamlMap? ciYaml = loadYaml(ciYamlContent) as YamlMap?;
-  final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()
-    ..mergeFromProto3Json(ciYaml);
+  final pb.SchedulerConfig unCheckedSchedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(ciYaml);
 
   final CiYamlSet ciYamlFromProto = CiYamlSet(
     slug: Config.flutterSlug,
@@ -326,8 +313,7 @@ List<String> validateOwnership(
     yamls: {CiType.any: unCheckedSchedulerConfig},
   );
 
-  final pb.SchedulerConfig schedulerConfig =
-      ciYamlFromProto.configFor(CiType.any);
+  final pb.SchedulerConfig schedulerConfig = ciYamlFromProto.configFor(CiType.any);
 
   for (pb.Target target in schedulerConfig.targets) {
     final String builder = target.name;

--- a/app_dart/lib/src/service/get_files_changed.dart
+++ b/app_dart/lib/src/service/get_files_changed.dart
@@ -1,0 +1,113 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/service/github_service.dart';
+import 'package:github/github.dart';
+import 'package:meta/meta.dart';
+
+/// Provides the ability to query a PR for the files changed.
+///
+/// This abstraction exists to simplify testing, and to swap out the
+/// implementation details; for example between using [GithubApiGetFilesChanged]
+/// and a hypothetical future `ActionsArtifactGetFilesChanged`.
+abstract interface class GetFilesChanged {
+  /// Returns a future that comples with [FilesChanged].
+  ///
+  /// There are two possible outcomes:
+  /// - [InconclusiveFilesChanged] an error state that is non-fatal;
+  /// - [SuccessfulFilesChanged] a success state, see [SuccessfulFilesChanged.filesChanged].
+  Future<FilesChanged> get(
+    RepositorySlug slug,
+    int pullRequestNumber,
+  );
+}
+
+/// Uses []"List pull requests files"](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files).
+///
+/// This implementation has a limitation where if 30 files are returned we
+/// consider the result [InconclusiveFilesChanged], as there are unknown
+/// additional pages of results that could exceed our GitHub burst API capacity
+/// to retrieve.
+///
+/// See <https://github.com/flutter/flutter/issues/161462>.
+final class GithubApiGetFilesChanged implements GetFilesChanged {
+  /// Creates from [GithubService].
+  const GithubApiGetFilesChanged(this._githubService);
+  final GithubService _githubService;
+
+  @override
+  Future<FilesChanged> get(
+    RepositorySlug slug,
+    int pullRequestNumber,
+  ) async {
+    final List<String> files;
+    try {
+      files = await _githubService.listFiles(
+        slug,
+        pullRequestNumber,
+      );
+    } on GitHubError catch (e) {
+      return InconclusiveFilesChanged(
+        pullRequestNumber: pullRequestNumber,
+        reason: 'An error occurred: $e',
+      );
+    }
+    // As currently implemented, the GitHub REST API returns a
+    // maximum of 30 changed files, meaning that if we get 30 files, there is a
+    // good chance *more* file were changed, we just do not know which ones.
+    //
+    // As a result, it's unsafe to filter out targets based on runIf. It actually
+    // might even be unsafe for smaller amounts of files if the patch diffs are
+    // really big, but for now just using the number of files.
+    if (files.length >= 30) {
+      return InconclusiveFilesChanged(
+        pullRequestNumber: pullRequestNumber,
+        reason: '>= 30 files were changed, not confident about result size.',
+      );
+    }
+    return SuccessfulFilesChanged(
+      pullRequestNumber: pullRequestNumber,
+      filesChanged: files,
+    );
+  }
+}
+
+/// Represents the result of requesting the files changed at a PR number.
+@immutable
+sealed class FilesChanged {
+  const FilesChanged({required this.pullRequestNumber});
+
+  /// Which pull request was queried.
+  final int pullRequestNumber;
+}
+
+/// An inconclusive request: assume that all files were changed.
+///
+/// For debugging, [reason] contains details on why the reuslt was inconclusive.
+final class InconclusiveFilesChanged extends FilesChanged {
+  const InconclusiveFilesChanged({
+    required super.pullRequestNumber,
+    required this.reason,
+  });
+
+  /// Why files changed could not be retrieved or cannot be safely used.
+  ///
+  /// Common reasons could include:
+  /// - An HTTP exception or network connectivity issues;
+  /// -
+  final String reason;
+}
+
+/// A successful request for files changed.
+final class SuccessfulFilesChanged extends FilesChanged {
+  SuccessfulFilesChanged({
+    required super.pullRequestNumber,
+    required Iterable<String> filesChanged,
+  }) : filesChanged = Set.unmodifiable(filesChanged);
+
+  /// A set of files changed, in no particular order.
+  ///
+  /// This list is unmodifiable.
+  final Set<String> filesChanged;
+}

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -13,9 +13,7 @@ class GithubService {
   GithubService(this.github);
 
   final GitHub github;
-  static final Map<String, String> headers = <String, String>{
-    'Accept': 'application/vnd.github.groot-preview+json'
-  };
+  static final Map<String, String> headers = <String, String>{'Accept': 'application/vnd.github.groot-preview+json'};
   static const String kRefsPrefix = 'refs/heads/';
 
   /// Return commits unique to [branch] for the repository [slug].
@@ -50,16 +48,12 @@ class GithubService {
       '/repos/${slug.fullName}/commits',
       params: <String, dynamic>{
         'sha': branch,
-        'since': DateTime.fromMillisecondsSinceEpoch(
-                (lastCommitTimestampMills ?? 0) + 1)
-            .toUtc()
-            .toIso8601String(),
+        'since': DateTime.fromMillisecondsSinceEpoch((lastCommitTimestampMills ?? 0) + 1).toUtc().toIso8601String(),
       },
       pages: pages,
       headers: headers,
     )) {
-      commits.addAll((json.decode(response.body) as List<dynamic>)
-          .cast<Map<String, dynamic>>());
+      commits.addAll((json.decode(response.body) as List<dynamic>).cast<Map<String, dynamic>>());
     }
 
     /// When a release branch is first detected only the most recent commit would be needed.
@@ -96,8 +90,7 @@ class GithubService {
   }
 
   /// List pull requests in the repository.
-  Future<List<PullRequest>> listPullRequests(
-      RepositorySlug slug, String? branch) {
+  Future<List<PullRequest>> listPullRequests(RepositorySlug slug, String? branch) {
     ArgumentError.checkNotNull(slug);
     return github.pullRequests
         .list(
@@ -128,11 +121,9 @@ class GithubService {
     ArgumentError.checkNotNull(title);
 
     final RepositorySlug clientSlug = await _getCurrentUserSlug(slug.name);
-    final GitTree tree = await github.git.createTree(
-        clientSlug, CreateGitTree(entries, baseTree: baseRef.object!.sha));
+    final GitTree tree = await github.git.createTree(clientSlug, CreateGitTree(entries, baseTree: baseRef.object!.sha));
     final CurrentUser currentUser = (await _getCurrentUser())!;
-    final GitCommitUser commitUser =
-        GitCommitUser(currentUser.name, currentUser.email, DateTime.now());
+    final GitCommitUser commitUser = GitCommitUser(currentUser.name, currentUser.email, DateTime.now());
     final GitCommit commit = await github.git.createCommit(
       clientSlug,
       CreateGitCommit(
@@ -143,13 +134,11 @@ class GithubService {
         committer: commitUser,
       ),
     );
-    final GitReference headRef = await github.git.createReference(
-        clientSlug, '$kRefsPrefix${_generateNewRef()}', commit.sha);
+    final GitReference headRef =
+        await github.git.createReference(clientSlug, '$kRefsPrefix${_generateNewRef()}', commit.sha);
     return github.pullRequests.create(
       slug,
-      CreatePullRequest(
-          title, '${clientSlug.owner}:${headRef.ref}', baseRef.ref,
-          body: body),
+      CreatePullRequest(title, '${clientSlug.owner}:${headRef.ref}', baseRef.ref, body: body),
     );
   }
 
@@ -172,8 +161,7 @@ class GithubService {
   }
 
   /// Gets label list for an issue.
-  Future<List<IssueLabel>> getIssueLabels(
-      RepositorySlug slug, int issueNumber) async {
+  Future<List<IssueLabel>> getIssueLabels(RepositorySlug slug, int issueNumber) async {
     return github.issues.listLabelsByIssue(slug, issueNumber).toList();
   }
 
@@ -205,9 +193,7 @@ class GithubService {
     String state = 'open',
   }) {
     ArgumentError.checkNotNull(slug);
-    return github.issues
-        .listByRepo(slug, labels: labels, state: state)
-        .toList();
+    return github.issues.listByRepo(slug, labels: labels, state: state).toList();
   }
 
   /// Removes a label from a pull request.
@@ -238,8 +224,7 @@ class GithubService {
     ArgumentError.checkNotNull(slug);
     ArgumentError.checkNotNull(issueNumber);
     ArgumentError.checkNotNull(assignee);
-    await github.issues
-        .edit(slug, issueNumber, IssueRequest(assignee: assignee));
+    await github.issues.edit(slug, issueNumber, IssueRequest(assignee: assignee));
   }
 
   Future<Issue> createIssue(
@@ -252,8 +237,7 @@ class GithubService {
     ArgumentError.checkNotNull(slug);
     return github.issues.create(
       slug,
-      IssueRequest(
-          title: title, body: body, labels: labels, assignee: assignee),
+      IssueRequest(title: title, body: body, labels: labels, assignee: assignee),
     );
   }
 
@@ -280,9 +264,7 @@ class GithubService {
       body: GitHubJson.encode(labels),
     );
     final List<dynamic> body = jsonDecode(response.body) as List<dynamic>;
-    return body
-        .map((dynamic it) => IssueLabel.fromJson(it as Map<String, dynamic>))
-        .toList();
+    return body.map((dynamic it) => IssueLabel.fromJson(it as Map<String, dynamic>)).toList();
   }
 
   /// Returns changed files for a [PullRequest].
@@ -293,24 +275,18 @@ class GithubService {
     RepositorySlug slug,
     int pullRequestNumber,
   ) async =>
-      github.pullRequests
-          .listFiles(slug, pullRequestNumber)
-          .map((file) => file.filename!)
-          .toList();
+      github.pullRequests.listFiles(slug, pullRequestNumber).map((file) => file.filename!).toList();
 
   /// Gets the file content as UTF8 string of the file specified by the `path`
   /// in the repository.
-  Future<String> getFileContent(RepositorySlug slug, String path,
-      {String? ref}) async {
+  Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
     ArgumentError.checkNotNull(slug);
     ArgumentError.checkNotNull(path);
-    final RepositoryContents contents =
-        await github.repositories.getContents(slug, path, ref: ref);
+    final RepositoryContents contents = await github.repositories.getContents(slug, path, ref: ref);
     if (!contents.isFile) {
       throw 'The path $path should point to a file, but it is not!';
     }
-    final String content = utf8
-        .decode(base64.decode(contents.file!.content!.replaceAll('\n', '')));
+    final String content = utf8.decode(base64.decode(contents.file!.content!.replaceAll('\n', '')));
     return content;
   }
 
@@ -341,11 +317,9 @@ class GithubService {
   }
 
   String _generateNewRef() {
-    const String chars =
-        'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
+    const String chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';
     final Random rnd = Random();
-    return String.fromCharCodes(Iterable<int>.generate(
-        10, (_) => chars.codeUnitAt(rnd.nextInt(chars.length))));
+    return String.fromCharCodes(Iterable<int>.generate(10, (_) => chars.codeUnitAt(rnd.nextInt(chars.length))));
   }
 
   /// Returns a [List] of [Issue]s that match the given [query].

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
 import 'package:http/http.dart';
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -60,8 +60,7 @@ class Scheduler {
     this.httpClientProvider = Providers.freshHttpClient,
     this.buildStatusProvider = BuildStatusService.defaultProvider,
     @visibleForTesting this.markCheckRunConclusion = CiStaging.markConclusion,
-    @visibleForTesting
-    this.initializeCiStagingDocument = CiStaging.initializeDocument,
+    @visibleForTesting this.initializeCiStagingDocument = CiStaging.initializeDocument,
     @visibleForTesting this.findPullRequestFor = PrCheckRuns.findPullRequestFor,
   });
 
@@ -106,10 +105,7 @@ class Scheduler {
 
   /// List of check runs that do not need to be tracked or looked up in
   /// any staging logic.
-  static const kCheckRunsToIgnore = [
-    Config.kMergeQueueLockName,
-    Config.kCiYamlCheckName
-  ];
+  static const kCheckRunsToIgnore = [Config.kMergeQueueLockName, Config.kCiYamlCheckName];
 
   /// Briefly describes what the "Merge Queue Guard" check is for.
   ///
@@ -143,8 +139,7 @@ class Scheduler {
     datastore = datastoreProvider(config.db);
     // TODO(chillers): Support triggering on presubmit. https://github.com/flutter/flutter/issues/77858
     if (!pr.merged!) {
-      log.warning(
-          'Only pull requests that were closed and merged should have tasks scheduled');
+      log.warning('Only pull requests that were closed and merged should have tasks scheduled');
       return;
     }
 
@@ -153,8 +148,7 @@ class Scheduler {
     final String sha = pr.mergeCommitSha!;
 
     final String id = '$fullRepo/$branch/$sha';
-    final Key<String> key =
-        datastore.db.emptyKey.append<String>(Commit, id: id);
+    final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit mergedCommit = Commit(
       author: pr.user!.login!,
       authorAvatarUrl: pr.user!.avatarUrl!,
@@ -185,33 +179,26 @@ class Scheduler {
 
     final CiYamlSet ciYaml = await getCiYaml(commit);
 
-    final List<Target> initialTargets =
-        ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-    final isFusion =
-        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
     if (isFusion) {
-      final fusionPostTargets =
-          ciYaml.postsubmitTargets(type: CiType.fusionEngine);
-      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets,
-          type: CiType.fusionEngine);
+      final fusionPostTargets = ciYaml.postsubmitTargets(type: CiType.fusionEngine);
+      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets, type: CiType.fusionEngine);
       initialTargets.addAll(fusionInitialTargets);
       // Note on post submit targets: CiYaml filters out release_true for release branches and fusion trees
     }
 
     final List<Task> tasks = [...targetsToTasks(commit, initialTargets)];
 
-    final List<Tuple<Target, Task, int>> toBeScheduled =
-        <Tuple<Target, Task, int>>[];
+    final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
     for (Target target in initialTargets) {
-      final Task task =
-          tasks.singleWhere((Task task) => task.name == target.value.name);
+      final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
       SchedulerPolicy policy = target.schedulerPolicy;
       // Release branches should run every task
       if (Config.defaultBranch(commit.slug) != commit.branch) {
         policy = GuaranteedPolicy();
       }
-      final int? priority =
-          await policy.triggerPriority(task: task, datastore: datastore);
+      final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over
         task.status = Task.statusInProgress;
@@ -221,14 +208,12 @@ class Scheduler {
 
     // Datastore must be written to generate task keys
     try {
-      log.info(
-          'Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
+      log.info('Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
       await datastore.withTransaction<void>((Transaction transaction) async {
         transaction.queueMutations(inserts: <Commit>[commit]);
         transaction.queueMutations(inserts: tasks);
         await transaction.commit();
-        log.fine(
-            'Committed ${tasks.length} new tasks for commit ${commit.sha!}');
+        log.fine('Committed ${tasks.length} new tasks for commit ${commit.sha!}');
       });
     } catch (error) {
       log.severe('Failed to add commit ${commit.sha!}: $error');
@@ -237,14 +222,10 @@ class Scheduler {
     log.info(
       'Firestore initial targets created for $commit: ${initialTargets.map((t) => '"${t.value.name}"').join(', ')}',
     );
-    final firestore_commmit.Commit commitDocument =
-        firestore_commmit.commitToCommitDocument(commit);
-    final List<firestore.Task> taskDocuments =
-        firestore.targetsToTaskDocuments(commit, initialTargets);
-    final List<Write> writes =
-        documentsToWrites([...taskDocuments, commitDocument], exists: false);
-    final FirestoreService firestoreService =
-        await config.createFirestoreService();
+    final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
+    final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
+    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
+    final FirestoreService firestoreService = await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.
     try {
       await firestoreService.writeViaTransaction(writes);
@@ -252,8 +233,7 @@ class Scheduler {
       log.warning('Failed to add to Firestore: $error');
     }
 
-    log.info(
-        'Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
+    log.info('Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
     await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
   }
@@ -261,17 +241,14 @@ class Scheduler {
   /// Schedule all builds in batch requests instead of a single request.
   ///
   /// Each batch request contains [Config.batchSize] builds to be scheduled.
-  Future<void> _batchScheduleBuilds(
-      Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+  Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final batchLog = StringBuffer(
       'Scheduling ${toBeScheduled.length} tasks in batches for ${commit.sha} as follows:\n',
     );
     final List<Future<void>> futures = <Future<void>>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
-      final batch = toBeScheduled.sublist(
-          i, min(i + config.batchSize, toBeScheduled.length));
-      batchLog
-          .writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
+      final batch = toBeScheduled.sublist(i, min(i + config.batchSize, toBeScheduled.length));
+      batchLog.writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
       futures.add(
         luciBuildService.schedulePostsubmitBuilds(
           commit: commit,
@@ -318,14 +295,10 @@ class Scheduler {
     Commit commit, {
     bool validate = false,
   }) async {
-    final isFusion =
-        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
-    final Commit totCommit = await generateTotCommit(
-        slug: commit.slug, branch: Config.defaultBranch(commit.slug));
-    final CiYamlSet totYaml =
-        await _getCiYaml(totCommit, isFusionCommit: isFusion);
-    return _getCiYaml(commit,
-        totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
+    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final Commit totCommit = await generateTotCommit(slug: commit.slug, branch: Config.defaultBranch(commit.slug));
+    final CiYamlSet totYaml = await _getCiYaml(totCommit, isFusionCommit: isFusion);
+    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
   }
 
   /// Load in memory the `.ci.yaml`.
@@ -333,8 +306,7 @@ class Scheduler {
     Commit commit, {
     CiYamlSet? totCiYaml,
     bool validate = false,
-    RetryOptions retryOptions =
-        const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
+    RetryOptions retryOptions = const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
     bool isFusionCommit = false,
   }) async {
     Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
@@ -351,8 +323,7 @@ class Scheduler {
             .writeToBuffer(),
         ttl: const Duration(hours: 1),
       ))!;
-      final pb.SchedulerConfig schedulerConfig =
-          pb.SchedulerConfig.fromBuffer(ciYamlBytes);
+      final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
       log.fine('Retrieved .ci.yaml for $ciPath');
       return schedulerConfig;
     }
@@ -396,8 +367,7 @@ class Scheduler {
       retryOptions: retryOptions,
     );
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
-    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()
-      ..mergeFromProto3Json(configYaml);
+    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
     return schedulerConfig;
   }
 
@@ -425,8 +395,7 @@ class Scheduler {
     List<String>? builderTriggerList,
   }) async {
     // Always cancel running builds so we don't ever schedule duplicates.
-    log.info(
-        'Attempting to cancel existing presubmit targets for ${pullRequest.number}');
+    log.info('Attempting to cancel existing presubmit targets for ${pullRequest.number}');
     await cancelPreSubmitTargets(
       pullRequest: pullRequest,
       reason: reason,
@@ -458,17 +427,14 @@ class Scheduler {
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!
-              .any((element) => element.name == Config.revertOfLabel)) {
-        log.info(
-            'Skipping generating the full set of checks for revert request.');
+          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
+        log.info('Skipping generating the full set of checks for revert request.');
         unlockMergeGroup = true;
       } else {
         final presubmitTargets = isFusion
             ? await getTestsForStage(pullRequest, CiStage.fusionEngineBuild)
             : await getPresubmitTargets(pullRequest);
-        final presubmitTriggerTargets =
-            filterTargets(presubmitTargets, builderTriggerList);
+        final presubmitTriggerTargets = filterTargets(presubmitTargets, builderTriggerList);
 
         // When running presubmits for a fusion PR; create a new staging document to track tasks needed
         // to complete before we can schedule more tests (i.e. build engine artifacts before testing against them).
@@ -488,20 +454,17 @@ class Scheduler {
         );
       }
     } on FormatException catch (error, backtrace) {
-      log.warning(
-          'FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning('FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     } catch (error, backtrace) {
-      log.warning(
-          'Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning('Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     }
 
     // Update validate ci.yaml check
-    await closeCiYamlCheckRun(
-        'PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
+    await closeCiYamlCheckRun('PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
 
     // Normally the lock stays pending until the PR is ready to be enqueued, but
     // there are situations (see code above) when it needs to be unlocked
@@ -532,8 +495,7 @@ class Scheduler {
         conclusion: CheckRunConclusion.success,
       );
     } else {
-      log.warning(
-          'Marking $description ${Config.kCiYamlCheckName} as failed', e);
+      log.warning('Marking $description ${Config.kCiYamlCheckName} as failed', e);
       // Failure when validating ci.yaml
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
@@ -550,19 +512,16 @@ class Scheduler {
     }
   }
 
-  Future<CheckRun> createCiYamlCheckRun(
-      PullRequest pullRequest, RepositorySlug slug) async {
+  Future<CheckRun> createCiYamlCheckRun(PullRequest pullRequest, RepositorySlug slug) async {
     log.info('Creating ciYaml validation check run for ${pullRequest.number}');
-    final CheckRun ciValidationCheckRun =
-        await githubChecksService.githubChecksUtil.createCheckRun(
+    final CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
       pullRequest.head!.sha!,
       Config.kCiYamlCheckName,
       output: const CheckRunOutput(
         title: Config.kCiYamlCheckName,
-        summary:
-            'If this check is stuck pending, push an empty commit to retrigger the checks',
+        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
     return ciValidationCheckRun;
@@ -584,8 +543,7 @@ class Scheduler {
     final slug = mergeGroupEvent.repository!.slug();
     final isFusion = await fusionTester.isFusionBasedRef(slug, headSha);
 
-    final logCrumb =
-        'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
+    final logCrumb = 'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
 
     log.info('$logCrumb: scheduling merge group checks');
 
@@ -613,13 +571,9 @@ class Scheduler {
         project: 'flutter',
         bucket: 'prod',
       );
-      final availableTargets = {
-        ...mergeGroupTargets
-            .where((target) => availableBuilders.contains(target.value.name))
-      };
+      final availableTargets = {...mergeGroupTargets.where((target) => availableBuilders.contains(target.value.name))};
       if (availableTargets.length != mergeGroupTargets.length) {
-        log.warning(
-            '$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
+        log.warning('$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
       }
       // Create the staging doc that will track our engine progress and allow us to unlock
       // the merge group lock later.
@@ -648,10 +602,7 @@ class Scheduler {
       // Do not unlock the merge group guard in successful case - that will be done by staging checks.
       log.info('$logCrumb: successfully scheduled merge group checks');
     } catch (error, stackTrace) {
-      log.warning(
-          '$logCrumb: error encountered when scheduling merge group checks',
-          error,
-          stackTrace);
+      log.warning('$logCrumb: error encountered when scheduling merge group checks', error, stackTrace);
       // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
       // of the queue. To do that, the merge queue guard must fail as it's the
       // only required GitHub check.
@@ -678,14 +629,11 @@ $stackTrace
   ) async {
     final mergeGroupTargets = [
       ...await getMergeGroupTargets(baseRef, slug, headSha),
-      ...await getMergeGroupTargets(baseRef, slug, headSha,
-          type: CiType.fusionEngine),
+      ...await getMergeGroupTargets(baseRef, slug, headSha, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild =>
-          target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests =>
-          target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
       },
     );
 
@@ -698,8 +646,7 @@ $stackTrace
     String headSha, {
     CiType type = CiType.any,
   }) async {
-    log.info(
-        'Attempting to read merge group targets from ci.yaml for $headSha');
+    log.info('Attempting to read merge group targets from ci.yaml for $headSha');
 
     final Commit commit = Commit(
       branch: baseRef.substring('refs/heads/'.length),
@@ -713,15 +660,13 @@ $stackTrace
     } else {
       ciYaml = await getCiYaml(commit);
     }
-    log.info(
-        'ci.yaml loaded successfully; collecting merge group targets for $headSha');
+    log.info('ci.yaml loaded successfully; collecting merge group targets for $headSha');
 
     final inner = ciYaml.ciYamlFor(type);
 
     // Filter out targets with schedulers different than luci or cocoon.
     bool filter(Target target) =>
-        target.value.scheduler == pb.SchedulerSystem.luci ||
-        target.value.scheduler == pb.SchedulerSystem.cocoon;
+        target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon;
     return [...inner.presubmitTargets.where(filter)];
   }
 
@@ -742,8 +687,7 @@ $stackTrace
   /// While this check is still in progress, the merge queue will not merge the
   /// respective PR onto the target branch (e.g. main or master), because this
   /// check is "required".
-  Future<CheckRun> lockMergeGroupChecks(
-      RepositorySlug slug, String headSha) async {
+  Future<CheckRun> lockMergeGroupChecks(RepositorySlug slug, String headSha) async {
     return githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
@@ -764,8 +708,7 @@ $stackTrace
   ///
   /// If the guard is guarding a pull request, this immediately makes the pull
   /// request eligible for enqueuing into the merge queue.
-  Future<void> unlockMergeQueueGuard(
-      RepositorySlug slug, String headSha, CheckRun lock) async {
+  Future<void> unlockMergeQueueGuard(RepositorySlug slug, String headSha, CheckRun lock) async {
     log.info('Unlocking Merge Queue Guard for $slug/$headSha');
     await githubChecksService.githubChecksUtil.updateCheckRun(
       config,
@@ -809,10 +752,7 @@ $stackTrace
     List<String>? builderTriggerList,
   ) {
     if (builderTriggerList != null && builderTriggerList.isNotEmpty) {
-      return presubmitTarget
-          .where(
-              (Target target) => builderTriggerList.contains(target.value.name))
-          .toList();
+      return presubmitTarget.where((Target target) => builderTriggerList.contains(target.value.name)).toList();
     }
     return presubmitTarget;
   }
@@ -826,17 +766,14 @@ $stackTrace
     required PullRequest pullRequest,
     required CheckSuiteEvent checkSuiteEvent,
   }) async {
-    final GitHub githubClient =
-        await config.createGitHubClient(pullRequest: pullRequest);
-    final Map<String, CheckRun> checkRuns =
-        await githubChecksService.githubChecksUtil.allCheckRuns(
+    final GitHub githubClient = await config.createGitHubClient(pullRequest: pullRequest);
+    final Map<String, CheckRun> checkRuns = await githubChecksService.githubChecksUtil.allCheckRuns(
       githubClient,
       checkSuiteEvent,
     );
-    final List<Target> presubmitTargets =
-        await getPresubmitTargets(pullRequest);
-    final List<bbv2.Build?> failedBuilds = await luciBuildService.failedBuilds(
-        pullRequest: pullRequest, targets: presubmitTargets);
+    final List<Target> presubmitTargets = await getPresubmitTargets(pullRequest);
+    final List<bbv2.Build?> failedBuilds =
+        await luciBuildService.failedBuilds(pullRequest: pullRequest, targets: presubmitTargets);
     for (bbv2.Build? build in failedBuilds) {
       final CheckRun checkRun = checkRuns[build!.builder.builder]!;
 
@@ -846,10 +783,7 @@ $stackTrace
       }
 
       await luciBuildService.scheduleTryBuilds(
-        targets: presubmitTargets
-            .where(
-                (Target target) => build.builder.builder == target.value.name)
-            .toList(),
+        targets: presubmitTargets.where((Target target) => build.builder.builder == target.value.name).toList(),
         pullRequest: pullRequest,
         checkSuiteEvent: checkSuiteEvent,
       );
@@ -872,8 +806,7 @@ $stackTrace
       sha: pullRequest.head!.sha,
     );
     late CiYamlSet ciYaml;
-    log.info(
-        'Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
+    log.info('Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
     if (commit.branch == Config.defaultBranch(commit.slug)) {
       ciYaml = await getCiYaml(commit, validate: true);
     } else {
@@ -888,23 +821,19 @@ $stackTrace
     final List<Target> presubmitTargets = inner.presubmitTargets
         .where(
           (Target target) =>
-              target.value.scheduler == pb.SchedulerSystem.luci ||
-              target.value.scheduler == pb.SchedulerSystem.cocoon,
+              target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
         )
         .toList();
 
     // See https://github.com/flutter/flutter/issues/138430.
-    final includePostsubmitAsPresubmit =
-        _includePostsubmitAsPresubmit(inner, pullRequest);
+    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(inner, pullRequest);
     if (includePostsubmitAsPresubmit) {
-      log.info(
-          'Including postsubmit targets as presubmit for ${pullRequest.number}');
+      log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in inner.postsubmitTargets) {
         // We don't want to include a presubmit twice
         // We don't want to run the builder_cache target as a presubmit
-        if (!target.value.presubmit &&
-            !target.value.properties.containsKey('cache_name')) {
+        if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
           presubmitTargets.add(target);
         }
       }
@@ -912,15 +841,12 @@ $stackTrace
 
     log.info('Collected ${presubmitTargets.length} presubmit targets.');
     // Release branches should run every test.
-    if (pullRequest.base!.ref !=
-        Config.defaultBranch(pullRequest.base!.repo!.slug())) {
-      log.info(
-          'Release branch found, scheduling all targets for ${pullRequest.number}');
+    if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
+      log.info('Release branch found, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
     if (includePostsubmitAsPresubmit) {
-      log.info(
-          'Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
+      log.info('Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
 
@@ -938,13 +864,11 @@ $stackTrace
   };
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-  static bool _includePostsubmitAsPresubmit(
-      CiYaml ciYaml, PullRequest pullRequest) {
+  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
     if (!_allowTestAll.contains(ciYaml.slug)) {
       return false;
     }
-    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ??
-        false) {
+    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
       return true;
     }
     return false;
@@ -954,19 +878,14 @@ $stackTrace
   ///
   /// Handles both fusion engine build and test stages, and both pull requests
   /// and merge groups.
-  Future<bool> processCheckRunCompletion(
-      cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRunCompletion(cocoon_checks.CheckRunEvent checkRunEvent) async {
     final checkRun = checkRunEvent.checkRun!;
     final name = checkRun.name;
     final sha = checkRun.headSha;
     final slug = checkRunEvent.repository?.slug();
     final conclusion = checkRun.conclusion;
 
-    if (name == null ||
-        sha == null ||
-        slug == null ||
-        conclusion == null ||
-        kCheckRunsToIgnore.contains(name)) {
+    if (name == null || sha == null || slug == null || conclusion == null || kCheckRunsToIgnore.contains(name)) {
       return true;
     }
 
@@ -1035,8 +954,7 @@ $stackTrace
 
     // Are there tests remaining? Keep waiting.
     if (stagingConclusion.isPending) {
-      log.info(
-          '$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
+      log.info('$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
       return false;
     }
 
@@ -1118,8 +1036,7 @@ $stackTrace
       return;
     }
 
-    log.info(
-        '$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
+    log.info('$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
 
     await _proceedToCiTestingStage(
       checkRun: checkRun,
@@ -1141,17 +1058,14 @@ $stackTrace
   }
 
   /// Returns the presubmit targets for the fusion repo [pullRequest] that should run for the given [stage].
-  Future<List<Target>> getTestsForStage(
-      PullRequest pullRequest, CiStage stage) async {
+  Future<List<Target>> getTestsForStage(PullRequest pullRequest, CiStage stage) async {
     final presubmitTargets = [
       ...await getPresubmitTargets(pullRequest),
       ...await getPresubmitTargets(pullRequest, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild =>
-          target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests =>
-          target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
       },
     );
     return [...presubmitTargets];
@@ -1197,8 +1111,7 @@ $stackTrace
     // We'va failed to find the pull request; try a reverse look it from the check suite.
     if (pullRequest == null) {
       final int checkSuiteId = checkRun.checkSuite!.id!;
-      pullRequest = await githubChecksService.findMatchingPullRequest(
-          slug, sha, checkSuiteId);
+      pullRequest = await githubChecksService.findMatchingPullRequest(slug, sha, checkSuiteId);
     }
 
     // We cannot make any forward progress. Abandon all hope, Check runs who enter here.
@@ -1210,15 +1123,12 @@ $stackTrace
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!
-              .any((element) => element.name == Config.revertOfLabel)) {
-        log.info(
-            '$logCrumb: skipping generating the full set of checks for revert request.');
+          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
+        log.info('$logCrumb: skipping generating the full set of checks for revert request.');
       } else {
         // Schedule the tests that would have run in a call to triggerPresubmitTargets - but for both the
         // engine and the framework.
-        final presubmitTargets =
-            await getTestsForStage(pullRequest, CiStage.fusionTests);
+        final presubmitTargets = await getTestsForStage(pullRequest, CiStage.fusionTests);
 
         // Create the document for tracking test check runs.
         await initializeCiStagingDocument(
@@ -1260,8 +1170,7 @@ $stackTrace
     required String conclusion,
   }) async {
     final logCrumb = 'checkCompleted($name, $slug, $sha, $conclusion)';
-    final documentName =
-        CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
+    final documentName = CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
     log.info('$logCrumb: $documentName');
 
     // We're doing a transactional update, which could fail if multiple tasks are running at the same time; so retry
@@ -1294,23 +1203,20 @@ $stackTrace
   ///
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
-  Future<bool> processCheckRun(
-      cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
     switch (checkRunEvent.action) {
       case 'completed':
         await processCheckRunCompletion(checkRunEvent);
         return true;
 
       case 'rerequested':
-        log.fine(
-            'Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
+        log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
         final String? name = checkRunEvent.checkRun!.name;
         bool success = false;
         if (name == Config.kMergeQueueLockName) {
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          log.fine(
-              'Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
+          log.fine('Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
           success = true;
         } else if (name == Config.kCiYamlCheckName) {
           // The CheckRunEvent.checkRun.pullRequests array is empty for this
@@ -1318,33 +1224,28 @@ $stackTrace
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final String headSha = checkRunEvent.checkRun!.headSha!;
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          final PullRequest? pullRequest = await githubChecksService
-              .findMatchingPullRequest(slug, headSha, checkSuiteId);
+          final PullRequest? pullRequest =
+              await githubChecksService.findMatchingPullRequest(slug, headSha, checkSuiteId);
           if (pullRequest != null) {
-            log.fine(
-                'Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
+            log.fine('Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
             await triggerPresubmitTargets(pullRequest: pullRequest);
             success = true;
           } else {
-            log.warning(
-                'No matching PR found for head_sha in check run event.');
+            log.warning('No matching PR found for head_sha in check run event.');
           }
         } else {
           try {
             final RepositorySlug slug = checkRunEvent.repository!.slug();
-            final String gitBranch =
-                checkRunEvent.checkRun!.checkSuite!.headBranch ??
-                    Config.defaultBranch(slug);
+            final String gitBranch = checkRunEvent.checkRun!.checkSuite!.headBranch ?? Config.defaultBranch(slug);
             final String sha = checkRunEvent.checkRun!.headSha!;
 
             // Only merged commits are added to the datastore. If a matching commit is found, this must be a postsubmit checkrun.
             datastore = datastoreProvider(config.db);
-            final Key<String> commitKey = Commit.createKey(
-                db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
+            final Key<String> commitKey =
+                Commit.createKey(db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
             Commit? commit;
             try {
-              commit = await Commit.fromDatastore(
-                  datastore: datastore, key: commitKey);
+              commit = await Commit.fromDatastore(datastore: datastore, key: commitKey);
               log.fine('Commit found in datastore.');
             } on KeyNotFoundException {
               log.fine('Commit not found in datastore.');
@@ -1353,27 +1254,21 @@ $stackTrace
             if (commit == null) {
               log.fine('Rescheduling presubmit build.');
               // Does not do anything with the returned build oddly.
-              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(
-                  checkRunEvent: checkRunEvent);
+              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(checkRunEvent: checkRunEvent);
             } else {
               log.fine('Rescheduling postsubmit build.');
               firestoreService = await config.createFirestoreService();
               final String checkName = checkRunEvent.checkRun!.name!;
-              final Task task = await Task.fromDatastore(
-                  datastore: datastore, commitKey: commitKey, name: checkName);
+              final Task task = await Task.fromDatastore(datastore: datastore, commitKey: commitKey, name: checkName);
               // Query the lastest run of the `checkName` againt commit `sha`.
-              final List<firestore.Task> taskDocuments =
-                  await firestoreService.queryCommitTasks(commit.sha!);
-              final firestore.Task taskDocument = taskDocuments
-                  .where((taskDocument) => taskDocument.taskName == checkName)
-                  .toList()
-                  .first;
+              final List<firestore.Task> taskDocuments = await firestoreService.queryCommitTasks(commit.sha!);
+              final firestore.Task taskDocument =
+                  taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYamlSet ciYaml = await getCiYaml(commit);
-              final Target target = ciYaml.postsubmitTargets().singleWhere(
-                  (Target target) => target.value.name == task.name);
-              await luciBuildService
-                  .reschedulePostsubmitBuildUsingCheckRunEvent(
+              final Target target =
+                  ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
+              await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,
                 task: task,
@@ -1405,10 +1300,8 @@ $stackTrace
 
     log.info('Uploading commit ${commit.sha} info to bigquery.');
 
-    final TabledataResource tabledataResource =
-        await config.createTabledataResourceApi();
-    final List<Map<String, Object>> tableDataInsertAllRequestRows =
-        <Map<String, Object>>[];
+    final TabledataResource tabledataResource = await config.createTabledataResourceApi();
+    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
 
     /// Consolidate [commits] together
     ///
@@ -1427,16 +1320,15 @@ $stackTrace
     });
 
     /// Final [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest rows = TableDataInsertAllRequest.fromJson(
-        <String, Object>{'rows': tableDataInsertAllRequestRows});
+    final TableDataInsertAllRequest rows =
+        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
 
     /// Insert [commits] to [BigQuery]
     try {
       if (rows.rows == null) {
         log.warning('Rows to be inserted is null');
       } else {
-        log.info(
-            'Inserting ${rows.rows!.length} into big query for ${commit.sha}');
+        log.info('Inserting ${rows.rows!.length} into big query for ${commit.sha}');
       }
       await tabledataResource.insertAll(rows, projectId, dataset, table);
     } on ApiRequestError {
@@ -1449,12 +1341,10 @@ $stackTrace
   /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlSet].
   /// The generated tip of tree [CiYamlSet] will be compared against Presubmit Targets in current [CiYamlSet],
   /// to ensure new targets without `bringup: true` label are not added into the build.
-  Future<Commit> generateTotCommit(
-      {required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);
     firestoreService = await config.createFirestoreService();
-    final BuildStatusService buildStatusService =
-        buildStatusProvider(datastore, firestoreService);
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final Commit totCommit = (await buildStatusService
             .retrieveCommitStatus(
               limit: 1,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -60,8 +60,7 @@ class Scheduler {
     this.httpClientProvider = Providers.freshHttpClient,
     this.buildStatusProvider = BuildStatusService.defaultProvider,
     @visibleForTesting this.markCheckRunConclusion = CiStaging.markConclusion,
-    @visibleForTesting
-    this.initializeCiStagingDocument = CiStaging.initializeDocument,
+    @visibleForTesting this.initializeCiStagingDocument = CiStaging.initializeDocument,
     @visibleForTesting this.findPullRequestFor = PrCheckRuns.findPullRequestFor,
   });
 
@@ -106,10 +105,7 @@ class Scheduler {
 
   /// List of check runs that do not need to be tracked or looked up in
   /// any staging logic.
-  static const kCheckRunsToIgnore = [
-    Config.kMergeQueueLockName,
-    Config.kCiYamlCheckName
-  ];
+  static const kCheckRunsToIgnore = [Config.kMergeQueueLockName, Config.kCiYamlCheckName];
 
   /// Briefly describes what the "Merge Queue Guard" check is for.
   ///
@@ -143,8 +139,7 @@ class Scheduler {
     datastore = datastoreProvider(config.db);
     // TODO(chillers): Support triggering on presubmit. https://github.com/flutter/flutter/issues/77858
     if (!pr.merged!) {
-      log.warning(
-          'Only pull requests that were closed and merged should have tasks scheduled');
+      log.warning('Only pull requests that were closed and merged should have tasks scheduled');
       return;
     }
 
@@ -153,8 +148,7 @@ class Scheduler {
     final String sha = pr.mergeCommitSha!;
 
     final String id = '$fullRepo/$branch/$sha';
-    final Key<String> key =
-        datastore.db.emptyKey.append<String>(Commit, id: id);
+    final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit mergedCommit = Commit(
       author: pr.user!.login!,
       authorAvatarUrl: pr.user!.avatarUrl!,
@@ -185,33 +179,26 @@ class Scheduler {
 
     final CiYamlSet ciYaml = await getCiYaml(commit);
 
-    final List<Target> initialTargets =
-        ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-    final isFusion =
-        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
     if (isFusion) {
-      final fusionPostTargets =
-          ciYaml.postsubmitTargets(type: CiType.fusionEngine);
-      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets,
-          type: CiType.fusionEngine);
+      final fusionPostTargets = ciYaml.postsubmitTargets(type: CiType.fusionEngine);
+      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets, type: CiType.fusionEngine);
       initialTargets.addAll(fusionInitialTargets);
       // Note on post submit targets: CiYaml filters out release_true for release branches and fusion trees
     }
 
     final List<Task> tasks = [...targetsToTasks(commit, initialTargets)];
 
-    final List<Tuple<Target, Task, int>> toBeScheduled =
-        <Tuple<Target, Task, int>>[];
+    final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
     for (Target target in initialTargets) {
-      final Task task =
-          tasks.singleWhere((Task task) => task.name == target.value.name);
+      final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
       SchedulerPolicy policy = target.schedulerPolicy;
       // Release branches should run every task
       if (Config.defaultBranch(commit.slug) != commit.branch) {
         policy = GuaranteedPolicy();
       }
-      final int? priority =
-          await policy.triggerPriority(task: task, datastore: datastore);
+      final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over
         task.status = Task.statusInProgress;
@@ -221,14 +208,12 @@ class Scheduler {
 
     // Datastore must be written to generate task keys
     try {
-      log.info(
-          'Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
+      log.info('Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
       await datastore.withTransaction<void>((Transaction transaction) async {
         transaction.queueMutations(inserts: <Commit>[commit]);
         transaction.queueMutations(inserts: tasks);
         await transaction.commit();
-        log.fine(
-            'Committed ${tasks.length} new tasks for commit ${commit.sha!}');
+        log.fine('Committed ${tasks.length} new tasks for commit ${commit.sha!}');
       });
     } catch (error) {
       log.severe('Failed to add commit ${commit.sha!}: $error');
@@ -237,14 +222,10 @@ class Scheduler {
     log.info(
       'Firestore initial targets created for $commit: ${initialTargets.map((t) => '"${t.value.name}"').join(', ')}',
     );
-    final firestore_commmit.Commit commitDocument =
-        firestore_commmit.commitToCommitDocument(commit);
-    final List<firestore.Task> taskDocuments =
-        firestore.targetsToTaskDocuments(commit, initialTargets);
-    final List<Write> writes =
-        documentsToWrites([...taskDocuments, commitDocument], exists: false);
-    final FirestoreService firestoreService =
-        await config.createFirestoreService();
+    final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
+    final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
+    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
+    final FirestoreService firestoreService = await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.
     try {
       await firestoreService.writeViaTransaction(writes);
@@ -252,8 +233,7 @@ class Scheduler {
       log.warning('Failed to add to Firestore: $error');
     }
 
-    log.info(
-        'Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
+    log.info('Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
     await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
   }
@@ -261,17 +241,14 @@ class Scheduler {
   /// Schedule all builds in batch requests instead of a single request.
   ///
   /// Each batch request contains [Config.batchSize] builds to be scheduled.
-  Future<void> _batchScheduleBuilds(
-      Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+  Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final batchLog = StringBuffer(
       'Scheduling ${toBeScheduled.length} tasks in batches for ${commit.sha} as follows:\n',
     );
     final List<Future<void>> futures = <Future<void>>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
-      final batch = toBeScheduled.sublist(
-          i, min(i + config.batchSize, toBeScheduled.length));
-      batchLog
-          .writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
+      final batch = toBeScheduled.sublist(i, min(i + config.batchSize, toBeScheduled.length));
+      batchLog.writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
       futures.add(
         luciBuildService.schedulePostsubmitBuilds(
           commit: commit,
@@ -318,14 +295,10 @@ class Scheduler {
     Commit commit, {
     bool validate = false,
   }) async {
-    final isFusion =
-        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
-    final Commit totCommit = await generateTotCommit(
-        slug: commit.slug, branch: Config.defaultBranch(commit.slug));
-    final CiYamlSet totYaml =
-        await _getCiYaml(totCommit, isFusionCommit: isFusion);
-    return _getCiYaml(commit,
-        totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
+    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final Commit totCommit = await generateTotCommit(slug: commit.slug, branch: Config.defaultBranch(commit.slug));
+    final CiYamlSet totYaml = await _getCiYaml(totCommit, isFusionCommit: isFusion);
+    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
   }
 
   /// Load in memory the `.ci.yaml`.
@@ -333,8 +306,7 @@ class Scheduler {
     Commit commit, {
     CiYamlSet? totCiYaml,
     bool validate = false,
-    RetryOptions retryOptions =
-        const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
+    RetryOptions retryOptions = const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
     bool isFusionCommit = false,
   }) async {
     Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
@@ -351,8 +323,7 @@ class Scheduler {
             .writeToBuffer(),
         ttl: const Duration(hours: 1),
       ))!;
-      final pb.SchedulerConfig schedulerConfig =
-          pb.SchedulerConfig.fromBuffer(ciYamlBytes);
+      final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
       log.fine('Retrieved .ci.yaml for $ciPath');
       return schedulerConfig;
     }
@@ -396,8 +367,7 @@ class Scheduler {
       retryOptions: retryOptions,
     );
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
-    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()
-      ..mergeFromProto3Json(configYaml);
+    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
     return schedulerConfig;
   }
 
@@ -425,8 +395,7 @@ class Scheduler {
     List<String>? builderTriggerList,
   }) async {
     // Always cancel running builds so we don't ever schedule duplicates.
-    log.info(
-        'Attempting to cancel existing presubmit targets for ${pullRequest.number}');
+    log.info('Attempting to cancel existing presubmit targets for ${pullRequest.number}');
     await cancelPreSubmitTargets(
       pullRequest: pullRequest,
       reason: reason,
@@ -458,17 +427,14 @@ class Scheduler {
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!
-              .any((element) => element.name == Config.revertOfLabel)) {
-        log.info(
-            'Skipping generating the full set of checks for revert request.');
+          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
+        log.info('Skipping generating the full set of checks for revert request.');
         unlockMergeGroup = true;
       } else {
         final presubmitTargets = isFusion
             ? await getTestsForStage(pullRequest, CiStage.fusionEngineBuild)
             : await getPresubmitTargets(pullRequest);
-        final presubmitTriggerTargets =
-            filterTargets(presubmitTargets, builderTriggerList);
+        final presubmitTriggerTargets = filterTargets(presubmitTargets, builderTriggerList);
 
         // When running presubmits for a fusion PR; create a new staging document to track tasks needed
         // to complete before we can schedule more tests (i.e. build engine artifacts before testing against them).
@@ -488,20 +454,17 @@ class Scheduler {
         );
       }
     } on FormatException catch (error, backtrace) {
-      log.warning(
-          'FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning('FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     } catch (error, backtrace) {
-      log.warning(
-          'Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning('Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     }
 
     // Update validate ci.yaml check
-    await closeCiYamlCheckRun(
-        'PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
+    await closeCiYamlCheckRun('PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
 
     // Normally the lock stays pending until the PR is ready to be enqueued, but
     // there are situations (see code above) when it needs to be unlocked
@@ -532,8 +495,7 @@ class Scheduler {
         conclusion: CheckRunConclusion.success,
       );
     } else {
-      log.warning(
-          'Marking $description ${Config.kCiYamlCheckName} as failed', e);
+      log.warning('Marking $description ${Config.kCiYamlCheckName} as failed', e);
       // Failure when validating ci.yaml
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
@@ -550,19 +512,16 @@ class Scheduler {
     }
   }
 
-  Future<CheckRun> createCiYamlCheckRun(
-      PullRequest pullRequest, RepositorySlug slug) async {
+  Future<CheckRun> createCiYamlCheckRun(PullRequest pullRequest, RepositorySlug slug) async {
     log.info('Creating ciYaml validation check run for ${pullRequest.number}');
-    final CheckRun ciValidationCheckRun =
-        await githubChecksService.githubChecksUtil.createCheckRun(
+    final CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
       pullRequest.head!.sha!,
       Config.kCiYamlCheckName,
       output: const CheckRunOutput(
         title: Config.kCiYamlCheckName,
-        summary:
-            'If this check is stuck pending, push an empty commit to retrigger the checks',
+        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
     return ciValidationCheckRun;
@@ -584,8 +543,7 @@ class Scheduler {
     final slug = mergeGroupEvent.repository!.slug();
     final isFusion = await fusionTester.isFusionBasedRef(slug, headSha);
 
-    final logCrumb =
-        'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
+    final logCrumb = 'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
 
     log.info('$logCrumb: scheduling merge group checks');
 
@@ -613,13 +571,9 @@ class Scheduler {
         project: 'flutter',
         bucket: 'prod',
       );
-      final availableTargets = {
-        ...mergeGroupTargets
-            .where((target) => availableBuilders.contains(target.value.name))
-      };
+      final availableTargets = {...mergeGroupTargets.where((target) => availableBuilders.contains(target.value.name))};
       if (availableTargets.length != mergeGroupTargets.length) {
-        log.warning(
-            '$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
+        log.warning('$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
       }
       // Create the staging doc that will track our engine progress and allow us to unlock
       // the merge group lock later.
@@ -648,10 +602,7 @@ class Scheduler {
       // Do not unlock the merge group guard in successful case - that will be done by staging checks.
       log.info('$logCrumb: successfully scheduled merge group checks');
     } catch (error, stackTrace) {
-      log.warning(
-          '$logCrumb: error encountered when scheduling merge group checks',
-          error,
-          stackTrace);
+      log.warning('$logCrumb: error encountered when scheduling merge group checks', error, stackTrace);
       // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
       // of the queue. To do that, the merge queue guard must fail as it's the
       // only required GitHub check.
@@ -678,14 +629,11 @@ $stackTrace
   ) async {
     final mergeGroupTargets = [
       ...await getMergeGroupTargets(baseRef, slug, headSha),
-      ...await getMergeGroupTargets(baseRef, slug, headSha,
-          type: CiType.fusionEngine),
+      ...await getMergeGroupTargets(baseRef, slug, headSha, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild =>
-          target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests =>
-          target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
       },
     );
 
@@ -698,8 +646,7 @@ $stackTrace
     String headSha, {
     CiType type = CiType.any,
   }) async {
-    log.info(
-        'Attempting to read merge group targets from ci.yaml for $headSha');
+    log.info('Attempting to read merge group targets from ci.yaml for $headSha');
 
     final Commit commit = Commit(
       branch: baseRef.substring('refs/heads/'.length),
@@ -713,15 +660,13 @@ $stackTrace
     } else {
       ciYaml = await getCiYaml(commit);
     }
-    log.info(
-        'ci.yaml loaded successfully; collecting merge group targets for $headSha');
+    log.info('ci.yaml loaded successfully; collecting merge group targets for $headSha');
 
     final inner = ciYaml.ciYamlFor(type);
 
     // Filter out targets with schedulers different than luci or cocoon.
     bool filter(Target target) =>
-        target.value.scheduler == pb.SchedulerSystem.luci ||
-        target.value.scheduler == pb.SchedulerSystem.cocoon;
+        target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon;
     return [...inner.presubmitTargets.where(filter)];
   }
 
@@ -742,8 +687,7 @@ $stackTrace
   /// While this check is still in progress, the merge queue will not merge the
   /// respective PR onto the target branch (e.g. main or master), because this
   /// check is "required".
-  Future<CheckRun> lockMergeGroupChecks(
-      RepositorySlug slug, String headSha) async {
+  Future<CheckRun> lockMergeGroupChecks(RepositorySlug slug, String headSha) async {
     return githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
@@ -764,8 +708,7 @@ $stackTrace
   ///
   /// If the guard is guarding a pull request, this immediately makes the pull
   /// request eligible for enqueuing into the merge queue.
-  Future<void> unlockMergeQueueGuard(
-      RepositorySlug slug, String headSha, CheckRun lock) async {
+  Future<void> unlockMergeQueueGuard(RepositorySlug slug, String headSha, CheckRun lock) async {
     log.info('Unlocking Merge Queue Guard for $slug/$headSha');
     await githubChecksService.githubChecksUtil.updateCheckRun(
       config,
@@ -809,10 +752,7 @@ $stackTrace
     List<String>? builderTriggerList,
   ) {
     if (builderTriggerList != null && builderTriggerList.isNotEmpty) {
-      return presubmitTarget
-          .where(
-              (Target target) => builderTriggerList.contains(target.value.name))
-          .toList();
+      return presubmitTarget.where((Target target) => builderTriggerList.contains(target.value.name)).toList();
     }
     return presubmitTarget;
   }
@@ -826,17 +766,14 @@ $stackTrace
     required PullRequest pullRequest,
     required CheckSuiteEvent checkSuiteEvent,
   }) async {
-    final GitHub githubClient =
-        await config.createGitHubClient(pullRequest: pullRequest);
-    final Map<String, CheckRun> checkRuns =
-        await githubChecksService.githubChecksUtil.allCheckRuns(
+    final GitHub githubClient = await config.createGitHubClient(pullRequest: pullRequest);
+    final Map<String, CheckRun> checkRuns = await githubChecksService.githubChecksUtil.allCheckRuns(
       githubClient,
       checkSuiteEvent,
     );
-    final List<Target> presubmitTargets =
-        await getPresubmitTargets(pullRequest);
-    final List<bbv2.Build?> failedBuilds = await luciBuildService.failedBuilds(
-        pullRequest: pullRequest, targets: presubmitTargets);
+    final List<Target> presubmitTargets = await getPresubmitTargets(pullRequest);
+    final List<bbv2.Build?> failedBuilds =
+        await luciBuildService.failedBuilds(pullRequest: pullRequest, targets: presubmitTargets);
     for (bbv2.Build? build in failedBuilds) {
       final CheckRun checkRun = checkRuns[build!.builder.builder]!;
 
@@ -846,10 +783,7 @@ $stackTrace
       }
 
       await luciBuildService.scheduleTryBuilds(
-        targets: presubmitTargets
-            .where(
-                (Target target) => build.builder.builder == target.value.name)
-            .toList(),
+        targets: presubmitTargets.where((Target target) => build.builder.builder == target.value.name).toList(),
         pullRequest: pullRequest,
         checkSuiteEvent: checkSuiteEvent,
       );
@@ -872,8 +806,7 @@ $stackTrace
       sha: pullRequest.head!.sha,
     );
     late CiYamlSet ciYaml;
-    log.info(
-        'Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
+    log.info('Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
     if (commit.branch == Config.defaultBranch(commit.slug)) {
       ciYaml = await getCiYaml(commit, validate: true);
     } else {
@@ -888,23 +821,19 @@ $stackTrace
     final List<Target> presubmitTargets = inner.presubmitTargets
         .where(
           (Target target) =>
-              target.value.scheduler == pb.SchedulerSystem.luci ||
-              target.value.scheduler == pb.SchedulerSystem.cocoon,
+              target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
         )
         .toList();
 
     // See https://github.com/flutter/flutter/issues/138430.
-    final includePostsubmitAsPresubmit =
-        _includePostsubmitAsPresubmit(inner, pullRequest);
+    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(inner, pullRequest);
     if (includePostsubmitAsPresubmit) {
-      log.info(
-          'Including postsubmit targets as presubmit for ${pullRequest.number}');
+      log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in inner.postsubmitTargets) {
         // We don't want to include a presubmit twice
         // We don't want to run the builder_cache target as a presubmit
-        if (!target.value.presubmit &&
-            !target.value.properties.containsKey('cache_name')) {
+        if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
           presubmitTargets.add(target);
         }
       }
@@ -912,15 +841,12 @@ $stackTrace
 
     log.info('Collected ${presubmitTargets.length} presubmit targets.');
     // Release branches should run every test.
-    if (pullRequest.base!.ref !=
-        Config.defaultBranch(pullRequest.base!.repo!.slug())) {
-      log.info(
-          'Release branch found, scheduling all targets for ${pullRequest.number}');
+    if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
+      log.info('Release branch found, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
     if (includePostsubmitAsPresubmit) {
-      log.info(
-          'Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
+      log.info('Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
 
@@ -934,13 +860,11 @@ $stackTrace
   };
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-  static bool _includePostsubmitAsPresubmit(
-      CiYaml ciYaml, PullRequest pullRequest) {
+  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
     if (!_allowTestAll.contains(ciYaml.slug)) {
       return false;
     }
-    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ??
-        false) {
+    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
       return true;
     }
     return false;
@@ -950,19 +874,14 @@ $stackTrace
   ///
   /// Handles both fusion engine build and test stages, and both pull requests
   /// and merge groups.
-  Future<bool> processCheckRunCompletion(
-      cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRunCompletion(cocoon_checks.CheckRunEvent checkRunEvent) async {
     final checkRun = checkRunEvent.checkRun!;
     final name = checkRun.name;
     final sha = checkRun.headSha;
     final slug = checkRunEvent.repository?.slug();
     final conclusion = checkRun.conclusion;
 
-    if (name == null ||
-        sha == null ||
-        slug == null ||
-        conclusion == null ||
-        kCheckRunsToIgnore.contains(name)) {
+    if (name == null || sha == null || slug == null || conclusion == null || kCheckRunsToIgnore.contains(name)) {
       return true;
     }
 
@@ -1031,8 +950,7 @@ $stackTrace
 
     // Are there tests remaining? Keep waiting.
     if (stagingConclusion.isPending) {
-      log.info(
-          '$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
+      log.info('$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
       return false;
     }
 
@@ -1114,8 +1032,7 @@ $stackTrace
       return;
     }
 
-    log.info(
-        '$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
+    log.info('$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
 
     await _proceedToCiTestingStage(
       checkRun: checkRun,
@@ -1137,17 +1054,14 @@ $stackTrace
   }
 
   /// Returns the presubmit targets for the fusion repo [pullRequest] that should run for the given [stage].
-  Future<List<Target>> getTestsForStage(
-      PullRequest pullRequest, CiStage stage) async {
+  Future<List<Target>> getTestsForStage(PullRequest pullRequest, CiStage stage) async {
     final presubmitTargets = [
       ...await getPresubmitTargets(pullRequest),
       ...await getPresubmitTargets(pullRequest, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild =>
-          target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests =>
-          target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
       },
     );
     return [...presubmitTargets];
@@ -1193,8 +1107,7 @@ $stackTrace
     // We'va failed to find the pull request; try a reverse look it from the check suite.
     if (pullRequest == null) {
       final int checkSuiteId = checkRun.checkSuite!.id!;
-      pullRequest = await githubChecksService.findMatchingPullRequest(
-          slug, sha, checkSuiteId);
+      pullRequest = await githubChecksService.findMatchingPullRequest(slug, sha, checkSuiteId);
     }
 
     // We cannot make any forward progress. Abandon all hope, Check runs who enter here.
@@ -1206,15 +1119,12 @@ $stackTrace
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!
-              .any((element) => element.name == Config.revertOfLabel)) {
-        log.info(
-            '$logCrumb: skipping generating the full set of checks for revert request.');
+          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
+        log.info('$logCrumb: skipping generating the full set of checks for revert request.');
       } else {
         // Schedule the tests that would have run in a call to triggerPresubmitTargets - but for both the
         // engine and the framework.
-        final presubmitTargets =
-            await getTestsForStage(pullRequest, CiStage.fusionTests);
+        final presubmitTargets = await getTestsForStage(pullRequest, CiStage.fusionTests);
 
         // Create the document for tracking test check runs.
         await initializeCiStagingDocument(
@@ -1256,8 +1166,7 @@ $stackTrace
     required String conclusion,
   }) async {
     final logCrumb = 'checkCompleted($name, $slug, $sha, $conclusion)';
-    final documentName =
-        CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
+    final documentName = CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
     log.info('$logCrumb: $documentName');
 
     // We're doing a transactional update, which could fail if multiple tasks are running at the same time; so retry
@@ -1290,23 +1199,20 @@ $stackTrace
   ///
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
-  Future<bool> processCheckRun(
-      cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
     switch (checkRunEvent.action) {
       case 'completed':
         await processCheckRunCompletion(checkRunEvent);
         return true;
 
       case 'rerequested':
-        log.fine(
-            'Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
+        log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
         final String? name = checkRunEvent.checkRun!.name;
         bool success = false;
         if (name == Config.kMergeQueueLockName) {
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          log.fine(
-              'Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
+          log.fine('Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
           success = true;
         } else if (name == Config.kCiYamlCheckName) {
           // The CheckRunEvent.checkRun.pullRequests array is empty for this
@@ -1314,33 +1220,28 @@ $stackTrace
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final String headSha = checkRunEvent.checkRun!.headSha!;
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          final PullRequest? pullRequest = await githubChecksService
-              .findMatchingPullRequest(slug, headSha, checkSuiteId);
+          final PullRequest? pullRequest =
+              await githubChecksService.findMatchingPullRequest(slug, headSha, checkSuiteId);
           if (pullRequest != null) {
-            log.fine(
-                'Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
+            log.fine('Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
             await triggerPresubmitTargets(pullRequest: pullRequest);
             success = true;
           } else {
-            log.warning(
-                'No matching PR found for head_sha in check run event.');
+            log.warning('No matching PR found for head_sha in check run event.');
           }
         } else {
           try {
             final RepositorySlug slug = checkRunEvent.repository!.slug();
-            final String gitBranch =
-                checkRunEvent.checkRun!.checkSuite!.headBranch ??
-                    Config.defaultBranch(slug);
+            final String gitBranch = checkRunEvent.checkRun!.checkSuite!.headBranch ?? Config.defaultBranch(slug);
             final String sha = checkRunEvent.checkRun!.headSha!;
 
             // Only merged commits are added to the datastore. If a matching commit is found, this must be a postsubmit checkrun.
             datastore = datastoreProvider(config.db);
-            final Key<String> commitKey = Commit.createKey(
-                db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
+            final Key<String> commitKey =
+                Commit.createKey(db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
             Commit? commit;
             try {
-              commit = await Commit.fromDatastore(
-                  datastore: datastore, key: commitKey);
+              commit = await Commit.fromDatastore(datastore: datastore, key: commitKey);
               log.fine('Commit found in datastore.');
             } on KeyNotFoundException {
               log.fine('Commit not found in datastore.');
@@ -1349,27 +1250,21 @@ $stackTrace
             if (commit == null) {
               log.fine('Rescheduling presubmit build.');
               // Does not do anything with the returned build oddly.
-              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(
-                  checkRunEvent: checkRunEvent);
+              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(checkRunEvent: checkRunEvent);
             } else {
               log.fine('Rescheduling postsubmit build.');
               firestoreService = await config.createFirestoreService();
               final String checkName = checkRunEvent.checkRun!.name!;
-              final Task task = await Task.fromDatastore(
-                  datastore: datastore, commitKey: commitKey, name: checkName);
+              final Task task = await Task.fromDatastore(datastore: datastore, commitKey: commitKey, name: checkName);
               // Query the lastest run of the `checkName` againt commit `sha`.
-              final List<firestore.Task> taskDocuments =
-                  await firestoreService.queryCommitTasks(commit.sha!);
-              final firestore.Task taskDocument = taskDocuments
-                  .where((taskDocument) => taskDocument.taskName == checkName)
-                  .toList()
-                  .first;
+              final List<firestore.Task> taskDocuments = await firestoreService.queryCommitTasks(commit.sha!);
+              final firestore.Task taskDocument =
+                  taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYamlSet ciYaml = await getCiYaml(commit);
-              final Target target = ciYaml.postsubmitTargets().singleWhere(
-                  (Target target) => target.value.name == task.name);
-              await luciBuildService
-                  .reschedulePostsubmitBuildUsingCheckRunEvent(
+              final Target target =
+                  ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
+              await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,
                 task: task,
@@ -1401,10 +1296,8 @@ $stackTrace
 
     log.info('Uploading commit ${commit.sha} info to bigquery.');
 
-    final TabledataResource tabledataResource =
-        await config.createTabledataResourceApi();
-    final List<Map<String, Object>> tableDataInsertAllRequestRows =
-        <Map<String, Object>>[];
+    final TabledataResource tabledataResource = await config.createTabledataResourceApi();
+    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
 
     /// Consolidate [commits] together
     ///
@@ -1423,16 +1316,15 @@ $stackTrace
     });
 
     /// Final [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest rows = TableDataInsertAllRequest.fromJson(
-        <String, Object>{'rows': tableDataInsertAllRequestRows});
+    final TableDataInsertAllRequest rows =
+        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
 
     /// Insert [commits] to [BigQuery]
     try {
       if (rows.rows == null) {
         log.warning('Rows to be inserted is null');
       } else {
-        log.info(
-            'Inserting ${rows.rows!.length} into big query for ${commit.sha}');
+        log.info('Inserting ${rows.rows!.length} into big query for ${commit.sha}');
       }
       await tabledataResource.insertAll(rows, projectId, dataset, table);
     } on ApiRequestError {
@@ -1445,12 +1337,10 @@ $stackTrace
   /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlSet].
   /// The generated tip of tree [CiYamlSet] will be compared against Presubmit Targets in current [CiYamlSet],
   /// to ensure new targets without `bringup: true` label are not added into the build.
-  Future<Commit> generateTotCommit(
-      {required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);
     firestoreService = await config.createFirestoreService();
-    final BuildStatusService buildStatusService =
-        buildStatusProvider(datastore, firestoreService);
+    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
     final Commit totCommit = (await buildStatusService
             .retrieveCommitStatus(
               limit: 1,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -12,6 +12,7 @@ import 'package:cocoon_service/src/model/firestore/ci_staging.dart';
 import 'package:cocoon_service/src/model/firestore/pr_check_runs.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/exceptions.dart';
+import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:cocoon_service/src/service/scheduler/policy.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
@@ -39,7 +40,6 @@ import 'config.dart';
 import 'datastore.dart';
 import 'firestore.dart';
 import 'github_checks_service.dart';
-import 'github_service.dart';
 import 'luci_build_service.dart';
 
 /// Scheduler service to validate all commits to supported Flutter repositories.
@@ -55,14 +55,17 @@ class Scheduler {
     required this.githubChecksService,
     required this.luciBuildService,
     required this.fusionTester,
+    required this.getFilesChanged,
     this.datastoreProvider = DatastoreService.defaultProvider,
     this.httpClientProvider = Providers.freshHttpClient,
     this.buildStatusProvider = BuildStatusService.defaultProvider,
     @visibleForTesting this.markCheckRunConclusion = CiStaging.markConclusion,
-    @visibleForTesting this.initializeCiStagingDocument = CiStaging.initializeDocument,
+    @visibleForTesting
+    this.initializeCiStagingDocument = CiStaging.initializeDocument,
     @visibleForTesting this.findPullRequestFor = PrCheckRuns.findPullRequestFor,
   });
 
+  final GetFilesChanged getFilesChanged;
   final BuildStatusServiceProvider buildStatusProvider;
   final CacheService cache;
   final Config config;
@@ -103,7 +106,10 @@ class Scheduler {
 
   /// List of check runs that do not need to be tracked or looked up in
   /// any staging logic.
-  static const kCheckRunsToIgnore = [Config.kMergeQueueLockName, Config.kCiYamlCheckName];
+  static const kCheckRunsToIgnore = [
+    Config.kMergeQueueLockName,
+    Config.kCiYamlCheckName
+  ];
 
   /// Briefly describes what the "Merge Queue Guard" check is for.
   ///
@@ -137,7 +143,8 @@ class Scheduler {
     datastore = datastoreProvider(config.db);
     // TODO(chillers): Support triggering on presubmit. https://github.com/flutter/flutter/issues/77858
     if (!pr.merged!) {
-      log.warning('Only pull requests that were closed and merged should have tasks scheduled');
+      log.warning(
+          'Only pull requests that were closed and merged should have tasks scheduled');
       return;
     }
 
@@ -146,7 +153,8 @@ class Scheduler {
     final String sha = pr.mergeCommitSha!;
 
     final String id = '$fullRepo/$branch/$sha';
-    final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
+    final Key<String> key =
+        datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit mergedCommit = Commit(
       author: pr.user!.login!,
       authorAvatarUrl: pr.user!.avatarUrl!,
@@ -177,26 +185,33 @@ class Scheduler {
 
     final CiYamlSet ciYaml = await getCiYaml(commit);
 
-    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final List<Target> initialTargets =
+        ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+    final isFusion =
+        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
     if (isFusion) {
-      final fusionPostTargets = ciYaml.postsubmitTargets(type: CiType.fusionEngine);
-      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets, type: CiType.fusionEngine);
+      final fusionPostTargets =
+          ciYaml.postsubmitTargets(type: CiType.fusionEngine);
+      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets,
+          type: CiType.fusionEngine);
       initialTargets.addAll(fusionInitialTargets);
       // Note on post submit targets: CiYaml filters out release_true for release branches and fusion trees
     }
 
     final List<Task> tasks = [...targetsToTasks(commit, initialTargets)];
 
-    final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
+    final List<Tuple<Target, Task, int>> toBeScheduled =
+        <Tuple<Target, Task, int>>[];
     for (Target target in initialTargets) {
-      final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
+      final Task task =
+          tasks.singleWhere((Task task) => task.name == target.value.name);
       SchedulerPolicy policy = target.schedulerPolicy;
       // Release branches should run every task
       if (Config.defaultBranch(commit.slug) != commit.branch) {
         policy = GuaranteedPolicy();
       }
-      final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
+      final int? priority =
+          await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over
         task.status = Task.statusInProgress;
@@ -206,12 +221,14 @@ class Scheduler {
 
     // Datastore must be written to generate task keys
     try {
-      log.info('Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
+      log.info(
+          'Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
       await datastore.withTransaction<void>((Transaction transaction) async {
         transaction.queueMutations(inserts: <Commit>[commit]);
         transaction.queueMutations(inserts: tasks);
         await transaction.commit();
-        log.fine('Committed ${tasks.length} new tasks for commit ${commit.sha!}');
+        log.fine(
+            'Committed ${tasks.length} new tasks for commit ${commit.sha!}');
       });
     } catch (error) {
       log.severe('Failed to add commit ${commit.sha!}: $error');
@@ -220,10 +237,14 @@ class Scheduler {
     log.info(
       'Firestore initial targets created for $commit: ${initialTargets.map((t) => '"${t.value.name}"').join(', ')}',
     );
-    final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
-    final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
-    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
-    final FirestoreService firestoreService = await config.createFirestoreService();
+    final firestore_commmit.Commit commitDocument =
+        firestore_commmit.commitToCommitDocument(commit);
+    final List<firestore.Task> taskDocuments =
+        firestore.targetsToTaskDocuments(commit, initialTargets);
+    final List<Write> writes =
+        documentsToWrites([...taskDocuments, commitDocument], exists: false);
+    final FirestoreService firestoreService =
+        await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.
     try {
       await firestoreService.writeViaTransaction(writes);
@@ -231,7 +252,8 @@ class Scheduler {
       log.warning('Failed to add to Firestore: $error');
     }
 
-    log.info('Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
+    log.info(
+        'Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
     await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
   }
@@ -239,14 +261,17 @@ class Scheduler {
   /// Schedule all builds in batch requests instead of a single request.
   ///
   /// Each batch request contains [Config.batchSize] builds to be scheduled.
-  Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+  Future<void> _batchScheduleBuilds(
+      Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final batchLog = StringBuffer(
       'Scheduling ${toBeScheduled.length} tasks in batches for ${commit.sha} as follows:\n',
     );
     final List<Future<void>> futures = <Future<void>>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
-      final batch = toBeScheduled.sublist(i, min(i + config.batchSize, toBeScheduled.length));
-      batchLog.writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
+      final batch = toBeScheduled.sublist(
+          i, min(i + config.batchSize, toBeScheduled.length));
+      batchLog
+          .writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
       futures.add(
         luciBuildService.schedulePostsubmitBuilds(
           commit: commit,
@@ -293,10 +318,14 @@ class Scheduler {
     Commit commit, {
     bool validate = false,
   }) async {
-    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
-    final Commit totCommit = await generateTotCommit(slug: commit.slug, branch: Config.defaultBranch(commit.slug));
-    final CiYamlSet totYaml = await _getCiYaml(totCommit, isFusionCommit: isFusion);
-    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
+    final isFusion =
+        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final Commit totCommit = await generateTotCommit(
+        slug: commit.slug, branch: Config.defaultBranch(commit.slug));
+    final CiYamlSet totYaml =
+        await _getCiYaml(totCommit, isFusionCommit: isFusion);
+    return _getCiYaml(commit,
+        totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
   }
 
   /// Load in memory the `.ci.yaml`.
@@ -304,7 +333,8 @@ class Scheduler {
     Commit commit, {
     CiYamlSet? totCiYaml,
     bool validate = false,
-    RetryOptions retryOptions = const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
+    RetryOptions retryOptions =
+        const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
     bool isFusionCommit = false,
   }) async {
     Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
@@ -321,7 +351,8 @@ class Scheduler {
             .writeToBuffer(),
         ttl: const Duration(hours: 1),
       ))!;
-      final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
+      final pb.SchedulerConfig schedulerConfig =
+          pb.SchedulerConfig.fromBuffer(ciYamlBytes);
       log.fine('Retrieved .ci.yaml for $ciPath');
       return schedulerConfig;
     }
@@ -365,7 +396,8 @@ class Scheduler {
       retryOptions: retryOptions,
     );
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
-    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
+    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()
+      ..mergeFromProto3Json(configYaml);
     return schedulerConfig;
   }
 
@@ -393,7 +425,8 @@ class Scheduler {
     List<String>? builderTriggerList,
   }) async {
     // Always cancel running builds so we don't ever schedule duplicates.
-    log.info('Attempting to cancel existing presubmit targets for ${pullRequest.number}');
+    log.info(
+        'Attempting to cancel existing presubmit targets for ${pullRequest.number}');
     await cancelPreSubmitTargets(
       pullRequest: pullRequest,
       reason: reason,
@@ -425,14 +458,17 @@ class Scheduler {
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
-        log.info('Skipping generating the full set of checks for revert request.');
+          pullRequest.labels!
+              .any((element) => element.name == Config.revertOfLabel)) {
+        log.info(
+            'Skipping generating the full set of checks for revert request.');
         unlockMergeGroup = true;
       } else {
         final presubmitTargets = isFusion
             ? await getTestsForStage(pullRequest, CiStage.fusionEngineBuild)
             : await getPresubmitTargets(pullRequest);
-        final presubmitTriggerTargets = filterTargets(presubmitTargets, builderTriggerList);
+        final presubmitTriggerTargets =
+            filterTargets(presubmitTargets, builderTriggerList);
 
         // When running presubmits for a fusion PR; create a new staging document to track tasks needed
         // to complete before we can schedule more tests (i.e. build engine artifacts before testing against them).
@@ -452,17 +488,20 @@ class Scheduler {
         );
       }
     } on FormatException catch (error, backtrace) {
-      log.warning('FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning(
+          'FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     } catch (error, backtrace) {
-      log.warning('Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning(
+          'Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     }
 
     // Update validate ci.yaml check
-    await closeCiYamlCheckRun('PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
+    await closeCiYamlCheckRun(
+        'PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
 
     // Normally the lock stays pending until the PR is ready to be enqueued, but
     // there are situations (see code above) when it needs to be unlocked
@@ -493,7 +532,8 @@ class Scheduler {
         conclusion: CheckRunConclusion.success,
       );
     } else {
-      log.warning('Marking $description ${Config.kCiYamlCheckName} as failed', e);
+      log.warning(
+          'Marking $description ${Config.kCiYamlCheckName} as failed', e);
       // Failure when validating ci.yaml
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
@@ -510,16 +550,19 @@ class Scheduler {
     }
   }
 
-  Future<CheckRun> createCiYamlCheckRun(PullRequest pullRequest, RepositorySlug slug) async {
+  Future<CheckRun> createCiYamlCheckRun(
+      PullRequest pullRequest, RepositorySlug slug) async {
     log.info('Creating ciYaml validation check run for ${pullRequest.number}');
-    final CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
+    final CheckRun ciValidationCheckRun =
+        await githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
       pullRequest.head!.sha!,
       Config.kCiYamlCheckName,
       output: const CheckRunOutput(
         title: Config.kCiYamlCheckName,
-        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+        summary:
+            'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
     return ciValidationCheckRun;
@@ -541,7 +584,8 @@ class Scheduler {
     final slug = mergeGroupEvent.repository!.slug();
     final isFusion = await fusionTester.isFusionBasedRef(slug, headSha);
 
-    final logCrumb = 'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
+    final logCrumb =
+        'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
 
     log.info('$logCrumb: scheduling merge group checks');
 
@@ -569,9 +613,13 @@ class Scheduler {
         project: 'flutter',
         bucket: 'prod',
       );
-      final availableTargets = {...mergeGroupTargets.where((target) => availableBuilders.contains(target.value.name))};
+      final availableTargets = {
+        ...mergeGroupTargets
+            .where((target) => availableBuilders.contains(target.value.name))
+      };
       if (availableTargets.length != mergeGroupTargets.length) {
-        log.warning('$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
+        log.warning(
+            '$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
       }
       // Create the staging doc that will track our engine progress and allow us to unlock
       // the merge group lock later.
@@ -600,7 +648,10 @@ class Scheduler {
       // Do not unlock the merge group guard in successful case - that will be done by staging checks.
       log.info('$logCrumb: successfully scheduled merge group checks');
     } catch (error, stackTrace) {
-      log.warning('$logCrumb: error encountered when scheduling merge group checks', error, stackTrace);
+      log.warning(
+          '$logCrumb: error encountered when scheduling merge group checks',
+          error,
+          stackTrace);
       // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
       // of the queue. To do that, the merge queue guard must fail as it's the
       // only required GitHub check.
@@ -627,11 +678,14 @@ $stackTrace
   ) async {
     final mergeGroupTargets = [
       ...await getMergeGroupTargets(baseRef, slug, headSha),
-      ...await getMergeGroupTargets(baseRef, slug, headSha, type: CiType.fusionEngine),
+      ...await getMergeGroupTargets(baseRef, slug, headSha,
+          type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild =>
+          target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests =>
+          target.value.properties['release_build'] != 'true'
       },
     );
 
@@ -644,7 +698,8 @@ $stackTrace
     String headSha, {
     CiType type = CiType.any,
   }) async {
-    log.info('Attempting to read merge group targets from ci.yaml for $headSha');
+    log.info(
+        'Attempting to read merge group targets from ci.yaml for $headSha');
 
     final Commit commit = Commit(
       branch: baseRef.substring('refs/heads/'.length),
@@ -658,13 +713,15 @@ $stackTrace
     } else {
       ciYaml = await getCiYaml(commit);
     }
-    log.info('ci.yaml loaded successfully; collecting merge group targets for $headSha');
+    log.info(
+        'ci.yaml loaded successfully; collecting merge group targets for $headSha');
 
     final inner = ciYaml.ciYamlFor(type);
 
     // Filter out targets with schedulers different than luci or cocoon.
     bool filter(Target target) =>
-        target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon;
+        target.value.scheduler == pb.SchedulerSystem.luci ||
+        target.value.scheduler == pb.SchedulerSystem.cocoon;
     return [...inner.presubmitTargets.where(filter)];
   }
 
@@ -685,7 +742,8 @@ $stackTrace
   /// While this check is still in progress, the merge queue will not merge the
   /// respective PR onto the target branch (e.g. main or master), because this
   /// check is "required".
-  Future<CheckRun> lockMergeGroupChecks(RepositorySlug slug, String headSha) async {
+  Future<CheckRun> lockMergeGroupChecks(
+      RepositorySlug slug, String headSha) async {
     return githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
@@ -706,7 +764,8 @@ $stackTrace
   ///
   /// If the guard is guarding a pull request, this immediately makes the pull
   /// request eligible for enqueuing into the merge queue.
-  Future<void> unlockMergeQueueGuard(RepositorySlug slug, String headSha, CheckRun lock) async {
+  Future<void> unlockMergeQueueGuard(
+      RepositorySlug slug, String headSha, CheckRun lock) async {
     log.info('Unlocking Merge Queue Guard for $slug/$headSha');
     await githubChecksService.githubChecksUtil.updateCheckRun(
       config,
@@ -750,7 +809,10 @@ $stackTrace
     List<String>? builderTriggerList,
   ) {
     if (builderTriggerList != null && builderTriggerList.isNotEmpty) {
-      return presubmitTarget.where((Target target) => builderTriggerList.contains(target.value.name)).toList();
+      return presubmitTarget
+          .where(
+              (Target target) => builderTriggerList.contains(target.value.name))
+          .toList();
     }
     return presubmitTarget;
   }
@@ -764,14 +826,17 @@ $stackTrace
     required PullRequest pullRequest,
     required CheckSuiteEvent checkSuiteEvent,
   }) async {
-    final GitHub githubClient = await config.createGitHubClient(pullRequest: pullRequest);
-    final Map<String, CheckRun> checkRuns = await githubChecksService.githubChecksUtil.allCheckRuns(
+    final GitHub githubClient =
+        await config.createGitHubClient(pullRequest: pullRequest);
+    final Map<String, CheckRun> checkRuns =
+        await githubChecksService.githubChecksUtil.allCheckRuns(
       githubClient,
       checkSuiteEvent,
     );
-    final List<Target> presubmitTargets = await getPresubmitTargets(pullRequest);
-    final List<bbv2.Build?> failedBuilds =
-        await luciBuildService.failedBuilds(pullRequest: pullRequest, targets: presubmitTargets);
+    final List<Target> presubmitTargets =
+        await getPresubmitTargets(pullRequest);
+    final List<bbv2.Build?> failedBuilds = await luciBuildService.failedBuilds(
+        pullRequest: pullRequest, targets: presubmitTargets);
     for (bbv2.Build? build in failedBuilds) {
       final CheckRun checkRun = checkRuns[build!.builder.builder]!;
 
@@ -781,7 +846,10 @@ $stackTrace
       }
 
       await luciBuildService.scheduleTryBuilds(
-        targets: presubmitTargets.where((Target target) => build.builder.builder == target.value.name).toList(),
+        targets: presubmitTargets
+            .where(
+                (Target target) => build.builder.builder == target.value.name)
+            .toList(),
         pullRequest: pullRequest,
         checkSuiteEvent: checkSuiteEvent,
       );
@@ -794,14 +862,18 @@ $stackTrace
   ///
   /// In the case there is an issue getting the diff from GitHub, all targets are returned.
   @visibleForTesting
-  Future<List<Target>> getPresubmitTargets(PullRequest pullRequest, {CiType type = CiType.any}) async {
+  Future<List<Target>> getPresubmitTargets(
+    PullRequest pullRequest, {
+    CiType type = CiType.any,
+  }) async {
     final Commit commit = Commit(
       branch: pullRequest.base!.ref,
       repository: pullRequest.base!.repo!.fullName,
       sha: pullRequest.head!.sha,
     );
     late CiYamlSet ciYaml;
-    log.info('Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
+    log.info(
+        'Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
     if (commit.branch == Config.defaultBranch(commit.slug)) {
       ciYaml = await getCiYaml(commit, validate: true);
     } else {
@@ -816,19 +888,23 @@ $stackTrace
     final List<Target> presubmitTargets = inner.presubmitTargets
         .where(
           (Target target) =>
-              target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
+              target.value.scheduler == pb.SchedulerSystem.luci ||
+              target.value.scheduler == pb.SchedulerSystem.cocoon,
         )
         .toList();
 
     // See https://github.com/flutter/flutter/issues/138430.
-    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(inner, pullRequest);
+    final includePostsubmitAsPresubmit =
+        _includePostsubmitAsPresubmit(inner, pullRequest);
     if (includePostsubmitAsPresubmit) {
-      log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
+      log.info(
+          'Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in inner.postsubmitTargets) {
         // We don't want to include a presubmit twice
         // We don't want to run the builder_cache target as a presubmit
-        if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
+        if (!target.value.presubmit &&
+            !target.value.properties.containsKey('cache_name')) {
           presubmitTargets.add(target);
         }
       }
@@ -836,27 +912,20 @@ $stackTrace
 
     log.info('Collected ${presubmitTargets.length} presubmit targets.');
     // Release branches should run every test.
-    if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
-      log.info('Release branch found, scheduling all targets for ${pullRequest.number}');
+    if (pullRequest.base!.ref !=
+        Config.defaultBranch(pullRequest.base!.repo!.slug())) {
+      log.info(
+          'Release branch found, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
     if (includePostsubmitAsPresubmit) {
-      log.info('Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
+      log.info(
+          'Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
 
     // Filter builders based on the PR diff
-    final GithubService githubService = await config.createGithubService(commit.slug);
-    List<String> files = <String>[];
-    try {
-      files = await githubService.listFiles(pullRequest);
-    } on GitHubError catch (error) {
-      log.warning(error);
-      log.warning('Unable to get diff for pullRequest=$pullRequest');
-      log.warning('Running all targets');
-      return presubmitTargets.toList();
-    }
-    return getTargetsToRun(presubmitTargets, files);
+    // FIXME: Implement.
   }
 
   static final _allowTestAll = {
@@ -865,11 +934,13 @@ $stackTrace
   };
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+  static bool _includePostsubmitAsPresubmit(
+      CiYaml ciYaml, PullRequest pullRequest) {
     if (!_allowTestAll.contains(ciYaml.slug)) {
       return false;
     }
-    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
+    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ??
+        false) {
       return true;
     }
     return false;
@@ -879,14 +950,19 @@ $stackTrace
   ///
   /// Handles both fusion engine build and test stages, and both pull requests
   /// and merge groups.
-  Future<bool> processCheckRunCompletion(cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRunCompletion(
+      cocoon_checks.CheckRunEvent checkRunEvent) async {
     final checkRun = checkRunEvent.checkRun!;
     final name = checkRun.name;
     final sha = checkRun.headSha;
     final slug = checkRunEvent.repository?.slug();
     final conclusion = checkRun.conclusion;
 
-    if (name == null || sha == null || slug == null || conclusion == null || kCheckRunsToIgnore.contains(name)) {
+    if (name == null ||
+        sha == null ||
+        slug == null ||
+        conclusion == null ||
+        kCheckRunsToIgnore.contains(name)) {
       return true;
     }
 
@@ -955,7 +1031,8 @@ $stackTrace
 
     // Are there tests remaining? Keep waiting.
     if (stagingConclusion.isPending) {
-      log.info('$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
+      log.info(
+          '$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
       return false;
     }
 
@@ -1037,7 +1114,8 @@ $stackTrace
       return;
     }
 
-    log.info('$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
+    log.info(
+        '$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
 
     await _proceedToCiTestingStage(
       checkRun: checkRun,
@@ -1059,14 +1137,17 @@ $stackTrace
   }
 
   /// Returns the presubmit targets for the fusion repo [pullRequest] that should run for the given [stage].
-  Future<List<Target>> getTestsForStage(PullRequest pullRequest, CiStage stage) async {
+  Future<List<Target>> getTestsForStage(
+      PullRequest pullRequest, CiStage stage) async {
     final presubmitTargets = [
       ...await getPresubmitTargets(pullRequest),
       ...await getPresubmitTargets(pullRequest, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild =>
+          target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests =>
+          target.value.properties['release_build'] != 'true'
       },
     );
     return [...presubmitTargets];
@@ -1112,7 +1193,8 @@ $stackTrace
     // We'va failed to find the pull request; try a reverse look it from the check suite.
     if (pullRequest == null) {
       final int checkSuiteId = checkRun.checkSuite!.id!;
-      pullRequest = await githubChecksService.findMatchingPullRequest(slug, sha, checkSuiteId);
+      pullRequest = await githubChecksService.findMatchingPullRequest(
+          slug, sha, checkSuiteId);
     }
 
     // We cannot make any forward progress. Abandon all hope, Check runs who enter here.
@@ -1124,12 +1206,15 @@ $stackTrace
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
-        log.info('$logCrumb: skipping generating the full set of checks for revert request.');
+          pullRequest.labels!
+              .any((element) => element.name == Config.revertOfLabel)) {
+        log.info(
+            '$logCrumb: skipping generating the full set of checks for revert request.');
       } else {
         // Schedule the tests that would have run in a call to triggerPresubmitTargets - but for both the
         // engine and the framework.
-        final presubmitTargets = await getTestsForStage(pullRequest, CiStage.fusionTests);
+        final presubmitTargets =
+            await getTestsForStage(pullRequest, CiStage.fusionTests);
 
         // Create the document for tracking test check runs.
         await initializeCiStagingDocument(
@@ -1171,7 +1256,8 @@ $stackTrace
     required String conclusion,
   }) async {
     final logCrumb = 'checkCompleted($name, $slug, $sha, $conclusion)';
-    final documentName = CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
+    final documentName =
+        CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
     log.info('$logCrumb: $documentName');
 
     // We're doing a transactional update, which could fail if multiple tasks are running at the same time; so retry
@@ -1204,20 +1290,23 @@ $stackTrace
   ///
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
-  Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRun(
+      cocoon_checks.CheckRunEvent checkRunEvent) async {
     switch (checkRunEvent.action) {
       case 'completed':
         await processCheckRunCompletion(checkRunEvent);
         return true;
 
       case 'rerequested':
-        log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
+        log.fine(
+            'Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
         final String? name = checkRunEvent.checkRun!.name;
         bool success = false;
         if (name == Config.kMergeQueueLockName) {
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          log.fine('Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
+          log.fine(
+              'Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
           success = true;
         } else if (name == Config.kCiYamlCheckName) {
           // The CheckRunEvent.checkRun.pullRequests array is empty for this
@@ -1225,28 +1314,33 @@ $stackTrace
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final String headSha = checkRunEvent.checkRun!.headSha!;
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          final PullRequest? pullRequest =
-              await githubChecksService.findMatchingPullRequest(slug, headSha, checkSuiteId);
+          final PullRequest? pullRequest = await githubChecksService
+              .findMatchingPullRequest(slug, headSha, checkSuiteId);
           if (pullRequest != null) {
-            log.fine('Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
+            log.fine(
+                'Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
             await triggerPresubmitTargets(pullRequest: pullRequest);
             success = true;
           } else {
-            log.warning('No matching PR found for head_sha in check run event.');
+            log.warning(
+                'No matching PR found for head_sha in check run event.');
           }
         } else {
           try {
             final RepositorySlug slug = checkRunEvent.repository!.slug();
-            final String gitBranch = checkRunEvent.checkRun!.checkSuite!.headBranch ?? Config.defaultBranch(slug);
+            final String gitBranch =
+                checkRunEvent.checkRun!.checkSuite!.headBranch ??
+                    Config.defaultBranch(slug);
             final String sha = checkRunEvent.checkRun!.headSha!;
 
             // Only merged commits are added to the datastore. If a matching commit is found, this must be a postsubmit checkrun.
             datastore = datastoreProvider(config.db);
-            final Key<String> commitKey =
-                Commit.createKey(db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
+            final Key<String> commitKey = Commit.createKey(
+                db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
             Commit? commit;
             try {
-              commit = await Commit.fromDatastore(datastore: datastore, key: commitKey);
+              commit = await Commit.fromDatastore(
+                  datastore: datastore, key: commitKey);
               log.fine('Commit found in datastore.');
             } on KeyNotFoundException {
               log.fine('Commit not found in datastore.');
@@ -1255,21 +1349,27 @@ $stackTrace
             if (commit == null) {
               log.fine('Rescheduling presubmit build.');
               // Does not do anything with the returned build oddly.
-              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(checkRunEvent: checkRunEvent);
+              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(
+                  checkRunEvent: checkRunEvent);
             } else {
               log.fine('Rescheduling postsubmit build.');
               firestoreService = await config.createFirestoreService();
               final String checkName = checkRunEvent.checkRun!.name!;
-              final Task task = await Task.fromDatastore(datastore: datastore, commitKey: commitKey, name: checkName);
+              final Task task = await Task.fromDatastore(
+                  datastore: datastore, commitKey: commitKey, name: checkName);
               // Query the lastest run of the `checkName` againt commit `sha`.
-              final List<firestore.Task> taskDocuments = await firestoreService.queryCommitTasks(commit.sha!);
-              final firestore.Task taskDocument =
-                  taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
+              final List<firestore.Task> taskDocuments =
+                  await firestoreService.queryCommitTasks(commit.sha!);
+              final firestore.Task taskDocument = taskDocuments
+                  .where((taskDocument) => taskDocument.taskName == checkName)
+                  .toList()
+                  .first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYamlSet ciYaml = await getCiYaml(commit);
-              final Target target =
-                  ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
-              await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
+              final Target target = ciYaml.postsubmitTargets().singleWhere(
+                  (Target target) => target.value.name == task.name);
+              await luciBuildService
+                  .reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,
                 task: task,
@@ -1301,8 +1401,10 @@ $stackTrace
 
     log.info('Uploading commit ${commit.sha} info to bigquery.');
 
-    final TabledataResource tabledataResource = await config.createTabledataResourceApi();
-    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
+    final TabledataResource tabledataResource =
+        await config.createTabledataResourceApi();
+    final List<Map<String, Object>> tableDataInsertAllRequestRows =
+        <Map<String, Object>>[];
 
     /// Consolidate [commits] together
     ///
@@ -1321,15 +1423,16 @@ $stackTrace
     });
 
     /// Final [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest rows =
-        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
+    final TableDataInsertAllRequest rows = TableDataInsertAllRequest.fromJson(
+        <String, Object>{'rows': tableDataInsertAllRequestRows});
 
     /// Insert [commits] to [BigQuery]
     try {
       if (rows.rows == null) {
         log.warning('Rows to be inserted is null');
       } else {
-        log.info('Inserting ${rows.rows!.length} into big query for ${commit.sha}');
+        log.info(
+            'Inserting ${rows.rows!.length} into big query for ${commit.sha}');
       }
       await tabledataResource.insertAll(rows, projectId, dataset, table);
     } on ApiRequestError {
@@ -1342,10 +1445,12 @@ $stackTrace
   /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlSet].
   /// The generated tip of tree [CiYamlSet] will be compared against Presubmit Targets in current [CiYamlSet],
   /// to ensure new targets without `bringup: true` label are not added into the build.
-  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit(
+      {required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);
     firestoreService = await config.createFirestoreService();
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
+    final BuildStatusService buildStatusService =
+        buildStatusProvider(datastore, firestoreService);
     final Commit totCommit = (await buildStatusService
             .retrieveCommitStatus(
               limit: 1,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -60,7 +60,8 @@ class Scheduler {
     this.httpClientProvider = Providers.freshHttpClient,
     this.buildStatusProvider = BuildStatusService.defaultProvider,
     @visibleForTesting this.markCheckRunConclusion = CiStaging.markConclusion,
-    @visibleForTesting this.initializeCiStagingDocument = CiStaging.initializeDocument,
+    @visibleForTesting
+    this.initializeCiStagingDocument = CiStaging.initializeDocument,
     @visibleForTesting this.findPullRequestFor = PrCheckRuns.findPullRequestFor,
   });
 
@@ -105,7 +106,10 @@ class Scheduler {
 
   /// List of check runs that do not need to be tracked or looked up in
   /// any staging logic.
-  static const kCheckRunsToIgnore = [Config.kMergeQueueLockName, Config.kCiYamlCheckName];
+  static const kCheckRunsToIgnore = [
+    Config.kMergeQueueLockName,
+    Config.kCiYamlCheckName
+  ];
 
   /// Briefly describes what the "Merge Queue Guard" check is for.
   ///
@@ -139,7 +143,8 @@ class Scheduler {
     datastore = datastoreProvider(config.db);
     // TODO(chillers): Support triggering on presubmit. https://github.com/flutter/flutter/issues/77858
     if (!pr.merged!) {
-      log.warning('Only pull requests that were closed and merged should have tasks scheduled');
+      log.warning(
+          'Only pull requests that were closed and merged should have tasks scheduled');
       return;
     }
 
@@ -148,7 +153,8 @@ class Scheduler {
     final String sha = pr.mergeCommitSha!;
 
     final String id = '$fullRepo/$branch/$sha';
-    final Key<String> key = datastore.db.emptyKey.append<String>(Commit, id: id);
+    final Key<String> key =
+        datastore.db.emptyKey.append<String>(Commit, id: id);
     final Commit mergedCommit = Commit(
       author: pr.user!.login!,
       authorAvatarUrl: pr.user!.avatarUrl!,
@@ -179,26 +185,33 @@ class Scheduler {
 
     final CiYamlSet ciYaml = await getCiYaml(commit);
 
-    final List<Target> initialTargets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
-    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final List<Target> initialTargets =
+        ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
+    final isFusion =
+        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
     if (isFusion) {
-      final fusionPostTargets = ciYaml.postsubmitTargets(type: CiType.fusionEngine);
-      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets, type: CiType.fusionEngine);
+      final fusionPostTargets =
+          ciYaml.postsubmitTargets(type: CiType.fusionEngine);
+      final fusionInitialTargets = ciYaml.getInitialTargets(fusionPostTargets,
+          type: CiType.fusionEngine);
       initialTargets.addAll(fusionInitialTargets);
       // Note on post submit targets: CiYaml filters out release_true for release branches and fusion trees
     }
 
     final List<Task> tasks = [...targetsToTasks(commit, initialTargets)];
 
-    final List<Tuple<Target, Task, int>> toBeScheduled = <Tuple<Target, Task, int>>[];
+    final List<Tuple<Target, Task, int>> toBeScheduled =
+        <Tuple<Target, Task, int>>[];
     for (Target target in initialTargets) {
-      final Task task = tasks.singleWhere((Task task) => task.name == target.value.name);
+      final Task task =
+          tasks.singleWhere((Task task) => task.name == target.value.name);
       SchedulerPolicy policy = target.schedulerPolicy;
       // Release branches should run every task
       if (Config.defaultBranch(commit.slug) != commit.branch) {
         policy = GuaranteedPolicy();
       }
-      final int? priority = await policy.triggerPriority(task: task, datastore: datastore);
+      final int? priority =
+          await policy.triggerPriority(task: task, datastore: datastore);
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over
         task.status = Task.statusInProgress;
@@ -208,12 +221,14 @@ class Scheduler {
 
     // Datastore must be written to generate task keys
     try {
-      log.info('Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
+      log.info(
+          'Datastore tasks created for $commit: ${tasks.map((t) => '"${t.name}"').join(', ')}');
       await datastore.withTransaction<void>((Transaction transaction) async {
         transaction.queueMutations(inserts: <Commit>[commit]);
         transaction.queueMutations(inserts: tasks);
         await transaction.commit();
-        log.fine('Committed ${tasks.length} new tasks for commit ${commit.sha!}');
+        log.fine(
+            'Committed ${tasks.length} new tasks for commit ${commit.sha!}');
       });
     } catch (error) {
       log.severe('Failed to add commit ${commit.sha!}: $error');
@@ -222,10 +237,14 @@ class Scheduler {
     log.info(
       'Firestore initial targets created for $commit: ${initialTargets.map((t) => '"${t.value.name}"').join(', ')}',
     );
-    final firestore_commmit.Commit commitDocument = firestore_commmit.commitToCommitDocument(commit);
-    final List<firestore.Task> taskDocuments = firestore.targetsToTaskDocuments(commit, initialTargets);
-    final List<Write> writes = documentsToWrites([...taskDocuments, commitDocument], exists: false);
-    final FirestoreService firestoreService = await config.createFirestoreService();
+    final firestore_commmit.Commit commitDocument =
+        firestore_commmit.commitToCommitDocument(commit);
+    final List<firestore.Task> taskDocuments =
+        firestore.targetsToTaskDocuments(commit, initialTargets);
+    final List<Write> writes =
+        documentsToWrites([...taskDocuments, commitDocument], exists: false);
+    final FirestoreService firestoreService =
+        await config.createFirestoreService();
     // TODO(keyonghan): remove try catch logic after validated to work.
     try {
       await firestoreService.writeViaTransaction(writes);
@@ -233,7 +252,8 @@ class Scheduler {
       log.warning('Failed to add to Firestore: $error');
     }
 
-    log.info('Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
+    log.info(
+        'Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.second.name}"').join(', ')}');
     await _batchScheduleBuilds(commit, toBeScheduled);
     await _uploadToBigQuery(commit);
   }
@@ -241,14 +261,17 @@ class Scheduler {
   /// Schedule all builds in batch requests instead of a single request.
   ///
   /// Each batch request contains [Config.batchSize] builds to be scheduled.
-  Future<void> _batchScheduleBuilds(Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
+  Future<void> _batchScheduleBuilds(
+      Commit commit, List<Tuple<Target, Task, int>> toBeScheduled) async {
     final batchLog = StringBuffer(
       'Scheduling ${toBeScheduled.length} tasks in batches for ${commit.sha} as follows:\n',
     );
     final List<Future<void>> futures = <Future<void>>[];
     for (int i = 0; i < toBeScheduled.length; i += config.batchSize) {
-      final batch = toBeScheduled.sublist(i, min(i + config.batchSize, toBeScheduled.length));
-      batchLog.writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
+      final batch = toBeScheduled.sublist(
+          i, min(i + config.batchSize, toBeScheduled.length));
+      batchLog
+          .writeln('  - ${batch.map((t) => '"${t.second.name}"').join(', ')}');
       futures.add(
         luciBuildService.schedulePostsubmitBuilds(
           commit: commit,
@@ -295,10 +318,14 @@ class Scheduler {
     Commit commit, {
     bool validate = false,
   }) async {
-    final isFusion = await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
-    final Commit totCommit = await generateTotCommit(slug: commit.slug, branch: Config.defaultBranch(commit.slug));
-    final CiYamlSet totYaml = await _getCiYaml(totCommit, isFusionCommit: isFusion);
-    return _getCiYaml(commit, totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
+    final isFusion =
+        await fusionTester.isFusionBasedRef(commit.slug, commit.sha!);
+    final Commit totCommit = await generateTotCommit(
+        slug: commit.slug, branch: Config.defaultBranch(commit.slug));
+    final CiYamlSet totYaml =
+        await _getCiYaml(totCommit, isFusionCommit: isFusion);
+    return _getCiYaml(commit,
+        totCiYaml: totYaml, validate: validate, isFusionCommit: isFusion);
   }
 
   /// Load in memory the `.ci.yaml`.
@@ -306,7 +333,8 @@ class Scheduler {
     Commit commit, {
     CiYamlSet? totCiYaml,
     bool validate = false,
-    RetryOptions retryOptions = const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
+    RetryOptions retryOptions =
+        const RetryOptions(delayFactor: Duration(seconds: 2), maxAttempts: 4),
     bool isFusionCommit = false,
   }) async {
     Future<pb.SchedulerConfig> getSchedulerConfig(String ciPath) async {
@@ -323,7 +351,8 @@ class Scheduler {
             .writeToBuffer(),
         ttl: const Duration(hours: 1),
       ))!;
-      final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig.fromBuffer(ciYamlBytes);
+      final pb.SchedulerConfig schedulerConfig =
+          pb.SchedulerConfig.fromBuffer(ciYamlBytes);
       log.fine('Retrieved .ci.yaml for $ciPath');
       return schedulerConfig;
     }
@@ -367,7 +396,8 @@ class Scheduler {
       retryOptions: retryOptions,
     );
     final YamlMap configYaml = loadYaml(configContent) as YamlMap;
-    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()..mergeFromProto3Json(configYaml);
+    final pb.SchedulerConfig schedulerConfig = pb.SchedulerConfig()
+      ..mergeFromProto3Json(configYaml);
     return schedulerConfig;
   }
 
@@ -395,7 +425,8 @@ class Scheduler {
     List<String>? builderTriggerList,
   }) async {
     // Always cancel running builds so we don't ever schedule duplicates.
-    log.info('Attempting to cancel existing presubmit targets for ${pullRequest.number}');
+    log.info(
+        'Attempting to cancel existing presubmit targets for ${pullRequest.number}');
     await cancelPreSubmitTargets(
       pullRequest: pullRequest,
       reason: reason,
@@ -427,14 +458,17 @@ class Scheduler {
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
-        log.info('Skipping generating the full set of checks for revert request.');
+          pullRequest.labels!
+              .any((element) => element.name == Config.revertOfLabel)) {
+        log.info(
+            'Skipping generating the full set of checks for revert request.');
         unlockMergeGroup = true;
       } else {
         final presubmitTargets = isFusion
             ? await getTestsForStage(pullRequest, CiStage.fusionEngineBuild)
             : await getPresubmitTargets(pullRequest);
-        final presubmitTriggerTargets = filterTargets(presubmitTargets, builderTriggerList);
+        final presubmitTriggerTargets =
+            filterTargets(presubmitTargets, builderTriggerList);
 
         // When running presubmits for a fusion PR; create a new staging document to track tasks needed
         // to complete before we can schedule more tests (i.e. build engine artifacts before testing against them).
@@ -454,17 +488,20 @@ class Scheduler {
         );
       }
     } on FormatException catch (error, backtrace) {
-      log.warning('FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning(
+          'FormatException encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     } catch (error, backtrace) {
-      log.warning('Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
+      log.warning(
+          'Exception encountered when scheduling presubmit targets for ${pullRequest.number}');
       log.warning(backtrace.toString());
       exception = error;
     }
 
     // Update validate ci.yaml check
-    await closeCiYamlCheckRun('PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
+    await closeCiYamlCheckRun(
+        'PR ${pullRequest.number}', exception, slug, ciValidationCheckRun);
 
     // Normally the lock stays pending until the PR is ready to be enqueued, but
     // there are situations (see code above) when it needs to be unlocked
@@ -495,7 +532,8 @@ class Scheduler {
         conclusion: CheckRunConclusion.success,
       );
     } else {
-      log.warning('Marking $description ${Config.kCiYamlCheckName} as failed', e);
+      log.warning(
+          'Marking $description ${Config.kCiYamlCheckName} as failed', e);
       // Failure when validating ci.yaml
       await githubChecksService.githubChecksUtil.updateCheckRun(
         config,
@@ -512,16 +550,19 @@ class Scheduler {
     }
   }
 
-  Future<CheckRun> createCiYamlCheckRun(PullRequest pullRequest, RepositorySlug slug) async {
+  Future<CheckRun> createCiYamlCheckRun(
+      PullRequest pullRequest, RepositorySlug slug) async {
     log.info('Creating ciYaml validation check run for ${pullRequest.number}');
-    final CheckRun ciValidationCheckRun = await githubChecksService.githubChecksUtil.createCheckRun(
+    final CheckRun ciValidationCheckRun =
+        await githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
       pullRequest.head!.sha!,
       Config.kCiYamlCheckName,
       output: const CheckRunOutput(
         title: Config.kCiYamlCheckName,
-        summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
+        summary:
+            'If this check is stuck pending, push an empty commit to retrigger the checks',
       ),
     );
     return ciValidationCheckRun;
@@ -543,7 +584,8 @@ class Scheduler {
     final slug = mergeGroupEvent.repository!.slug();
     final isFusion = await fusionTester.isFusionBasedRef(slug, headSha);
 
-    final logCrumb = 'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
+    final logCrumb =
+        'triggerMergeGroupTargets($slug, $headSha, ${isFusion ? 'real' : 'simulated'})';
 
     log.info('$logCrumb: scheduling merge group checks');
 
@@ -571,9 +613,13 @@ class Scheduler {
         project: 'flutter',
         bucket: 'prod',
       );
-      final availableTargets = {...mergeGroupTargets.where((target) => availableBuilders.contains(target.value.name))};
+      final availableTargets = {
+        ...mergeGroupTargets
+            .where((target) => availableBuilders.contains(target.value.name))
+      };
       if (availableTargets.length != mergeGroupTargets.length) {
-        log.warning('$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
+        log.warning(
+            '$logCrumb: missing builders for targtets: ${mergeGroupTargets.difference(availableTargets)}');
       }
       // Create the staging doc that will track our engine progress and allow us to unlock
       // the merge group lock later.
@@ -602,7 +648,10 @@ class Scheduler {
       // Do not unlock the merge group guard in successful case - that will be done by staging checks.
       log.info('$logCrumb: successfully scheduled merge group checks');
     } catch (error, stackTrace) {
-      log.warning('$logCrumb: error encountered when scheduling merge group checks', error, stackTrace);
+      log.warning(
+          '$logCrumb: error encountered when scheduling merge group checks',
+          error,
+          stackTrace);
       // If Cocoon/LUCI failed to schedule targets, the PR should be kicked out
       // of the queue. To do that, the merge queue guard must fail as it's the
       // only required GitHub check.
@@ -629,11 +678,14 @@ $stackTrace
   ) async {
     final mergeGroupTargets = [
       ...await getMergeGroupTargets(baseRef, slug, headSha),
-      ...await getMergeGroupTargets(baseRef, slug, headSha, type: CiType.fusionEngine),
+      ...await getMergeGroupTargets(baseRef, slug, headSha,
+          type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild =>
+          target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests =>
+          target.value.properties['release_build'] != 'true'
       },
     );
 
@@ -646,7 +698,8 @@ $stackTrace
     String headSha, {
     CiType type = CiType.any,
   }) async {
-    log.info('Attempting to read merge group targets from ci.yaml for $headSha');
+    log.info(
+        'Attempting to read merge group targets from ci.yaml for $headSha');
 
     final Commit commit = Commit(
       branch: baseRef.substring('refs/heads/'.length),
@@ -660,13 +713,15 @@ $stackTrace
     } else {
       ciYaml = await getCiYaml(commit);
     }
-    log.info('ci.yaml loaded successfully; collecting merge group targets for $headSha');
+    log.info(
+        'ci.yaml loaded successfully; collecting merge group targets for $headSha');
 
     final inner = ciYaml.ciYamlFor(type);
 
     // Filter out targets with schedulers different than luci or cocoon.
     bool filter(Target target) =>
-        target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon;
+        target.value.scheduler == pb.SchedulerSystem.luci ||
+        target.value.scheduler == pb.SchedulerSystem.cocoon;
     return [...inner.presubmitTargets.where(filter)];
   }
 
@@ -687,7 +742,8 @@ $stackTrace
   /// While this check is still in progress, the merge queue will not merge the
   /// respective PR onto the target branch (e.g. main or master), because this
   /// check is "required".
-  Future<CheckRun> lockMergeGroupChecks(RepositorySlug slug, String headSha) async {
+  Future<CheckRun> lockMergeGroupChecks(
+      RepositorySlug slug, String headSha) async {
     return githubChecksService.githubChecksUtil.createCheckRun(
       config,
       slug,
@@ -708,7 +764,8 @@ $stackTrace
   ///
   /// If the guard is guarding a pull request, this immediately makes the pull
   /// request eligible for enqueuing into the merge queue.
-  Future<void> unlockMergeQueueGuard(RepositorySlug slug, String headSha, CheckRun lock) async {
+  Future<void> unlockMergeQueueGuard(
+      RepositorySlug slug, String headSha, CheckRun lock) async {
     log.info('Unlocking Merge Queue Guard for $slug/$headSha');
     await githubChecksService.githubChecksUtil.updateCheckRun(
       config,
@@ -752,7 +809,10 @@ $stackTrace
     List<String>? builderTriggerList,
   ) {
     if (builderTriggerList != null && builderTriggerList.isNotEmpty) {
-      return presubmitTarget.where((Target target) => builderTriggerList.contains(target.value.name)).toList();
+      return presubmitTarget
+          .where(
+              (Target target) => builderTriggerList.contains(target.value.name))
+          .toList();
     }
     return presubmitTarget;
   }
@@ -766,14 +826,17 @@ $stackTrace
     required PullRequest pullRequest,
     required CheckSuiteEvent checkSuiteEvent,
   }) async {
-    final GitHub githubClient = await config.createGitHubClient(pullRequest: pullRequest);
-    final Map<String, CheckRun> checkRuns = await githubChecksService.githubChecksUtil.allCheckRuns(
+    final GitHub githubClient =
+        await config.createGitHubClient(pullRequest: pullRequest);
+    final Map<String, CheckRun> checkRuns =
+        await githubChecksService.githubChecksUtil.allCheckRuns(
       githubClient,
       checkSuiteEvent,
     );
-    final List<Target> presubmitTargets = await getPresubmitTargets(pullRequest);
-    final List<bbv2.Build?> failedBuilds =
-        await luciBuildService.failedBuilds(pullRequest: pullRequest, targets: presubmitTargets);
+    final List<Target> presubmitTargets =
+        await getPresubmitTargets(pullRequest);
+    final List<bbv2.Build?> failedBuilds = await luciBuildService.failedBuilds(
+        pullRequest: pullRequest, targets: presubmitTargets);
     for (bbv2.Build? build in failedBuilds) {
       final CheckRun checkRun = checkRuns[build!.builder.builder]!;
 
@@ -783,7 +846,10 @@ $stackTrace
       }
 
       await luciBuildService.scheduleTryBuilds(
-        targets: presubmitTargets.where((Target target) => build.builder.builder == target.value.name).toList(),
+        targets: presubmitTargets
+            .where(
+                (Target target) => build.builder.builder == target.value.name)
+            .toList(),
         pullRequest: pullRequest,
         checkSuiteEvent: checkSuiteEvent,
       );
@@ -806,7 +872,8 @@ $stackTrace
       sha: pullRequest.head!.sha,
     );
     late CiYamlSet ciYaml;
-    log.info('Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
+    log.info(
+        'Attempting to read presubmit targets from ci.yaml for ${pullRequest.number}');
     if (commit.branch == Config.defaultBranch(commit.slug)) {
       ciYaml = await getCiYaml(commit, validate: true);
     } else {
@@ -821,19 +888,23 @@ $stackTrace
     final List<Target> presubmitTargets = inner.presubmitTargets
         .where(
           (Target target) =>
-              target.value.scheduler == pb.SchedulerSystem.luci || target.value.scheduler == pb.SchedulerSystem.cocoon,
+              target.value.scheduler == pb.SchedulerSystem.luci ||
+              target.value.scheduler == pb.SchedulerSystem.cocoon,
         )
         .toList();
 
     // See https://github.com/flutter/flutter/issues/138430.
-    final includePostsubmitAsPresubmit = _includePostsubmitAsPresubmit(inner, pullRequest);
+    final includePostsubmitAsPresubmit =
+        _includePostsubmitAsPresubmit(inner, pullRequest);
     if (includePostsubmitAsPresubmit) {
-      log.info('Including postsubmit targets as presubmit for ${pullRequest.number}');
+      log.info(
+          'Including postsubmit targets as presubmit for ${pullRequest.number}');
 
       for (Target target in inner.postsubmitTargets) {
         // We don't want to include a presubmit twice
         // We don't want to run the builder_cache target as a presubmit
-        if (!target.value.presubmit && !target.value.properties.containsKey('cache_name')) {
+        if (!target.value.presubmit &&
+            !target.value.properties.containsKey('cache_name')) {
           presubmitTargets.add(target);
         }
       }
@@ -841,17 +912,24 @@ $stackTrace
 
     log.info('Collected ${presubmitTargets.length} presubmit targets.');
     // Release branches should run every test.
-    if (pullRequest.base!.ref != Config.defaultBranch(pullRequest.base!.repo!.slug())) {
-      log.info('Release branch found, scheduling all targets for ${pullRequest.number}');
+    if (pullRequest.base!.ref !=
+        Config.defaultBranch(pullRequest.base!.repo!.slug())) {
+      log.info(
+          'Release branch found, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
     if (includePostsubmitAsPresubmit) {
-      log.info('Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
+      log.info(
+          'Postsubmit targets included as presubmit, scheduling all targets for ${pullRequest.number}');
       return presubmitTargets;
     }
 
     // Filter builders based on the PR diff
-    // FIXME: Implement.
+    final filesChanged = await getFilesChanged.get(
+      pullRequest.base!.repo!.slug(),
+      pullRequest.number!,
+    );
+    return getTargetsToRun(presubmitTargets, filesChanged);
   }
 
   static final _allowTestAll = {
@@ -860,11 +938,13 @@ $stackTrace
   };
 
   /// Returns `true` if [ciYaml.postsubmitTargets] should be ran during presubmit.
-  static bool _includePostsubmitAsPresubmit(CiYaml ciYaml, PullRequest pullRequest) {
+  static bool _includePostsubmitAsPresubmit(
+      CiYaml ciYaml, PullRequest pullRequest) {
     if (!_allowTestAll.contains(ciYaml.slug)) {
       return false;
     }
-    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ?? false) {
+    if (pullRequest.labels?.any((label) => label.name.contains('test: all')) ??
+        false) {
       return true;
     }
     return false;
@@ -874,14 +954,19 @@ $stackTrace
   ///
   /// Handles both fusion engine build and test stages, and both pull requests
   /// and merge groups.
-  Future<bool> processCheckRunCompletion(cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRunCompletion(
+      cocoon_checks.CheckRunEvent checkRunEvent) async {
     final checkRun = checkRunEvent.checkRun!;
     final name = checkRun.name;
     final sha = checkRun.headSha;
     final slug = checkRunEvent.repository?.slug();
     final conclusion = checkRun.conclusion;
 
-    if (name == null || sha == null || slug == null || conclusion == null || kCheckRunsToIgnore.contains(name)) {
+    if (name == null ||
+        sha == null ||
+        slug == null ||
+        conclusion == null ||
+        kCheckRunsToIgnore.contains(name)) {
       return true;
     }
 
@@ -950,7 +1035,8 @@ $stackTrace
 
     // Are there tests remaining? Keep waiting.
     if (stagingConclusion.isPending) {
-      log.info('$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
+      log.info(
+          '$logCrumb: not progressing, remaining work count: ${stagingConclusion.remaining}');
       return false;
     }
 
@@ -1032,7 +1118,8 @@ $stackTrace
       return;
     }
 
-    log.info('$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
+    log.info(
+        '$logCrumb: Stage completed successfully: ${CiStage.fusionEngineBuild}');
 
     await _proceedToCiTestingStage(
       checkRun: checkRun,
@@ -1054,14 +1141,17 @@ $stackTrace
   }
 
   /// Returns the presubmit targets for the fusion repo [pullRequest] that should run for the given [stage].
-  Future<List<Target>> getTestsForStage(PullRequest pullRequest, CiStage stage) async {
+  Future<List<Target>> getTestsForStage(
+      PullRequest pullRequest, CiStage stage) async {
     final presubmitTargets = [
       ...await getPresubmitTargets(pullRequest),
       ...await getPresubmitTargets(pullRequest, type: CiType.fusionEngine),
     ].where(
       (Target target) => switch (stage) {
-        CiStage.fusionEngineBuild => target.value.properties['release_build'] == 'true',
-        CiStage.fusionTests => target.value.properties['release_build'] != 'true'
+        CiStage.fusionEngineBuild =>
+          target.value.properties['release_build'] == 'true',
+        CiStage.fusionTests =>
+          target.value.properties['release_build'] != 'true'
       },
     );
     return [...presubmitTargets];
@@ -1107,7 +1197,8 @@ $stackTrace
     // We'va failed to find the pull request; try a reverse look it from the check suite.
     if (pullRequest == null) {
       final int checkSuiteId = checkRun.checkSuite!.id!;
-      pullRequest = await githubChecksService.findMatchingPullRequest(slug, sha, checkSuiteId);
+      pullRequest = await githubChecksService.findMatchingPullRequest(
+          slug, sha, checkSuiteId);
     }
 
     // We cannot make any forward progress. Abandon all hope, Check runs who enter here.
@@ -1119,12 +1210,15 @@ $stackTrace
       // Both the author and label should be checked to make sure that no one is
       // attempting to get a pull request without check through.
       if (pullRequest.user!.login == config.autosubmitBot &&
-          pullRequest.labels!.any((element) => element.name == Config.revertOfLabel)) {
-        log.info('$logCrumb: skipping generating the full set of checks for revert request.');
+          pullRequest.labels!
+              .any((element) => element.name == Config.revertOfLabel)) {
+        log.info(
+            '$logCrumb: skipping generating the full set of checks for revert request.');
       } else {
         // Schedule the tests that would have run in a call to triggerPresubmitTargets - but for both the
         // engine and the framework.
-        final presubmitTargets = await getTestsForStage(pullRequest, CiStage.fusionTests);
+        final presubmitTargets =
+            await getTestsForStage(pullRequest, CiStage.fusionTests);
 
         // Create the document for tracking test check runs.
         await initializeCiStagingDocument(
@@ -1166,7 +1260,8 @@ $stackTrace
     required String conclusion,
   }) async {
     final logCrumb = 'checkCompleted($name, $slug, $sha, $conclusion)';
-    final documentName = CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
+    final documentName =
+        CiStaging.documentNameFor(slug: slug, sha: sha, stage: stage);
     log.info('$logCrumb: $documentName');
 
     // We're doing a transactional update, which could fail if multiple tasks are running at the same time; so retry
@@ -1199,20 +1294,23 @@ $stackTrace
   ///
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
-  Future<bool> processCheckRun(cocoon_checks.CheckRunEvent checkRunEvent) async {
+  Future<bool> processCheckRun(
+      cocoon_checks.CheckRunEvent checkRunEvent) async {
     switch (checkRunEvent.action) {
       case 'completed':
         await processCheckRunCompletion(checkRunEvent);
         return true;
 
       case 'rerequested':
-        log.fine('Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
+        log.fine(
+            'Rerun requested by GitHub user: ${checkRunEvent.sender?.login}');
         final String? name = checkRunEvent.checkRun!.name;
         bool success = false;
         if (name == Config.kMergeQueueLockName) {
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          log.fine('Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
+          log.fine(
+              'Requested re-run of "${Config.kMergeQueueLockName}" for $slug / $checkSuiteId - ignoring');
           success = true;
         } else if (name == Config.kCiYamlCheckName) {
           // The CheckRunEvent.checkRun.pullRequests array is empty for this
@@ -1220,28 +1318,33 @@ $stackTrace
           final RepositorySlug slug = checkRunEvent.repository!.slug();
           final String headSha = checkRunEvent.checkRun!.headSha!;
           final int checkSuiteId = checkRunEvent.checkRun!.checkSuite!.id!;
-          final PullRequest? pullRequest =
-              await githubChecksService.findMatchingPullRequest(slug, headSha, checkSuiteId);
+          final PullRequest? pullRequest = await githubChecksService
+              .findMatchingPullRequest(slug, headSha, checkSuiteId);
           if (pullRequest != null) {
-            log.fine('Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
+            log.fine(
+                'Matched PR: ${pullRequest.number} Repo: ${slug.fullName}');
             await triggerPresubmitTargets(pullRequest: pullRequest);
             success = true;
           } else {
-            log.warning('No matching PR found for head_sha in check run event.');
+            log.warning(
+                'No matching PR found for head_sha in check run event.');
           }
         } else {
           try {
             final RepositorySlug slug = checkRunEvent.repository!.slug();
-            final String gitBranch = checkRunEvent.checkRun!.checkSuite!.headBranch ?? Config.defaultBranch(slug);
+            final String gitBranch =
+                checkRunEvent.checkRun!.checkSuite!.headBranch ??
+                    Config.defaultBranch(slug);
             final String sha = checkRunEvent.checkRun!.headSha!;
 
             // Only merged commits are added to the datastore. If a matching commit is found, this must be a postsubmit checkrun.
             datastore = datastoreProvider(config.db);
-            final Key<String> commitKey =
-                Commit.createKey(db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
+            final Key<String> commitKey = Commit.createKey(
+                db: datastore.db, slug: slug, gitBranch: gitBranch, sha: sha);
             Commit? commit;
             try {
-              commit = await Commit.fromDatastore(datastore: datastore, key: commitKey);
+              commit = await Commit.fromDatastore(
+                  datastore: datastore, key: commitKey);
               log.fine('Commit found in datastore.');
             } on KeyNotFoundException {
               log.fine('Commit not found in datastore.');
@@ -1250,21 +1353,27 @@ $stackTrace
             if (commit == null) {
               log.fine('Rescheduling presubmit build.');
               // Does not do anything with the returned build oddly.
-              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(checkRunEvent: checkRunEvent);
+              await luciBuildService.reschedulePresubmitBuildUsingCheckRunEvent(
+                  checkRunEvent: checkRunEvent);
             } else {
               log.fine('Rescheduling postsubmit build.');
               firestoreService = await config.createFirestoreService();
               final String checkName = checkRunEvent.checkRun!.name!;
-              final Task task = await Task.fromDatastore(datastore: datastore, commitKey: commitKey, name: checkName);
+              final Task task = await Task.fromDatastore(
+                  datastore: datastore, commitKey: commitKey, name: checkName);
               // Query the lastest run of the `checkName` againt commit `sha`.
-              final List<firestore.Task> taskDocuments = await firestoreService.queryCommitTasks(commit.sha!);
-              final firestore.Task taskDocument =
-                  taskDocuments.where((taskDocument) => taskDocument.taskName == checkName).toList().first;
+              final List<firestore.Task> taskDocuments =
+                  await firestoreService.queryCommitTasks(commit.sha!);
+              final firestore.Task taskDocument = taskDocuments
+                  .where((taskDocument) => taskDocument.taskName == checkName)
+                  .toList()
+                  .first;
               log.fine('Latest firestore task is $taskDocument');
               final CiYamlSet ciYaml = await getCiYaml(commit);
-              final Target target =
-                  ciYaml.postsubmitTargets().singleWhere((Target target) => target.value.name == task.name);
-              await luciBuildService.reschedulePostsubmitBuildUsingCheckRunEvent(
+              final Target target = ciYaml.postsubmitTargets().singleWhere(
+                  (Target target) => target.value.name == task.name);
+              await luciBuildService
+                  .reschedulePostsubmitBuildUsingCheckRunEvent(
                 checkRunEvent,
                 commit: commit,
                 task: task,
@@ -1296,8 +1405,10 @@ $stackTrace
 
     log.info('Uploading commit ${commit.sha} info to bigquery.');
 
-    final TabledataResource tabledataResource = await config.createTabledataResourceApi();
-    final List<Map<String, Object>> tableDataInsertAllRequestRows = <Map<String, Object>>[];
+    final TabledataResource tabledataResource =
+        await config.createTabledataResourceApi();
+    final List<Map<String, Object>> tableDataInsertAllRequestRows =
+        <Map<String, Object>>[];
 
     /// Consolidate [commits] together
     ///
@@ -1316,15 +1427,16 @@ $stackTrace
     });
 
     /// Final [rows] to be inserted to [BigQuery]
-    final TableDataInsertAllRequest rows =
-        TableDataInsertAllRequest.fromJson(<String, Object>{'rows': tableDataInsertAllRequestRows});
+    final TableDataInsertAllRequest rows = TableDataInsertAllRequest.fromJson(
+        <String, Object>{'rows': tableDataInsertAllRequestRows});
 
     /// Insert [commits] to [BigQuery]
     try {
       if (rows.rows == null) {
         log.warning('Rows to be inserted is null');
       } else {
-        log.info('Inserting ${rows.rows!.length} into big query for ${commit.sha}');
+        log.info(
+            'Inserting ${rows.rows!.length} into big query for ${commit.sha}');
       }
       await tabledataResource.insertAll(rows, projectId, dataset, table);
     } on ApiRequestError {
@@ -1337,10 +1449,12 @@ $stackTrace
   /// A tip of tree [Commit] is used to help generate the tip of tree [CiYamlSet].
   /// The generated tip of tree [CiYamlSet] will be compared against Presubmit Targets in current [CiYamlSet],
   /// to ensure new targets without `bringup: true` label are not added into the build.
-  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit(
+      {required String branch, required RepositorySlug slug}) async {
     datastore = datastoreProvider(config.db);
     firestoreService = await config.createFirestoreService();
-    final BuildStatusService buildStatusService = buildStatusProvider(datastore, firestoreService);
+    final BuildStatusService buildStatusService =
+        buildStatusProvider(datastore, firestoreService);
     final Commit totCommit = (await buildStatusService
             .retrieveCommitStatus(
               limit: 1,

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -50,8 +50,7 @@ void main() {
 
     test('github merge queue branch parsing', () {
       expect(
-        tryParseGitHubMergeQueueBranch(
-            'gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56'),
+        tryParseGitHubMergeQueueBranch('gh-readonly-queue/master/pr-160481-1398dc7eecb696d302e4edb19ad79901e615ed56'),
         (parsed: true, branch: 'master', pullRequestNumber: 160481),
         reason: 'parses expected magic branch',
       );
@@ -66,16 +65,14 @@ void main() {
       late MockClient branchHttpClient;
 
       test('returns branches', () async {
-        branchHttpClient =
-            MockClient((_) async => http.Response(branchRegExp, HttpStatus.ok));
+        branchHttpClient = MockClient((_) async => http.Response(branchRegExp, HttpStatus.ok));
         final String branches = await githubFileContent(
           RepositorySlug('flutter', 'cocoon'),
           'branches.txt',
           httpClientProvider: () => branchHttpClient,
           retryOptions: noRetry,
         );
-        final List<String> branchList =
-            branches.split('\n').map((String branch) => branch.trim()).toList();
+        final List<String> branchList = branches.split('\n').map((String branch) => branch.trim()).toList();
         branchList.removeWhere((String branch) => branch.isEmpty);
         expect(branchList, <String>['master', 'flutter-1.1-candidate.1']);
       });
@@ -100,8 +97,7 @@ void main() {
             maxDelay: Duration.zero,
           ),
         );
-        final List<String> branchList =
-            branches.split('\n').map((String branch) => branch.trim()).toList();
+        final List<String> branchList = branches.split('\n').map((String branch) => branch.trim()).toList();
         branchList.removeWhere((String branch) => branch.isEmpty);
         expect(retry, 2);
         expect(branchList, <String>['master', 'flutter-1.1-candidate.1']);
@@ -140,8 +136,7 @@ void main() {
             maxDelay: Duration.zero,
           ),
         );
-        final List<String> branchList =
-            branches.split('\n').map((String branch) => branch.trim()).toList();
+        final List<String> branchList = branches.split('\n').map((String branch) => branch.trim()).toList();
         branchList.removeWhere((String branch) => branch.isEmpty);
         expect(branchList, <String>['master', 'flutter-1.1-candidate.1']);
       });
@@ -171,8 +166,7 @@ void main() {
             maxDelay: Duration.zero,
           ),
         );
-        final List<String> branchList =
-            branches.split('\n').map((String branch) => branch.trim()).toList();
+        final List<String> branchList = branches.split('\n').map((String branch) => branch.trim()).toList();
         branchList.removeWhere((String branch) => branch.isEmpty);
         expect(branchList, <String>['master', 'flutter-1.1-candidate.1']);
       });
@@ -228,15 +222,13 @@ void main() {
           <String, dynamic>{'test': 'test'},
           tabledataResourceApi,
         );
-        final TableDataList tableDataList =
-            await tabledataResourceApi.list('test', 'test', 'test');
+        final TableDataList tableDataList = await tabledataResourceApi.list('test', 'test', 'test');
         expect(tableDataList.totalRows, '1');
       });
     });
 
     group('getFilteredBuilders', () {
-      test('does not return builders when run_if does not match any file',
-          () async {
+      test('does not return builders when run_if does not match any file', () async {
         final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['cde/']),
         ];
@@ -278,8 +270,7 @@ void main() {
         expect(result, targets);
       });
 
-      test('returns builders when run_if matches files using full path',
-          () async {
+      test('returns builders when run_if matches files using full path', () async {
         final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['abc/cde.py']),
         ];
@@ -313,9 +304,7 @@ void main() {
         expect(result, targets);
       });
 
-      test(
-          'returns builders when run_if matches files with ** that contain digits',
-          () async {
+      test('returns builders when run_if matches files with ** that contain digits', () async {
         final List<Target> targets = <Target>[
           generateTarget(
             1,
@@ -347,9 +336,7 @@ void main() {
         expect(result, targets);
       });
 
-      test(
-          'returns builders when run_if matches files with * and ** that contains digits',
-          () async {
+      test('returns builders when run_if matches files with * and ** that contains digits', () async {
         final List<Target> targets = <Target>[
           generateTarget(
             1,
@@ -382,8 +369,7 @@ void main() {
         expect(result, targets);
       });
 
-      test('returns builders when run_if matches files with * trailing glob',
-          () async {
+      test('returns builders when run_if matches files with * trailing glob', () async {
         final List<Target> targets = <Target>[
           generateTarget(
             1,
@@ -406,8 +392,7 @@ void main() {
         expect(result, targets);
       });
 
-      test('returns builders when run_if matches files with * trailing glob 2',
-          () async {
+      test('returns builders when run_if matches files with * trailing glob 2', () async {
         final List<Target> targets = <Target>[
           generateTarget(
             1,
@@ -430,8 +415,7 @@ void main() {
         expect(result, targets);
       });
 
-      test('returns builders when run_if matches files with ** in the middle',
-          () async {
+      test('returns builders when run_if matches files with ** in the middle', () async {
         final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['abc/**/hj.dart']),
         ];
@@ -448,8 +432,7 @@ void main() {
         expect(result, [targets[0]]);
       });
 
-      test('returns builders when run_if matches files with both * and **',
-          () async {
+      test('returns builders when run_if matches files with both * and **', () async {
         final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['a/b*c/**']),
         ];
@@ -466,8 +449,7 @@ void main() {
         expect(result, targets);
       });
 
-      test('returns correct builders when file and folder share the same name',
-          () async {
+      test('returns correct builders when file and folder share the same name', () async {
         final List<Target> targets = <Target>[
           generateTarget(1, runIf: <String>['a/b/']),
           generateTarget(2, runIf: <String>['a']),
@@ -494,15 +476,13 @@ void main() {
       maxDelay: Duration.zero,
     );
 
-    final goodFlutterRef =
-        (slug: RepositorySlug.full('flutter/flutter'), sha: '1234');
+    final goodFlutterRef = (slug: RepositorySlug.full('flutter/flutter'), sha: '1234');
 
     test('isFusionPR returns false non-flutter repo', () async {
       final branchHttpClient = MockClient(
         (req) async {
           final url = '${req.url}';
-          if (!url.contains(
-              'https://raw.githubusercontent.com/flutter/flutter/DEPS')) {
+          if (!url.contains('https://raw.githubusercontent.com/flutter/flutter/DEPS')) {
             return http.Response('', HttpStatus.notFound);
           }
           return http.Response('test', HttpStatus.ok);
@@ -675,14 +655,8 @@ void main() {
         retryOptions: noRetry,
       );
       expect(fusion, isTrue);
-      expect(
-          urlCalled[
-              'https://raw.githubusercontent.com/flutter/flutter/1234/engine/src/.gn'],
-          1);
-      expect(
-          urlCalled[
-              'https://raw.githubusercontent.com/flutter/flutter/1234/DEPS'],
-          1);
+      expect(urlCalled['https://raw.githubusercontent.com/flutter/flutter/1234/engine/src/.gn'], 1);
+      expect(urlCalled['https://raw.githubusercontent.com/flutter/flutter/1234/DEPS'], 1);
     });
   });
 }

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -248,11 +248,9 @@ void main() {
         ];
         final List<Target> result = await getTargetsToRun(
           targets,
-          SuccessfulFilesChanged(
+          const InconclusiveFilesChanged(
             pullRequestNumber: 1234,
-            filesChanged: <String>[
-              for (var i = 0; i < 30; i++) 'abc/file_$i.dart',
-            ],
+            reason: 'We gave up',
           ),
         );
         expect(result, targets);

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -28,7 +28,6 @@ void main() {
   setUp(() {
     mockGithubService = MockGithubService();
     mockLuciBuildService = MockLuciBuildService();
-    when(mockGithubService.listFiles(any)).thenAnswer((_) async => <String>[]);
     mockGithubChecksUtil = MockGithubChecksUtil();
     config = FakeConfig(githubService: mockGithubService, rollerAccountsValue: {'engine-flutter-autoroll'});
     githubChecksService = GithubChecksService(

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1826,6 +1826,9 @@ targets:
             labels: <IssueLabel>[],
             repo: Config.engineSlug.name,
           );
+
+          // Assume a file that is not runIf'd was changed.
+          getFilesChanged.cannedFiles = ['README.md'];
           final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(
             presubmitTargets.map((Target target) => target.value.name).toList(),
@@ -1885,6 +1888,7 @@ targets:
       });
 
       test('triggers expected presubmit build checks', () async {
+        getFilesChanged.cannedFiles = ['README.md'];
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
           verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -152,8 +152,7 @@ void main() {
   group('Scheduler', () {
     setUp(() {
       final MockTabledataResource tabledataResource = MockTabledataResource();
-      when(tabledataResource.insertAll(any, any, any, any))
-          .thenAnswer((_) async {
+      when(tabledataResource.insertAll(any, any, any, any)).thenAnswer((_) async {
         return TableDataInsertAllResponse();
       });
 
@@ -164,9 +163,7 @@ void main() {
       buildStatusService = FakeBuildStatusService(
         commitStatuses: <CommitStatus>[
           CommitStatus(generateCommit(1), const <Stage>[]),
-          CommitStatus(
-              generateCommit(1, branch: 'main', repo: Config.engineSlug.name),
-              const <Stage>[]),
+          CommitStatus(generateCommit(1, branch: 'main', repo: Config.engineSlug.name), const <Stage>[]),
         ],
       );
       config = FakeConfig(
@@ -189,8 +186,7 @@ void main() {
 
       mockGithubChecksUtil = MockGithubChecksUtil();
       // Generate check runs based on the name hash code
-      when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-              output: anyNamed('output')))
+      when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
           .thenAnswer((Invocation invocation) async {
         return generateCheckRun(
           invocation.positionalArguments[2].hashCode,
@@ -206,8 +202,7 @@ void main() {
         config: config,
         datastoreProvider: (DatastoreDB db) => DatastoreService(db, 2),
         buildStatusProvider: (_, __) => buildStatusService,
-        githubChecksService:
-            GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
+        githubChecksService: GithubChecksService(config, githubChecksUtil: mockGithubChecksUtil),
         httpClientProvider: () => httpClient,
         getFilesChanged: getFilesChanged,
         luciBuildService: FakeLuciBuildService(
@@ -221,8 +216,7 @@ void main() {
         markCheckRunConclusion: callbacks.markCheckRunConclusion,
       );
 
-      when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-          .thenAnswer((_) async {
+      when(mockGithubChecksUtil.createCheckRun(any, any, any, any)).thenAnswer((_) async {
         return CheckRun.fromJson(const <String, dynamic>{
           'id': 1,
           'started_at': '2020-05-10T02:49:31Z',
@@ -243,8 +237,7 @@ void main() {
 
       fakeFusion.isFusion = (_, __) => true;
 
-      final List<Target> presubmitTargets =
-          await scheduler.getPresubmitTargets(pullRequest);
+      final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(pullRequest);
 
       expect(
         [...presubmitTargets.map((Target target) => target.value.name)],
@@ -277,14 +270,11 @@ void main() {
             author: 'Username',
             authorAvatarUrl: 'http://example.org/avatar.jpg',
             branch: branch,
-            key: db.emptyKey
-                .append(Commit, id: 'flutter/$repo/$branch/${shas[index]}'),
+            key: db.emptyKey.append(Commit, id: 'flutter/$repo/$branch/${shas[index]}'),
             message: 'commit message',
             repository: 'flutter/$repo',
             sha: shas[index],
-            timestamp:
-                DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index]))
-                    .millisecondsSinceEpoch,
+            timestamp: DateTime.fromMillisecondsSinceEpoch(int.parse(shas[index])).millisecondsSinceEpoch,
           ),
         );
       }
@@ -318,8 +308,7 @@ void main() {
 
       test('skips scheduling for unsupported repos', () async {
         config.supportedBranchesValue = <String>['master'];
-        await scheduler
-            .addCommits(createCommitList(<String>['1'], repo: 'not-supported'));
+        await scheduler.addCommits(createCommitList(<String>['1'], repo: 'not-supported'));
         expect(db.values.values.whereType<Commit>().length, 0);
       });
 
@@ -337,12 +326,8 @@ void main() {
         final Commit commit = shaToCommit('1');
         db.values[commit.key] = commit;
 
-        db.onCommit = (List<gcloud_db.Model<Object?>> inserts,
-            List<gcloud_db.Key<Object?>> deletes) {
-          if (inserts
-              .whereType<Commit>()
-              .where((Commit commit) => commit.sha == '3')
-              .isNotEmpty) {
+        db.onCommit = (List<gcloud_db.Model<Object?>> inserts, List<gcloud_db.Key<Object?>> deletes) {
+          if (inserts.whereType<Commit>().where((Commit commit) => commit.sha == '3').isNotEmpty) {
             throw StateError('Commit failed');
           }
         };
@@ -352,10 +337,8 @@ void main() {
         // The 2 new commits are scheduled 3 tasks, existing commit has none.
         expect(db.values.values.whereType<Task>().length, 2 * 3);
         // Check commits were added, but 3 was not
-        expect(db.values.values.whereType<Commit>().map<String>(toSha),
-            containsAll(<String>['1', '2', '4']));
-        expect(db.values.values.whereType<Commit>().map<String>(toSha),
-            isNot(contains('3')));
+        expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
+        expect(db.values.values.whereType<Commit>().map<String>(toSha), isNot(contains('3')));
       });
 
       test('skips commits for which task transaction fails', () async {
@@ -372,12 +355,8 @@ void main() {
         final Commit commit = shaToCommit('1');
         db.values[commit.key] = commit;
 
-        db.onCommit = (List<gcloud_db.Model<Object?>> inserts,
-            List<gcloud_db.Key<Object?>> deletes) {
-          if (inserts
-              .whereType<Task>()
-              .where((Task task) => task.createTimestamp == 3)
-              .isNotEmpty) {
+        db.onCommit = (List<gcloud_db.Model<Object?>> inserts, List<gcloud_db.Key<Object?>> deletes) {
+          if (inserts.whereType<Task>().where((Task task) => task.createTimestamp == 3).isNotEmpty) {
             throw StateError('Task failed');
           }
         };
@@ -387,10 +366,8 @@ void main() {
         // The 2 new commits are scheduled 3 tasks, existing commit has none.
         expect(db.values.values.whereType<Task>().length, 2 * 3);
         // Check commits were added, but 3 was not
-        expect(db.values.values.whereType<Commit>().map<String>(toSha),
-            containsAll(<String>['1', '2', '4']));
-        expect(db.values.values.whereType<Commit>().map<String>(toSha),
-            isNot(contains('3')));
+        expect(db.values.values.whereType<Commit>().map<String>(toSha), containsAll(<String>['1', '2', '4']));
+        expect(db.values.values.whereType<Commit>().map<String>(toSha), isNot(contains('3')));
       });
 
       test('schedules cocoon based targets', () async {
@@ -407,12 +384,10 @@ void main() {
             commit: anyNamed('commit'),
             toBeScheduled: captureAnyNamed('toBeScheduled'),
           ),
-        ).thenAnswer((_) => Future<List<Tuple<Target, Task, int>>>.value(
-            <Tuple<Target, Task, int>>[]));
+        ).thenAnswer((_) => Future<List<Tuple<Target, Task, int>>>.value(<Tuple<Target, Task, int>>[]));
         buildStatusService = FakeBuildStatusService(
           commitStatuses: <CommitStatus>[
-            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'),
-                const <Stage>[]),
+            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[]),
           ],
         );
         scheduler = Scheduler(
@@ -430,8 +405,7 @@ void main() {
           fusionTester: fakeFusion,
         );
 
-        await scheduler.addCommits(
-            createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
+        await scheduler.addCommits(createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
         final List<Object?> captured = verify(
           luciBuildService.schedulePostsubmitBuilds(
             commit: anyNamed('commit'),
@@ -440,19 +414,17 @@ void main() {
         ).captured;
         final List<Object?> toBeScheduled = captured.first as List<Object?>;
         expect(toBeScheduled.length, 2);
-        final Iterable<Tuple<Target, Task, int>> tuples = toBeScheduled
-            .map((dynamic tuple) => tuple as Tuple<Target, Task, int>);
+        final Iterable<Tuple<Target, Task, int>> tuples =
+            toBeScheduled.map((dynamic tuple) => tuple as Tuple<Target, Task, int>);
         final Iterable<String> scheduledTargetNames =
             tuples.map((Tuple<Target, Task, int> tuple) => tuple.second.name!);
         expect(scheduledTargetNames, ['Linux A', 'Linux runIf']);
         // Tasks triggered by cocoon are marked as in progress
         final Iterable<Task> tasks = db.values.values.whereType<Task>();
-        expect(tasks.singleWhere((Task task) => task.name == 'Linux A').status,
-            Task.statusInProgress);
+        expect(tasks.singleWhere((Task task) => task.name == 'Linux A').status, Task.statusInProgress);
       });
 
-      test('schedules cocoon based targets - multiple batch requests',
-          () async {
+      test('schedules cocoon based targets - multiple batch requests', () async {
         when(
           mockFirestoreService.writeViaTransaction(
             captureAny,
@@ -460,8 +432,7 @@ void main() {
         ).thenAnswer((Invocation invocation) {
           return Future<CommitResponse>.value(CommitResponse());
         });
-        final MockBuildBucketClient mockBuildBucketClient =
-            MockBuildBucketClient();
+        final MockBuildBucketClient mockBuildBucketClient = MockBuildBucketClient();
         final FakeLuciBuildService luciBuildService = FakeLuciBuildService(
           config: config,
           buildBucketClient: mockBuildBucketClient,
@@ -469,28 +440,20 @@ void main() {
           githubChecksUtil: mockGithubChecksUtil,
           pubsub: pubsub,
         );
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-                output: anyNamed('output')))
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
             .thenAnswer((_) async => generateCheckRun(1, name: 'Linux A'));
 
         when(mockBuildBucketClient.listBuilders(any)).thenAnswer((_) async {
           return bbv2.ListBuildersResponse(
             builders: [
-              bbv2.BuilderItem(
-                  id: bbv2.BuilderID(
-                      bucket: 'prod', project: 'flutter', builder: 'Linux A')),
-              bbv2.BuilderItem(
-                  id: bbv2.BuilderID(
-                      bucket: 'prod',
-                      project: 'flutter',
-                      builder: 'Linux runIf')),
+              bbv2.BuilderItem(id: bbv2.BuilderID(bucket: 'prod', project: 'flutter', builder: 'Linux A')),
+              bbv2.BuilderItem(id: bbv2.BuilderID(bucket: 'prod', project: 'flutter', builder: 'Linux runIf')),
             ],
           );
         });
         buildStatusService = FakeBuildStatusService(
           commitStatuses: <CommitStatus>[
-            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'),
-                const <Stage>[]),
+            CommitStatus(generateCommit(1, repo: 'engine', branch: 'main'), const <Stage>[]),
           ],
         );
         config.batchSizeValue = 1;
@@ -509,8 +472,7 @@ void main() {
           fusionTester: fakeFusion,
         );
 
-        await scheduler.addCommits(
-            createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
+        await scheduler.addCommits(createCommitList(<String>['1'], repo: 'engine', branch: 'main'));
         expect(pubsub.messages.length, 2);
       });
     });
@@ -537,9 +499,7 @@ void main() {
         expect(commit.authorAvatarUrl, 'dashatar');
         expect(commit.message, 'example message');
 
-        final List<Object?> captured =
-            verify(mockFirestoreService.writeViaTransaction(captureAny))
-                .captured;
+        final List<Object?> captured = verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
         expect(captured.length, 1);
         final List<Write> commitResponse = captured[0] as List<Write>;
         expect(commitResponse.length, 4);
@@ -583,11 +543,8 @@ void main() {
         await scheduler.addPullRequest(mergedPr);
 
         expect(db.values.values.whereType<Commit>().length, 1);
-        expect(db.values.values.whereType<Task>().length, 5,
-            reason: 'removes release_build targets');
-        final captured =
-            verify(mockFirestoreService.writeViaTransaction(captureAny))
-                .captured;
+        expect(db.values.values.whereType<Task>().length, 5, reason: 'removes release_build targets');
+        final captured = verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
         expect(
           captured.first.map((write) => write.update?.name),
           [
@@ -602,8 +559,7 @@ void main() {
         );
       });
 
-      test('guarantees scheduling of tasks against merged release branch PR',
-          () async {
+      test('guarantees scheduling of tasks against merged release branch PR', () async {
         when(
           mockFirestoreService.writeViaTransaction(
             captureAny,
@@ -611,18 +567,13 @@ void main() {
         ).thenAnswer((Invocation invocation) {
           return Future<CommitResponse>.value(CommitResponse());
         });
-        final PullRequest mergedPr =
-            generatePullRequest(branch: 'flutter-3.2-candidate.5');
+        final PullRequest mergedPr = generatePullRequest(branch: 'flutter-3.2-candidate.5');
         await scheduler.addPullRequest(mergedPr);
 
         expect(db.values.values.whereType<Commit>().length, 1);
         expect(db.values.values.whereType<Task>().length, 3);
         // Ensure all tasks have been marked in progress
-        expect(
-            db.values.values
-                .whereType<Task>()
-                .where((Task task) => task.status == Task.statusNew),
-            isEmpty);
+        expect(db.values.values.whereType<Task>().where((Task task) => task.status == Task.statusNew), isEmpty);
       });
 
       test('guarantees scheduling of tasks against merged engine PR', () async {
@@ -642,17 +593,10 @@ void main() {
         expect(db.values.values.whereType<Commit>().length, 1);
         expect(db.values.values.whereType<Task>().length, 3);
         // Ensure all tasks under cocoon scheduler have been marked in progress
-        expect(
-            db.values.values
-                .whereType<Task>()
-                .where((Task task) => task.status == Task.statusInProgress)
-                .length,
-            2);
+        expect(db.values.values.whereType<Task>().where((Task task) => task.status == Task.statusInProgress).length, 2);
       });
 
-      test(
-          'Release candidate branch commit filters builders not in default branch',
-          () async {
+      test('Release candidate branch commit filters builders not in default branch', () async {
         when(
           mockFirestoreService.writeViaTransaction(
             captureAny,
@@ -711,20 +655,14 @@ targets:
         expect(tasks, hasLength(1));
         expect(tasks.first.name, 'Linux A');
         // Ensure all tasks under cocoon scheduler have been marked in progress
-        expect(
-            db.values.values
-                .whereType<Task>()
-                .where((Task task) => task.status == Task.statusInProgress)
-                .length,
-            1);
+        expect(db.values.values.whereType<Task>().where((Task task) => task.status == Task.statusInProgress).length, 1);
       });
 
       test('does not schedule tasks against non-merged PRs', () async {
         final PullRequest notMergedPr = generatePullRequest(merged: false);
         await scheduler.addPullRequest(notMergedPr);
 
-        expect(
-            db.values.values.whereType<Commit>().map<String>(toSha).length, 0);
+        expect(db.values.values.whereType<Commit>().map<String>(toSha).length, 0);
         expect(db.values.values.whereType<Task>().length, 0);
       });
 
@@ -736,8 +674,7 @@ targets:
         final PullRequest alreadyLandedPr = generatePullRequest(sha: '1');
         await scheduler.addPullRequest(alreadyLandedPr);
 
-        expect(
-            db.values.values.whereType<Commit>().map<String>(toSha).length, 1);
+        expect(db.values.values.whereType<Commit>().map<String>(toSha).length, 1);
         // No tasks should be scheduled as that is done on commit insert.
         expect(db.values.values.whereType<Task>().length, 0);
       });
@@ -769,10 +706,8 @@ targets:
       test('rerequested ci.yaml check retriggers presubmit', () async {
         final MockGithubService mockGithubService = MockGithubService();
         final MockGitHub mockGithubClient = MockGitHub();
-        buildStatusService = FakeBuildStatusService(
-            commitStatuses: <CommitStatus>[
-              CommitStatus(generateCommit(1), const <Stage>[])
-            ]);
+        buildStatusService =
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         config = FakeConfig(
           githubService: mockGithubService,
           firestoreService: mockFirestoreService,
@@ -794,19 +729,15 @@ targets:
           fusionTester: fakeFusion,
         );
         when(mockGithubService.github).thenReturn(mockGithubClient);
-        when(mockGithubService.searchIssuesAndPRs(any, any,
-                sort: anyNamed('sort'), pages: anyNamed('pages')))
+        when(mockGithubService.searchIssuesAndPRs(any, any, sort: anyNamed('sort'), pages: anyNamed('pages')))
             .thenAnswer((_) async => [generateIssue(3)]);
-        when(mockGithubChecksUtil.listCheckSuitesForRef(any, any,
-                ref: anyNamed('ref')))
-            .thenAnswer(
+        when(mockGithubChecksUtil.listCheckSuitesForRef(any, any, ref: anyNamed('ref'))).thenAnswer(
           (_) async => [
             // From check_run.check_suite.id in [checkRunString].
             generateCheckSuite(668083231),
           ],
         );
-        when(mockGithubService.getPullRequest(any, any))
-            .thenAnswer((_) async => generatePullRequest());
+        when(mockGithubService.getPullRequest(any, any)).thenAnswer((_) async => generatePullRequest());
         getFilesChanged.cannedFiles = ['abc/def'];
         when(
           mockGithubChecksUtil.createCheckRun(
@@ -824,11 +755,9 @@ targets:
             'check_suite': <String, dynamic>{'id': 2},
           });
         });
-        final Map<String, dynamic> checkRunEventJson =
-            jsonDecode(checkRunString) as Map<String, dynamic>;
+        final Map<String, dynamic> checkRunEventJson = jsonDecode(checkRunString) as Map<String, dynamic>;
         checkRunEventJson['check_run']['name'] = Config.kCiYamlCheckName;
-        final cocoon_checks.CheckRunEvent checkRunEvent =
-            cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
+        final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
         expect(await scheduler.processCheckRun(checkRunEvent), true);
         verify(
           mockGithubChecksUtil.createCheckRun(
@@ -840,17 +769,14 @@ targets:
           ),
         );
         // Verfies Linux A was created
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-            .called(1);
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any)).called(1);
       });
 
       test('rerequested merge queue guard check is ignored', () async {
         final MockGithubService mockGithubService = MockGithubService();
         final MockGitHub mockGithubClient = MockGitHub();
-        buildStatusService = FakeBuildStatusService(
-            commitStatuses: <CommitStatus>[
-              CommitStatus(generateCommit(1), const <Stage>[])
-            ]);
+        buildStatusService =
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         config = FakeConfig(
           githubService: mockGithubService,
           firestoreService: mockFirestoreService,
@@ -872,19 +798,15 @@ targets:
           fusionTester: fakeFusion,
         );
         when(mockGithubService.github).thenReturn(mockGithubClient);
-        when(mockGithubService.searchIssuesAndPRs(any, any,
-                sort: anyNamed('sort'), pages: anyNamed('pages')))
+        when(mockGithubService.searchIssuesAndPRs(any, any, sort: anyNamed('sort'), pages: anyNamed('pages')))
             .thenAnswer((_) async => [generateIssue(3)]);
-        when(mockGithubChecksUtil.listCheckSuitesForRef(any, any,
-                ref: anyNamed('ref')))
-            .thenAnswer(
+        when(mockGithubChecksUtil.listCheckSuitesForRef(any, any, ref: anyNamed('ref'))).thenAnswer(
           (_) async => [
             // From check_run.check_suite.id in [checkRunString].
             generateCheckSuite(668083231),
           ],
         );
-        when(mockGithubService.getPullRequest(any, any))
-            .thenAnswer((_) async => generatePullRequest());
+        when(mockGithubService.getPullRequest(any, any)).thenAnswer((_) async => generatePullRequest());
         getFilesChanged.cannedFiles = ['abc/def'];
         when(
           mockGithubChecksUtil.createCheckRun(
@@ -902,11 +824,9 @@ targets:
             'check_suite': <String, dynamic>{'id': 2},
           });
         });
-        final Map<String, dynamic> checkRunEventJson =
-            jsonDecode(checkRunString) as Map<String, dynamic>;
+        final Map<String, dynamic> checkRunEventJson = jsonDecode(checkRunString) as Map<String, dynamic>;
         checkRunEventJson['check_run']['name'] = Config.kMergeQueueLockName;
-        final cocoon_checks.CheckRunEvent checkRunEvent =
-            cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
+        final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(checkRunEventJson);
         expect(await scheduler.processCheckRun(checkRunEvent), true);
         verifyNever(
           mockGithubChecksUtil.createCheckRun(
@@ -934,11 +854,9 @@ targets:
           return FakeBuildBucketClient().batch(i.positionalArguments[0]);
         });
 
-        when(mockBuildbucket.scheduleBuild(any,
-                buildBucketUri: anyNamed('buildBucketUri')))
+        when(mockBuildbucket.scheduleBuild(any, buildBucketUri: anyNamed('buildBucketUri')))
             .thenAnswer((realInvocation) async {
-          final bbv2.ScheduleBuildRequest scheduleBuildRequest =
-              realInvocation.positionalArguments[0];
+          final bbv2.ScheduleBuildRequest scheduleBuildRequest = realInvocation.positionalArguments[0];
           // Ensure this is an attempt to schedule a presubmit build by
           // verifying that bucket == 'try'.
           expect(scheduleBuildRequest.builder.bucket, equals('try'));
@@ -961,18 +879,14 @@ targets:
           fusionTester: fakeFusion,
         );
 
-        final cocoon_checks.CheckRunEvent checkRunEvent =
-            cocoon_checks.CheckRunEvent.fromJson(
+        final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           jsonDecode(checkRunString) as Map<String, dynamic>,
         );
 
         expect(await scheduler.processCheckRun(checkRunEvent), true);
 
-        verify(mockBuildbucket.scheduleBuild(any,
-                buildBucketUri: anyNamed('buildBucketUri')))
-            .called(1);
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-            .called(1);
+        verify(mockBuildbucket.scheduleBuild(any, buildBucketUri: anyNamed('buildBucketUri'))).called(1);
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any)).called(1);
       });
 
       test('rerequested postsubmit check triggers postsubmit build', () async {
@@ -1041,11 +955,9 @@ targets:
         when(mockBuildbucket.batch(any)).thenAnswer((i) async {
           return FakeBuildBucketClient().batch(i.positionalArguments[0]);
         });
-        when(mockBuildbucket.scheduleBuild(any,
-                buildBucketUri: anyNamed('buildBucketUri')))
+        when(mockBuildbucket.scheduleBuild(any, buildBucketUri: anyNamed('buildBucketUri')))
             .thenAnswer((realInvocation) async {
-          final bbv2.ScheduleBuildRequest scheduleBuildRequest =
-              realInvocation.positionalArguments[0];
+          final bbv2.ScheduleBuildRequest scheduleBuildRequest = realInvocation.positionalArguments[0];
           // Ensure this is an attempt to schedule a postsubmit build by
           // verifying that bucket == 'prod'.
           expect(scheduleBuildRequest.builder.bucket, equals('prod'));
@@ -1073,32 +985,27 @@ targets:
           luciBuildService: luciBuildService,
           fusionTester: fakeFusion,
         );
-        final cocoon_checks.CheckRunEvent checkRunEvent =
-            cocoon_checks.CheckRunEvent.fromJson(
+        final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           jsonDecode(checkRunString) as Map<String, dynamic>,
         );
         expect(await scheduler.processCheckRun(checkRunEvent), true);
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-            .called(1);
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any)).called(1);
         expect(pubsub.messages.length, 1);
       });
 
       test('rerequested does not fail on empty pull request list', () async {
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-            .thenAnswer((_) async {
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any)).thenAnswer((_) async {
           return CheckRun.fromJson(const <String, dynamic>{
             'id': 1,
             'started_at': '2020-05-10T02:49:31Z',
             'check_suite': <String, dynamic>{'id': 2},
           });
         });
-        final cocoon_checks.CheckRunEvent checkRunEvent =
-            cocoon_checks.CheckRunEvent.fromJson(
+        final cocoon_checks.CheckRunEvent checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           jsonDecode(checkRunWithEmptyPullRequests) as Map<String, dynamic>,
         );
         expect(await scheduler.processCheckRun(checkRunEvent), true);
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any))
-            .called(1);
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, any)).called(1);
       });
 
       group('completed action', () {
@@ -1119,8 +1026,7 @@ targets:
             fakeFusion.isFusion = (_, __) => true;
           });
 
-          test('ignores default check runs that have no side effects',
-              () async {
+          test('ignores default check runs that have no side effects', () async {
             when(
               callbacks.markCheckRunConclusion(
                 firestoreService: anyNamed('firestoreService'),
@@ -1198,8 +1104,7 @@ targets:
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: '1234',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1251,8 +1156,7 @@ targets:
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: '1234',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1274,9 +1178,7 @@ targets:
           // complete and are successful.
           // This behavior is explained here:
           // https://github.com/flutter/flutter/issues/159898#issuecomment-2597209435
-          test(
-              'failed tests neither unlock merge queue guard nor schedule test stage',
-              () async {
+          test('failed tests neither unlock merge queue guard nor schedule test stage', () async {
             when(
               callbacks.markCheckRunConclusion(
                 firestoreService: anyNamed('firestoreService'),
@@ -1310,8 +1212,7 @@ targets:
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: '1234',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1333,17 +1234,13 @@ targets:
             final githubService = config.githubService = MockGithubService();
             final githubClient = MockGitHub();
             when(githubService.github).thenReturn(githubClient);
-            when(githubService.searchIssuesAndPRs(any, any,
-                    sort: anyNamed('sort'), pages: anyNamed('pages')))
+            when(githubService.searchIssuesAndPRs(any, any, sort: anyNamed('sort'), pages: anyNamed('pages')))
                 .thenAnswer((_) async => [generateIssue(42)]);
 
             final pullRequest = generatePullRequest();
-            when(githubService.getPullRequest(any, any))
-                .thenAnswer((_) async => pullRequest);
+            when(githubService.getPullRequest(any, any)).thenAnswer((_) async => pullRequest);
             getFilesChanged.cannedFiles = ['abc/def'];
-            when(mockGithubChecksUtil.listCheckSuitesForRef(any, any,
-                    ref: anyNamed('ref')))
-                .thenAnswer(
+            when(mockGithubChecksUtil.listCheckSuitesForRef(any, any, ref: anyNamed('ref'))).thenAnswer(
               (_) async => [
                 // From check_run.check_suite.id in [checkRunString].
                 generateCheckSuite(668083231),
@@ -1359,18 +1256,14 @@ targets:
               throw Exception('Failed to find ${request.url.path}');
             });
             final luci = MockLuciBuildService();
-            when(luci.scheduleTryBuilds(
-                    targets: anyNamed('targets'),
-                    pullRequest: anyNamed('pullRequest')))
+            when(luci.scheduleTryBuilds(targets: anyNamed('targets'), pullRequest: anyNamed('pullRequest')))
                 .thenAnswer((inv) async {
               return [];
             });
 
             final gitHubChecksService = MockGithubChecksService();
-            when(gitHubChecksService.githubChecksUtil)
-                .thenReturn(mockGithubChecksUtil);
-            when(gitHubChecksService.findMatchingPullRequest(any, any, any))
-                .thenAnswer((inv) async {
+            when(gitHubChecksService.githubChecksUtil).thenReturn(mockGithubChecksUtil);
+            when(gitHubChecksService.findMatchingPullRequest(any, any, any)).thenAnswer((inv) async {
               return pullRequest;
             });
 
@@ -1424,24 +1317,20 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(
-                      checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
+                  json.decode(checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
                 ),
               ),
               isTrue,
             );
 
-            verify(gitHubChecksService.findMatchingPullRequest(
-                    Config.flutterSlug, 'testSha', 668083231))
-                .called(1);
+            verify(gitHubChecksService.findMatchingPullRequest(Config.flutterSlug, 'testSha', 668083231)).called(1);
 
             verify(
               callbacks.markCheckRunConclusion(
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: 'testSha',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1480,8 +1369,7 @@ targets:
             final gitHubChecksService = MockGithubChecksService();
 
             when(githubService.github).thenReturn(githubClient);
-            when(gitHubChecksService.githubChecksUtil)
-                .thenReturn(mockGithubChecksUtil);
+            when(gitHubChecksService.githubChecksUtil).thenReturn(mockGithubChecksUtil);
 
             scheduler = Scheduler(
               cache: cache,
@@ -1523,8 +1411,7 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(
-                      checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
+                  json.decode(checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
                 ),
               ),
               isTrue,
@@ -1537,8 +1424,7 @@ targets:
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: 'testSha',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1569,26 +1455,21 @@ targets:
                     return true;
                   }),
                 ),
-                status:
-                    argThat(equals(CheckRunStatus.completed), named: 'status'),
-                conclusion: argThat(equals(CheckRunConclusion.success),
-                    named: 'conclusion'),
+                status: argThat(equals(CheckRunStatus.completed), named: 'status'),
+                conclusion: argThat(equals(CheckRunConclusion.success), named: 'conclusion'),
                 output: anyNamed('output'),
               ),
             ).called(1);
           });
 
-          test(
-              'does not fail the merge queue guard when a test check run fails',
-              () async {
+          test('does not fail the merge queue guard when a test check run fails', () async {
             final githubService = config.githubService = MockGithubService();
             final githubClient = MockGitHub();
             final luci = MockLuciBuildService();
             final gitHubChecksService = MockGithubChecksService();
 
             when(githubService.github).thenReturn(githubClient);
-            when(gitHubChecksService.githubChecksUtil)
-                .thenReturn(mockGithubChecksUtil);
+            when(gitHubChecksService.githubChecksUtil).thenReturn(mockGithubChecksUtil);
 
             scheduler = Scheduler(
               cache: cache,
@@ -1633,8 +1514,7 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(
-                      checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
+                  json.decode(checkRunEventFor(test: 'Bar bar', sha: 'testSha')),
                 ),
               ),
               isTrue,
@@ -1647,8 +1527,7 @@ targets:
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: 'testSha',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1681,30 +1560,24 @@ targets:
             );
           });
 
-          test('schedules tests after engine stage - with pr caching',
-              () async {
+          test('schedules tests after engine stage - with pr caching', () async {
             final githubService = config.githubService = MockGithubService();
             final githubClient = MockGitHub();
             when(githubService.github).thenReturn(githubClient);
-            when(githubService.searchIssuesAndPRs(any, any,
-                    sort: anyNamed('sort'), pages: anyNamed('pages')))
+            when(githubService.searchIssuesAndPRs(any, any, sort: anyNamed('sort'), pages: anyNamed('pages')))
                 .thenAnswer((_) async => [generateIssue(42)]);
 
             final pullRequest = generatePullRequest();
-            when(githubService.getPullRequest(any, any))
-                .thenAnswer((_) async => pullRequest);
+            when(githubService.getPullRequest(any, any)).thenAnswer((_) async => pullRequest);
             getFilesChanged.cannedFiles = ['abc/def'];
-            when(mockGithubChecksUtil.listCheckSuitesForRef(any, any,
-                    ref: anyNamed('ref')))
-                .thenAnswer(
+            when(mockGithubChecksUtil.listCheckSuitesForRef(any, any, ref: anyNamed('ref'))).thenAnswer(
               (_) async => [
                 // From check_run.check_suite.id in [checkRunString].
                 generateCheckSuite(668083231),
               ],
             );
 
-            when(callbacks.findPullRequestFor(any, any, any))
-                .thenAnswer((inv) async {
+            when(callbacks.findPullRequestFor(any, any, any)).thenAnswer((inv) async {
               return pullRequest;
             });
 
@@ -1717,16 +1590,13 @@ targets:
               throw Exception('Failed to find ${request.url.path}');
             });
             final luci = MockLuciBuildService();
-            when(luci.scheduleTryBuilds(
-                    targets: anyNamed('targets'),
-                    pullRequest: anyNamed('pullRequest')))
+            when(luci.scheduleTryBuilds(targets: anyNamed('targets'), pullRequest: anyNamed('pullRequest')))
                 .thenAnswer((inv) async {
               return [];
             });
 
             final gitHubChecksService = MockGithubChecksService();
-            when(gitHubChecksService.githubChecksUtil)
-                .thenReturn(mockGithubChecksUtil);
+            when(gitHubChecksService.githubChecksUtil).thenReturn(mockGithubChecksUtil);
 
             // Cocoon creates a Firestore document to track the tasks in the
             // test stage.
@@ -1785,19 +1655,15 @@ targets:
               isTrue,
             );
 
-            verify(callbacks.findPullRequestFor(
-                    mockFirestoreService, 1, 'Bar bar'))
-                .called(1);
-            verifyNever(
-                gitHubChecksService.findMatchingPullRequest(any, any, any));
+            verify(callbacks.findPullRequestFor(mockFirestoreService, 1, 'Bar bar')).called(1);
+            verifyNever(gitHubChecksService.findMatchingPullRequest(any, any, any));
 
             verify(
               callbacks.markCheckRunConclusion(
                 firestoreService: argThat(isNotNull, named: 'firestoreService'),
                 slug: argThat(equals(Config.flutterSlug), named: 'slug'),
                 sha: '1234',
-                stage:
-                    argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
+                stage: argThat(equals(CiStage.fusionEngineBuild), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
                 conclusion: argThat(equals('success'), named: 'conclusion'),
               ),
@@ -1870,8 +1736,7 @@ targets:
           }
           throw Exception('Failed to find ${request.url.path}');
         });
-        final List<Target> presubmitTargets =
-            await scheduler.getPresubmitTargets(pullRequest);
+        final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(pullRequest);
         expect(
           presubmitTargets.map((Target target) => target.value.name).toList(),
           containsAll(<String>['Linux A', 'Linux C']),
@@ -1921,8 +1786,7 @@ targets:
             labels: <IssueLabel>[runAllTests],
             repo: Config.engineSlug.name,
           );
-          final List<Target> presubmitTargets =
-              await scheduler.getPresubmitTargets(enginePr);
+          final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(
             presubmitTargets.map((Target target) => target.value.name).toList(),
             <String>[
@@ -1942,8 +1806,7 @@ targets:
             labels: <IssueLabel>[runAllTests],
             repo: Config.flutterSlug.name,
           );
-          final List<Target> presubmitTargets =
-              await scheduler.getPresubmitTargets(frameworkPr);
+          final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(frameworkPr);
           expect(
             presubmitTargets.map((Target target) => target.value.name).toList(),
             <String>[
@@ -1963,8 +1826,7 @@ targets:
             labels: <IssueLabel>[],
             repo: Config.engineSlug.name,
           );
-          final List<Target> presubmitTargets =
-              await scheduler.getPresubmitTargets(enginePr);
+          final List<Target> presubmitTargets = await scheduler.getPresubmitTargets(enginePr);
           expect(
             presubmitTargets.map((Target target) => target.value.name).toList(),
             (<String>[
@@ -1995,8 +1857,7 @@ targets:
         });
         expect(
           scheduler.getPresubmitTargets(generatePullRequest(branch: branch)),
-          throwsA(predicate((Exception e) =>
-              e.toString().contains('$branch is not enabled'))),
+          throwsA(predicate((Exception e) => e.toString().contains('$branch is not enabled'))),
         );
       });
 
@@ -2019,16 +1880,14 @@ targets:
           }
           throw Exception('Failed to find ${request.url.path}');
         });
-        final List<Target> targets = await scheduler
-            .getPresubmitTargets(generatePullRequest(branch: branch));
+        final List<Target> targets = await scheduler.getPresubmitTargets(generatePullRequest(branch: branch));
         expect(targets.single.value.name, 'Linux A');
       });
 
       test('triggers expected presubmit build checks', () async {
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
-          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                  output: captureAnyNamed('output')))
+          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
             Config.kMergeQueueLockName,
@@ -2039,8 +1898,7 @@ targets:
             Config.kCiYamlCheckName,
             const CheckRunOutput(
               title: Config.kCiYamlCheckName,
-              summary:
-                  'If this check is stuck pending, push an empty commit to retrigger the checks',
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',
             null,
@@ -2056,11 +1914,9 @@ targets:
 
         releasePullRequest.user = User(login: 'auto-submit[bot]');
 
-        await scheduler.triggerPresubmitTargets(
-            pullRequest: releasePullRequest);
+        await scheduler.triggerPresubmitTargets(pullRequest: releasePullRequest);
         expect(
-          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                  output: captureAnyNamed('output')))
+          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
             Config.kMergeQueueLockName,
@@ -2072,8 +1928,7 @@ targets:
             // No other targets should be created.
             const CheckRunOutput(
               title: Config.kCiYamlCheckName,
-              summary:
-                  'If this check is stuck pending, push an empty commit to retrigger the checks',
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
           ],
         );
@@ -2088,8 +1943,7 @@ targets:
 
         releasePullRequest.user = User(login: 'auto-submit[bot]');
 
-        await scheduler.triggerPresubmitTargets(
-            pullRequest: releasePullRequest);
+        await scheduler.triggerPresubmitTargets(pullRequest: releasePullRequest);
         expect(
           verify(
             mockGithubChecksUtil.updateCheckRun(
@@ -2112,9 +1966,7 @@ targets:
         );
       });
 
-      test(
-          'filters out presubmit targets that do not exist in main and do not filter targets not in main',
-          () async {
+      test('filters out presubmit targets that do not exist in main and do not filter targets not in main', () async {
         const String singleCiYaml = r'''
 enabled_branches:
   - master
@@ -2185,14 +2037,11 @@ targets:
         );
       });
 
-      test('triggers all presubmit build checks when diff cannot be found',
-          () async {
+      test('triggers all presubmit build checks when diff cannot be found', () async {
         final MockGithubService mockGithubService = MockGithubService();
         getFilesChanged.cannedFiles = null;
-        buildStatusService = FakeBuildStatusService(
-            commitStatuses: <CommitStatus>[
-              CommitStatus(generateCommit(1), const <Stage>[])
-            ]);
+        buildStatusService =
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         scheduler = Scheduler(
           cache: cache,
           config: FakeConfig(
@@ -2219,8 +2068,7 @@ targets:
         );
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
-          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                  output: captureAnyNamed('output')))
+          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
             Config.kMergeQueueLockName,
@@ -2231,8 +2079,7 @@ targets:
             Config.kCiYamlCheckName,
             const CheckRunOutput(
               title: Config.kCiYamlCheckName,
-              summary:
-                  'If this check is stuck pending, push an empty commit to retrigger the checks',
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',
             null,
@@ -2243,16 +2090,13 @@ targets:
         );
       });
 
-      test('triggers all presubmit targets on release branch pull request',
-          () async {
+      test('triggers all presubmit targets on release branch pull request', () async {
         final PullRequest releasePullRequest = generatePullRequest(
           branch: 'flutter-1.24-candidate.1',
         );
-        await scheduler.triggerPresubmitTargets(
-            pullRequest: releasePullRequest);
+        await scheduler.triggerPresubmitTargets(pullRequest: releasePullRequest);
         expect(
-          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                  output: captureAnyNamed('output')))
+          verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
               .captured,
           <Object?>[
             Config.kMergeQueueLockName,
@@ -2263,8 +2107,7 @@ targets:
             Config.kCiYamlCheckName,
             const CheckRunOutput(
               title: Config.kCiYamlCheckName,
-              summary:
-                  'If this check is stuck pending, push an empty commit to retrigger the checks',
+              summary: 'If this check is stuck pending, push an empty commit to retrigger the checks',
             ),
             'Linux A',
             null,
@@ -2306,8 +2149,7 @@ targets:
           throw Exception('Failed to find ${request.url.path}');
         });
 
-        final capturedUpdates =
-            <(String, CheckRunStatus, CheckRunConclusion)>[];
+        final capturedUpdates = <(String, CheckRunStatus, CheckRunConclusion)>[];
 
         when(
           mockGithubChecksUtil.updateCheckRun(
@@ -2349,8 +2191,7 @@ targets:
       });
 
       test('ci.yaml validation fails on not enabled branch', () async {
-        final PullRequest pullRequest =
-            generatePullRequest(branch: 'not-valid');
+        final PullRequest pullRequest = generatePullRequest(branch: 'not-valid');
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
           verify(
@@ -2372,8 +2213,7 @@ targets:
         );
       });
 
-      test('ci.yaml validation fails with config with unknown dependencies',
-          () async {
+      test('ci.yaml validation fails with config with unknown dependencies', () async {
         httpClient = MockClient((http.Request request) async {
           if (request.url.path.contains('.ci.yaml')) {
             return http.Response(
@@ -2409,10 +2249,8 @@ targets:
 
       test('retries only triggers failed builds only', () async {
         final MockBuildBucketClient mockBuildbucket = MockBuildBucketClient();
-        buildStatusService = FakeBuildStatusService(
-            commitStatuses: <CommitStatus>[
-              CommitStatus(generateCommit(1), const <Stage>[])
-            ]);
+        buildStatusService =
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         final FakePubSub pubsub = FakePubSub();
         scheduler = Scheduler(
           cache: cache,
@@ -2440,22 +2278,11 @@ targets:
               bbv2.BatchResponse_Response(
                 searchBuilds: bbv2.SearchBuildsResponse(
                   builds: <bbv2.Build>[
-                    generateBbv2Build(Int64(1000),
-                        name: 'Linux', bucket: 'try'),
-                    generateBbv2Build(Int64(2000),
-                        name: 'Linux Coverage', bucket: 'try'),
-                    generateBbv2Build(Int64(3000),
-                        name: 'Mac',
-                        bucket: 'try',
-                        status: bbv2.Status.SCHEDULED),
-                    generateBbv2Build(Int64(4000),
-                        name: 'Windows',
-                        bucket: 'try',
-                        status: bbv2.Status.STARTED),
-                    generateBbv2Build(Int64(5000),
-                        name: 'Linux A',
-                        bucket: 'try',
-                        status: bbv2.Status.FAILURE),
+                    generateBbv2Build(Int64(1000), name: 'Linux', bucket: 'try'),
+                    generateBbv2Build(Int64(2000), name: 'Linux Coverage', bucket: 'try'),
+                    generateBbv2Build(Int64(3000), name: 'Mac', bucket: 'try', status: bbv2.Status.SCHEDULED),
+                    generateBbv2Build(Int64(4000), name: 'Windows', bucket: 'try', status: bbv2.Status.STARTED),
+                    generateBbv2Build(Int64(5000), name: 'Linux A', bucket: 'try', status: bbv2.Status.FAILURE),
                   ],
                 ),
               ),
@@ -2463,52 +2290,43 @@ targets:
           ),
         );
         when(mockBuildbucket.scheduleBuild(any)).thenAnswer(
-          (_) async => generateBbv2Build(Int64(5001),
-              name: 'Linux A', bucket: 'try', status: bbv2.Status.SCHEDULED),
+          (_) async => generateBbv2Build(Int64(5001), name: 'Linux A', bucket: 'try', status: bbv2.Status.SCHEDULED),
         );
         // Only Linux A should be retried
         final Map<String, CheckRun> checkRuns = <String, CheckRun>{
           'Linux': createCheckRun(name: 'Linux', id: 100),
           'Linux Coverage': createCheckRun(name: 'Linux Coverage', id: 200),
-          'Mac': createCheckRun(
-              name: 'Mac', id: 300, status: CheckRunStatus.queued),
-          'Windows': createCheckRun(
-              name: 'Windows', id: 400, status: CheckRunStatus.inProgress),
+          'Mac': createCheckRun(name: 'Mac', id: 300, status: CheckRunStatus.queued),
+          'Windows': createCheckRun(name: 'Windows', id: 400, status: CheckRunStatus.inProgress),
           'Linux A': createCheckRun(name: 'Linux A', id: 500),
         };
         when(mockGithubChecksUtil.allCheckRuns(any, any)).thenAnswer((_) async {
           return checkRuns;
         });
 
-        final CheckSuiteEvent checkSuiteEvent = CheckSuiteEvent.fromJson(
-            jsonDecode(checkSuiteTemplate('rerequested'))
-                as Map<String, dynamic>);
+        final CheckSuiteEvent checkSuiteEvent =
+            CheckSuiteEvent.fromJson(jsonDecode(checkSuiteTemplate('rerequested')) as Map<String, dynamic>);
         await scheduler.retryPresubmitTargets(
           pullRequest: pullRequest,
           checkSuiteEvent: checkSuiteEvent,
         );
 
         expect(pubsub.messages.length, 1);
-        final bbv2.BatchRequest batchRequest =
-            bbv2.BatchRequest().createEmptyInstance();
+        final bbv2.BatchRequest batchRequest = bbv2.BatchRequest().createEmptyInstance();
         batchRequest.mergeFromProto3Json(pubsub.messages.single);
         expect(batchRequest.requests.length, 1);
         // Schedule build should have been sent
         expect(batchRequest.requests.single.scheduleBuild, isNotNull);
-        final bbv2.ScheduleBuildRequest scheduleBuildRequest =
-            batchRequest.requests.single.scheduleBuild;
+        final bbv2.ScheduleBuildRequest scheduleBuildRequest = batchRequest.requests.single.scheduleBuild;
         // Verify expected parameters to schedule build
         expect(scheduleBuildRequest.builder.builder, 'Linux A');
-        expect(scheduleBuildRequest.properties.fields['custom']?.stringValue,
-            'abc');
+        expect(scheduleBuildRequest.properties.fields['custom']?.stringValue, 'abc');
       });
 
       test('pass github_build_label to properties', () async {
         final MockBuildBucketClient mockBuildbucket = MockBuildBucketClient();
-        buildStatusService = FakeBuildStatusService(
-            commitStatuses: <CommitStatus>[
-              CommitStatus(generateCommit(1), const <Stage>[])
-            ]);
+        buildStatusService =
+            FakeBuildStatusService(commitStatuses: <CommitStatus>[CommitStatus(generateCommit(1), const <Stage>[])]);
         final FakePubSub pubsub = FakePubSub();
         scheduler = Scheduler(
           cache: cache,
@@ -2536,22 +2354,11 @@ targets:
               bbv2.BatchResponse_Response(
                 searchBuilds: bbv2.SearchBuildsResponse(
                   builds: <bbv2.Build>[
-                    generateBbv2Build(Int64(1000),
-                        name: 'Linux', bucket: 'try'),
-                    generateBbv2Build(Int64(2000),
-                        name: 'Linux Coverage', bucket: 'try'),
-                    generateBbv2Build(Int64(3000),
-                        name: 'Mac',
-                        bucket: 'try',
-                        status: bbv2.Status.SCHEDULED),
-                    generateBbv2Build(Int64(4000),
-                        name: 'Windows',
-                        bucket: 'try',
-                        status: bbv2.Status.STARTED),
-                    generateBbv2Build(Int64(5000),
-                        name: 'Linux A',
-                        bucket: 'try',
-                        status: bbv2.Status.FAILURE),
+                    generateBbv2Build(Int64(1000), name: 'Linux', bucket: 'try'),
+                    generateBbv2Build(Int64(2000), name: 'Linux Coverage', bucket: 'try'),
+                    generateBbv2Build(Int64(3000), name: 'Mac', bucket: 'try', status: bbv2.Status.SCHEDULED),
+                    generateBbv2Build(Int64(4000), name: 'Windows', bucket: 'try', status: bbv2.Status.STARTED),
+                    generateBbv2Build(Int64(5000), name: 'Linux A', bucket: 'try', status: bbv2.Status.FAILURE),
                   ],
                 ),
               ),
@@ -2559,86 +2366,61 @@ targets:
           ),
         );
         when(mockBuildbucket.scheduleBuild(any)).thenAnswer(
-          (_) async => generateBbv2Build(Int64(5001),
-              name: 'Linux A', bucket: 'try', status: bbv2.Status.SCHEDULED),
+          (_) async => generateBbv2Build(Int64(5001), name: 'Linux A', bucket: 'try', status: bbv2.Status.SCHEDULED),
         );
         // Only Linux A should be retried
         final Map<String, CheckRun> checkRuns = <String, CheckRun>{
           'Linux': createCheckRun(name: 'Linux', id: 100),
           'Linux Coverage': createCheckRun(name: 'Linux Coverage', id: 200),
-          'Mac': createCheckRun(
-              name: 'Mac', id: 300, status: CheckRunStatus.queued),
-          'Windows': createCheckRun(
-              name: 'Windows', id: 400, status: CheckRunStatus.inProgress),
+          'Mac': createCheckRun(name: 'Mac', id: 300, status: CheckRunStatus.queued),
+          'Windows': createCheckRun(name: 'Windows', id: 400, status: CheckRunStatus.inProgress),
           'Linux A': createCheckRun(name: 'Linux A', id: 500),
         };
         when(mockGithubChecksUtil.allCheckRuns(any, any)).thenAnswer((_) async {
           return checkRuns;
         });
 
-        final CheckSuiteEvent checkSuiteEvent = CheckSuiteEvent.fromJson(
-            jsonDecode(checkSuiteTemplate('rerequested'))
-                as Map<String, dynamic>);
+        final CheckSuiteEvent checkSuiteEvent =
+            CheckSuiteEvent.fromJson(jsonDecode(checkSuiteTemplate('rerequested')) as Map<String, dynamic>);
         await scheduler.retryPresubmitTargets(
           pullRequest: pullRequest,
           checkSuiteEvent: checkSuiteEvent,
         );
 
         expect(pubsub.messages.length, 1);
-        final bbv2.BatchRequest batchRequest =
-            bbv2.BatchRequest().createEmptyInstance();
+        final bbv2.BatchRequest batchRequest = bbv2.BatchRequest().createEmptyInstance();
         batchRequest.mergeFromProto3Json(pubsub.messages.single);
         expect(batchRequest.requests.length, 1);
         // Schedule build should have been sent
         expect(batchRequest.requests.single.scheduleBuild, isNotNull);
-        final bbv2.ScheduleBuildRequest scheduleBuildRequest =
-            batchRequest.requests.single.scheduleBuild;
+        final bbv2.ScheduleBuildRequest scheduleBuildRequest = batchRequest.requests.single.scheduleBuild;
         // Verify expected parameters to schedule build
         expect(scheduleBuildRequest.builder.builder, 'Linux A');
-        expect(scheduleBuildRequest.properties.fields['custom']?.stringValue,
-            'abc');
+        expect(scheduleBuildRequest.properties.fields['custom']?.stringValue, 'abc');
       });
 
       test('triggers only specificed targets', () async {
-        final List<Target> presubmitTargets = <Target>[
-          generateTarget(1),
-          generateTarget(2)
-        ];
-        final List<Target> presubmitTriggerTargets =
-            scheduler.filterTargets(presubmitTargets, <String>['Linux 1']);
+        final List<Target> presubmitTargets = <Target>[generateTarget(1), generateTarget(2)];
+        final List<Target> presubmitTriggerTargets = scheduler.filterTargets(presubmitTargets, <String>['Linux 1']);
         expect(presubmitTriggerTargets.length, 1);
       });
 
-      test('triggers all presubmit targets when trigger list is null',
-          () async {
-        final List<Target> presubmitTargets = <Target>[
-          generateTarget(1),
-          generateTarget(2)
-        ];
-        final List<Target> presubmitTriggerTargets =
-            scheduler.filterTargets(presubmitTargets, null);
+      test('triggers all presubmit targets when trigger list is null', () async {
+        final List<Target> presubmitTargets = <Target>[generateTarget(1), generateTarget(2)];
+        final List<Target> presubmitTriggerTargets = scheduler.filterTargets(presubmitTargets, null);
         expect(presubmitTriggerTargets.length, 2);
       });
 
-      test('triggers all presubmit targets when trigger list is empty',
-          () async {
-        final List<Target> presubmitTargets = <Target>[
-          generateTarget(1),
-          generateTarget(2)
-        ];
-        final List<Target> presubmitTriggerTargets =
-            scheduler.filterTargets(presubmitTargets, <String>[]);
+      test('triggers all presubmit targets when trigger list is empty', () async {
+        final List<Target> presubmitTargets = <Target>[generateTarget(1), generateTarget(2)];
+        final List<Target> presubmitTriggerTargets = scheduler.filterTargets(presubmitTargets, <String>[]);
         expect(presubmitTriggerTargets.length, 2);
       });
 
-      test('triggers only targets that are contained in the trigger list',
-          () async {
-        final List<Target> presubmitTargets = <Target>[
-          generateTarget(1),
-          generateTarget(2)
-        ];
-        final List<Target> presubmitTriggerTargets = scheduler
-            .filterTargets(presubmitTargets, <String>['Linux 1', 'Linux 3']);
+      test('triggers only targets that are contained in the trigger list', () async {
+        final List<Target> presubmitTargets = <Target>[generateTarget(1), generateTarget(2)];
+        final List<Target> presubmitTriggerTargets =
+            scheduler.filterTargets(presubmitTargets, <String>['Linux 1', 'Linux 3']);
         expect(presubmitTriggerTargets.length, 1);
         expect(presubmitTargets[0].value.name, 'Linux 1');
       });
@@ -2653,22 +2435,18 @@ targets:
           throw Exception('Failed to find ${request.url.path}');
         });
         final luci = MockLuciBuildService();
-        when(luci.scheduleTryBuilds(
-                targets: anyNamed('targets'),
-                pullRequest: anyNamed('pullRequest')))
+        when(luci.scheduleTryBuilds(targets: anyNamed('targets'), pullRequest: anyNamed('pullRequest')))
             .thenAnswer((inv) async {
           return [];
         });
         final MockGithubService mockGithubService = MockGithubService();
         final checkRuns = <CheckRun>[];
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-                output: anyNamed('output')))
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
             .thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
           final sha = inv.positionalArguments[2];
           final name = inv.positionalArguments[3];
-          checkRuns.add(createCheckRun(
-              id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
+          checkRuns.add(createCheckRun(id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
           return checkRuns.last;
         });
         getFilesChanged.cannedFiles = ['abc/def'];
@@ -2708,15 +2486,13 @@ targets:
           initializeCiStagingDocument: callbacks.initializeDocument,
         );
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
-        final results = verify(mockGithubChecksUtil.createCheckRun(
-                any, any, any, captureAny,
-                output: captureAnyNamed('output')))
-            .captured;
+        final results =
+            verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
+                .captured;
         stdout.writeAll(results);
 
-        final result = verify(luci.scheduleTryBuilds(
-            targets: captureAnyNamed('targets'),
-            pullRequest: anyNamed('pullRequest')));
+        final result =
+            verify(luci.scheduleTryBuilds(targets: captureAnyNamed('targets'), pullRequest: anyNamed('pullRequest')));
         expect(result.callCount, 1);
         final captured = result.captured;
         expect(captured[0], hasLength(1));
@@ -2730,8 +2506,7 @@ targets:
             Config.flutterSlug,
             checkRuns[1],
             status: argThat(equals(CheckRunStatus.completed), named: 'status'),
-            conclusion: argThat(equals(CheckRunConclusion.success),
-                named: 'conclusion'),
+            conclusion: argThat(equals(CheckRunConclusion.success), named: 'conclusion'),
             output: anyNamed('output'),
           ),
         ).called(1);
@@ -2769,30 +2544,25 @@ targets:
           throw Exception('Failed to find ${request.url.path}');
         });
         final luci = MockLuciBuildService();
-        when(luci.getAvailableBuilderSet(
-                project: anyNamed('project'), bucket: anyNamed('bucket')))
+        when(luci.getAvailableBuilderSet(project: anyNamed('project'), bucket: anyNamed('bucket')))
             .thenAnswer((inv) async {
           return {
             'Mac engine_build',
             'Linux engine_build',
           };
         });
-        when(luci.scheduleTryBuilds(
-                targets: anyNamed('targets'),
-                pullRequest: anyNamed('pullRequest')))
+        when(luci.scheduleTryBuilds(targets: anyNamed('targets'), pullRequest: anyNamed('pullRequest')))
             .thenAnswer((inv) async {
           return [];
         });
         final MockGithubService mockGithubService = MockGithubService();
         final checkRuns = <CheckRun>[];
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-                output: anyNamed('output')))
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
             .thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
           final sha = inv.positionalArguments[2];
           final name = inv.positionalArguments[3];
-          checkRuns.add(createCheckRun(
-              id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
+          checkRuns.add(createCheckRun(id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
           return checkRuns.last;
         });
         getFilesChanged.cannedFiles = ['abc/def'];
@@ -2842,17 +2612,14 @@ targets:
           ),
         );
 
-        await scheduler.triggerMergeGroupTargets(
-            mergeGroupEvent: mergeGroupEvent);
+        await scheduler.triggerMergeGroupTargets(mergeGroupEvent: mergeGroupEvent);
         verify(
           callbacks.initializeDocument(
             firestoreService: anyNamed('firestoreService'),
             slug: anyNamed('slug'),
-            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'),
-                named: 'sha'),
+            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'), named: 'sha'),
             stage: anyNamed('stage'),
-            tasks: argThat(equals(['Linux engine_build', 'Mac engine_build']),
-                named: 'tasks'),
+            tasks: argThat(equals(['Linux engine_build', 'Mac engine_build']), named: 'tasks'),
             checkRunGuard: anyNamed('checkRunGuard'),
           ),
         ).called(1);
@@ -2863,14 +2630,12 @@ targets:
           ),
         ).called(1);
 
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                output: captureAnyNamed('output')))
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
             .called(1);
-        final result = verify(luci.scheduleMergeGroupBuilds(
-            targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
+        final result =
+            verify(luci.scheduleMergeGroupBuilds(targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
         expect(result.callCount, 1);
-        expect(result.captured[0].map((target) => target.value.name),
-            ['Linux engine_build', 'Mac engine_build']);
+        expect(result.captured[0].map((target) => target.value.name), ['Linux engine_build', 'Mac engine_build']);
 
         expect(checkRuns, hasLength(1));
         verifyNever(
@@ -2895,29 +2660,24 @@ targets:
           throw Exception('Failed to find ${request.url.path}');
         });
         final luci = MockLuciBuildService();
-        when(luci.getAvailableBuilderSet(
-                project: anyNamed('project'), bucket: anyNamed('bucket')))
+        when(luci.getAvailableBuilderSet(project: anyNamed('project'), bucket: anyNamed('bucket')))
             .thenAnswer((inv) async {
           return {
             'Mac engine_build',
           };
         });
-        when(luci.scheduleTryBuilds(
-                targets: anyNamed('targets'),
-                pullRequest: anyNamed('pullRequest')))
+        when(luci.scheduleTryBuilds(targets: anyNamed('targets'), pullRequest: anyNamed('pullRequest')))
             .thenAnswer((inv) async {
           return [];
         });
         final MockGithubService mockGithubService = MockGithubService();
         final checkRuns = <CheckRun>[];
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-                output: anyNamed('output')))
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
             .thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
           final sha = inv.positionalArguments[2];
           final name = inv.positionalArguments[3];
-          checkRuns.add(createCheckRun(
-              id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
+          checkRuns.add(createCheckRun(id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
           return checkRuns.last;
         });
         getFilesChanged.cannedFiles = ['abc/def'];
@@ -2966,27 +2726,23 @@ targets:
           ),
         );
 
-        await scheduler.triggerMergeGroupTargets(
-            mergeGroupEvent: mergeGroupEvent);
+        await scheduler.triggerMergeGroupTargets(mergeGroupEvent: mergeGroupEvent);
         verify(
           callbacks.initializeDocument(
             firestoreService: anyNamed('firestoreService'),
             slug: anyNamed('slug'),
-            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'),
-                named: 'sha'),
+            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'), named: 'sha'),
             stage: anyNamed('stage'),
             tasks: argThat(equals(['Mac engine_build']), named: 'tasks'),
             checkRunGuard: anyNamed('checkRunGuard'),
           ),
         ).called(1);
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                output: captureAnyNamed('output')))
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
             .called(1);
-        final result = verify(luci.scheduleMergeGroupBuilds(
-            targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
+        final result =
+            verify(luci.scheduleMergeGroupBuilds(targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
         expect(result.callCount, 1);
-        expect(result.captured[0].map((target) => target.value.name),
-            ['Mac engine_build']);
+        expect(result.captured[0].map((target) => target.value.name), ['Mac engine_build']);
 
         expect(checkRuns, hasLength(1));
         verifyNever(
@@ -3011,8 +2767,7 @@ targets:
           throw Exception('Failed to find ${request.url.path}');
         });
         final luci = MockLuciBuildService();
-        when(luci.getAvailableBuilderSet(
-                project: anyNamed('project'), bucket: anyNamed('bucket')))
+        when(luci.getAvailableBuilderSet(project: anyNamed('project'), bucket: anyNamed('bucket')))
             .thenAnswer((inv) async {
           return {
             'Mac engine_build',
@@ -3030,14 +2785,12 @@ targets:
 
         final MockGithubService mockGithubService = MockGithubService();
         final checkRuns = <CheckRun>[];
-        when(mockGithubChecksUtil.createCheckRun(any, any, any, any,
-                output: anyNamed('output')))
+        when(mockGithubChecksUtil.createCheckRun(any, any, any, any, output: anyNamed('output')))
             .thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
           final sha = inv.positionalArguments[2];
           final name = inv.positionalArguments[3];
-          checkRuns.add(createCheckRun(
-              id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
+          checkRuns.add(createCheckRun(id: 1, owner: slug.owner, repo: slug.name, sha: sha, name: name));
           return checkRuns.last;
         });
         getFilesChanged.cannedFiles = ['abc/def'];
@@ -3087,17 +2840,14 @@ targets:
           ),
         );
 
-        await scheduler.triggerMergeGroupTargets(
-            mergeGroupEvent: mergeGroupEvent);
+        await scheduler.triggerMergeGroupTargets(mergeGroupEvent: mergeGroupEvent);
         verify(
           callbacks.initializeDocument(
             firestoreService: anyNamed('firestoreService'),
             slug: anyNamed('slug'),
-            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'),
-                named: 'sha'),
+            sha: argThat(equals('c9affbbb12aa40cb3afbe94b9ea6b119a256bebf'), named: 'sha'),
             stage: anyNamed('stage'),
-            tasks: argThat(equals(['Linux engine_build', 'Mac engine_build']),
-                named: 'tasks'),
+            tasks: argThat(equals(['Linux engine_build', 'Mac engine_build']), named: 'tasks'),
             checkRunGuard: anyNamed('checkRunGuard'),
           ),
         ).called(1);
@@ -3108,14 +2858,12 @@ targets:
           ),
         ).called(1);
 
-        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny,
-                output: captureAnyNamed('output')))
+        verify(mockGithubChecksUtil.createCheckRun(any, any, any, captureAny, output: captureAnyNamed('output')))
             .called(1);
-        final result = verify(luci.scheduleMergeGroupBuilds(
-            targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
+        final result =
+            verify(luci.scheduleMergeGroupBuilds(targets: captureAnyNamed('targets'), commit: anyNamed('commit')));
         expect(result.callCount, 1);
-        expect(result.captured[0].map((target) => target.value.name),
-            ['Linux engine_build', 'Mac engine_build']);
+        expect(result.captured[0].map((target) => target.value.name), ['Linux engine_build', 'Mac engine_build']);
 
         expect(checkRuns, hasLength(1));
 

--- a/app_dart/test/src/service/fake_get_files_changed.dart
+++ b/app_dart/test/src/service/fake_get_files_changed.dart
@@ -1,0 +1,32 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/service/get_files_changed.dart';
+import 'package:github/src/common/model/repos.dart';
+
+/// A fake implementation of [GetFilesChanged] that always returned [cannedFiles].
+final class FakeGetFilesChanged implements GetFilesChanged {
+  FakeGetFilesChanged({
+    this.cannedFiles,
+  });
+
+  /// Files to return on [get].
+  ///
+  /// If this is `null`, returns [InconclusiveFilesChanged].
+  List<String>? cannedFiles;
+
+  @override
+  Future<FilesChanged> get(RepositorySlug slug, int pullRequestNumber) async {
+    if (cannedFiles case final cannedFiles?) {
+      return SuccessfulFilesChanged(
+        pullRequestNumber: pullRequestNumber,
+        filesChanged: cannedFiles,
+      );
+    }
+    return InconclusiveFilesChanged(
+      pullRequestNumber: pullRequestNumber,
+      reason: 'No files were provided to FakeGetFilesChanged',
+    );
+  }
+}

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -36,8 +36,7 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<List<PullRequest>> listPullRequests(
-      RepositorySlug slug, String? branch) async {
+  Future<List<PullRequest>> listPullRequests(RepositorySlug slug, String? branch) async {
     return listPullRequestsBranch(branch);
   }
 
@@ -50,19 +49,16 @@ class FakeGithubService implements GithubService {
     return <IssueLabel>[];
   }
 
-  final List<(RepositorySlug slug, int issueNumber, String label)>
-      removedLabels = [];
+  final List<(RepositorySlug slug, int issueNumber, String label)> removedLabels = [];
 
   @override
-  Future<bool> removeLabel(
-      RepositorySlug slug, int issueNumber, String label) async {
+  Future<bool> removeLabel(RepositorySlug slug, int issueNumber, String label) async {
     removedLabels.add(((slug, issueNumber, label)));
     return true;
   }
 
   @override
-  Future<void> assignReviewer(RepositorySlug slug,
-      {int? pullRequestNumber, String? reviewer}) async {}
+  Future<void> assignReviewer(RepositorySlug slug, {int? pullRequestNumber, String? reviewer}) async {}
 
   @override
   Future<Issue> createIssue(
@@ -97,8 +93,7 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<String> getFileContent(RepositorySlug slug, String path,
-      {String? ref}) async {
+  Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
     return GithubService(github).getFileContent(slug, path, ref: ref);
   }
 
@@ -116,8 +111,7 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<List<IssueLabel>> getIssueLabels(
-      RepositorySlug slug, int issueNumber) {
+  Future<List<IssueLabel>> getIssueLabels(RepositorySlug slug, int issueNumber) {
     return Future.value(<IssueLabel>[IssueLabel(name: 'override: test')]);
   }
 

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -36,7 +36,8 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<List<PullRequest>> listPullRequests(RepositorySlug slug, String? branch) async {
+  Future<List<PullRequest>> listPullRequests(
+      RepositorySlug slug, String? branch) async {
     return listPullRequestsBranch(branch);
   }
 
@@ -49,16 +50,19 @@ class FakeGithubService implements GithubService {
     return <IssueLabel>[];
   }
 
-  final List<(RepositorySlug slug, int issueNumber, String label)> removedLabels = [];
+  final List<(RepositorySlug slug, int issueNumber, String label)>
+      removedLabels = [];
 
   @override
-  Future<bool> removeLabel(RepositorySlug slug, int issueNumber, String label) async {
+  Future<bool> removeLabel(
+      RepositorySlug slug, int issueNumber, String label) async {
     removedLabels.add(((slug, issueNumber, label)));
     return true;
   }
 
   @override
-  Future<void> assignReviewer(RepositorySlug slug, {int? pullRequestNumber, String? reviewer}) async {}
+  Future<void> assignReviewer(RepositorySlug slug,
+      {int? pullRequestNumber, String? reviewer}) async {}
 
   @override
   Future<Issue> createIssue(
@@ -93,12 +97,16 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<String> getFileContent(RepositorySlug slug, String path, {String? ref}) async {
+  Future<String> getFileContent(RepositorySlug slug, String path,
+      {String? ref}) async {
     return GithubService(github).getFileContent(slug, path, ref: ref);
   }
 
   @override
-  Future<List<String>> listFiles(PullRequest pullRequest) async {
+  Future<List<String>> listFiles(
+    RepositorySlug slug,
+    int pullRequestNumber,
+  ) async {
     return <String>['abc/def'];
   }
 
@@ -108,7 +116,8 @@ class FakeGithubService implements GithubService {
   }
 
   @override
-  Future<List<IssueLabel>> getIssueLabels(RepositorySlug slug, int issueNumber) {
+  Future<List<IssueLabel>> getIssueLabels(
+      RepositorySlug slug, int issueNumber) {
     return Future.value(<IssueLabel>[IssueLabel(name: 'override: test')]);
   }
 

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -72,8 +72,7 @@ class FakeScheduler extends Scheduler {
   }
 
   @override
-  Future<Commit> generateTotCommit(
-      {required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
     return generateCommit(1);
   }
 
@@ -81,8 +80,7 @@ class FakeScheduler extends Scheduler {
 
   int get cancelPreSubmitTargetsCallCount => cancelPreSubmitTargetsCallCnt;
 
-  void resetCancelPreSubmitTargetsCallCount() =>
-      cancelPreSubmitTargetsCallCnt = 0;
+  void resetCancelPreSubmitTargetsCallCount() => cancelPreSubmitTargetsCallCnt = 0;
 
   @override
   Future<void> cancelPreSubmitTargets({
@@ -97,8 +95,7 @@ class FakeScheduler extends Scheduler {
 
   int get triggerPresubmitTargetsCallCount => triggerPresubmitTargetsCnt;
 
-  void resetTriggerPresubmitTargetsCallCount() =>
-      triggerPresubmitTargetsCnt = 0;
+  void resetTriggerPresubmitTargetsCallCount() => triggerPresubmitTargetsCnt = 0;
 
   @override
   Future<void> triggerPresubmitTargets({

--- a/app_dart/test/src/service/fake_scheduler.dart
+++ b/app_dart/test/src/service/fake_scheduler.dart
@@ -10,6 +10,7 @@ import 'package:cocoon_service/src/model/proto/protos.dart' as pb;
 import 'package:cocoon_service/src/service/build_bucket_client.dart';
 import 'package:cocoon_service/src/service/cache_service.dart';
 import 'package:cocoon_service/src/service/config.dart';
+import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:cocoon_service/src/service/github_checks_service.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
@@ -18,6 +19,7 @@ import 'package:retry/retry.dart';
 
 import '../utilities/entity_generators.dart';
 import 'fake_fusion_tester.dart';
+import 'fake_get_files_changed.dart';
 import 'fake_luci_build_service.dart';
 
 /// Fake for [Scheduler] to use for tests that rely on it.
@@ -26,6 +28,7 @@ class FakeScheduler extends Scheduler {
     this.ciYaml,
     LuciBuildService? luciBuildService,
     BuildBucketClient? buildbucket,
+    GetFilesChanged? getFilesChanged,
     required super.config,
     GithubChecksUtil? githubChecksUtil,
     FusionTester? fusionTester,
@@ -35,6 +38,7 @@ class FakeScheduler extends Scheduler {
             config,
             githubChecksUtil: githubChecksUtil,
           ),
+          getFilesChanged: getFilesChanged ?? FakeGetFilesChanged(),
           luciBuildService: luciBuildService ??
               FakeLuciBuildService(
                 config: config,
@@ -68,7 +72,8 @@ class FakeScheduler extends Scheduler {
   }
 
   @override
-  Future<Commit> generateTotCommit({required String branch, required RepositorySlug slug}) async {
+  Future<Commit> generateTotCommit(
+      {required String branch, required RepositorySlug slug}) async {
     return generateCommit(1);
   }
 
@@ -76,7 +81,8 @@ class FakeScheduler extends Scheduler {
 
   int get cancelPreSubmitTargetsCallCount => cancelPreSubmitTargetsCallCnt;
 
-  void resetCancelPreSubmitTargetsCallCount() => cancelPreSubmitTargetsCallCnt = 0;
+  void resetCancelPreSubmitTargetsCallCount() =>
+      cancelPreSubmitTargetsCallCnt = 0;
 
   @override
   Future<void> cancelPreSubmitTargets({
@@ -91,7 +97,8 @@ class FakeScheduler extends Scheduler {
 
   int get triggerPresubmitTargetsCallCount => triggerPresubmitTargetsCnt;
 
-  void resetTriggerPresubmitTargetsCallCount() => triggerPresubmitTargetsCnt = 0;
+  void resetTriggerPresubmitTargetsCallCount() =>
+      triggerPresubmitTargetsCnt = 0;
 
   @override
   Future<void> triggerPresubmitTargets({

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -15,20 +15,16 @@ import 'package:cocoon_service/cocoon_service.dart' as _i15;
 import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i24;
 import 'package:cocoon_service/src/model/appengine/branch.dart' as _i35;
 import 'package:cocoon_service/src/model/appengine/commit.dart' as _i36;
-import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart'
-    as _i18;
-import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart'
-    as _i19;
+import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i38;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i37;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i43;
 import 'package:cocoon_service/src/model/firestore/ci_staging.dart' as _i28;
 import 'package:cocoon_service/src/model/firestore/commit.dart' as _i41;
-import 'package:cocoon_service/src/model/firestore/github_build_status.dart'
-    as _i23;
-import 'package:cocoon_service/src/model/firestore/github_gold_status.dart'
-    as _i22;
+import 'package:cocoon_service/src/model/firestore/github_build_status.dart' as _i23;
+import 'package:cocoon_service/src/model/firestore/github_gold_status.dart' as _i22;
 import 'package:cocoon_service/src/model/firestore/task.dart' as _i42;
 import 'package:cocoon_service/src/model/github/checks.dart' as _i44;
 import 'package:cocoon_service/src/service/access_token_provider.dart' as _i30;
@@ -90,8 +86,7 @@ class _FakeAccessToken_1 extends _i1.SmartFake implements _i3.AccessToken {
         );
 }
 
-class _FakeAccessClientProvider_2 extends _i1.SmartFake
-    implements _i4.AccessClientProvider {
+class _FakeAccessClientProvider_2 extends _i1.SmartFake implements _i4.AccessClientProvider {
   _FakeAccessClientProvider_2(
     Object parent,
     Invocation parentInvocation,
@@ -101,8 +96,7 @@ class _FakeAccessClientProvider_2 extends _i1.SmartFake
         );
 }
 
-class _FakeTabledataResource_3 extends _i1.SmartFake
-    implements _i5.TabledataResource {
+class _FakeTabledataResource_3 extends _i1.SmartFake implements _i5.TabledataResource {
   _FakeTabledataResource_3(
     Object parent,
     Invocation parentInvocation,
@@ -152,8 +146,7 @@ class _FakeBuild_7 extends _i1.SmartFake implements _i8.Build {
         );
 }
 
-class _FakeSearchBuildsResponse_8 extends _i1.SmartFake
-    implements _i8.SearchBuildsResponse {
+class _FakeSearchBuildsResponse_8 extends _i1.SmartFake implements _i8.SearchBuildsResponse {
   _FakeSearchBuildsResponse_8(
     Object parent,
     Invocation parentInvocation,
@@ -173,8 +166,7 @@ class _FakeBatchResponse_9 extends _i1.SmartFake implements _i8.BatchResponse {
         );
 }
 
-class _FakeListBuildersResponse_10 extends _i1.SmartFake
-    implements _i8.ListBuildersResponse {
+class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuildersResponse {
   _FakeListBuildersResponse_10(
     Object parent,
     Invocation parentInvocation,
@@ -184,8 +176,7 @@ class _FakeListBuildersResponse_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDatastoreService_11 extends _i1.SmartFake
-    implements _i9.DatastoreService {
+class _FakeDatastoreService_11 extends _i1.SmartFake implements _i9.DatastoreService {
   _FakeDatastoreService_11(
     Object parent,
     Invocation parentInvocation,
@@ -245,8 +236,7 @@ class _FakeGitHub_16 extends _i1.SmartFake implements _i13.GitHub {
         );
 }
 
-class _FakeGraphQLClient_17 extends _i1.SmartFake
-    implements _i14.GraphQLClient {
+class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient {
   _FakeGraphQLClient_17(
     Object parent,
     Invocation parentInvocation,
@@ -256,8 +246,7 @@ class _FakeGraphQLClient_17 extends _i1.SmartFake
         );
 }
 
-class _FakeFirestoreService_18 extends _i1.SmartFake
-    implements _i15.FirestoreService {
+class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreService {
   _FakeFirestoreService_18(
     Object parent,
     Invocation parentInvocation,
@@ -267,8 +256,7 @@ class _FakeFirestoreService_18 extends _i1.SmartFake
         );
 }
 
-class _FakeBigqueryService_19 extends _i1.SmartFake
-    implements _i16.BigqueryService {
+class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryService {
   _FakeBigqueryService_19(
     Object parent,
     Invocation parentInvocation,
@@ -278,8 +266,7 @@ class _FakeBigqueryService_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubService_20 extends _i1.SmartFake
-    implements _i17.GithubService {
+class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService {
   _FakeGithubService_20(
     Object parent,
     Invocation parentInvocation,
@@ -289,8 +276,7 @@ class _FakeGithubService_20 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
-    implements _i18.GithubBuildStatusUpdate {
+class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.GithubBuildStatusUpdate {
   _FakeGithubBuildStatusUpdate_21(
     Object parent,
     Invocation parentInvocation,
@@ -300,8 +286,7 @@ class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake
-    implements _i19.GithubGoldStatusUpdate {
+class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake implements _i19.GithubGoldStatusUpdate {
   _FakeGithubGoldStatusUpdate_22(
     Object parent,
     Invocation parentInvocation,
@@ -342,8 +327,7 @@ class _FakeDocument_25 extends _i1.SmartFake implements _i21.Document {
         );
 }
 
-class _FakeBatchWriteResponse_26 extends _i1.SmartFake
-    implements _i21.BatchWriteResponse {
+class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWriteResponse {
   _FakeBatchWriteResponse_26(
     Object parent,
     Invocation parentInvocation,
@@ -353,8 +337,7 @@ class _FakeBatchWriteResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeCommitResponse_27 extends _i1.SmartFake
-    implements _i21.CommitResponse {
+class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitResponse {
   _FakeCommitResponse_27(
     Object parent,
     Invocation parentInvocation,
@@ -364,8 +347,7 @@ class _FakeCommitResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubGoldStatus_28 extends _i1.SmartFake
-    implements _i22.GithubGoldStatus {
+class _FakeGithubGoldStatus_28 extends _i1.SmartFake implements _i22.GithubGoldStatus {
   _FakeGithubGoldStatus_28(
     Object parent,
     Invocation parentInvocation,
@@ -375,8 +357,7 @@ class _FakeGithubGoldStatus_28 extends _i1.SmartFake
         );
 }
 
-class _FakeGithubBuildStatus_29 extends _i1.SmartFake
-    implements _i23.GithubBuildStatus {
+class _FakeGithubBuildStatus_29 extends _i1.SmartFake implements _i23.GithubBuildStatus {
   _FakeGithubBuildStatus_29(
     Object parent,
     Invocation parentInvocation,
@@ -446,8 +427,7 @@ class _FakeMilestone_35 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_36 extends _i1.SmartFake
-    implements _i24.GithubChecksUtil {
+class _FakeGithubChecksUtil_36 extends _i1.SmartFake implements _i24.GithubChecksUtil {
   _FakeGithubChecksUtil_36(
     Object parent,
     Invocation parentInvocation,
@@ -457,8 +437,7 @@ class _FakeGithubChecksUtil_36 extends _i1.SmartFake
         );
 }
 
-class _FakeCheckRunConclusion_37 extends _i1.SmartFake
-    implements _i13.CheckRunConclusion {
+class _FakeCheckRunConclusion_37 extends _i1.SmartFake implements _i13.CheckRunConclusion {
   _FakeCheckRunConclusion_37(
     Object parent,
     Invocation parentInvocation,
@@ -468,8 +447,7 @@ class _FakeCheckRunConclusion_37 extends _i1.SmartFake
         );
 }
 
-class _FakeCheckRunStatus_38 extends _i1.SmartFake
-    implements _i13.CheckRunStatus {
+class _FakeCheckRunStatus_38 extends _i1.SmartFake implements _i13.CheckRunStatus {
   _FakeCheckRunStatus_38(
     Object parent,
     Invocation parentInvocation,
@@ -569,8 +547,7 @@ class _FakeGitTree_47 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_48 extends _i1.SmartFake
-    implements _i14.DefaultPolicies {
+class _FakeDefaultPolicies_48 extends _i1.SmartFake implements _i14.DefaultPolicies {
   _FakeDefaultPolicies_48(
     Object parent,
     Invocation parentInvocation,
@@ -610,8 +587,7 @@ class _FakeQueryManager_51 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake
-    implements _i14.ObservableQuery<TParsed1> {
+class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
   _FakeObservableQuery_52(
     Object parent,
     Invocation parentInvocation,
@@ -621,8 +597,7 @@ class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake
         );
 }
 
-class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake
-    implements _i14.QueryResult<TParsed1> {
+class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
   _FakeQueryResult_53(
     Object parent,
     Invocation parentInvocation,
@@ -632,8 +607,7 @@ class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake
         );
 }
 
-class _FakeHttpClientRequest_54 extends _i1.SmartFake
-    implements _i25.HttpClientRequest {
+class _FakeHttpClientRequest_54 extends _i1.SmartFake implements _i25.HttpClientRequest {
   _FakeHttpClientRequest_54(
     Object parent,
     Invocation parentInvocation,
@@ -663,8 +637,7 @@ class _FakeHttpHeaders_56 extends _i1.SmartFake implements _i25.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_57 extends _i1.SmartFake
-    implements _i25.HttpClientResponse {
+class _FakeHttpClientResponse_57 extends _i1.SmartFake implements _i25.HttpClientResponse {
   _FakeHttpClientResponse_57(
     Object parent,
     Invocation parentInvocation,
@@ -694,8 +667,7 @@ class _FakeSocket_59 extends _i1.SmartFake implements _i25.Socket {
         );
 }
 
-class _FakeStreamSubscription_60<T> extends _i1.SmartFake
-    implements _i20.StreamSubscription<T> {
+class _FakeStreamSubscription_60<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
   _FakeStreamSubscription_60(
     Object parent,
     Invocation parentInvocation,
@@ -715,8 +687,7 @@ class _FakeFusionTester_61 extends _i1.SmartFake implements _i15.FusionTester {
         );
 }
 
-class _FakeBuildBucketClient_62 extends _i1.SmartFake
-    implements _i15.BuildBucketClient {
+class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
   _FakeBuildBucketClient_62(
     Object parent,
     Invocation parentInvocation,
@@ -756,8 +727,7 @@ class _FakeProcess_65 extends _i1.SmartFake implements _i25.Process {
         );
 }
 
-class _FakeTableDataInsertAllResponse_66 extends _i1.SmartFake
-    implements _i5.TableDataInsertAllResponse {
+class _FakeTableDataInsertAllResponse_66 extends _i1.SmartFake implements _i5.TableDataInsertAllResponse {
   _FakeTableDataInsertAllResponse_66(
     Object parent,
     Invocation parentInvocation,
@@ -807,8 +777,7 @@ class _FakePublicKey_70 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeBeginTransactionResponse_71 extends _i1.SmartFake
-    implements _i21.BeginTransactionResponse {
+class _FakeBeginTransactionResponse_71 extends _i1.SmartFake implements _i21.BeginTransactionResponse {
   _FakeBeginTransactionResponse_71(
     Object parent,
     Invocation parentInvocation,
@@ -828,8 +797,7 @@ class _Fake$Empty_72 extends _i1.SmartFake implements _i27.$Empty {
         );
 }
 
-class _FakeListDocumentsResponse_73 extends _i1.SmartFake
-    implements _i21.ListDocumentsResponse {
+class _FakeListDocumentsResponse_73 extends _i1.SmartFake implements _i21.ListDocumentsResponse {
   _FakeListDocumentsResponse_73(
     Object parent,
     Invocation parentInvocation,
@@ -839,8 +807,7 @@ class _FakeListDocumentsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake
-    implements _i21.ListCollectionIdsResponse {
+class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake implements _i21.ListCollectionIdsResponse {
   _FakeListCollectionIdsResponse_74(
     Object parent,
     Invocation parentInvocation,
@@ -850,8 +817,7 @@ class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakePartitionQueryResponse_75 extends _i1.SmartFake
-    implements _i21.PartitionQueryResponse {
+class _FakePartitionQueryResponse_75 extends _i1.SmartFake implements _i21.PartitionQueryResponse {
   _FakePartitionQueryResponse_75(
     Object parent,
     Invocation parentInvocation,
@@ -861,8 +827,7 @@ class _FakePartitionQueryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeWriteResponse_76 extends _i1.SmartFake
-    implements _i21.WriteResponse {
+class _FakeWriteResponse_76 extends _i1.SmartFake implements _i21.WriteResponse {
   _FakeWriteResponse_76(
     Object parent,
     Invocation parentInvocation,
@@ -872,8 +837,7 @@ class _FakeWriteResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeStagingConclusion_77 extends _i1.SmartFake
-    implements _i28.StagingConclusion {
+class _FakeStagingConclusion_77 extends _i1.SmartFake implements _i28.StagingConclusion {
   _FakeStagingConclusion_77(
     Object parent,
     Invocation parentInvocation,
@@ -906,8 +870,7 @@ class _FakeCache_79<T> extends _i1.SmartFake implements _i29.Cache<T> {
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock
-    implements _i30.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock implements _i30.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -960,8 +923,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
           #defaultTabledata,
           [],
         ),
-        returnValue:
-            _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
+        returnValue: _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
           this,
           Invocation.method(
             #defaultTabledata,
@@ -1000,8 +962,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #bucket: bucket,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(
-            <_i16.BuilderStatistic>[]),
+        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(<_i16.BuilderStatistic>[]),
       ) as _i20.Future<List<_i16.BuilderStatistic>>);
 
   @override
@@ -1019,8 +980,7 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #limit: limit,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
+        returnValue: _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
       ) as _i20.Future<List<_i16.BuilderRecord>>);
 }
 
@@ -1090,8 +1050,7 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Future<List<Map<String, String>>>.value(
-            <Map<String, String>>[]),
+        returnValue: _i20.Future<List<Map<String, String>>>.value(<Map<String, String>>[]),
       ) as _i20.Future<List<Map<String, String>>>);
 }
 
@@ -1134,8 +1093,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> scheduleBuild(
     _i8.ScheduleBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1156,8 +1114,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.SearchBuildsResponse> searchBuilds(
     _i8.SearchBuildsRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1165,8 +1122,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(
-            _FakeSearchBuildsResponse_8(
+        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(_FakeSearchBuildsResponse_8(
           this,
           Invocation.method(
             #searchBuilds,
@@ -1179,8 +1135,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.BatchResponse> batch(
     _i8.BatchRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1201,8 +1156,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> cancelBuild(
     _i8.CancelBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1223,8 +1177,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> getBuild(
     _i8.GetBuildRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1245,8 +1198,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.ListBuildersResponse> listBuilders(
     _i8.ListBuildersRequest? request, {
-    String? buildBucketUri =
-        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
+    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1254,8 +1206,7 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(
-            _FakeListBuildersResponse_10(
+        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(_FakeListBuildersResponse_10(
           this,
           Invocation.method(
             #listBuilders,
@@ -1302,8 +1253,7 @@ class MockCommitService extends _i1.Mock implements _i33.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i34.CreateEvent? createEvent) =>
-      (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i34.CreateEvent? createEvent) => (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1313,8 +1263,7 @@ class MockCommitService extends _i1.Mock implements _i33.CommitService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) =>
-      (super.noSuchMethod(
+  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) => (super.noSuchMethod(
         Invocation.method(
           #handlePushGithubRequest,
           [pushEvent],
@@ -1390,11 +1339,9 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<Map<String, dynamic>> get githubAppInstallations =>
-      (super.noSuchMethod(
+  _i20.Future<Map<String, dynamic>> get githubAppInstallations => (super.noSuchMethod(
         Invocation.getter(#githubAppInstallations),
-        returnValue:
-            _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+        returnValue: _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i20.Future<Map<String, dynamic>>);
 
   @override
@@ -1638,8 +1585,7 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i35.Branch>> getBranches(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<Iterable<_i35.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
@@ -1648,8 +1594,7 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<Iterable<_i35.Branch>>);
 
   @override
-  String wrongHeadBranchPullRequestMessage(String? branch) =>
-      (super.noSuchMethod(
+  String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
         Invocation.method(
           #wrongHeadBranchPullRequestMessage,
           [branch],
@@ -1694,8 +1639,7 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as String);
 
   @override
-  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #flutterGoldAlertConstant,
           [slug],
@@ -1740,8 +1684,7 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #generateGithubToken,
           [slug],
@@ -1798,14 +1741,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i13.GitHub);
 
   @override
-  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() => (super.noSuchMethod(
         Invocation.method(
           #createGitHubGraphQLClient,
           [],
         ),
-        returnValue:
-            _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
+        returnValue: _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
           this,
           Invocation.method(
             #createGitHubGraphQLClient,
@@ -1815,14 +1756,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i14.GraphQLClient>);
 
   @override
-  _i20.Future<_i15.FirestoreService> createFirestoreService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i15.FirestoreService> createFirestoreService() => (super.noSuchMethod(
         Invocation.method(
           #createFirestoreService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
+        returnValue: _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
           this,
           Invocation.method(
             #createFirestoreService,
@@ -1832,14 +1771,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i15.FirestoreService>);
 
   @override
-  _i20.Future<_i16.BigqueryService> createBigQueryService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i16.BigqueryService> createBigQueryService() => (super.noSuchMethod(
         Invocation.method(
           #createBigQueryService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
+        returnValue: _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
           this,
           Invocation.method(
             #createBigQueryService,
@@ -1849,14 +1786,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i16.BigqueryService>);
 
   @override
-  _i20.Future<_i5.TabledataResource> createTabledataResourceApi() =>
-      (super.noSuchMethod(
+  _i20.Future<_i5.TabledataResource> createTabledataResourceApi() => (super.noSuchMethod(
         Invocation.method(
           #createTabledataResourceApi,
           [],
         ),
-        returnValue:
-            _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
+        returnValue: _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
           this,
           Invocation.method(
             #createTabledataResourceApi,
@@ -1866,14 +1801,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i5.TabledataResource>);
 
   @override
-  _i20.Future<_i17.GithubService> createDefaultGitHubService() =>
-      (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createDefaultGitHubService() => (super.noSuchMethod(
         Invocation.method(
           #createDefaultGitHubService,
           [],
         ),
-        returnValue:
-            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createDefaultGitHubService,
@@ -1883,15 +1816,12 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i20.Future<_i17.GithubService> createGithubService(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createGithubService(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #createGithubService,
           [slug],
         ),
-        returnValue:
-            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createGithubService,
@@ -1901,8 +1831,7 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i17.GithubService createGithubServiceWithToken(String? token) =>
-      (super.noSuchMethod(
+  _i17.GithubService createGithubServiceWithToken(String? token) => (super.noSuchMethod(
         Invocation.method(
           #createGithubServiceWithToken,
           [token],
@@ -2019,8 +1948,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Stream<_i37.FullTask>);
 
   @override
-  _i20.Future<List<_i38.Stage>> queryTasksGroupedByStage(_i36.Commit? commit) =>
-      (super.noSuchMethod(
+  _i20.Future<List<_i38.Stage>> queryTasksGroupedByStage(_i36.Commit? commit) => (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
@@ -2041,8 +1969,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(
-            _FakeGithubBuildStatusUpdate_21(
+        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(_FakeGithubBuildStatusUpdate_21(
           this,
           Invocation.method(
             #queryLastStatusUpdate,
@@ -2067,8 +1994,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(
-            _FakeGithubGoldStatusUpdate_22(
+        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(_FakeGithubGoldStatusUpdate_22(
           this,
           Invocation.method(
             #queryLastGoldUpdate,
@@ -2081,20 +2007,16 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<_i19.GithubGoldStatusUpdate>);
 
   @override
-  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(
-          List<_i11.Model<dynamic>>? rows) =>
-      (super.noSuchMethod(
+  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
         Invocation.method(
           #shard,
           [rows],
         ),
-        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(
-            <List<_i11.Model<dynamic>>>[]),
+        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(<List<_i11.Model<dynamic>>>[]),
       ) as _i20.Future<List<List<_i11.Model<dynamic>>>>);
 
   @override
-  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) =>
-      (super.noSuchMethod(
+  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
         Invocation.method(
           #insert,
           [rows],
@@ -2104,8 +2026,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(
-          List<_i11.Key<dynamic>>? keys) =>
+  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(List<_i11.Key<dynamic>>? keys) =>
       (super.noSuchMethod(
         Invocation.method(
           #lookupByKey,
@@ -2147,9 +2068,7 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T>);
 
   @override
-  _i20.Future<T?> withTransaction<T>(
-          _i20.Future<T> Function(_i11.Transaction)? handler) =>
-      (super.noSuchMethod(
+  _i20.Future<T?> withTransaction<T>(_i20.Future<T> Function(_i11.Transaction)? handler) => (super.noSuchMethod(
         Invocation.method(
           #withTransaction,
           [handler],
@@ -2257,14 +2176,13 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i4.AccessClientProvider);
 
   @override
-  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() =>
-      (super.noSuchMethod(
+  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() => (super.noSuchMethod(
         Invocation.method(
           #documentResource,
           [],
         ),
-        returnValue: _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(
-            _FakeProjectsDatabasesDocumentsResource_24(
+        returnValue:
+            _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(_FakeProjectsDatabasesDocumentsResource_24(
           this,
           Invocation.method(
             #documentResource,
@@ -2301,8 +2219,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             database,
           ],
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
-            _FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWriteDocuments,
@@ -2315,15 +2232,12 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.BatchWriteResponse>);
 
   @override
-  _i20.Future<_i21.CommitResponse> writeViaTransaction(
-          List<_i21.Write>? writes) =>
-      (super.noSuchMethod(
+  _i20.Future<_i21.CommitResponse> writeViaTransaction(List<_i21.Write>? writes) => (super.noSuchMethod(
         Invocation.method(
           #writeViaTransaction,
           [writes],
         ),
-        returnValue:
-            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #writeViaTransaction,
@@ -2354,8 +2268,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<List<_i41.Commit>>);
 
   @override
-  _i20.Future<List<_i42.Task>> queryCommitTasks(String? commitSha) =>
-      (super.noSuchMethod(
+  _i20.Future<List<_i42.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
         Invocation.method(
           #queryCommitTasks,
           [commitSha],
@@ -2376,8 +2289,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             prNumber,
           ],
         ),
-        returnValue:
-            _i20.Future<_i22.GithubGoldStatus>.value(_FakeGithubGoldStatus_28(
+        returnValue: _i20.Future<_i22.GithubGoldStatus>.value(_FakeGithubGoldStatus_28(
           this,
           Invocation.method(
             #queryLastGoldStatus,
@@ -2404,8 +2316,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             head,
           ],
         ),
-        returnValue:
-            _i20.Future<_i23.GithubBuildStatus>.value(_FakeGithubBuildStatus_29(
+        returnValue: _i20.Future<_i23.GithubBuildStatus>.value(_FakeGithubBuildStatus_29(
           this,
           Invocation.method(
             #queryLastBuildStatus,
@@ -2483,8 +2394,7 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<List<_i21.Document>>);
 
   @override
-  List<_i21.Document> documentsFromQueryResponse(
-          List<_i21.RunQueryResponseElement>? runQueryResponseElements) =>
+  List<_i21.Document> documentsFromQueryResponse(List<_i21.RunQueryResponseElement>? runQueryResponseElements) =>
       (super.noSuchMethod(
         Invocation.method(
           #documentsFromQueryResponse,
@@ -2718,8 +2628,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<_i13.Issue>);
 
   @override
-  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listAssignees,
           [slug],
@@ -2760,9 +2669,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Stream<_i13.IssueComment>);
 
   @override
-  _i20.Stream<_i13.IssueComment> listCommentsByRepo(
-          _i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.IssueComment> listCommentsByRepo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listCommentsByRepo,
           [slug],
@@ -2868,8 +2775,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listLabels,
           [slug],
@@ -3050,8 +2956,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3069,8 +2974,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3108,8 +3012,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) => (super.noSuchMethod(
         Invocation.method(
           #listMilestones,
           [slug],
@@ -3214,8 +3117,7 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
 /// A class which mocks [GithubChecksService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksService extends _i1.Mock
-    implements _i15.GithubChecksService {
+class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksService {
   MockGithubChecksService() {
     _i1.throwOnMissingStub(this);
   }
@@ -3248,8 +3150,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) =>
-      super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3314,8 +3215,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i8.Status? status) =>
-      (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i8.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [status],
@@ -3330,8 +3230,7 @@ class MockGithubChecksService extends _i1.Mock
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i8.Status? status) =>
-      (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i8.Status? status) => (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
@@ -3385,8 +3284,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i24.GithubChecksUtil {
             checkSuiteEvent,
           ],
         ),
-        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(
-            <String, _i13.CheckRun>{}),
+        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(<String, _i13.CheckRun>{}),
       ) as _i20.Future<Map<String, _i13.CheckRun>>);
 
   @override
@@ -3438,8 +3336,7 @@ class MockGithubChecksUtil extends _i1.Mock implements _i24.GithubChecksUtil {
             #checkName: checkName,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
+        returnValue: _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
       ) as _i20.Future<List<_i13.CheckSuite>>);
 
   @override
@@ -3566,8 +3463,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             lastCommitTimestampMills,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(
-            <_i13.RepositoryCommit>[]),
+        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(<_i13.RepositoryCommit>[]),
       ) as _i20.Future<List<_i13.RepositoryCommit>>);
 
   @override
@@ -3599,8 +3495,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             branch,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
+        returnValue: _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
       ) as _i20.Future<List<_i13.PullRequest>>);
 
   @override
@@ -3672,8 +3567,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             issueNumber,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3691,8 +3585,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             labels,
           ],
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3828,8 +3721,7 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #labels: labels,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -4317,8 +4209,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.DefaultPolicies);
 
   @override
-  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) =>
-      super.noSuchMethod(
+  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) => super.noSuchMethod(
         Invocation.setter(
           #defaultPolicies,
           _defaultPolicies,
@@ -4396,9 +4287,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.GraphQLClient);
 
   @override
-  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(
-          _i14.WatchQueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #watchQuery,
           [options],
@@ -4413,9 +4302,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(
-          _i14.WatchQueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #watchMutation,
           [options],
@@ -4430,15 +4317,12 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(
-          _i14.QueryOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(_i14.QueryOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4448,15 +4332,12 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(
-          _i14.MutationOptions<TParsed>? options) =>
-      (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(_i14.MutationOptions<TParsed>? options) => (super.noSuchMethod(
         Invocation.method(
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4466,8 +4347,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(
-          _i14.SubscriptionOptions<TParsed>? options) =>
+  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(_i14.SubscriptionOptions<TParsed>? options) =>
       (super.noSuchMethod(
         Invocation.method(
           #subscribe,
@@ -4491,8 +4371,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
-            _FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4564,8 +4443,7 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       );
 
   @override
-  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore(
-          {bool? refetchQueries = true}) =>
+  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore({bool? refetchQueries = true}) =>
       (super.noSuchMethod(Invocation.method(
         #resetStore,
         [],
@@ -4737,8 +4615,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #open,
@@ -4765,8 +4642,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             url,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #openUrl,
@@ -4793,8 +4669,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #get,
@@ -4813,8 +4688,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #getUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #getUrl,
@@ -4838,8 +4712,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #post,
@@ -4858,8 +4731,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #postUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #postUrl,
@@ -4883,8 +4755,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #put,
@@ -4903,8 +4774,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #putUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #putUrl,
@@ -4928,8 +4798,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #delete,
@@ -4943,14 +4812,12 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
       ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i25.HttpClientRequest> deleteUrl(Uri? url) =>
-      (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #deleteUrl,
@@ -4974,8 +4841,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patch,
@@ -4994,8 +4860,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #patchUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patchUrl,
@@ -5019,8 +4884,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #head,
@@ -5039,8 +4903,7 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #headUrl,
           [url],
         ),
-        returnValue:
-            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #headUrl,
@@ -5217,8 +5080,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
   @override
   _i20.Future<_i25.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
-            _FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.getter(#done),
         )),
@@ -5248,8 +5110,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
-            _FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #close,
@@ -5343,8 +5204,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
       );
 
   @override
-  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) =>
-      (super.noSuchMethod(
+  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) => (super.noSuchMethod(
         Invocation.method(
           #addStream,
           [stream],
@@ -5365,8 +5225,7 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock
-    implements _i25.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5393,8 +5252,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as int);
 
   @override
-  _i25.HttpClientResponseCompressionState get compressionState =>
-      (super.noSuchMethod(
+  _i25.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
         Invocation.getter(#compressionState),
         returnValue: _i25.HttpClientResponseCompressionState.notCompressed,
       ) as _i25.HttpClientResponseCompressionState);
@@ -5483,8 +5341,7 @@ class MockHttpClientResponse extends _i1.Mock
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
-            _FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #redirect,
@@ -5561,8 +5418,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.StreamSubscription<List<int>>);
 
   @override
-  _i20.Stream<List<int>> where(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> where(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #where,
           [test],
@@ -5580,8 +5436,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #asyncMap,
           [convert],
@@ -5590,8 +5445,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<E>);
 
   @override
-  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #asyncExpand,
           [convert],
@@ -5614,8 +5468,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) =>
-      (super.noSuchMethod(
+  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) => (super.noSuchMethod(
         Invocation.method(
           #expand,
           [convert],
@@ -5624,8 +5477,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) =>
-      (super.noSuchMethod(
+  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) => (super.noSuchMethod(
         Invocation.method(
           #pipe,
           [streamConsumer],
@@ -5634,9 +5486,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<dynamic>);
 
   @override
-  _i20.Stream<S> transform<S>(
-          _i20.StreamTransformer<List<int>, S>? streamTransformer) =>
-      (super.noSuchMethod(
+  _i20.Stream<S> transform<S>(_i20.StreamTransformer<List<int>, S>? streamTransformer) => (super.noSuchMethod(
         Invocation.method(
           #transform,
           [streamTransformer],
@@ -5724,8 +5574,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Future<void> forEach(void Function(List<int>)? action) =>
-      (super.noSuchMethod(
+  _i20.Future<void> forEach(void Function(List<int>)? action) => (super.noSuchMethod(
         Invocation.method(
           #forEach,
           [action],
@@ -5735,8 +5584,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<bool> every(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #every,
           [test],
@@ -5815,8 +5663,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #takeWhile,
           [test],
@@ -5834,8 +5681,7 @@ class MockHttpClientResponse extends _i1.Mock
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) =>
-      (super.noSuchMethod(
+  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
         Invocation.method(
           #skipWhile,
           [test],
@@ -5950,8 +5796,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i15.BuildBucketClient);
 
   @override
-  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) =>
-      super.noSuchMethod(
+  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) => super.noSuchMethod(
         Invocation.setter(
           #buildBucketClient,
           _buildBucketClient,
@@ -5996,8 +5841,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) =>
-      super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -6090,8 +5934,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #maxShardSize: maxShardSize,
           },
         ),
-        returnValue: _i20.Future<List<List<_i8.BatchRequest_Request>>>.value(
-            <List<_i8.BatchRequest_Request>>[]),
+        returnValue: _i20.Future<List<List<_i8.BatchRequest_Request>>>.value(<List<_i8.BatchRequest_Request>>[]),
       ) as _i20.Future<List<List<_i8.BatchRequest_Request>>>);
 
   @override
@@ -6112,8 +5955,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(
-          {required _i13.PullRequest? pullRequest}) =>
+  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest({required _i13.PullRequest? pullRequest}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTryBuildsByPullRequest,
@@ -6265,8 +6107,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(
-          {required _i44.CheckRunEvent? checkRunEvent}) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent({required _i44.CheckRunEvent? checkRunEvent}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6363,8 +6204,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<
-      List<_i15.Tuple<_i43.Target, _i37.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>> schedulePostsubmitBuilds({
     required _i36.Commit? commit,
     required List<_i15.Tuple<_i43.Target, _i37.Task, int>>? toBeScheduled,
   }) =>
@@ -6377,9 +6217,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue:
-            _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>.value(
-                <_i15.Tuple<_i43.Target, _i37.Task, int>>[]),
+        returnValue: _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>.value(
+            <_i15.Tuple<_i43.Target, _i37.Task, int>>[]),
       ) as _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>);
 
   @override
@@ -6517,8 +6356,7 @@ class MockProcessManager extends _i1.Mock implements _i46.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i25.ProcessResult>.value(
-            _i32.dummyValue<_i25.ProcessResult>(
+        returnValue: _i20.Future<_i25.ProcessResult>.value(_i32.dummyValue<_i25.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6747,8 +6585,7 @@ class MockTabledataResource extends _i1.Mock implements _i5.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(
-            _FakeTableDataInsertAllResponse_66(
+        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_66(
           this,
           Invocation.method(
             #insertAll,
@@ -6953,8 +6790,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.UserEmail>);
 
   @override
-  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) => (super.noSuchMethod(
         Invocation.method(
           #addEmails,
           [emails],
@@ -7042,8 +6878,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.User>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) =>
-      (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) => (super.noSuchMethod(
         Invocation.method(
           #listPublicKeys,
           [userLogin],
@@ -7052,8 +6887,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.PublicKey>);
 
   @override
-  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) =>
-      (super.noSuchMethod(
+  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) => (super.noSuchMethod(
         Invocation.method(
           #createPublicKey,
           [key],
@@ -7071,8 +6905,7 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
 /// A class which mocks [ProjectsDatabasesDocumentsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsDatabasesDocumentsResource extends _i1.Mock
-    implements _i21.ProjectsDatabasesDocumentsResource {
+class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.ProjectsDatabasesDocumentsResource {
   MockProjectsDatabasesDocumentsResource() {
     _i1.throwOnMissingStub(this);
   }
@@ -7093,8 +6926,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           {#$fields: $fields},
         ),
         returnValue:
-            _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>.value(
-                <_i21.BatchGetDocumentsResponseElement>[]),
+            _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>.value(<_i21.BatchGetDocumentsResponseElement>[]),
       ) as _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>);
 
   @override
@@ -7112,8 +6944,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
-            _FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWrite,
@@ -7141,8 +6972,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(
-            _FakeBeginTransactionResponse_71(
+        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(_FakeBeginTransactionResponse_71(
           this,
           Invocation.method(
             #beginTransaction,
@@ -7170,8 +7000,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue:
-            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #commit,
@@ -7321,8 +7150,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(
-            _FakeListDocumentsResponse_73(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #list,
@@ -7359,8 +7187,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(
-            _FakeListCollectionIdsResponse_74(
+        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(_FakeListCollectionIdsResponse_74(
           this,
           Invocation.method(
             #listCollectionIds,
@@ -7404,8 +7231,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(
-            _FakeListDocumentsResponse_73(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #listDocuments,
@@ -7442,8 +7268,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(
-            _FakePartitionQueryResponse_75(
+        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(_FakePartitionQueryResponse_75(
           this,
           Invocation.method(
             #partitionQuery,
@@ -7529,8 +7354,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
       ) as _i20.Future<_i27.$Empty>);
 
   @override
-  _i20.Future<
-      List<_i21.RunAggregationQueryResponseElement>> runAggregationQuery(
+  _i20.Future<List<_i21.RunAggregationQueryResponseElement>> runAggregationQuery(
     _i21.RunAggregationQueryRequest? request,
     String? parent, {
     String? $fields,
@@ -7544,9 +7368,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue:
-            _i20.Future<List<_i21.RunAggregationQueryResponseElement>>.value(
-                <_i21.RunAggregationQueryResponseElement>[]),
+        returnValue: _i20.Future<List<_i21.RunAggregationQueryResponseElement>>.value(
+            <_i21.RunAggregationQueryResponseElement>[]),
       ) as _i20.Future<List<_i21.RunAggregationQueryResponseElement>>);
 
   @override
@@ -7564,8 +7387,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<List<_i21.RunQueryResponseElement>>.value(
-            <_i21.RunQueryResponseElement>[]),
+        returnValue: _i20.Future<List<_i21.RunQueryResponseElement>>.value(<_i21.RunQueryResponseElement>[]),
       ) as _i20.Future<List<_i21.RunQueryResponseElement>>);
 
   @override
@@ -7583,8 +7405,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
           ],
           {#$fields: $fields},
         ),
-        returnValue:
-            _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_76(
+        returnValue: _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_76(
           this,
           Invocation.method(
             #write,
@@ -7601,8 +7422,7 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock
 /// A class which mocks [BeginTransactionResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBeginTransactionResponse extends _i1.Mock
-    implements _i21.BeginTransactionResponse {
+class MockBeginTransactionResponse extends _i1.Mock implements _i21.BeginTransactionResponse {
   MockBeginTransactionResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -7671,8 +7491,7 @@ class MockCallbacks extends _i1.Mock implements _i47.Callbacks {
             #conclusion: conclusion,
           },
         ),
-        returnValue:
-            _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_77(
+        returnValue: _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_77(
           this,
           Invocation.method(
             #markCheckRunConclusion,
@@ -7826,8 +7645,7 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
       ) as _i29.Cache<_i40.Uint8List>);
 
   @override
-  _i29.Cache<S> withCodec<S>(_i26.Codec<S, _i40.Uint8List>? codec) =>
-      (super.noSuchMethod(
+  _i29.Cache<S> withCodec<S>(_i26.Codec<S, _i40.Uint8List>? codec) => (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -15,16 +15,20 @@ import 'package:cocoon_service/cocoon_service.dart' as _i15;
 import 'package:cocoon_service/src/foundation/github_checks_util.dart' as _i24;
 import 'package:cocoon_service/src/model/appengine/branch.dart' as _i35;
 import 'package:cocoon_service/src/model/appengine/commit.dart' as _i36;
-import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart' as _i18;
-import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart' as _i19;
+import 'package:cocoon_service/src/model/appengine/github_build_status_update.dart'
+    as _i18;
+import 'package:cocoon_service/src/model/appengine/github_gold_status_update.dart'
+    as _i19;
 import 'package:cocoon_service/src/model/appengine/key_helper.dart' as _i12;
 import 'package:cocoon_service/src/model/appengine/stage.dart' as _i38;
 import 'package:cocoon_service/src/model/appengine/task.dart' as _i37;
 import 'package:cocoon_service/src/model/ci_yaml/target.dart' as _i43;
 import 'package:cocoon_service/src/model/firestore/ci_staging.dart' as _i28;
 import 'package:cocoon_service/src/model/firestore/commit.dart' as _i41;
-import 'package:cocoon_service/src/model/firestore/github_build_status.dart' as _i23;
-import 'package:cocoon_service/src/model/firestore/github_gold_status.dart' as _i22;
+import 'package:cocoon_service/src/model/firestore/github_build_status.dart'
+    as _i23;
+import 'package:cocoon_service/src/model/firestore/github_gold_status.dart'
+    as _i22;
 import 'package:cocoon_service/src/model/firestore/task.dart' as _i42;
 import 'package:cocoon_service/src/model/github/checks.dart' as _i44;
 import 'package:cocoon_service/src/service/access_token_provider.dart' as _i30;
@@ -86,7 +90,8 @@ class _FakeAccessToken_1 extends _i1.SmartFake implements _i3.AccessToken {
         );
 }
 
-class _FakeAccessClientProvider_2 extends _i1.SmartFake implements _i4.AccessClientProvider {
+class _FakeAccessClientProvider_2 extends _i1.SmartFake
+    implements _i4.AccessClientProvider {
   _FakeAccessClientProvider_2(
     Object parent,
     Invocation parentInvocation,
@@ -96,7 +101,8 @@ class _FakeAccessClientProvider_2 extends _i1.SmartFake implements _i4.AccessCli
         );
 }
 
-class _FakeTabledataResource_3 extends _i1.SmartFake implements _i5.TabledataResource {
+class _FakeTabledataResource_3 extends _i1.SmartFake
+    implements _i5.TabledataResource {
   _FakeTabledataResource_3(
     Object parent,
     Invocation parentInvocation,
@@ -146,7 +152,8 @@ class _FakeBuild_7 extends _i1.SmartFake implements _i8.Build {
         );
 }
 
-class _FakeSearchBuildsResponse_8 extends _i1.SmartFake implements _i8.SearchBuildsResponse {
+class _FakeSearchBuildsResponse_8 extends _i1.SmartFake
+    implements _i8.SearchBuildsResponse {
   _FakeSearchBuildsResponse_8(
     Object parent,
     Invocation parentInvocation,
@@ -166,7 +173,8 @@ class _FakeBatchResponse_9 extends _i1.SmartFake implements _i8.BatchResponse {
         );
 }
 
-class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuildersResponse {
+class _FakeListBuildersResponse_10 extends _i1.SmartFake
+    implements _i8.ListBuildersResponse {
   _FakeListBuildersResponse_10(
     Object parent,
     Invocation parentInvocation,
@@ -176,7 +184,8 @@ class _FakeListBuildersResponse_10 extends _i1.SmartFake implements _i8.ListBuil
         );
 }
 
-class _FakeDatastoreService_11 extends _i1.SmartFake implements _i9.DatastoreService {
+class _FakeDatastoreService_11 extends _i1.SmartFake
+    implements _i9.DatastoreService {
   _FakeDatastoreService_11(
     Object parent,
     Invocation parentInvocation,
@@ -236,7 +245,8 @@ class _FakeGitHub_16 extends _i1.SmartFake implements _i13.GitHub {
         );
 }
 
-class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient {
+class _FakeGraphQLClient_17 extends _i1.SmartFake
+    implements _i14.GraphQLClient {
   _FakeGraphQLClient_17(
     Object parent,
     Invocation parentInvocation,
@@ -246,7 +256,8 @@ class _FakeGraphQLClient_17 extends _i1.SmartFake implements _i14.GraphQLClient 
         );
 }
 
-class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreService {
+class _FakeFirestoreService_18 extends _i1.SmartFake
+    implements _i15.FirestoreService {
   _FakeFirestoreService_18(
     Object parent,
     Invocation parentInvocation,
@@ -256,7 +267,8 @@ class _FakeFirestoreService_18 extends _i1.SmartFake implements _i15.FirestoreSe
         );
 }
 
-class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryService {
+class _FakeBigqueryService_19 extends _i1.SmartFake
+    implements _i16.BigqueryService {
   _FakeBigqueryService_19(
     Object parent,
     Invocation parentInvocation,
@@ -266,7 +278,8 @@ class _FakeBigqueryService_19 extends _i1.SmartFake implements _i16.BigqueryServ
         );
 }
 
-class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService {
+class _FakeGithubService_20 extends _i1.SmartFake
+    implements _i17.GithubService {
   _FakeGithubService_20(
     Object parent,
     Invocation parentInvocation,
@@ -276,7 +289,8 @@ class _FakeGithubService_20 extends _i1.SmartFake implements _i17.GithubService 
         );
 }
 
-class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.GithubBuildStatusUpdate {
+class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake
+    implements _i18.GithubBuildStatusUpdate {
   _FakeGithubBuildStatusUpdate_21(
     Object parent,
     Invocation parentInvocation,
@@ -286,7 +300,8 @@ class _FakeGithubBuildStatusUpdate_21 extends _i1.SmartFake implements _i18.Gith
         );
 }
 
-class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake implements _i19.GithubGoldStatusUpdate {
+class _FakeGithubGoldStatusUpdate_22 extends _i1.SmartFake
+    implements _i19.GithubGoldStatusUpdate {
   _FakeGithubGoldStatusUpdate_22(
     Object parent,
     Invocation parentInvocation,
@@ -327,7 +342,8 @@ class _FakeDocument_25 extends _i1.SmartFake implements _i21.Document {
         );
 }
 
-class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWriteResponse {
+class _FakeBatchWriteResponse_26 extends _i1.SmartFake
+    implements _i21.BatchWriteResponse {
   _FakeBatchWriteResponse_26(
     Object parent,
     Invocation parentInvocation,
@@ -337,7 +353,8 @@ class _FakeBatchWriteResponse_26 extends _i1.SmartFake implements _i21.BatchWrit
         );
 }
 
-class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitResponse {
+class _FakeCommitResponse_27 extends _i1.SmartFake
+    implements _i21.CommitResponse {
   _FakeCommitResponse_27(
     Object parent,
     Invocation parentInvocation,
@@ -347,7 +364,8 @@ class _FakeCommitResponse_27 extends _i1.SmartFake implements _i21.CommitRespons
         );
 }
 
-class _FakeGithubGoldStatus_28 extends _i1.SmartFake implements _i22.GithubGoldStatus {
+class _FakeGithubGoldStatus_28 extends _i1.SmartFake
+    implements _i22.GithubGoldStatus {
   _FakeGithubGoldStatus_28(
     Object parent,
     Invocation parentInvocation,
@@ -357,7 +375,8 @@ class _FakeGithubGoldStatus_28 extends _i1.SmartFake implements _i22.GithubGoldS
         );
 }
 
-class _FakeGithubBuildStatus_29 extends _i1.SmartFake implements _i23.GithubBuildStatus {
+class _FakeGithubBuildStatus_29 extends _i1.SmartFake
+    implements _i23.GithubBuildStatus {
   _FakeGithubBuildStatus_29(
     Object parent,
     Invocation parentInvocation,
@@ -427,7 +446,8 @@ class _FakeMilestone_35 extends _i1.SmartFake implements _i13.Milestone {
         );
 }
 
-class _FakeGithubChecksUtil_36 extends _i1.SmartFake implements _i24.GithubChecksUtil {
+class _FakeGithubChecksUtil_36 extends _i1.SmartFake
+    implements _i24.GithubChecksUtil {
   _FakeGithubChecksUtil_36(
     Object parent,
     Invocation parentInvocation,
@@ -437,7 +457,8 @@ class _FakeGithubChecksUtil_36 extends _i1.SmartFake implements _i24.GithubCheck
         );
 }
 
-class _FakeCheckRunConclusion_37 extends _i1.SmartFake implements _i13.CheckRunConclusion {
+class _FakeCheckRunConclusion_37 extends _i1.SmartFake
+    implements _i13.CheckRunConclusion {
   _FakeCheckRunConclusion_37(
     Object parent,
     Invocation parentInvocation,
@@ -447,7 +468,8 @@ class _FakeCheckRunConclusion_37 extends _i1.SmartFake implements _i13.CheckRunC
         );
 }
 
-class _FakeCheckRunStatus_38 extends _i1.SmartFake implements _i13.CheckRunStatus {
+class _FakeCheckRunStatus_38 extends _i1.SmartFake
+    implements _i13.CheckRunStatus {
   _FakeCheckRunStatus_38(
     Object parent,
     Invocation parentInvocation,
@@ -547,7 +569,8 @@ class _FakeGitTree_47 extends _i1.SmartFake implements _i13.GitTree {
         );
 }
 
-class _FakeDefaultPolicies_48 extends _i1.SmartFake implements _i14.DefaultPolicies {
+class _FakeDefaultPolicies_48 extends _i1.SmartFake
+    implements _i14.DefaultPolicies {
   _FakeDefaultPolicies_48(
     Object parent,
     Invocation parentInvocation,
@@ -587,7 +610,8 @@ class _FakeQueryManager_51 extends _i1.SmartFake implements _i14.QueryManager {
         );
 }
 
-class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake implements _i14.ObservableQuery<TParsed1> {
+class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake
+    implements _i14.ObservableQuery<TParsed1> {
   _FakeObservableQuery_52(
     Object parent,
     Invocation parentInvocation,
@@ -597,7 +621,8 @@ class _FakeObservableQuery_52<TParsed1> extends _i1.SmartFake implements _i14.Ob
         );
 }
 
-class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake implements _i14.QueryResult<TParsed1> {
+class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake
+    implements _i14.QueryResult<TParsed1> {
   _FakeQueryResult_53(
     Object parent,
     Invocation parentInvocation,
@@ -607,7 +632,8 @@ class _FakeQueryResult_53<TParsed1 extends Object?> extends _i1.SmartFake implem
         );
 }
 
-class _FakeHttpClientRequest_54 extends _i1.SmartFake implements _i25.HttpClientRequest {
+class _FakeHttpClientRequest_54 extends _i1.SmartFake
+    implements _i25.HttpClientRequest {
   _FakeHttpClientRequest_54(
     Object parent,
     Invocation parentInvocation,
@@ -637,7 +663,8 @@ class _FakeHttpHeaders_56 extends _i1.SmartFake implements _i25.HttpHeaders {
         );
 }
 
-class _FakeHttpClientResponse_57 extends _i1.SmartFake implements _i25.HttpClientResponse {
+class _FakeHttpClientResponse_57 extends _i1.SmartFake
+    implements _i25.HttpClientResponse {
   _FakeHttpClientResponse_57(
     Object parent,
     Invocation parentInvocation,
@@ -667,7 +694,8 @@ class _FakeSocket_59 extends _i1.SmartFake implements _i25.Socket {
         );
 }
 
-class _FakeStreamSubscription_60<T> extends _i1.SmartFake implements _i20.StreamSubscription<T> {
+class _FakeStreamSubscription_60<T> extends _i1.SmartFake
+    implements _i20.StreamSubscription<T> {
   _FakeStreamSubscription_60(
     Object parent,
     Invocation parentInvocation,
@@ -687,7 +715,8 @@ class _FakeFusionTester_61 extends _i1.SmartFake implements _i15.FusionTester {
         );
 }
 
-class _FakeBuildBucketClient_62 extends _i1.SmartFake implements _i15.BuildBucketClient {
+class _FakeBuildBucketClient_62 extends _i1.SmartFake
+    implements _i15.BuildBucketClient {
   _FakeBuildBucketClient_62(
     Object parent,
     Invocation parentInvocation,
@@ -727,7 +756,8 @@ class _FakeProcess_65 extends _i1.SmartFake implements _i25.Process {
         );
 }
 
-class _FakeTableDataInsertAllResponse_66 extends _i1.SmartFake implements _i5.TableDataInsertAllResponse {
+class _FakeTableDataInsertAllResponse_66 extends _i1.SmartFake
+    implements _i5.TableDataInsertAllResponse {
   _FakeTableDataInsertAllResponse_66(
     Object parent,
     Invocation parentInvocation,
@@ -777,7 +807,8 @@ class _FakePublicKey_70 extends _i1.SmartFake implements _i13.PublicKey {
         );
 }
 
-class _FakeBeginTransactionResponse_71 extends _i1.SmartFake implements _i21.BeginTransactionResponse {
+class _FakeBeginTransactionResponse_71 extends _i1.SmartFake
+    implements _i21.BeginTransactionResponse {
   _FakeBeginTransactionResponse_71(
     Object parent,
     Invocation parentInvocation,
@@ -797,7 +828,8 @@ class _Fake$Empty_72 extends _i1.SmartFake implements _i27.$Empty {
         );
 }
 
-class _FakeListDocumentsResponse_73 extends _i1.SmartFake implements _i21.ListDocumentsResponse {
+class _FakeListDocumentsResponse_73 extends _i1.SmartFake
+    implements _i21.ListDocumentsResponse {
   _FakeListDocumentsResponse_73(
     Object parent,
     Invocation parentInvocation,
@@ -807,7 +839,8 @@ class _FakeListDocumentsResponse_73 extends _i1.SmartFake implements _i21.ListDo
         );
 }
 
-class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake implements _i21.ListCollectionIdsResponse {
+class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake
+    implements _i21.ListCollectionIdsResponse {
   _FakeListCollectionIdsResponse_74(
     Object parent,
     Invocation parentInvocation,
@@ -817,7 +850,8 @@ class _FakeListCollectionIdsResponse_74 extends _i1.SmartFake implements _i21.Li
         );
 }
 
-class _FakePartitionQueryResponse_75 extends _i1.SmartFake implements _i21.PartitionQueryResponse {
+class _FakePartitionQueryResponse_75 extends _i1.SmartFake
+    implements _i21.PartitionQueryResponse {
   _FakePartitionQueryResponse_75(
     Object parent,
     Invocation parentInvocation,
@@ -827,7 +861,8 @@ class _FakePartitionQueryResponse_75 extends _i1.SmartFake implements _i21.Parti
         );
 }
 
-class _FakeWriteResponse_76 extends _i1.SmartFake implements _i21.WriteResponse {
+class _FakeWriteResponse_76 extends _i1.SmartFake
+    implements _i21.WriteResponse {
   _FakeWriteResponse_76(
     Object parent,
     Invocation parentInvocation,
@@ -837,7 +872,8 @@ class _FakeWriteResponse_76 extends _i1.SmartFake implements _i21.WriteResponse 
         );
 }
 
-class _FakeStagingConclusion_77 extends _i1.SmartFake implements _i28.StagingConclusion {
+class _FakeStagingConclusion_77 extends _i1.SmartFake
+    implements _i28.StagingConclusion {
   _FakeStagingConclusion_77(
     Object parent,
     Invocation parentInvocation,
@@ -870,7 +906,8 @@ class _FakeCache_79<T> extends _i1.SmartFake implements _i29.Cache<T> {
 /// A class which mocks [AccessTokenService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccessTokenService extends _i1.Mock implements _i30.AccessTokenService {
+class MockAccessTokenService extends _i1.Mock
+    implements _i30.AccessTokenService {
   MockAccessTokenService() {
     _i1.throwOnMissingStub(this);
   }
@@ -923,7 +960,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
           #defaultTabledata,
           [],
         ),
-        returnValue: _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
+        returnValue:
+            _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
           this,
           Invocation.method(
             #defaultTabledata,
@@ -962,7 +1000,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #bucket: bucket,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(<_i16.BuilderStatistic>[]),
+        returnValue: _i20.Future<List<_i16.BuilderStatistic>>.value(
+            <_i16.BuilderStatistic>[]),
       ) as _i20.Future<List<_i16.BuilderStatistic>>);
 
   @override
@@ -980,7 +1019,8 @@ class MockBigqueryService extends _i1.Mock implements _i16.BigqueryService {
             #limit: limit,
           },
         ),
-        returnValue: _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
+        returnValue:
+            _i20.Future<List<_i16.BuilderRecord>>.value(<_i16.BuilderRecord>[]),
       ) as _i20.Future<List<_i16.BuilderRecord>>);
 }
 
@@ -1050,7 +1090,8 @@ class MockBranchService extends _i1.Mock implements _i15.BranchService {
             #slug: slug,
           },
         ),
-        returnValue: _i20.Future<List<Map<String, String>>>.value(<Map<String, String>>[]),
+        returnValue: _i20.Future<List<Map<String, String>>>.value(
+            <Map<String, String>>[]),
       ) as _i20.Future<List<Map<String, String>>>);
 }
 
@@ -1093,7 +1134,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> scheduleBuild(
     _i8.ScheduleBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1114,7 +1156,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.SearchBuildsResponse> searchBuilds(
     _i8.SearchBuildsRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1122,7 +1165,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(_FakeSearchBuildsResponse_8(
+        returnValue: _i20.Future<_i8.SearchBuildsResponse>.value(
+            _FakeSearchBuildsResponse_8(
           this,
           Invocation.method(
             #searchBuilds,
@@ -1135,7 +1179,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.BatchResponse> batch(
     _i8.BatchRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1156,7 +1201,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> cancelBuild(
     _i8.CancelBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1177,7 +1223,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.Build> getBuild(
     _i8.GetBuildRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1198,7 +1245,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
   @override
   _i20.Future<_i8.ListBuildersResponse> listBuilders(
     _i8.ListBuildersRequest? request, {
-    String? buildBucketUri = r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
+    String? buildBucketUri =
+        r'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builders',
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1206,7 +1254,8 @@ class MockBuildBucketClient extends _i1.Mock implements _i15.BuildBucketClient {
           [request],
           {#buildBucketUri: buildBucketUri},
         ),
-        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(_FakeListBuildersResponse_10(
+        returnValue: _i20.Future<_i8.ListBuildersResponse>.value(
+            _FakeListBuildersResponse_10(
           this,
           Invocation.method(
             #listBuilders,
@@ -1253,7 +1302,8 @@ class MockCommitService extends _i1.Mock implements _i33.CommitService {
       ) as _i9.DatastoreServiceProvider);
 
   @override
-  _i20.Future<void> handleCreateGithubRequest(_i34.CreateEvent? createEvent) => (super.noSuchMethod(
+  _i20.Future<void> handleCreateGithubRequest(_i34.CreateEvent? createEvent) =>
+      (super.noSuchMethod(
         Invocation.method(
           #handleCreateGithubRequest,
           [createEvent],
@@ -1263,7 +1313,8 @@ class MockCommitService extends _i1.Mock implements _i33.CommitService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) => (super.noSuchMethod(
+  _i20.Future<void> handlePushGithubRequest(Map<String, dynamic>? pushEvent) =>
+      (super.noSuchMethod(
         Invocation.method(
           #handlePushGithubRequest,
           [pushEvent],
@@ -1321,15 +1372,6 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<String> get overrideTreeStatusLabel => (super.noSuchMethod(
-        Invocation.getter(#overrideTreeStatusLabel),
-        returnValue: _i20.Future<String>.value(_i32.dummyValue<String>(
-          this,
-          Invocation.getter(#overrideTreeStatusLabel),
-        )),
-      ) as _i20.Future<String>);
-
-  @override
   _i20.Future<String> get githubPublicKey => (super.noSuchMethod(
         Invocation.getter(#githubPublicKey),
         returnValue: _i20.Future<String>.value(_i32.dummyValue<String>(
@@ -1348,9 +1390,11 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<Map<String, dynamic>> get githubAppInstallations => (super.noSuchMethod(
+  _i20.Future<Map<String, dynamic>> get githubAppInstallations =>
+      (super.noSuchMethod(
         Invocation.getter(#githubAppInstallations),
-        returnValue: _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+        returnValue:
+            _i20.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
       ) as _i20.Future<Map<String, dynamic>>);
 
   @override
@@ -1594,7 +1638,8 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as Set<String>);
 
   @override
-  _i20.Future<Iterable<_i35.Branch>> getBranches(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<Iterable<_i35.Branch>> getBranches(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getBranches,
           [slug],
@@ -1603,7 +1648,8 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<Iterable<_i35.Branch>>);
 
   @override
-  String wrongHeadBranchPullRequestMessage(String? branch) => (super.noSuchMethod(
+  String wrongHeadBranchPullRequestMessage(String? branch) =>
+      (super.noSuchMethod(
         Invocation.method(
           #wrongHeadBranchPullRequestMessage,
           [branch],
@@ -1648,7 +1694,8 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as String);
 
   @override
-  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  String flutterGoldAlertConstant(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #flutterGoldAlertConstant,
           [slug],
@@ -1693,7 +1740,8 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<String>);
 
   @override
-  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<String> generateGithubToken(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #generateGithubToken,
           [slug],
@@ -1750,12 +1798,14 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i13.GitHub);
 
   @override
-  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() => (super.noSuchMethod(
+  _i20.Future<_i14.GraphQLClient> createGitHubGraphQLClient() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGitHubGraphQLClient,
           [],
         ),
-        returnValue: _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
+        returnValue:
+            _i20.Future<_i14.GraphQLClient>.value(_FakeGraphQLClient_17(
           this,
           Invocation.method(
             #createGitHubGraphQLClient,
@@ -1765,12 +1815,14 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i14.GraphQLClient>);
 
   @override
-  _i20.Future<_i15.FirestoreService> createFirestoreService() => (super.noSuchMethod(
+  _i20.Future<_i15.FirestoreService> createFirestoreService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createFirestoreService,
           [],
         ),
-        returnValue: _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
+        returnValue:
+            _i20.Future<_i15.FirestoreService>.value(_FakeFirestoreService_18(
           this,
           Invocation.method(
             #createFirestoreService,
@@ -1780,12 +1832,14 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i15.FirestoreService>);
 
   @override
-  _i20.Future<_i16.BigqueryService> createBigQueryService() => (super.noSuchMethod(
+  _i20.Future<_i16.BigqueryService> createBigQueryService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createBigQueryService,
           [],
         ),
-        returnValue: _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
+        returnValue:
+            _i20.Future<_i16.BigqueryService>.value(_FakeBigqueryService_19(
           this,
           Invocation.method(
             #createBigQueryService,
@@ -1795,12 +1849,14 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i16.BigqueryService>);
 
   @override
-  _i20.Future<_i5.TabledataResource> createTabledataResourceApi() => (super.noSuchMethod(
+  _i20.Future<_i5.TabledataResource> createTabledataResourceApi() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createTabledataResourceApi,
           [],
         ),
-        returnValue: _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
+        returnValue:
+            _i20.Future<_i5.TabledataResource>.value(_FakeTabledataResource_3(
           this,
           Invocation.method(
             #createTabledataResourceApi,
@@ -1810,12 +1866,14 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i5.TabledataResource>);
 
   @override
-  _i20.Future<_i17.GithubService> createDefaultGitHubService() => (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createDefaultGitHubService() =>
+      (super.noSuchMethod(
         Invocation.method(
           #createDefaultGitHubService,
           [],
         ),
-        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue:
+            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createDefaultGitHubService,
@@ -1825,12 +1883,15 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i20.Future<_i17.GithubService> createGithubService(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Future<_i17.GithubService> createGithubService(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGithubService,
           [slug],
         ),
-        returnValue: _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
+        returnValue:
+            _i20.Future<_i17.GithubService>.value(_FakeGithubService_20(
           this,
           Invocation.method(
             #createGithubService,
@@ -1840,7 +1901,8 @@ class MockConfig extends _i1.Mock implements _i2.Config {
       ) as _i20.Future<_i17.GithubService>);
 
   @override
-  _i17.GithubService createGithubServiceWithToken(String? token) => (super.noSuchMethod(
+  _i17.GithubService createGithubServiceWithToken(String? token) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createGithubServiceWithToken,
           [token],
@@ -1957,7 +2019,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Stream<_i37.FullTask>);
 
   @override
-  _i20.Future<List<_i38.Stage>> queryTasksGroupedByStage(_i36.Commit? commit) => (super.noSuchMethod(
+  _i20.Future<List<_i38.Stage>> queryTasksGroupedByStage(_i36.Commit? commit) =>
+      (super.noSuchMethod(
         Invocation.method(
           #queryTasksGroupedByStage,
           [commit],
@@ -1978,7 +2041,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(_FakeGithubBuildStatusUpdate_21(
+        returnValue: _i20.Future<_i18.GithubBuildStatusUpdate>.value(
+            _FakeGithubBuildStatusUpdate_21(
           this,
           Invocation.method(
             #queryLastStatusUpdate,
@@ -2003,7 +2067,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
             pr,
           ],
         ),
-        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(_FakeGithubGoldStatusUpdate_22(
+        returnValue: _i20.Future<_i19.GithubGoldStatusUpdate>.value(
+            _FakeGithubGoldStatusUpdate_22(
           this,
           Invocation.method(
             #queryLastGoldUpdate,
@@ -2016,16 +2081,20 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<_i19.GithubGoldStatusUpdate>);
 
   @override
-  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
+  _i20.Future<List<List<_i11.Model<dynamic>>>> shard(
+          List<_i11.Model<dynamic>>? rows) =>
+      (super.noSuchMethod(
         Invocation.method(
           #shard,
           [rows],
         ),
-        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(<List<_i11.Model<dynamic>>>[]),
+        returnValue: _i20.Future<List<List<_i11.Model<dynamic>>>>.value(
+            <List<_i11.Model<dynamic>>>[]),
       ) as _i20.Future<List<List<_i11.Model<dynamic>>>>);
 
   @override
-  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) => (super.noSuchMethod(
+  _i20.Future<void> insert(List<_i11.Model<dynamic>>? rows) =>
+      (super.noSuchMethod(
         Invocation.method(
           #insert,
           [rows],
@@ -2035,7 +2104,8 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(List<_i11.Key<dynamic>>? keys) =>
+  _i20.Future<List<T?>> lookupByKey<T extends _i11.Model<dynamic>>(
+          List<_i11.Key<dynamic>>? keys) =>
       (super.noSuchMethod(
         Invocation.method(
           #lookupByKey,
@@ -2077,7 +2147,9 @@ class MockDatastoreService extends _i1.Mock implements _i9.DatastoreService {
       ) as _i20.Future<T>);
 
   @override
-  _i20.Future<T?> withTransaction<T>(_i20.Future<T> Function(_i11.Transaction)? handler) => (super.noSuchMethod(
+  _i20.Future<T?> withTransaction<T>(
+          _i20.Future<T> Function(_i11.Transaction)? handler) =>
+      (super.noSuchMethod(
         Invocation.method(
           #withTransaction,
           [handler],
@@ -2185,13 +2257,14 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i4.AccessClientProvider);
 
   @override
-  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() => (super.noSuchMethod(
+  _i20.Future<_i21.ProjectsDatabasesDocumentsResource> documentResource() =>
+      (super.noSuchMethod(
         Invocation.method(
           #documentResource,
           [],
         ),
-        returnValue:
-            _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(_FakeProjectsDatabasesDocumentsResource_24(
+        returnValue: _i20.Future<_i21.ProjectsDatabasesDocumentsResource>.value(
+            _FakeProjectsDatabasesDocumentsResource_24(
           this,
           Invocation.method(
             #documentResource,
@@ -2228,7 +2301,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             database,
           ],
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
+            _FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWriteDocuments,
@@ -2241,12 +2315,15 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<_i21.BatchWriteResponse>);
 
   @override
-  _i20.Future<_i21.CommitResponse> writeViaTransaction(List<_i21.Write>? writes) => (super.noSuchMethod(
+  _i20.Future<_i21.CommitResponse> writeViaTransaction(
+          List<_i21.Write>? writes) =>
+      (super.noSuchMethod(
         Invocation.method(
           #writeViaTransaction,
           [writes],
         ),
-        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue:
+            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #writeViaTransaction,
@@ -2277,7 +2354,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<List<_i41.Commit>>);
 
   @override
-  _i20.Future<List<_i42.Task>> queryCommitTasks(String? commitSha) => (super.noSuchMethod(
+  _i20.Future<List<_i42.Task>> queryCommitTasks(String? commitSha) =>
+      (super.noSuchMethod(
         Invocation.method(
           #queryCommitTasks,
           [commitSha],
@@ -2298,7 +2376,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             prNumber,
           ],
         ),
-        returnValue: _i20.Future<_i22.GithubGoldStatus>.value(_FakeGithubGoldStatus_28(
+        returnValue:
+            _i20.Future<_i22.GithubGoldStatus>.value(_FakeGithubGoldStatus_28(
           this,
           Invocation.method(
             #queryLastGoldStatus,
@@ -2325,7 +2404,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
             head,
           ],
         ),
-        returnValue: _i20.Future<_i23.GithubBuildStatus>.value(_FakeGithubBuildStatus_29(
+        returnValue:
+            _i20.Future<_i23.GithubBuildStatus>.value(_FakeGithubBuildStatus_29(
           this,
           Invocation.method(
             #queryLastBuildStatus,
@@ -2403,7 +2483,8 @@ class MockFirestoreService extends _i1.Mock implements _i15.FirestoreService {
       ) as _i20.Future<List<_i21.Document>>);
 
   @override
-  List<_i21.Document> documentsFromQueryResponse(List<_i21.RunQueryResponseElement>? runQueryResponseElements) =>
+  List<_i21.Document> documentsFromQueryResponse(
+          List<_i21.RunQueryResponseElement>? runQueryResponseElements) =>
       (super.noSuchMethod(
         Invocation.method(
           #documentsFromQueryResponse,
@@ -2637,7 +2718,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<_i13.Issue>);
 
   @override
-  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.User> listAssignees(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listAssignees,
           [slug],
@@ -2678,7 +2760,9 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Stream<_i13.IssueComment>);
 
   @override
-  _i20.Stream<_i13.IssueComment> listCommentsByRepo(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.IssueComment> listCommentsByRepo(
+          _i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listCommentsByRepo,
           [slug],
@@ -2784,7 +2868,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.IssueLabel> listLabels(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listLabels,
           [slug],
@@ -2965,7 +3050,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -2983,7 +3069,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3021,7 +3108,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) => (super.noSuchMethod(
+  _i20.Stream<_i13.Milestone> listMilestones(_i13.RepositorySlug? slug) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listMilestones,
           [slug],
@@ -3126,7 +3214,8 @@ class MockIssuesService extends _i1.Mock implements _i13.IssuesService {
 /// A class which mocks [GithubChecksService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksService {
+class MockGithubChecksService extends _i1.Mock
+    implements _i15.GithubChecksService {
   MockGithubChecksService() {
     _i1.throwOnMissingStub(this);
   }
@@ -3159,7 +3248,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) =>
+      super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -3224,7 +3314,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as String);
 
   @override
-  _i13.CheckRunConclusion conclusionForResult(_i8.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunConclusion conclusionForResult(_i8.Status? status) =>
+      (super.noSuchMethod(
         Invocation.method(
           #conclusionForResult,
           [status],
@@ -3239,7 +3330,8 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
       ) as _i13.CheckRunConclusion);
 
   @override
-  _i13.CheckRunStatus statusForResult(_i8.Status? status) => (super.noSuchMethod(
+  _i13.CheckRunStatus statusForResult(_i8.Status? status) =>
+      (super.noSuchMethod(
         Invocation.method(
           #statusForResult,
           [status],
@@ -3293,7 +3385,8 @@ class MockGithubChecksUtil extends _i1.Mock implements _i24.GithubChecksUtil {
             checkSuiteEvent,
           ],
         ),
-        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(<String, _i13.CheckRun>{}),
+        returnValue: _i20.Future<Map<String, _i13.CheckRun>>.value(
+            <String, _i13.CheckRun>{}),
       ) as _i20.Future<Map<String, _i13.CheckRun>>);
 
   @override
@@ -3345,7 +3438,8 @@ class MockGithubChecksUtil extends _i1.Mock implements _i24.GithubChecksUtil {
             #checkName: checkName,
           },
         ),
-        returnValue: _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
+        returnValue:
+            _i20.Future<List<_i13.CheckSuite>>.value(<_i13.CheckSuite>[]),
       ) as _i20.Future<List<_i13.CheckSuite>>);
 
   @override
@@ -3472,7 +3566,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             lastCommitTimestampMills,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(<_i13.RepositoryCommit>[]),
+        returnValue: _i20.Future<List<_i13.RepositoryCommit>>.value(
+            <_i13.RepositoryCommit>[]),
       ) as _i20.Future<List<_i13.RepositoryCommit>>);
 
   @override
@@ -3504,7 +3599,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             branch,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
+        returnValue:
+            _i20.Future<List<_i13.PullRequest>>.value(<_i13.PullRequest>[]),
       ) as _i20.Future<List<_i13.PullRequest>>);
 
   @override
@@ -3576,7 +3672,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             issueNumber,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3594,7 +3691,8 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             labels,
           ],
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
@@ -3730,14 +3828,22 @@ class MockGithubService extends _i1.Mock implements _i17.GithubService {
             #labels: labels,
           },
         ),
-        returnValue: _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
+        returnValue:
+            _i20.Future<List<_i13.IssueLabel>>.value(<_i13.IssueLabel>[]),
       ) as _i20.Future<List<_i13.IssueLabel>>);
 
   @override
-  _i20.Future<List<String>> listFiles(_i13.PullRequest? pullRequest) => (super.noSuchMethod(
+  _i20.Future<List<String>> listFiles(
+    _i13.RepositorySlug? slug,
+    int? pullRequestNumber,
+  ) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listFiles,
-          [pullRequest],
+          [
+            slug,
+            pullRequestNumber,
+          ],
         ),
         returnValue: _i20.Future<List<String>>.value(<String>[]),
       ) as _i20.Future<List<String>>);
@@ -4211,7 +4317,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.DefaultPolicies);
 
   @override
-  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) => super.noSuchMethod(
+  set defaultPolicies(_i14.DefaultPolicies? _defaultPolicies) =>
+      super.noSuchMethod(
         Invocation.setter(
           #defaultPolicies,
           _defaultPolicies,
@@ -4289,7 +4396,9 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.GraphQLClient);
 
   @override
-  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchQuery<TParsed>(
+          _i14.WatchQueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #watchQuery,
           [options],
@@ -4304,7 +4413,9 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(_i14.WatchQueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i14.ObservableQuery<TParsed> watchMutation<TParsed>(
+          _i14.WatchQueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #watchMutation,
           [options],
@@ -4319,12 +4430,15 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i14.ObservableQuery<TParsed>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(_i14.QueryOptions<TParsed>? options) => (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> query<TParsed>(
+          _i14.QueryOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #query,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #query,
@@ -4334,12 +4448,15 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(_i14.MutationOptions<TParsed>? options) => (super.noSuchMethod(
+  _i20.Future<_i14.QueryResult<TParsed>> mutate<TParsed>(
+          _i14.MutationOptions<TParsed>? options) =>
+      (super.noSuchMethod(
         Invocation.method(
           #mutate,
           [options],
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #mutate,
@@ -4349,7 +4466,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       ) as _i20.Future<_i14.QueryResult<TParsed>>);
 
   @override
-  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(_i14.SubscriptionOptions<TParsed>? options) =>
+  _i20.Stream<_i14.QueryResult<TParsed>> subscribe<TParsed>(
+          _i14.SubscriptionOptions<TParsed>? options) =>
       (super.noSuchMethod(
         Invocation.method(
           #subscribe,
@@ -4373,7 +4491,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
             #previousResult: previousResult,
           },
         ),
-        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(_FakeQueryResult_53<TParsed>(
+        returnValue: _i20.Future<_i14.QueryResult<TParsed>>.value(
+            _FakeQueryResult_53<TParsed>(
           this,
           Invocation.method(
             #fetchMore,
@@ -4445,7 +4564,8 @@ class MockGraphQLClient extends _i1.Mock implements _i14.GraphQLClient {
       );
 
   @override
-  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore({bool? refetchQueries = true}) =>
+  _i20.Future<List<_i14.QueryResult<Object?>?>>? resetStore(
+          {bool? refetchQueries = true}) =>
       (super.noSuchMethod(Invocation.method(
         #resetStore,
         [],
@@ -4617,7 +4737,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #open,
@@ -4644,7 +4765,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             url,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #openUrl,
@@ -4671,7 +4793,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #get,
@@ -4690,7 +4813,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #getUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #getUrl,
@@ -4714,7 +4838,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #post,
@@ -4733,7 +4858,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #postUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #postUrl,
@@ -4757,7 +4883,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #put,
@@ -4776,7 +4903,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #putUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #putUrl,
@@ -4800,7 +4928,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #delete,
@@ -4814,12 +4943,14 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
       ) as _i20.Future<_i25.HttpClientRequest>);
 
   @override
-  _i20.Future<_i25.HttpClientRequest> deleteUrl(Uri? url) => (super.noSuchMethod(
+  _i20.Future<_i25.HttpClientRequest> deleteUrl(Uri? url) =>
+      (super.noSuchMethod(
         Invocation.method(
           #deleteUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #deleteUrl,
@@ -4843,7 +4974,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patch,
@@ -4862,7 +4994,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #patchUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #patchUrl,
@@ -4886,7 +5019,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
             path,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #head,
@@ -4905,7 +5039,8 @@ class MockHttpClient extends _i1.Mock implements _i25.HttpClient {
           #headUrl,
           [url],
         ),
-        returnValue: _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
+        returnValue:
+            _i20.Future<_i25.HttpClientRequest>.value(_FakeHttpClientRequest_54(
           this,
           Invocation.method(
             #headUrl,
@@ -5082,7 +5217,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
   @override
   _i20.Future<_i25.HttpClientResponse> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
+            _FakeHttpClientResponse_57(
           this,
           Invocation.getter(#done),
         )),
@@ -5112,7 +5248,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
           #close,
           [],
         ),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
+            _FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #close,
@@ -5206,7 +5343,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
       );
 
   @override
-  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) => (super.noSuchMethod(
+  _i20.Future<dynamic> addStream(_i20.Stream<List<int>>? stream) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addStream,
           [stream],
@@ -5227,7 +5365,8 @@ class MockHttpClientRequest extends _i1.Mock implements _i25.HttpClientRequest {
 /// A class which mocks [HttpClientResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse {
+class MockHttpClientResponse extends _i1.Mock
+    implements _i25.HttpClientResponse {
   MockHttpClientResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -5254,7 +5393,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as int);
 
   @override
-  _i25.HttpClientResponseCompressionState get compressionState => (super.noSuchMethod(
+  _i25.HttpClientResponseCompressionState get compressionState =>
+      (super.noSuchMethod(
         Invocation.getter(#compressionState),
         returnValue: _i25.HttpClientResponseCompressionState.notCompressed,
       ) as _i25.HttpClientResponseCompressionState);
@@ -5343,7 +5483,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
             followLoops,
           ],
         ),
-        returnValue: _i20.Future<_i25.HttpClientResponse>.value(_FakeHttpClientResponse_57(
+        returnValue: _i20.Future<_i25.HttpClientResponse>.value(
+            _FakeHttpClientResponse_57(
           this,
           Invocation.method(
             #redirect,
@@ -5420,7 +5561,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.StreamSubscription<List<int>>);
 
   @override
-  _i20.Stream<List<int>> where(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> where(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #where,
           [test],
@@ -5438,7 +5580,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<E> asyncMap<E>(_i20.FutureOr<E> Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #asyncMap,
           [convert],
@@ -5447,7 +5590,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<E>);
 
   @override
-  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<E> asyncExpand<E>(_i20.Stream<E>? Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #asyncExpand,
           [convert],
@@ -5470,7 +5614,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) => (super.noSuchMethod(
+  _i20.Stream<S> expand<S>(Iterable<S> Function(List<int>)? convert) =>
+      (super.noSuchMethod(
         Invocation.method(
           #expand,
           [convert],
@@ -5479,7 +5624,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<S>);
 
   @override
-  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) => (super.noSuchMethod(
+  _i20.Future<dynamic> pipe(_i20.StreamConsumer<List<int>>? streamConsumer) =>
+      (super.noSuchMethod(
         Invocation.method(
           #pipe,
           [streamConsumer],
@@ -5488,7 +5634,9 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Future<dynamic>);
 
   @override
-  _i20.Stream<S> transform<S>(_i20.StreamTransformer<List<int>, S>? streamTransformer) => (super.noSuchMethod(
+  _i20.Stream<S> transform<S>(
+          _i20.StreamTransformer<List<int>, S>? streamTransformer) =>
+      (super.noSuchMethod(
         Invocation.method(
           #transform,
           [streamTransformer],
@@ -5576,7 +5724,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Future<bool>);
 
   @override
-  _i20.Future<void> forEach(void Function(List<int>)? action) => (super.noSuchMethod(
+  _i20.Future<void> forEach(void Function(List<int>)? action) =>
+      (super.noSuchMethod(
         Invocation.method(
           #forEach,
           [action],
@@ -5586,7 +5735,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Future<void>);
 
   @override
-  _i20.Future<bool> every(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Future<bool> every(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #every,
           [test],
@@ -5665,7 +5815,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> takeWhile(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #takeWhile,
           [test],
@@ -5683,7 +5834,8 @@ class MockHttpClientResponse extends _i1.Mock implements _i25.HttpClientResponse
       ) as _i20.Stream<List<int>>);
 
   @override
-  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) => (super.noSuchMethod(
+  _i20.Stream<List<int>> skipWhile(bool Function(List<int>)? test) =>
+      (super.noSuchMethod(
         Invocation.method(
           #skipWhile,
           [test],
@@ -5798,7 +5950,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i15.BuildBucketClient);
 
   @override
-  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) => super.noSuchMethod(
+  set buildBucketClient(_i15.BuildBucketClient? _buildBucketClient) =>
+      super.noSuchMethod(
         Invocation.setter(
           #buildBucketClient,
           _buildBucketClient,
@@ -5843,7 +5996,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i24.GithubChecksUtil);
 
   @override
-  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) => super.noSuchMethod(
+  set githubChecksUtil(_i24.GithubChecksUtil? _githubChecksUtil) =>
+      super.noSuchMethod(
         Invocation.setter(
           #githubChecksUtil,
           _githubChecksUtil,
@@ -5936,7 +6090,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #maxShardSize: maxShardSize,
           },
         ),
-        returnValue: _i20.Future<List<List<_i8.BatchRequest_Request>>>.value(<List<_i8.BatchRequest_Request>>[]),
+        returnValue: _i20.Future<List<List<_i8.BatchRequest_Request>>>.value(
+            <List<_i8.BatchRequest_Request>>[]),
       ) as _i20.Future<List<List<_i8.BatchRequest_Request>>>);
 
   @override
@@ -5957,7 +6112,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Iterable<_i8.Build>>);
 
   @override
-  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest({required _i13.PullRequest? pullRequest}) =>
+  _i20.Future<Iterable<_i8.Build>> getTryBuildsByPullRequest(
+          {required _i13.PullRequest? pullRequest}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getTryBuildsByPullRequest,
@@ -6109,7 +6265,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<_i8.Build>);
 
   @override
-  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent({required _i44.CheckRunEvent? checkRunEvent}) =>
+  _i20.Future<_i8.Build> reschedulePresubmitBuildUsingCheckRunEvent(
+          {required _i44.CheckRunEvent? checkRunEvent}) =>
       (super.noSuchMethod(
         Invocation.method(
           #reschedulePresubmitBuildUsingCheckRunEvent,
@@ -6206,7 +6363,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<
+      List<_i15.Tuple<_i43.Target, _i37.Task, int>>> schedulePostsubmitBuilds({
     required _i36.Commit? commit,
     required List<_i15.Tuple<_i43.Target, _i37.Task, int>>? toBeScheduled,
   }) =>
@@ -6219,8 +6377,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>.value(
-            <_i15.Tuple<_i43.Target, _i37.Task, int>>[]),
+        returnValue:
+            _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>.value(
+                <_i15.Tuple<_i43.Target, _i37.Task, int>>[]),
       ) as _i20.Future<List<_i15.Tuple<_i43.Target, _i37.Task, int>>>);
 
   @override
@@ -6358,7 +6517,8 @@ class MockProcessManager extends _i1.Mock implements _i46.ProcessManager {
             #stderrEncoding: stderrEncoding,
           },
         ),
-        returnValue: _i20.Future<_i25.ProcessResult>.value(_i32.dummyValue<_i25.ProcessResult>(
+        returnValue: _i20.Future<_i25.ProcessResult>.value(
+            _i32.dummyValue<_i25.ProcessResult>(
           this,
           Invocation.method(
             #run,
@@ -6587,7 +6747,8 @@ class MockTabledataResource extends _i1.Mock implements _i5.TabledataResource {
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(_FakeTableDataInsertAllResponse_66(
+        returnValue: _i20.Future<_i5.TableDataInsertAllResponse>.value(
+            _FakeTableDataInsertAllResponse_66(
           this,
           Invocation.method(
             #insertAll,
@@ -6792,7 +6953,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.UserEmail>);
 
   @override
-  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) => (super.noSuchMethod(
+  _i20.Stream<_i13.UserEmail> addEmails(List<String>? emails) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addEmails,
           [emails],
@@ -6880,7 +7042,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.User>);
 
   @override
-  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) => (super.noSuchMethod(
+  _i20.Stream<_i13.PublicKey> listPublicKeys([String? userLogin]) =>
+      (super.noSuchMethod(
         Invocation.method(
           #listPublicKeys,
           [userLogin],
@@ -6889,7 +7052,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
       ) as _i20.Stream<_i13.PublicKey>);
 
   @override
-  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) => (super.noSuchMethod(
+  _i20.Future<_i13.PublicKey> createPublicKey(_i13.CreatePublicKey? key) =>
+      (super.noSuchMethod(
         Invocation.method(
           #createPublicKey,
           [key],
@@ -6907,7 +7071,8 @@ class MockUsersService extends _i1.Mock implements _i13.UsersService {
 /// A class which mocks [ProjectsDatabasesDocumentsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.ProjectsDatabasesDocumentsResource {
+class MockProjectsDatabasesDocumentsResource extends _i1.Mock
+    implements _i21.ProjectsDatabasesDocumentsResource {
   MockProjectsDatabasesDocumentsResource() {
     _i1.throwOnMissingStub(this);
   }
@@ -6928,7 +7093,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           {#$fields: $fields},
         ),
         returnValue:
-            _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>.value(<_i21.BatchGetDocumentsResponseElement>[]),
+            _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>.value(
+                <_i21.BatchGetDocumentsResponseElement>[]),
       ) as _i20.Future<List<_i21.BatchGetDocumentsResponseElement>>);
 
   @override
@@ -6946,7 +7112,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(_FakeBatchWriteResponse_26(
+        returnValue: _i20.Future<_i21.BatchWriteResponse>.value(
+            _FakeBatchWriteResponse_26(
           this,
           Invocation.method(
             #batchWrite,
@@ -6974,7 +7141,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(_FakeBeginTransactionResponse_71(
+        returnValue: _i20.Future<_i21.BeginTransactionResponse>.value(
+            _FakeBeginTransactionResponse_71(
           this,
           Invocation.method(
             #beginTransaction,
@@ -7002,7 +7170,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
+        returnValue:
+            _i20.Future<_i21.CommitResponse>.value(_FakeCommitResponse_27(
           this,
           Invocation.method(
             #commit,
@@ -7152,7 +7321,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(
+            _FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #list,
@@ -7189,7 +7359,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(_FakeListCollectionIdsResponse_74(
+        returnValue: _i20.Future<_i21.ListCollectionIdsResponse>.value(
+            _FakeListCollectionIdsResponse_74(
           this,
           Invocation.method(
             #listCollectionIds,
@@ -7233,7 +7404,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
             #$fields: $fields,
           },
         ),
-        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(_FakeListDocumentsResponse_73(
+        returnValue: _i20.Future<_i21.ListDocumentsResponse>.value(
+            _FakeListDocumentsResponse_73(
           this,
           Invocation.method(
             #listDocuments,
@@ -7270,7 +7442,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(_FakePartitionQueryResponse_75(
+        returnValue: _i20.Future<_i21.PartitionQueryResponse>.value(
+            _FakePartitionQueryResponse_75(
           this,
           Invocation.method(
             #partitionQuery,
@@ -7356,7 +7529,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
       ) as _i20.Future<_i27.$Empty>);
 
   @override
-  _i20.Future<List<_i21.RunAggregationQueryResponseElement>> runAggregationQuery(
+  _i20.Future<
+      List<_i21.RunAggregationQueryResponseElement>> runAggregationQuery(
     _i21.RunAggregationQueryRequest? request,
     String? parent, {
     String? $fields,
@@ -7370,8 +7544,9 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<List<_i21.RunAggregationQueryResponseElement>>.value(
-            <_i21.RunAggregationQueryResponseElement>[]),
+        returnValue:
+            _i20.Future<List<_i21.RunAggregationQueryResponseElement>>.value(
+                <_i21.RunAggregationQueryResponseElement>[]),
       ) as _i20.Future<List<_i21.RunAggregationQueryResponseElement>>);
 
   @override
@@ -7389,7 +7564,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<List<_i21.RunQueryResponseElement>>.value(<_i21.RunQueryResponseElement>[]),
+        returnValue: _i20.Future<List<_i21.RunQueryResponseElement>>.value(
+            <_i21.RunQueryResponseElement>[]),
       ) as _i20.Future<List<_i21.RunQueryResponseElement>>);
 
   @override
@@ -7407,7 +7583,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
           ],
           {#$fields: $fields},
         ),
-        returnValue: _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_76(
+        returnValue:
+            _i20.Future<_i21.WriteResponse>.value(_FakeWriteResponse_76(
           this,
           Invocation.method(
             #write,
@@ -7424,7 +7601,8 @@ class MockProjectsDatabasesDocumentsResource extends _i1.Mock implements _i21.Pr
 /// A class which mocks [BeginTransactionResponse].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBeginTransactionResponse extends _i1.Mock implements _i21.BeginTransactionResponse {
+class MockBeginTransactionResponse extends _i1.Mock
+    implements _i21.BeginTransactionResponse {
   MockBeginTransactionResponse() {
     _i1.throwOnMissingStub(this);
   }
@@ -7493,7 +7671,8 @@ class MockCallbacks extends _i1.Mock implements _i47.Callbacks {
             #conclusion: conclusion,
           },
         ),
-        returnValue: _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_77(
+        returnValue:
+            _i20.Future<_i28.StagingConclusion>.value(_FakeStagingConclusion_77(
           this,
           Invocation.method(
             #markCheckRunConclusion,
@@ -7647,7 +7826,8 @@ class MockCache extends _i1.Mock implements _i29.Cache<_i40.Uint8List> {
       ) as _i29.Cache<_i40.Uint8List>);
 
   @override
-  _i29.Cache<S> withCodec<S>(_i26.Codec<S, _i40.Uint8List>? codec) => (super.noSuchMethod(
+  _i29.Cache<S> withCodec<S>(_i26.Codec<S, _i40.Uint8List>? codec) =>
+      (super.noSuchMethod(
         Invocation.method(
           #withCodec,
           [codec],


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/161462, towards https://github.com/flutter/flutter/issues/162201.

This PR does a few things:

1. Introduces an abstraction, `GetFilesChanged`
2. Codifies "we aren't confident" as `InconclusiveFilesChanged`
3. Refactors the existing implementation into `GithubApiGetFilesChanged`

The intention is no user-facing behavioral changes, but this PR enables:

1. Swapping out the implementation (i.e. to `CheckRunArtifactsGetFilesChanged`)
2. Reusing the logic, including inconclusive-ness, for https://github.com/flutter/flutter/issues/162201 (framework-only PRs).