### PR TITLE
`flutter_realm` is cleared when  `app_dart/bin/codefu.dart` is set

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -338,6 +338,7 @@ class LuciBuildService {
 
       if (flutterPrebuiltEngineVersion != null) {
         properties['flutter_prebuilt_engine_version'] = flutterPrebuiltEngineVersion;
+        properties['flutter_realm'] = '';
       }
 
       final List<bbv2.RequestedDimension> requestedDimensions = target.getDimensions();

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -532,6 +532,8 @@ void main() {
 
       expect(properties, contains('flutter_prebuilt_engine_version'));
       expect(properties['flutter_prebuilt_engine_version']!.stringValue, 'sha1234');
+      expect(properties, contains('flutter_realm'));
+      expect(properties['flutter_realm']!.stringValue, '');
     });
 
     test('Schedule builds no-ops when targets list is empty', () async {


### PR DESCRIPTION
![matrix_see](https://github.com/user-attachments/assets/6c2a7046-8cd2-4d87-88cb-519b6281442f)
