### PR TITLE
Use the authenticated client when requested PR files

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -51,9 +51,7 @@ Future<void> main() async {
       cache: cache,
       config: config,
       githubChecksService: githubChecksService,
-      getFilesChanged: GithubApiGetFilesChanged(
-        await config.createDefaultGitHubService(),
-      ),
+      getFilesChanged: GithubApiGetFilesChanged(config),
       luciBuildService: luciBuildService,
       fusionTester: fusionTester,
     );

--- a/app_dart/bin/local_server.dart
+++ b/app_dart/bin/local_server.dart
@@ -55,9 +55,7 @@ Future<void> main() async {
     cache: cache,
     config: config,
     githubChecksService: githubChecksService,
-    getFilesChanged: GithubApiGetFilesChanged(
-      await config.createDefaultGitHubService(),
-    ),
+    getFilesChanged: GithubApiGetFilesChanged(config),
     luciBuildService: luciBuildService,
     fusionTester: fusionTester,
   );

--- a/app_dart/lib/src/service/get_files_changed.dart
+++ b/app_dart/lib/src/service/get_files_changed.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
@@ -33,8 +34,8 @@ abstract interface class GetFilesChanged {
 /// See <https://github.com/flutter/flutter/issues/161462>.
 final class GithubApiGetFilesChanged implements GetFilesChanged {
   /// Creates from [GithubService].
-  const GithubApiGetFilesChanged(this._githubService);
-  final GithubService _githubService;
+  const GithubApiGetFilesChanged(this._config);
+  final Config _config;
 
   @override
   Future<FilesChanged> get(
@@ -43,7 +44,8 @@ final class GithubApiGetFilesChanged implements GetFilesChanged {
   ) async {
     final List<String> files;
     try {
-      files = await _githubService.listFiles(
+      final githubService = await _config.createGithubService(slug);
+      files = await githubService.listFiles(
         slug,
         pullRequestNumber,
       );


### PR DESCRIPTION
Currently hitting free quota; which fails and falls back to "build everything"

There wasn't any tests for `GithubApiGetFilesChanged`, but we'd only verify one api was called over another.