### PR TITLE
Test for master branch when applying optimization.

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -436,7 +436,7 @@ class Scheduler {
         // Feature request: skip engine builds and tests in monorepo if the PR only contains framework related
         // files.
         // NOTE: This creates an empty staging doc for the engine builds as staging is handled on check_run completion
-        //       events from GitHub. Engine Tests are also skipped, and the base.ref is passed to LUCI to use prod
+        //       events from GitHub. Engine Tests are also skipped, and the base.sha is passed to LUCI to use prod
         //       binaries.
         if (isFusion && _isFrameworkOnlyAllowed(pullRequest) && await _isFrameworkOnlyPr(slug, pullRequest.number!)) {
           final logCrumb = 'triggerPresubmitTargets($slug, $sha){frameworkOnly}';
@@ -508,7 +508,11 @@ class Scheduler {
 
   /// Checks if the framework only path is enabled
   static bool _isFrameworkOnlyAllowed(PullRequest pullRequest) {
-    // An allow-list or flag checking could be done here.
+    // TODO(matanlurey): Debug further why this doesn't work on release branches.
+    if (pullRequest.base?.ref case final branch? when branch != 'master') {
+      log.info('Refusing to skip engine builds for PR#${pullRequest.number} branch: $branch');
+      return false;
+    }
 
     // Ensure this optimization only runs on flutter/flutter.
     return pullRequest.base!.repo!.slug() == Config.flutterSlug;

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -3109,6 +3109,27 @@ targets:
         // (the engine build) phase was written to Firestore, but as an emtpy tasks
         // list.
       });
+
+      // Regression test for https://github.com/flutter/flutter/issues/162403.
+      test('engine builds still run for release branches', () async {
+        fakeFusion.isFusion = (_, __) => true;
+        getFilesChanged.cannedFiles = ['packages/flutter/lib/material.dart'];
+        final pullRequest = generatePullRequest(
+          branch: 'flutter-3.29-candidate.0',
+        );
+
+        await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
+        expect(
+          fakeLuciBuildService.flutterPrebuiltEngineVersion,
+          pullRequest.base!.sha,
+          reason: 'Should use the base ref for the engine artifacts',
+        );
+        expect(
+          fakeLuciBuildService.scheduledTryBuilds.map((t) => t.value.name),
+          ['Linux engine_build'],
+          reason: 'Should run the engine_build',
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Unblocks presubmits such as https://github.com/flutter/flutter/pull/162383 without hacks required.

I want to fix this logic properly, but will do that in a follow-up.