### PR TITLE
log pull_request/labeled events in app_dart

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -155,11 +155,12 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     }
     final String? eventAction = pullRequestEvent.action;
     final PullRequest pr = pullRequestEvent.pullRequest!;
+    final crumb = '$GithubWebhookSubscription._handlePullRequest(${pr.number})';
 
     // See the API reference:
     // https://developer.github.com/v3/activity/events/types/#pullrequestevent
     // which unfortunately is a bit light on explanations.
-    log.fine('Processing $eventAction for ${pr.htmlUrl}');
+    log.info('$crumb: processing $eventAction for ${pr.htmlUrl}');
     switch (eventAction) {
       case 'closed':
         await _processPullRequestClosed(pullRequestEvent);
@@ -180,6 +181,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         await _tryReleaseApproval(pullRequestEvent);
         break;
       case 'labeled':
+        log.info('$crumb: PR labels = [${pr.labels?.map((label) => '"${label.name}"').join(', ')}]');
         break;
       case 'synchronize':
         // This indicates the PR has new commits. We need to cancel old jobs

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -685,6 +685,34 @@ void main() {
       );
     });
 
+    test('logs pull_request/labeled events', () async {
+      const int prNumber = 123;
+
+      final records = <String>[];
+      final subscription = log.onRecord.listen((record) {
+        if (record.level >= Level.FINE) {
+          records.add(record.message);
+        }
+      });
+
+      tester.message = generateGithubWebhookMessage(
+        action: 'labeled',
+        number: prNumber,
+      );
+
+      await tester.post(webhook);
+      await subscription.cancel();
+
+      expect(
+        records,
+        containsAll([
+          'Processing pull_request',
+          'GithubWebhookSubscription._handlePullRequest(123): processing labeled for https://github.com/flutter/flutter/pull/123',
+          'GithubWebhookSubscription._handlePullRequest(123): PR labels = ["cla: yes", "framework", "tool"]',
+        ]),
+      );
+    });
+
     group('Auto-roller accounts do not label Framework PR with test label or comment.', () {
       final Set<String> inputs = {
         'skia-flutter-autoroll',


### PR DESCRIPTION
Log the `labeled` action for `pull_request` event. Know this works will help us determine if the `emergency` logic can be implemented in the `app_dart` rather than `auto_submit`.