### PR TITLE
Let tree-status be "neutral" for emergency labels

### DIFF
--- a/app_dart/lib/src/model/appengine/github_build_status_update.dart
+++ b/app_dart/lib/src/model/appengine/github_build_status_update.dart
@@ -25,6 +25,8 @@ class GithubBuildStatusUpdate extends Model<int> {
 
   static const String statusFailure = 'failure';
 
+  static const String statusNeutral = 'neutral';
+
   @StringProperty(propertyName: 'Repository', required: true)
   String? repository;
 

--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -44,6 +44,8 @@ class GithubBuildStatus extends Document {
 
   static const String statusFailure = 'failure';
 
+  static const String statusNeutral = 'neutral';
+
   int? get prNumber => int.parse(fields![kGithubBuildStatusPrNumberField]!.integerValue!);
 
   /// A serializable form of [slug].

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -199,7 +199,7 @@ class BuildStatus {
   factory BuildStatus.success() => const BuildStatus._(GithubBuildStatusUpdate.statusSuccess);
   factory BuildStatus.failure([List<String> failedTasks = const <String>[]]) =>
       BuildStatus._(GithubBuildStatusUpdate.statusFailure, failedTasks);
-  factory BuildStatus.emergency() => const BuildStatus._(GithubBuildStatusUpdate.statusNeutral);
+  factory BuildStatus.neutral() => const BuildStatus._(GithubBuildStatusUpdate.statusNeutral);
 
   final String value;
   final List<String> failedTasks;

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -191,10 +191,15 @@ class CommitStatus {
 @immutable
 class BuildStatus {
   const BuildStatus._(this.value, [this.failedTasks = const <String>[]])
-      : assert(value == GithubBuildStatusUpdate.statusSuccess || value == GithubBuildStatusUpdate.statusFailure);
+      : assert(
+          value == GithubBuildStatusUpdate.statusSuccess ||
+              value == GithubBuildStatusUpdate.statusFailure ||
+              value == GithubBuildStatusUpdate.statusNeutral,
+        );
   factory BuildStatus.success() => const BuildStatus._(GithubBuildStatusUpdate.statusSuccess);
   factory BuildStatus.failure([List<String> failedTasks = const <String>[]]) =>
       BuildStatus._(GithubBuildStatusUpdate.statusFailure, failedTasks);
+  factory BuildStatus.emergency() => const BuildStatus._(GithubBuildStatusUpdate.statusNeutral);
 
   final String value;
   final List<String> failedTasks;

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -347,18 +347,22 @@ class Config {
 
   KeyHelper get keyHelper => KeyHelper(applicationContext: context.applicationContext);
 
-  // Default number of commits to return for benchmark dashboard.
+  /// Default number of commits to return for benchmark dashboard.
   int /*!*/ get maxRecords => 50;
 
-  // Delay between consecutive GitHub deflake request calls.
+  /// Delay between consecutive GitHub deflake request calls.
   Duration get githubRequestDelay => const Duration(seconds: 1);
 
-  // Repository status context for github status.
+  /// Repository status context for github status.
   String get flutterBuild => 'flutter-build';
 
-  // Repository status description for github status.
-  String get flutterBuildDescription => 'Tree is currently broken. Please do not merge this '
+  /// Repository status description for github status.
+  String get flutterTreeStatusRed => 'Tree is currently broken. Please do not merge this '
       'PR unless it contains a fix for the tree.';
+
+  /// Repository status description for GitHub PRs with the `emergency` label when the tree is red.
+  String get flutterTreeStatusEmergency =>
+      'The tree is currently broken; however, this PR is marked as `emergency` and will be allowed to merge.';
 
   static gh.RepositorySlug get cocoonSlug => gh.RepositorySlug('flutter', 'cocoon');
   static gh.RepositorySlug get engineSlug => gh.RepositorySlug('flutter', 'engine');

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -7,6 +7,7 @@ import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
 import 'package:cocoon_service/src/request_handlers/push_build_status_to_github.dart';
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
+import 'package:cocoon_service/src/service/config.dart' show Config;
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
@@ -173,6 +174,36 @@ void main() {
       final GithubBuildStatus updatedDocument =
           GithubBuildStatus.fromDocument(githubBuildStatus: batchWriteRequest.writes![0].update!);
       expect(updatedDocument.updates, githubBuildStatus!.updates);
+    });
+
+    test('updates github and datastore if status is neutral', () async {
+      when(
+        mockFirestoreService.batchWriteDocuments(
+          captureAny,
+          captureAny,
+        ),
+      ).thenAnswer((Invocation invocation) {
+        return Future<BatchWriteResponse>.value(BatchWriteResponse());
+      });
+      final PullRequest pr =
+          generatePullRequest(id: 1, sha: 'sha1', labels: [IssueLabel(name: Config.kEmergencyLabel)]);
+      when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
+      buildStatusService.cumulativeStatus = BuildStatus.failure(const ['all bad']);
+      githubBuildStatus = generateFirestoreGithubBuildStatus(1, status: GithubBuildStatus.statusFailure);
+      final Body body = await tester.get<Body>(handler);
+      expect(body, same(Body.empty));
+      expect(githubBuildStatus!.updates, 1);
+      expect(githubBuildStatus!.updateTimeMillis, isNotNull);
+      expect(githubBuildStatus!.status, BuildStatus.neutral().githubStatus);
+
+      final List<dynamic> captured = verify(mockFirestoreService.batchWriteDocuments(captureAny, captureAny)).captured;
+      expect(captured.length, 2);
+      final BatchWriteRequest batchWriteRequest = captured[0] as BatchWriteRequest;
+      expect(batchWriteRequest.writes!.length, 1);
+      final GithubBuildStatus updatedDocument =
+          GithubBuildStatus.fromDocument(githubBuildStatus: batchWriteRequest.writes![0].update!);
+      expect(updatedDocument.updates, githubBuildStatus!.updates);
+      expect(updatedDocument.status, GithubBuildStatus.statusNeutral);
     });
   });
 }

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -112,7 +112,7 @@ void main() {
       });
 
       test('only if pull request is for the default branch', () async {
-        when(pullRequestsService.list(any)).thenAnswer(
+        when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer(
           (_) => Stream<PullRequest>.value(
             generatePullRequest(
               id: 1,

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -221,10 +221,13 @@ class FakeConfig implements Config {
   String get flutterBuild => flutterBuildValue!;
 
   @override
-  String get flutterBuildDescription =>
+  String get flutterTreeStatusRed =>
       flutterBuildDescriptionValue ??
       'Tree is currently broken. Please do not merge this '
           'PR unless it contains a fix for the tree.';
+  @override
+  String get flutterTreeStatusEmergency =>
+      'The tree is currently broken; however, this PR is marked as `emergency` and will be allowed to merge.';
 
   @override
   Logging get loggingService => loggingServiceValue!;


### PR DESCRIPTION
Part of flutter/flutter#162715

Check for PR labels before labeling the "tree status" check.
