### PR TITLE
Fix Ubuntu branch in Device Lab provision script

### DIFF
--- a/dev/provision_salt.sh
+++ b/dev/provision_salt.sh
@@ -40,6 +40,9 @@ function install_salt() {
         curl -L -o "/tmp/$PACKAGE" "https://packages.broadcom.com/artifactory/saltproject-deb/pool/$PACKAGE"
         sudo dpkg --install "/tmp/$PACKAGE"
       done
+
+      # Install m2crypto in SaltStack's python environment (for the x509 module).
+      sudo /opt/saltstack/salt/bin/pip install m2crypto
     else
       echo "Unsupported Linux distribution: $DISTRO" >&2
       exit 1

--- a/dev/provision_salt.sh
+++ b/dev/provision_salt.sh
@@ -42,7 +42,7 @@ function install_salt() {
       done
 
       # Install m2crypto in SaltStack's python environment (for the x509 module).
-      sudo /opt/saltstack/salt/bin/pip install m2crypto
+      sudo /opt/saltstack/salt/bin/pip install m2crypto==0.39
     else
       echo "Unsupported Linux distribution: $DISTRO" >&2
       exit 1

--- a/dev/provision_salt.sh
+++ b/dev/provision_salt.sh
@@ -24,10 +24,10 @@ function install_salt() {
     if [[ "$DISTRO" == 'Ubuntu' ]]; then
       # Uninstall previous SaltStack packages, if any.
       sudo dpkg --remove salt-minion salt-api salt-common
-      
+
       # Install SaltStack's dependencies.
       sudo apt install -y dctrl-tools
-      
+
       # Install SaltStack.
       declare -a SALT_PACKAGES=(
         "salt-common_3006.9_amd64.deb"
@@ -36,7 +36,7 @@ function install_salt() {
       for PACKAGE in "${SALT_PACKAGES[@]}"
       do
         echo "Installing salt package $PACKAGE..."
-      
+
         curl -L -o "/tmp/$PACKAGE" "https://packages.broadcom.com/artifactory/saltproject-deb/pool/$PACKAGE"
         sudo dpkg --install "/tmp/$PACKAGE"
       done

--- a/dev/provision_salt.sh
+++ b/dev/provision_salt.sh
@@ -22,14 +22,24 @@ function install_salt() {
   elif [[ "$OS" == 'Linux' ]]; then
     DISTRO="$(lsb_release -is)"
     if [[ "$DISTRO" == 'Ubuntu' ]]; then
-      # Download the SALT client tarball
-      SALT_DEB_PKG="/tmp/salt.deb"
-      curl -L -o "$SALT_DEB_PKG" https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-api_3006.9_amd64.deb
-      # Uninstall previous package, if any
-      sudo dpkg --remove salt-minion
-
-      # Install our downloaded .deb package
-      sudo dpkg --install "$SALT_DEB_PKG"
+      # Uninstall previous SaltStack packages, if any.
+      sudo dpkg --remove salt-minion salt-api salt-common
+      
+      # Install SaltStack's dependencies.
+      sudo apt install -y dctrl-tools
+      
+      # Install SaltStack.
+      declare -a SALT_PACKAGES=(
+        "salt-common_3006.9_amd64.deb"
+        "salt-minion_3006.9_amd64.deb"
+      )
+      for PACKAGE in "${SALT_PACKAGES[@]}"
+      do
+        echo "Installing salt package $PACKAGE..."
+      
+        curl -L -o "/tmp/$PACKAGE" "https://packages.broadcom.com/artifactory/saltproject-deb/pool/$PACKAGE"
+        sudo dpkg --install "/tmp/$PACKAGE"
+      done
     else
       echo "Unsupported Linux distribution: $DISTRO" >&2
       exit 1


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/162630.
Resolves https://github.com/flutter/flutter/issues/157963.

Fixes the provision script for Ubuntu bots.

Diff succeeds on linux-74.