### PR TITLE
Avoid a REST API call to github when the `PR.changedFilesCount` >= 30.

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -330,6 +330,9 @@ class Config {
     'flutter-dashboard@appspot.gserviceaccount.com',
   };
 
+  /// The maximum [gh.PullRequest.changedFilesCount] to consider a PR for a "framework-only" CI optimization.
+  int get maxFilesChangedForSkippingEnginePhase => 29;
+
   /// Max retries for Luci builder with infra failure.
   int get maxLuciTaskRetries => 2;
 

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -25,6 +25,7 @@ class FakeConfig implements Config {
     this.deviceLabServiceAccountValue,
     this.maxTaskRetriesValue,
     this.maxLuciTaskRetriesValue,
+    this.maxFilesChangedForSkippingEnginePhaseValue,
     this.keyHelperValue,
     this.oauthClientIdValue,
     this.githubOAuthTokenValue,
@@ -72,6 +73,7 @@ class FakeConfig implements Config {
   FakeDatastoreDB dbValue;
   ServiceAccountInfo? deviceLabServiceAccountValue;
   int? maxTaskRetriesValue;
+  int? maxFilesChangedForSkippingEnginePhaseValue;
   int? maxLuciTaskRetriesValue;
   int? batchSizeValue;
   FakeKeyHelper? keyHelperValue;
@@ -150,6 +152,9 @@ class FakeConfig implements Config {
 
   @override
   int get batchSize => batchSizeValue ?? 5;
+
+  @override
+  int get maxFilesChangedForSkippingEnginePhase => maxFilesChangedForSkippingEnginePhaseValue!;
 
   @override
   int get maxLuciTaskRetries => maxLuciTaskRetriesValue!;

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -309,6 +309,7 @@ github.PullRequest generatePullRequest({
   String sha = 'abc',
   bool merged = true,
   List<github.IssueLabel> labels = const [],
+  int changedFilesCount = 1,
 }) {
   mergedAt ??= DateTime.fromMillisecondsSinceEpoch(1);
   return github.PullRequest(
@@ -340,6 +341,7 @@ github.PullRequest generatePullRequest({
     mergeCommitSha: sha,
     merged: merged,
     labels: labels,
+    changedFilesCount: changedFilesCount,
   );
 }
 


### PR DESCRIPTION
No need to use up quota when the PR already says it has changed 30 or more files.

Also took the opportunity to code the check in as a config file if we ever want to tweak it.