### PR TITLE
Do not update patch versions for `dependabot/github-actions`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       timezone: "America/Los_Angeles"
     labels:
       - "autosubmit"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Pub ecosystem.
   - package-ecosystem: "pub"
     directory: "/analyze"


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158350.