### PR TITLE
Revert "Always set `FLUTTER_PREBUILT_ENGINE_VERSION` for framework-stage PRs. (#4254)"

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -461,9 +461,8 @@ class Scheduler {
             pullRequest: pullRequest,
             checkRunGuard: '$lock',
             logCrumb: logCrumb,
-
-            // The if-branch already skips the engine build phase.
             skipEngine: true,
+            flutterPrebuiltEngineVersion: pullRequest.base!.sha,
           );
           break;
         }
@@ -1169,16 +1168,12 @@ $stackTrace
     await unlockMergeQueueGuard(slug, sha, checkRunGuard);
   }
 
-  /// Fetches, and schedules, tests that execute _after_ the engine is built.
-  ///
-  /// If [skipEngine] is `true`, engine tests are not scheduled (it is
-  /// assumed that the engine has not changed in [pullRequest] so there are no
-  /// need to run them at this PR).
   Future<void> _runCiTestingStage({
     required PullRequest pullRequest,
     required String checkRunGuard,
     required String logCrumb,
     bool skipEngine = false,
+    String? flutterPrebuiltEngineVersion,
   }) async {
     try {
       // Both the author and label should be checked to make sure that no one is
@@ -1190,7 +1185,6 @@ $stackTrace
         // Schedule the tests that would have run in a call to triggerPresubmitTargets - but for both the
         // engine and the framework.
         final presubmitTargets = await getTestsForStage(pullRequest, CiStage.fusionTests, skipEngine: skipEngine);
-
         // Create the document for tracking test check runs.
         await initializeCiStagingDocument(
           firestoreService: firestoreService,
@@ -1200,22 +1194,6 @@ $stackTrace
           tasks: [...presubmitTargets.map((t) => t.value.name)],
           checkRunGuard: checkRunGuard,
         );
-
-        // Here is where it gets fun: how do framework tests* know what engine
-        // artifacts to fetch and use on CI? For presubmits on flutter/flutter;
-        // see https://github.com/flutter/flutter/issues/164031.
-        //
-        // *In theory, also engine tests, but engine tests build from the engine
-        // from source and rely on remote-build execution (RBE) for builds to
-        // fast and cached.
-        final String flutterPrebuiltEngineVersion;
-        if (skipEngine) {
-          // Use the engine that this PR was branched off of.
-          flutterPrebuiltEngineVersion = pullRequest.base!.sha!;
-        } else {
-          // Use the engine that was built from source *for* this PR.
-          flutterPrebuiltEngineVersion = pullRequest.head!.sha!;
-        }
 
         await luciBuildService.scheduleTryBuilds(
           targets: presubmitTargets,

--- a/app_dart/test/model/firestore/pr_check_runs_test.dart
+++ b/app_dart/test/model/firestore/pr_check_runs_test.dart
@@ -27,7 +27,7 @@ void main() {
         generateCheckRun(1, name: 'check 1'),
         generateCheckRun(2, name: 'check 2'),
       ];
-      final pr = generatePullRequest(id: 11252024, repo: 'fluax', headSha: '1234abc');
+      final pr = generatePullRequest(id: 11252024, repo: 'fluax', sha: '1234abc');
 
       late MockProjectsDatabasesDocumentsResource docRes;
 

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2499,7 +2499,7 @@ void foo() {
       test('applies emergency label on approved PRs', () async {
         final pullRequest = generatePullRequest(
           number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           labels: [
             IssueLabel(
               name: 'emergency',
@@ -2545,7 +2545,7 @@ void foo() {
       test('logs and gracefully skips emergency label on missing Merge Queue Guard', () async {
         final pullRequest = generatePullRequest(
           number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           labels: [
             IssueLabel(
               name: 'emergency',
@@ -2610,7 +2610,7 @@ void foo() {
       test('leaves educational comment for new emergency PRs', () async {
         final pullRequest = generatePullRequest(
           number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           labels: [
             IssueLabel(
               name: 'emergency',
@@ -2656,7 +2656,7 @@ void foo() {
       test('leaves only one educational comment for new emergency PRs', () async {
         final pullRequest = generatePullRequest(
           number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           labels: [
             IssueLabel(
               name: 'emergency',
@@ -2707,7 +2707,7 @@ void foo() {
       test('does not leave educational comment for non-new emergency PRs', () async {
         final pullRequest = generatePullRequest(
           number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
           labels: [
             IssueLabel(
               name: 'emergency',

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -127,7 +127,7 @@ void main() {
       });
 
       test('if status has not changed since last update', () async {
-        final PullRequest pr = generatePullRequest(id: 1, headSha: 'sha1');
+        final PullRequest pr = generatePullRequest(id: 1, sha: 'sha1');
         when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
         buildStatusService.cumulativeStatus = BuildStatus.success();
         githubBuildStatus = generateFirestoreGithubBuildStatus(1);
@@ -137,7 +137,7 @@ void main() {
       });
 
       test('if there is no pr found for a targeted branch', () async {
-        final PullRequest pr = generatePullRequest(id: 1, headSha: 'sha1', branch: 'test_branch');
+        final PullRequest pr = generatePullRequest(id: 1, sha: 'sha1', branch: 'test_branch');
         when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
         buildStatusService.cumulativeStatus = BuildStatus.success();
         githubBuildStatus = generateFirestoreGithubBuildStatus(1, status: GithubBuildStatus.statusFailure);
@@ -157,7 +157,7 @@ void main() {
       ).thenAnswer((Invocation invocation) {
         return Future<BatchWriteResponse>.value(BatchWriteResponse());
       });
-      final PullRequest pr = generatePullRequest(id: 1, headSha: 'sha1');
+      final PullRequest pr = generatePullRequest(id: 1, sha: 'sha1');
       when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
       buildStatusService.cumulativeStatus = BuildStatus.success();
       githubBuildStatus = generateFirestoreGithubBuildStatus(1, status: GithubBuildStatus.statusFailure);
@@ -186,7 +186,7 @@ void main() {
         return Future<BatchWriteResponse>.value(BatchWriteResponse());
       });
       final PullRequest pr =
-          generatePullRequest(id: 1, headSha: 'sha1', labels: [IssueLabel(name: Config.kEmergencyLabel)]);
+          generatePullRequest(id: 1, sha: 'sha1', labels: [IssueLabel(name: Config.kEmergencyLabel)]);
       when(pullRequestsService.list(any, base: anyNamed('base'))).thenAnswer((_) => Stream<PullRequest>.value(pr));
       buildStatusService.cumulativeStatus = BuildStatus.failure(const ['all bad']);
       githubBuildStatus = generateFirestoreGithubBuildStatus(1, status: GithubBuildStatus.statusFailure);

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -306,8 +306,7 @@ github.PullRequest generatePullRequest({
   String title = 'example message',
   int number = 123,
   DateTime? mergedAt,
-  String headSha = 'abc',
-  String baseSha = 'def',
+  String sha = 'abc',
   bool merged = true,
   List<github.IssueLabel> labels = const [],
   int changedFilesCount = 1,
@@ -320,7 +319,6 @@ github.PullRequest generatePullRequest({
     mergedAt: mergedAt,
     base: github.PullRequestHead(
       ref: branch,
-      sha: baseSha,
       repo: github.Repository(
         fullName: 'flutter/$repo',
         name: repo,
@@ -329,7 +327,7 @@ github.PullRequest generatePullRequest({
     ),
     head: github.PullRequestHead(
       ref: branch,
-      sha: headSha,
+      sha: sha,
       repo: github.Repository(
         fullName: 'flutter/$repo',
         name: repo,
@@ -340,7 +338,7 @@ github.PullRequest generatePullRequest({
       login: authorLogin,
       avatarUrl: authorAvatar,
     ),
-    mergeCommitSha: headSha,
+    mergeCommitSha: sha,
     merged: merged,
     labels: labels,
     changedFilesCount: changedFilesCount,


### PR DESCRIPTION
This reverts commit fc543f1837abaeb8bfb8aa68be95bc5c731e8b8e.

This is causing errors when presubmit CI jobs try to download the Dart SDK from a URL that is missing the "flutter_archives_v2" realm.