### PR TITLE
Update `checkRerunBuilder` to use `BuildTagSet`.

### DIFF
--- a/app_dart/lib/src/request_handlers/reset_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_prod_task.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_service/src/service/luci_build_service.dart';
+import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart';
 import 'package:cocoon_service/src/service/scheduler.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
@@ -171,23 +171,14 @@ class ResetProdTask extends ApiRequestHandler<Body> {
       documentName: taskDocumentName,
     );
 
-    final List<bbv2.StringPair> tags = <bbv2.StringPair>[
-      bbv2.StringPair(
-        key: 'triggered_by',
-        value: email,
-      ),
-      bbv2.StringPair(
-        key: 'trigger_type',
-        value: 'manual_retry',
-      ),
-    ];
-
     final bool isRerunning = await luciBuildService.checkRerunBuilder(
       commit: commit,
       task: task,
       target: target,
       datastore: datastore,
-      tags: tags,
+      tags: [
+        TriggerdByBuildTag(email: email),
+      ],
       ignoreChecks: ignoreChecks,
       firestoreService: firestoreService,
       taskDocument: taskDocument,

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -10,6 +10,7 @@ import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/firestore/pr_check_runs.dart';
+import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart';
 import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart' as github;
@@ -1147,7 +1148,7 @@ class LuciBuildService {
     required DatastoreService datastore,
     required firestore.Task taskDocument,
     required FirestoreService firestoreService,
-    List<bbv2.StringPair>? tags,
+    Iterable<BuildTag> tags = const [],
     bool ignoreChecks = false,
   }) async {
     if (ignoreChecks == false && await _shouldRerunBuilderFirestore(taskDocument, firestoreService) == false) {
@@ -1155,18 +1156,9 @@ class LuciBuildService {
     }
 
     log.info('Rerun builder: ${target.value.name} for commit ${commit.sha}');
-    tags ??= <bbv2.StringPair>[];
-    final bbv2.StringPair? triggerTag = tags.singleWhereOrNull(
-      (element) => element.key == 'trigger_type' && element.value == 'auto_retry',
-    );
-    if (triggerTag == null) {
-      tags.add(
-        bbv2.StringPair(
-          key: 'trigger_type',
-          value: 'auto_retry',
-        ),
-      );
-    }
+
+    final buildTags = BuildTagSet(tags);
+    buildTags.add(TriggerTypeBuildTag.autoRetry);
 
     try {
       final int newAttempt = await _updateTaskStatusInDatabaseForRetry(
@@ -1175,12 +1167,7 @@ class LuciBuildService {
         firestoreService = firestoreService,
         datastore = datastore,
       );
-      tags.add(
-        bbv2.StringPair(
-          key: 'current_attempt',
-          value: newAttempt.toString(),
-        ),
-      );
+      buildTags.add(CurrentAttemptBuildTag(attemptNumber: newAttempt));
     } catch (error) {
       log.severe(
         'updating task ${taskDocument.taskName} of commit ${taskDocument.commitSha} failure: $error. Skipping rescheduling.',
@@ -1199,7 +1186,7 @@ class LuciBuildService {
             task: task,
             priority: kRerunPriority,
             properties: Config.defaultProperties,
-            tags: tags,
+            tags: buildTags.toStringPairs(),
           ),
         ),
       ],

--- a/app_dart/lib/src/service/luci_build_service/build_tags.dart
+++ b/app_dart/lib/src/service/luci_build_service/build_tags.dart
@@ -6,6 +6,41 @@ import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
+/// A set of [BuildTag]s where only a single tag with each key is permitted.
+final class BuildTagSet {
+  /// Creates a new set, optionally with the provided initial entries.
+  ///
+  /// If the iterable is non-empty and contains multiple tags with the same
+  /// key, the last item in the iterable is stored and the remaining are
+  /// discarded.
+  factory BuildTagSet([Iterable<BuildTag> buildTags = const []]) {
+    return BuildTagSet._({
+      for (final tag in buildTags) tag._key: tag,
+    });
+  }
+
+  BuildTagSet._(this._buildTagsByKey);
+  final Map<String, BuildTag> _buildTagsByKey;
+
+  /// Adds [buildTag] to the set.
+  ///
+  /// If a previous build tag exited with the same key, it is replaced.
+  void add(BuildTag buildTag) {
+    _buildTagsByKey[buildTag._key] = buildTag;
+  }
+
+  /// Creates a copy of the current state of the set.
+  BuildTagSet clone() => BuildTagSet._({..._buildTagsByKey});
+
+  /// Each [BuildTag] in the set.
+  Iterable<BuildTag> get buildTags => _buildTagsByKey.values;
+
+  /// Returns a copy of the build tags as a list of [bbv2.StringPair]s.
+  List<bbv2.StringPair> toStringPairs() {
+    return buildTags.map((e) => e.toStringPair()).toList();
+  }
+}
+
 /// Valid tags for [bbv2.ScheduleBuildRequest.tags].
 ///
 /// Tags are indexed arbitrary string key-value pairs, defined by the user that

--- a/app_dart/test/service/build_tags_test.dart
+++ b/app_dart/test/service/build_tags_test.dart
@@ -48,7 +48,7 @@ void main() {
       expect(
         set.buildTags,
         unorderedEquals([
-          TriggerTypeBuildTag.checkRunManualRetry,
+          TriggerTypeBuildTag.autoRetry,
           GitHubCheckRunIdBuildTag(checkRunId: 1234),
         ]),
       );

--- a/app_dart/test/service/build_tags_test.dart
+++ b/app_dart/test/service/build_tags_test.dart
@@ -7,6 +7,86 @@ import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('BuildTagSet', () {
+    test('creates an empty set', () {
+      final set = BuildTagSet();
+      expect(set.buildTags, isEmpty);
+    });
+
+    test('creates an initial set', () {
+      final set = BuildTagSet([
+        TriggerTypeBuildTag.autoRetry,
+        GitHubCheckRunIdBuildTag(checkRunId: 1234),
+      ]);
+      expect(
+        set.buildTags,
+        unorderedEquals([
+          TriggerTypeBuildTag.autoRetry,
+          GitHubCheckRunIdBuildTag(checkRunId: 1234),
+        ]),
+      );
+    });
+
+    test('creates an initial set of "last wins" tags', () {
+      final set = BuildTagSet([
+        TriggerTypeBuildTag.autoRetry,
+        GitHubCheckRunIdBuildTag(checkRunId: 1234),
+        TriggerTypeBuildTag.checkRunManualRetry,
+      ]);
+      expect(
+        set.buildTags,
+        unorderedEquals([
+          TriggerTypeBuildTag.checkRunManualRetry,
+          GitHubCheckRunIdBuildTag(checkRunId: 1234),
+        ]),
+      );
+    });
+
+    test('adds a new tag', () {
+      final set = BuildTagSet([TriggerTypeBuildTag.autoRetry]);
+      set.add(GitHubCheckRunIdBuildTag(checkRunId: 1234));
+      expect(
+        set.buildTags,
+        unorderedEquals([
+          TriggerTypeBuildTag.checkRunManualRetry,
+          GitHubCheckRunIdBuildTag(checkRunId: 1234),
+        ]),
+      );
+    });
+
+    test('adds a new tag replacing an existing one', () {
+      final set = BuildTagSet([TriggerTypeBuildTag.autoRetry]);
+      set.add(TriggerTypeBuildTag.manualRetry);
+      expect(
+        set.buildTags,
+        unorderedEquals([
+          TriggerTypeBuildTag.manualRetry,
+        ]),
+      );
+    });
+
+    test('clones a set', () {
+      final a = BuildTagSet([TriggerTypeBuildTag.autoRetry]);
+      final b = a.clone();
+
+      a.add(TriggerTypeBuildTag.checkRunManualRetry);
+      b.add(TriggerTypeBuildTag.manualRetry);
+
+      expect(a.buildTags, unorderedEquals([TriggerTypeBuildTag.checkRunManualRetry]));
+      expect(b.buildTags, unorderedEquals([TriggerTypeBuildTag.manualRetry]));
+    });
+
+    test('creates string pairs', () {
+      final set = BuildTagSet([TriggerTypeBuildTag.autoRetry]);
+      expect(
+        set.toStringPairs(),
+        unorderedEquals([
+          bbv2.StringPair(key: 'trigger_type', value: 'auto_retry'),
+        ]),
+      );
+    });
+  });
+
   group('UserAgentBuildTag', () {
     test('can be produced', () {
       final userAgent = UserAgentBuildTag(value: 'flutter-foo');

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -34,6 +34,7 @@ import 'package:cocoon_service/src/service/config.dart' as _i2;
 import 'package:cocoon_service/src/service/datastore.dart' as _i9;
 import 'package:cocoon_service/src/service/gerrit_service.dart' as _i6;
 import 'package:cocoon_service/src/service/github_service.dart' as _i17;
+import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart' as _i46;
 import 'package:fixnum/fixnum.dart' as _i45;
 import 'package:gcloud/db.dart' as _i11;
 import 'package:github/github.dart' as _i13;
@@ -47,11 +48,11 @@ import 'package:http/http.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i32;
 import 'package:neat_cache/neat_cache.dart' as _i29;
-import 'package:process/process.dart' as _i46;
+import 'package:process/process.dart' as _i47;
 import 'package:retry/retry.dart' as _i31;
 
 import '../../service/cache_service_test.dart' as _i39;
-import 'mocks.dart' as _i47;
+import 'mocks.dart' as _i48;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -6391,7 +6392,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
     required _i9.DatastoreService? datastore,
     required _i42.Task? taskDocument,
     required _i15.FirestoreService? firestoreService,
-    List<_i8.StringPair>? tags,
+    Iterable<_i46.BuildTag>? tags = const [],
     bool? ignoreChecks = false,
   }) =>
       (super.noSuchMethod(
@@ -6416,7 +6417,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 /// A class which mocks [ProcessManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessManager extends _i1.Mock implements _i46.ProcessManager {
+class MockProcessManager extends _i1.Mock implements _i47.ProcessManager {
   MockProcessManager() {
     _i1.throwOnMissingStub(this);
   }
@@ -7589,7 +7590,7 @@ class MockBeginTransactionResponse extends _i1.Mock implements _i21.BeginTransac
 /// A class which mocks [Callbacks].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallbacks extends _i1.Mock implements _i47.Callbacks {
+class MockCallbacks extends _i1.Mock implements _i48.Callbacks {
   MockCallbacks() {
     _i1.throwOnMissingStub(this);
   }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/164242.

It's also obvious the previous logic was flawed for `checkRerunBuilder`, regardless of (initially) putting `manual_retry`, it always got immediately replaced with `auto_retry`. I'm not sure which one is correct, please LMK.

