### PR TITLE
Add meaningful `toString` to some objects we log.

### DIFF
--- a/app_dart/lib/src/model/github/checks.dart
+++ b/app_dart/lib/src/model/github/checks.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:github/github.dart' show CheckSuite, PullRequest, User, Repository;
 import 'package:github/hooks.dart' show HookEvent;
 import 'package:json_annotation/json_annotation.dart';
@@ -28,6 +30,11 @@ class CheckRunEvent extends HookEvent {
   Repository? repository;
 
   Map<String, dynamic> toJson() => _$CheckRunEventToJson(this);
+
+  @override
+  String toString() {
+    return 'CheckRunEvent ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
@@ -51,6 +58,11 @@ class CheckRun {
   final List<PullRequest>? pullRequests;
 
   Map<String, dynamic> toJson() => _$CheckRunToJson(this);
+
+  @override
+  String toString() {
+    return 'CheckRun ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
 }
 
 /// Data model for a `merge_group` event.
@@ -98,6 +110,11 @@ class MergeGroupEvent extends HookEvent {
   User? sender;
 
   Map<String, dynamic> toJson() => _$MergeGroupEventToJson(this);
+
+  @override
+  String toString() {
+    return 'MergeGroupEvent ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
 }
 
 /// Data model for a `merge_group`.
@@ -133,6 +150,11 @@ class MergeGroup {
   final HeadCommit headCommit;
 
   Map<String, dynamic> toJson() => _$MergeGroupToJson(this);
+
+  @override
+  String toString() {
+    return 'MergeGroup ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
 }
 
 /// Data model for `merge_group.head_commit`.
@@ -162,4 +184,9 @@ class HeadCommit {
   final String message;
 
   Map<String, dynamic> toJson() => _$HeadCommitToJson(this);
+
+  @override
+  String toString() {
+    return 'HeadCommit ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
 }

--- a/app_dart/test/model/github/hooks_tostring_test.dart
+++ b/app_dart/test/model/github/hooks_tostring_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/github/checks.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('CheckRunEvent', () {
+    final object = CheckRunEvent(action: 'Amazing');
+    expect(
+      object.toString(),
+      stringContainsInOrder([
+        'CheckRunEvent',
+        '"action": "Amazing"',
+      ]),
+    );
+  });
+
+  test('CheckRun', () {
+    const object = CheckRun(conclusion: 'Amazing');
+    expect(
+      object.toString(),
+      stringContainsInOrder([
+        'CheckRun',
+        '"conclusion": "Amazing"',
+      ]),
+    );
+  });
+
+  test('MergeGroupEvent', () {
+    final object = MergeGroupEvent(
+      mergeGroup: const MergeGroup(
+        headSha: 'headSha',
+        headRef: 'headRef',
+        baseSha: 'baseSha',
+        baseRef: 'baseRef',
+        headCommit: HeadCommit(id: 'id', treeId: 'treeId', message: 'message'),
+      ),
+      action: 'Amazing',
+    );
+    expect(
+      object.toString(),
+      stringContainsInOrder([
+        'MergeGroupEvent',
+        '"action": "Amazing"',
+        '"head_sha": "headSha"',
+        '"tree_id": "treeId"',
+      ]),
+    );
+  });
+}


### PR DESCRIPTION
Addresses this wonderful log:

```txt
Failed to process Instance of 'PushMessage'. (500) Failed to process check_run event. checkRunEvent: Instance of 'CheckRunEvent'
```