### PR TITLE
Leave comment, even if the MQG is already completed

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -951,18 +951,16 @@ The "Merge" button is also unlocked. To bypass presubmits as well as the tree st
     logInfo('unlocked "${Config.kMergeQueueLockName}", allowing it to land as an emergency.');
 
     // Let the developer know what is happening with the MQ when this label is found the first time.
-    if (guard.status != CheckRunStatus.completed) {
-      try {
-        if (!await githubService.commentExists(slug, prNumber, PullRequestLabelProcessor.kEmergencyLabelEducation)) {
-          await githubService.createComment(
-            slug,
-            issueNumber: prNumber,
-            body: PullRequestLabelProcessor.kEmergencyLabelEducation,
-          );
-        }
-      } catch (e, s) {
-        logSevere('failed to leave educational comment for emergency label.', error: e, stackTrace: s);
+    try {
+      if (!await githubService.commentExists(slug, prNumber, PullRequestLabelProcessor.kEmergencyLabelEducation)) {
+        await githubService.createComment(
+          slug,
+          issueNumber: prNumber,
+          body: PullRequestLabelProcessor.kEmergencyLabelEducation,
+        );
       }
+    } catch (e, s) {
+      logSevere('failed to leave educational comment for emergency label.', error: e, stackTrace: s);
     }
   }
 }

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -2745,46 +2745,6 @@ void foo() {
         ]);
         expect(githubService.commentExistsCalls, hasLength(2));
       });
-
-      test('does not leave educational comment for non-new emergency PRs', () async {
-        final pullRequest = generatePullRequest(
-          number: 123,
-          headSha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
-          labels: [
-            IssueLabel(
-              name: 'emergency',
-            ),
-          ],
-        );
-        githubService.createdComments.clear();
-        githubService.checkRunsMock = '''{
-  "total_count": 2,
-  "check_runs": [
-    {
-      "id": 2,
-      "head_sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-      "external_id": "",
-      "details_url": "https://example.com",
-      "status": "completed",
-      "started_at": "2018-05-04T01:14:52Z",
-      "name": "Merge Queue Guard",
-      "check_suite": {
-        "id": 5
-      }
-    }
-  ]
-}''';
-
-        final pullRequestLabelProcessor = PullRequestLabelProcessor(
-          config: config,
-          githubService: githubService,
-          pullRequest: pullRequest,
-        );
-
-        await pullRequestLabelProcessor.processLabels();
-
-        expect(githubService.createdComments, isEmpty);
-      });
     });
   });
 


### PR DESCRIPTION
We now search for a previous comment; so we'll be limited to 1 on the PR. To keep things consistent, leave a comment even if the MQG was already unlocked
