### PR TITLE
Update ktlint_metadata.txt to use 1.5.0 since 1.5 returns "not found"

### DIFF
--- a/cipd_packages/ktlint/ktlint_metadata.txt
+++ b/cipd_packages/ktlint/ktlint_metadata.txt
@@ -1,1 +1,1 @@
-1.5,ktlint
+1.5.0,ktlint


### PR DESCRIPTION
Required for flutter/flutter/issues/164408. 
Discovered when trying to use ktlint in https://github.com/flutter/flutter/pull/164409
current code is a text file with "not found" https://chrome-infra-packages.appspot.com/p/flutter/ktlint/linux-amd64/+/PGscrVjJsPjl_CqtUV6kKH-JBNvGVlIKY9BnHpko6SIC 

can be verified by running `curl -L https://github.com/pinterest/ktlint/releases/download/1.5.0/ktlint  -o ktlint` vs `curl -L https://github.com/pinterest/ktlint/releases/download/1.5/ktlint  -o ktlint`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

