### PR TITLE
Refactor `Tuple<Target, Task, int>` as `PendingTask`.

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -164,12 +164,12 @@ class BatchBackfiller extends RequestHandler {
     try {
       await retryOptions.retry(
         () async {
-          final List<List<PendingTask>> tupleLists =
+          final List<List<PendingTask>> pendingTasks =
               await Future.wait<List<PendingTask>>(backfillRequestList(backfill));
-          if (tupleLists.any((List<PendingTask> tupleList) => tupleList.isNotEmpty)) {
-            final int nonEmptyListLenght = tupleLists.where((element) => element.isNotEmpty).toList().length;
+          if (pendingTasks.any((List<PendingTask> tupleList) => tupleList.isNotEmpty)) {
+            final int nonEmptyListLenght = pendingTasks.where((element) => element.isNotEmpty).toList().length;
             log.info('Backfill fails and retry backfilling $nonEmptyListLenght targets.');
-            backfill = _updateBackfill(backfill, tupleLists);
+            backfill = _updateBackfill(backfill, pendingTasks);
             throw InternalServerError('Failed to backfill ${backfill.length} targets.');
           }
         },

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -7,6 +7,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
 import 'package:cocoon_service/src/service/datastore.dart';
+import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart';
 import 'package:cocoon_service/src/service/scheduler/policy.dart';
 import 'package:gcloud/db.dart';
 import 'package:github/github.dart';
@@ -163,9 +164,9 @@ class BatchBackfiller extends RequestHandler {
     try {
       await retryOptions.retry(
         () async {
-          final List<List<Tuple<Target, Task, int>>> tupleLists =
-              await Future.wait<List<Tuple<Target, Task, int>>>(backfillRequestList(backfill));
-          if (tupleLists.any((List<Tuple<Target, Task, int>> tupleList) => tupleList.isNotEmpty)) {
+          final List<List<PendingTask>> tupleLists =
+              await Future.wait<List<PendingTask>>(backfillRequestList(backfill));
+          if (tupleLists.any((List<PendingTask> tupleList) => tupleList.isNotEmpty)) {
             final int nonEmptyListLenght = tupleLists.where((element) => element.isNotEmpty).toList().length;
             log.info('Backfill fails and retry backfilling $nonEmptyListLenght targets.');
             backfill = _updateBackfill(backfill, tupleLists);
@@ -186,7 +187,7 @@ class BatchBackfiller extends RequestHandler {
   /// [scheduler.luciBuildService.schedulePostsubmitBuilds].
   List<Tuple<Target, FullTask, int>> _updateBackfill(
     List<Tuple<Target, FullTask, int>> backfill,
-    List<List<Tuple<Target, Task, int>>> tupleLists,
+    List<List<PendingTask>> tupleLists,
   ) {
     final List<Tuple<Target, FullTask, int>> updatedBackfill = <Tuple<Target, FullTask, int>>[];
     for (int i = 0; i < tupleLists.length; i++) {
@@ -198,14 +199,14 @@ class BatchBackfiller extends RequestHandler {
   }
 
   /// Creates a list of backfill requests.
-  List<Future<List<Tuple<Target, Task, int>>>> backfillRequestList(List<Tuple<Target, FullTask, int>> backfill) {
-    final List<Future<List<Tuple<Target, Task, int>>>> futures = <Future<List<Tuple<Target, Task, int>>>>[];
+  List<Future<List<PendingTask>>> backfillRequestList(List<Tuple<Target, FullTask, int>> backfill) {
+    final List<Future<List<PendingTask>>> futures = <Future<List<PendingTask>>>[];
     for (Tuple<Target, FullTask, int> tuple in backfill) {
       // TODO(chillers): The backfill priority is always going to be low. If this is a ToT task, we should run it at the default priority.
-      final Tuple<Target, Task, int> toBeScheduled = Tuple(
-        tuple.first,
-        tuple.second.task,
-        tuple.third,
+      final PendingTask toBeScheduled = PendingTask(
+        target: tuple.first,
+        task: tuple.second.task,
+        priority: tuple.third,
       );
       futures.add(
         scheduler.luciBuildService.schedulePostsubmitBuilds(

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -13,6 +13,7 @@ import 'package:cocoon_service/src/model/firestore/pr_check_runs.dart';
 import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart';
 import 'package:cocoon_service/src/service/luci_build_service/cipd_version.dart';
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart';
+import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart';
 import 'package:cocoon_service/src/service/luci_build_service/user_data.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart' as github;
@@ -655,9 +656,9 @@ class LuciBuildService {
   ///
   /// Returns empty list if all targets are successfully published to pub/sub. Otherwise,
   /// returns the original list.
-  Future<List<Tuple<Target, Task, int>>> schedulePostsubmitBuilds({
+  Future<List<PendingTask>> schedulePostsubmitBuilds({
     required Commit commit,
-    required List<Tuple<Target, Task, int>> toBeScheduled,
+    required List<PendingTask> toBeScheduled,
   }) async {
     if (toBeScheduled.isEmpty) {
       log.fine(
@@ -679,26 +680,26 @@ class LuciBuildService {
       return toBeScheduled;
     }
     log.info('Available builder list: $availableBuilderSet');
-    for (Tuple<Target, Task, int> tuple in toBeScheduled) {
+    for (PendingTask pending in toBeScheduled) {
       // Non-existing builder target will be skipped from scheduling.
-      if (!availableBuilderSet.contains(tuple.first.value.name)) {
+      if (!availableBuilderSet.contains(pending.target.value.name)) {
         log.warning(
-          'Found no available builder for ${tuple.first.value.name}, commit ${commit.sha}',
+          'Found no available builder for ${pending.target.value.name}, commit ${commit.sha}',
         );
         continue;
       }
       log.info(
-        'create postsubmit schedule request for target: ${tuple.first.value} in commit ${commit.sha}',
+        'create postsubmit schedule request for target: ${pending.target.value} in commit ${commit.sha}',
       );
       final bbv2.ScheduleBuildRequest scheduleBuildRequest = await _createPostsubmitScheduleBuild(
         commit: commit,
-        target: tuple.first,
-        task: tuple.second,
-        priority: tuple.third,
+        target: pending.target,
+        task: pending.task,
+        priority: pending.priority,
       );
       buildRequests.add(bbv2.BatchRequest_Request(scheduleBuild: scheduleBuildRequest));
       log.info(
-        'created postsubmit schedule request for target: ${tuple.first.value} in commit ${commit.sha}',
+        'created postsubmit schedule request for target: ${pending.target.value} in commit ${commit.sha}',
       );
     }
 
@@ -717,7 +718,7 @@ class LuciBuildService {
       return toBeScheduled;
     }
     log.info('Published a request with ${buildRequests.length} builds');
-    return <Tuple<Target, Task, int>>[];
+    return <PendingTask>[];
   }
 
   /// Schedules [targets] for building of prod artifacts while in a merge queue.

--- a/app_dart/lib/src/service/luci_build_service/pending_task.dart
+++ b/app_dart/lib/src/service/luci_build_service/pending_task.dart
@@ -1,0 +1,44 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:cocoon_service/src/service/luci_build_service.dart';
+library;
+
+import 'package:cocoon_service/ci_yaml.dart';
+import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:meta/meta.dart';
+
+/// Represents a task that has yet to be scheduled in [LuciBuildService].
+///
+/// This is a glorified tuple that has a concrete type and documentation.
+@immutable
+final class PendingTask {
+  const PendingTask({
+    required this.target,
+    required this.task,
+    required this.priority,
+  });
+
+  /// Target that is represented by [task].
+  final Target target;
+
+  /// Task that, when executed, faithfully cares out the request in [target].
+  final Task task;
+
+  /// Priority of the task.
+  final int priority;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PendingTask && target == other.target && task == other.task && priority == other.priority;
+  }
+
+  @override
+  int get hashCode => Object.hash(target, task, priority);
+
+  @override
+  String toString() {
+    return 'PendingTask <${task.builderName}: $priority>';
+  }
+}

--- a/app_dart/lib/src/service/luci_build_service/pending_task.dart
+++ b/app_dart/lib/src/service/luci_build_service/pending_task.dart
@@ -39,6 +39,6 @@ final class PendingTask {
 
   @override
   String toString() {
-    return 'PendingTask <${task.builderName}: $priority>';
+    return 'PendingTask <${task.builderName} | $target | $priority>';
   }
 }

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -17,6 +17,7 @@ import 'package:cocoon_service/src/model/luci/user_data.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/exceptions.dart';
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart';
+import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:gcloud/datastore.dart';
 import 'package:github/github.dart';
@@ -688,8 +689,8 @@ void main() {
           ],
         );
       });
-      final Tuple<Target, Task, int> toBeScheduled = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'recipe': 'devicelab/devicelab',
@@ -697,12 +698,12 @@ void main() {
           },
           slug: Config.packagesSlug,
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled,
         ],
       );
@@ -786,8 +787,8 @@ void main() {
           ],
         );
       });
-      final Tuple<Target, Task, int> toBeScheduled = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'recipe': 'devicelab/devicelab',
@@ -795,12 +796,12 @@ void main() {
           },
           slug: Config.packagesSlug,
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled,
         ],
       );
@@ -878,20 +879,20 @@ void main() {
           ],
         );
       });
-      final Tuple<Target, Task, int> toBeScheduled = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'os': 'debian-10.12',
           },
           slug: RepositorySlug('flutter', 'packages'),
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled,
         ],
       );
@@ -931,24 +932,24 @@ void main() {
       when(mockBuildBucketClient.listBuilders(any)).thenAnswer((_) async {
         throw const BuildBucketException(1, 'error');
       });
-      final Tuple<Target, Task, int> toBeScheduled = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'os': 'debian-10.12',
           },
           slug: RepositorySlug('flutter', 'packages'),
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
-      final List<Tuple<Target, Task, int>> results = await service.schedulePostsubmitBuilds(
+      final List<PendingTask> results = await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled,
         ],
       );
-      expect(results, <Tuple<Target, Task, int>>[
+      expect(results, <PendingTask>[
         toBeScheduled,
       ]);
     });
@@ -1060,8 +1061,8 @@ void main() {
           ],
         );
       });
-      final Tuple<Target, Task, int> toBeScheduled = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'os': 'debian-10.12',
@@ -1069,12 +1070,12 @@ void main() {
           bringup: true,
           slug: Config.packagesSlug,
         ),
-        generateTask(1, parent: commit),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1, parent: commit),
+        priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled,
         ],
       );
@@ -1121,29 +1122,29 @@ void main() {
           ],
         );
       });
-      final Tuple<Target, Task, int> toBeScheduled1 = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled1 = PendingTask(
+        target: generateTarget(
           1,
           properties: <String, String>{
             'os': 'debian-10.12',
           },
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
-      final Tuple<Target, Task, int> toBeScheduled2 = Tuple<Target, Task, int>(
-        generateTarget(
+      final PendingTask toBeScheduled2 = PendingTask(
+        target: generateTarget(
           2,
           properties: <String, String>{
             'os': 'debian-10.12',
           },
         ),
-        generateTask(1),
-        LuciBuildService.kDefaultPriority,
+        task: generateTask(1),
+        priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
         commit: commit,
-        toBeScheduled: <Tuple<Target, Task, int>>[
+        toBeScheduled: <PendingTask>[
           toBeScheduled1,
           toBeScheduled2,
         ],

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -20,6 +20,7 @@ import 'package:cocoon_service/src/model/github/checks.dart' as cocoon_checks;
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart';
+import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:gcloud/db.dart' as gcloud_db;
 import 'package:gcloud/db.dart';
@@ -386,7 +387,7 @@ void main() {
             commit: anyNamed('commit'),
             toBeScheduled: captureAnyNamed('toBeScheduled'),
           ),
-        ).thenAnswer((_) => Future<List<Tuple<Target, Task, int>>>.value(<Tuple<Target, Task, int>>[]));
+        ).thenAnswer((_) async => []);
         buildStatusService = FakeBuildStatusService(
           commitStatuses: <CommitStatus>[
             CommitStatus(generateCommit(1, repo: 'packages', branch: 'main'), const <Stage>[]),
@@ -417,10 +418,8 @@ void main() {
         ).captured;
         final List<Object?> toBeScheduled = captured.first as List<Object?>;
         expect(toBeScheduled.length, 2);
-        final Iterable<Tuple<Target, Task, int>> tuples =
-            toBeScheduled.map((dynamic tuple) => tuple as Tuple<Target, Task, int>);
-        final Iterable<String> scheduledTargetNames =
-            tuples.map((Tuple<Target, Task, int> tuple) => tuple.second.name!);
+        final Iterable<PendingTask> tuples = toBeScheduled.map((dynamic tuple) => tuple as PendingTask);
+        final Iterable<String> scheduledTargetNames = tuples.map((PendingTask tuple) => tuple.task.name!);
         expect(scheduledTargetNames, ['Linux A', 'Linux runIf']);
         // Tasks triggered by cocoon are marked as in progress
         final Iterable<Task> tasks = db.values.values.whereType<Task>();

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -37,6 +37,7 @@ import 'package:cocoon_service/src/service/github_service.dart' as _i17;
 import 'package:cocoon_service/src/service/luci_build_service/build_tags.dart' as _i44;
 import 'package:cocoon_service/src/service/luci_build_service/cipd_version.dart' as _i35;
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart' as _i46;
+import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart' as _i49;
 import 'package:fixnum/fixnum.dart' as _i48;
 import 'package:gcloud/db.dart' as _i11;
 import 'package:github/github.dart' as _i13;
@@ -50,11 +51,11 @@ import 'package:http/http.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i32;
 import 'package:neat_cache/neat_cache.dart' as _i29;
-import 'package:process/process.dart' as _i49;
+import 'package:process/process.dart' as _i50;
 import 'package:retry/retry.dart' as _i31;
 
 import '../../service/cache_service_test.dart' as _i40;
-import 'mocks.dart' as _i50;
+import 'mocks.dart' as _i51;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -6323,9 +6324,9 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<Set<String>>);
 
   @override
-  _i20.Future<List<_i15.Tuple<_i45.Target, _i38.Task, int>>> schedulePostsubmitBuilds({
+  _i20.Future<List<_i49.PendingTask>> schedulePostsubmitBuilds({
     required _i37.Commit? commit,
-    required List<_i15.Tuple<_i45.Target, _i38.Task, int>>? toBeScheduled,
+    required List<_i49.PendingTask>? toBeScheduled,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6336,9 +6337,8 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
             #toBeScheduled: toBeScheduled,
           },
         ),
-        returnValue: _i20.Future<List<_i15.Tuple<_i45.Target, _i38.Task, int>>>.value(
-            <_i15.Tuple<_i45.Target, _i38.Task, int>>[]),
-      ) as _i20.Future<List<_i15.Tuple<_i45.Target, _i38.Task, int>>>);
+        returnValue: _i20.Future<List<_i49.PendingTask>>.value(<_i49.PendingTask>[]),
+      ) as _i20.Future<List<_i49.PendingTask>>);
 
   @override
   _i20.Future<void> scheduleMergeGroupBuilds({
@@ -6410,7 +6410,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
 /// A class which mocks [ProcessManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProcessManager extends _i1.Mock implements _i49.ProcessManager {
+class MockProcessManager extends _i1.Mock implements _i50.ProcessManager {
   MockProcessManager() {
     _i1.throwOnMissingStub(this);
   }
@@ -7583,7 +7583,7 @@ class MockBeginTransactionResponse extends _i1.Mock implements _i21.BeginTransac
 /// A class which mocks [Callbacks].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallbacks extends _i1.Mock implements _i50.Callbacks {
+class MockCallbacks extends _i1.Mock implements _i51.Callbacks {
   MockCallbacks() {
     _i1.throwOnMissingStub(this);
   }


### PR DESCRIPTION
No behavioral changes, but `pending.target` is much nicer to read and write than `pending.first` and nasty generics.

![tumblr_nevfqijNkr1suzl23o3_400-ezgif com-webp-to-gif-converter](https://github.com/user-attachments/assets/852aba14-cf3a-4c66-922a-53ffa12be9e1)
