### PR TITLE
Be more explicit about required parameters, `userData`, and correct tests.

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -162,7 +162,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       log.info('Updating check status for ${target.getTestName}');
       await githubChecksService.updateCheckStatus(
         build: build,
-        userDataMap: userDataMap,
+        checkRunId: userDataMap['check_run_id'],
         luciBuildService: scheduler.luciBuildService,
         slug: commit.slug,
       );

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -44,25 +44,11 @@ class GithubChecksService {
   ///   https://docs.github.com/en/rest/reference/checks#update-a-check-run
   Future<bool> updateCheckStatus({
     required bbv2.Build build,
-    required Map<String, dynamic> userDataMap,
     required LuciBuildService luciBuildService,
     required github.RepositorySlug slug,
+    required int checkRunId,
     bool rescheduled = false,
   }) async {
-    if (userDataMap.isEmpty) {
-      return false;
-    }
-
-    if (!userDataMap.containsKey('check_run_id') ||
-        !userDataMap.containsKey('repo_owner') ||
-        !userDataMap.containsKey('repo_name')) {
-      log.severe(
-        'UserData did not contain check_run_id,'
-        'repo_owner, or repo_name: $userDataMap',
-      );
-      return false;
-    }
-
     github.CheckRunStatus status = statusForResult(build.status);
     log.info('status for build ${build.id} is ${status.value}');
 
@@ -70,7 +56,7 @@ class GithubChecksService {
     // Instead of making an API call to get the details of each check run, we
     // generate the check run with only necessary info.
     final github.CheckRun checkRun = github.CheckRun.fromJson({
-      'id': userDataMap['check_run_id'] as int?,
+      'id': checkRunId,
       'status': status,
       'check_suite': const {'id': null},
       'started_at': build.startTime.toDateTime().toString(),

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -486,7 +486,7 @@ class LuciBuildService {
   /// are also preserved.
   ///
   /// The [currentAttempt] is used to track the number of current build attempt.
-  Future<bbv2.Build> rescheduleBuild({
+  Future<bbv2.Build> reschedulePresubmitBuild({
     required String builderName,
     required bbv2.Build build,
     required int nextAttempt,

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -54,7 +54,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -443,7 +443,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -463,6 +463,7 @@ void main() {
       'commit_key': '${task.key.parent?.id}',
       'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -476,7 +477,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -489,7 +490,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -522,7 +523,7 @@ void main() {
     verifyNever(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -534,7 +535,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -569,7 +570,7 @@ void main() {
     verifyNever(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),

--- a/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
@@ -76,7 +76,7 @@ void main() {
     verifyNever(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -87,7 +87,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -98,6 +98,7 @@ void main() {
     const Map<String, dynamic> userDataMap = {
       'repo_owner': 'flutter',
       'repo_name': 'cocoon',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -111,7 +112,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -122,7 +123,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -134,6 +135,7 @@ void main() {
       'commit_branch': 'main',
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -151,7 +153,7 @@ void main() {
 
     await tester.post(handler);
     verifyNever(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: buildsPubSub.build,
         builderName: 'Linux Coverage',
         nextAttempt: 0,
@@ -161,7 +163,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
       ),
@@ -172,7 +174,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: true,
@@ -185,6 +187,7 @@ void main() {
       'commit_branch': 'main',
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -198,7 +201,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: true,
@@ -210,7 +213,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: true,
@@ -223,6 +226,7 @@ void main() {
       'commit_branch': 'main',
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -237,7 +241,7 @@ void main() {
     );
 
     when(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: anyNamed('build'),
         builderName: anyNamed('builderName'),
         nextAttempt: anyNamed('nextAttempt'),
@@ -262,7 +266,7 @@ void main() {
 
     await tester.post(luciHandler);
     verify(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: anyNamed('build'),
         builderName: 'Linux A',
         nextAttempt: 2,
@@ -272,7 +276,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: true,
@@ -284,7 +288,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: false,
@@ -298,6 +302,7 @@ void main() {
       'commit_branch': 'main',
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -315,7 +320,7 @@ void main() {
 
     await tester.post(handler);
     verifyNever(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: buildsPubSub.build,
         builderName: 'Linux C',
         userDataMap: userDataMap,
@@ -325,7 +330,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: false,
@@ -338,7 +343,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: false,
@@ -352,6 +357,7 @@ void main() {
       'commit_branch': Config.defaultBranch(Config.flutterSlug),
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -369,7 +375,7 @@ void main() {
 
     await tester.post(handler);
     verifyNever(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: buildsPubSub.build,
         builderName: 'Linux C',
         userDataMap: userDataMap,
@@ -379,7 +385,7 @@ void main() {
     verify(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: false,
@@ -391,7 +397,7 @@ void main() {
     when(
       mockGithubChecksService.updateCheckStatus(
         build: anyNamed('build'),
-        userDataMap: anyNamed('userDataMap'),
+        checkRunId: anyNamed('checkRunId'),
         luciBuildService: anyNamed('luciBuildService'),
         slug: anyNamed('slug'),
         rescheduled: anyNamed('rescheduled'),
@@ -404,6 +410,7 @@ void main() {
       'commit_branch': 'main',
       'commit_sha': 'abc',
       'repo_name': 'flutter',
+      'check_run_id': 1,
     };
 
     tester.message = createPushMessage(
@@ -414,7 +421,7 @@ void main() {
     );
 
     when(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: captureAnyNamed('build'),
         builderName: anyNamed('builderName'),
         nextAttempt: anyNamed('nextAttempt'),
@@ -440,7 +447,7 @@ void main() {
     await tester.post(luciHandler);
 
     final bbv2.Build build = verify(
-      mockLuciBuildService.rescheduleBuild(
+      mockLuciBuildService.reschedulePresubmitBuild(
         build: captureAnyNamed('build'),
         builderName: anyNamed('builderName'),
         nextAttempt: anyNamed('nextAttempt'),

--- a/app_dart/test/service/github_checks_service_test.dart
+++ b/app_dart/test/service/github_checks_service_test.dart
@@ -47,24 +47,6 @@ void main() {
   });
 
   group('updateCheckStatus', () {
-    test('Userdata is empty', () async {
-      final bool success = await githubChecksService.updateCheckStatus(
-        build: _fakeBuild,
-        userDataMap: {},
-        luciBuildService: mockLuciBuildService,
-        slug: slug,
-      );
-      expect(success, isFalse);
-    });
-    test('Userdata does not contain check_run_id', () async {
-      final bool success = await githubChecksService.updateCheckStatus(
-        build: _fakeBuild,
-        userDataMap: {'repo_name': 'flutter/flutter'},
-        luciBuildService: mockLuciBuildService,
-        slug: slug,
-      );
-      expect(success, isFalse);
-    });
     test('Userdata contain check_run_id', () async {
       when(mockGithubChecksUtil.getCheckRun(any, any, any)).thenAnswer((_) async => checkRun);
       when(
@@ -79,14 +61,9 @@ void main() {
           summaryMarkdown: 'test summary',
         ),
       );
-      final userData = {
-        'check_run_id': 123,
-        'repo_owner': 'flutter',
-        'repo_name': 'cocoon',
-      };
       await githubChecksService.updateCheckStatus(
         build: _fakeBuild,
-        userDataMap: userData,
+        checkRunId: 123,
         luciBuildService: mockLuciBuildService,
         slug: slug,
       );
@@ -113,7 +90,7 @@ void main() {
         'user_login': 'engine-flutter-autoroll',
       };
       when(
-        mockLuciBuildService.rescheduleBuild(
+        mockLuciBuildService.reschedulePresubmitBuild(
           builderName: 'Linux Coverage',
           build: _fakeBuild,
           userDataMap: userData,
@@ -128,7 +105,7 @@ void main() {
       expect(checkRun.status, github.CheckRunStatus.completed);
       await githubChecksService.updateCheckStatus(
         build: _fakeBuild,
-        userDataMap: userData,
+        checkRunId: 1,
         luciBuildService: mockLuciBuildService,
         slug: slug,
         rescheduled: true,
@@ -157,7 +134,7 @@ void main() {
         'user_login': 'test-account',
       };
       when(
-        mockLuciBuildService.rescheduleBuild(
+        mockLuciBuildService.reschedulePresubmitBuild(
           builderName: 'Linux Coverage',
           build: _fakeBuild,
           userDataMap: userData,
@@ -183,7 +160,7 @@ void main() {
       );
       await githubChecksService.updateCheckStatus(
         build: _fakeBuild,
-        userDataMap: userData,
+        checkRunId: 1,
         luciBuildService: mockLuciBuildService,
         slug: slug,
       );

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1331,7 +1331,7 @@ void main() {
 
     test('Reschedule an existing build', () async {
       when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((_) async => generateBbv2Build(Int64(1)));
-      final build = await service.rescheduleBuild(
+      final build = await service.reschedulePresubmitBuild(
         builderName: 'mybuild',
         build: rescheduleBuild.build,
         nextAttempt: 2,
@@ -1364,7 +1364,7 @@ void main() {
         ref: 'refs/heads/gh-readonly-queue/master/pr-160690-021b2b36275342ad94a1ef44f9748b1e6153b0a3',
         id: '3dc695d1ad9a76a56420efc09fd66abd501fc691',
       );
-      final build = await service.rescheduleBuild(
+      final build = await service.reschedulePresubmitBuild(
         builderName: 'mybuild',
         build: rescheduleBuild.build,
         nextAttempt: 2,

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -3190,9 +3190,9 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
   @override
   _i20.Future<bool> updateCheckStatus({
     required _i8.Build? build,
-    required Map<String, dynamic>? userDataMap,
     required _i15.LuciBuildService? luciBuildService,
     required _i13.RepositorySlug? slug,
+    required int? checkRunId,
     bool? rescheduled = false,
   }) =>
       (super.noSuchMethod(
@@ -3201,9 +3201,9 @@ class MockGithubChecksService extends _i1.Mock implements _i15.GithubChecksServi
           [],
           {
             #build: build,
-            #userDataMap: userDataMap,
             #luciBuildService: luciBuildService,
             #slug: slug,
+            #checkRunId: checkRunId,
             #rescheduled: rescheduled,
           },
         ),
@@ -6212,7 +6212,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
       ) as _i20.Future<List<_i8.Build?>>);
 
   @override
-  _i20.Future<_i8.Build> rescheduleBuild({
+  _i20.Future<_i8.Build> reschedulePresubmitBuild({
     required String? builderName,
     required _i8.Build? build,
     required int? nextAttempt,
@@ -6220,7 +6220,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
   }) =>
       (super.noSuchMethod(
         Invocation.method(
-          #rescheduleBuild,
+          #reschedulePresubmitBuild,
           [],
           {
             #builderName: builderName,
@@ -6232,7 +6232,7 @@ class MockLuciBuildService extends _i1.Mock implements _i15.LuciBuildService {
         returnValue: _i20.Future<_i8.Build>.value(_FakeBuild_7(
           this,
           Invocation.method(
-            #rescheduleBuild,
+            #reschedulePresubmitBuild,
             [],
             {
               #builderName: builderName,


### PR DESCRIPTION
Before:

> Be me
> Pass a `Map<String, Object?>` around
> Check a key, and just `return false` with a log message if it wouldn't work, even though it was documented as required

After:

- Pass around exactly what is needed from `userData`
- Don't silently fail if we require data
- Update the tests that were "benefiting" from this by omitting required data

I don't _imagine_ this is a breaking change, but I'll monitor error logs tomorrow I guess?