### PR TITLE
Refactor `UserData`->`Presubmit.*`+`Postsubmit.*`, remove unused key.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -890,7 +890,6 @@ class LuciBuildService {
     final Map<String, dynamic> rawUserData = <String, dynamic>{
       'commit_key': commitKey,
       'task_key': taskKey,
-      'firestore_commit_document_name': commit.sha,
     };
 
     // Creates post submit checkrun only for unflaky targets from [config.postsubmitSupportedRepos].

--- a/app_dart/lib/src/service/luci_build_service/user_data.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.dart
@@ -9,34 +9,59 @@ import 'package:meta/meta.dart';
 
 part 'user_data.g.dart';
 
-/// Represents the data passed per-buid by Buildbucket pubsub.
+/// A base type for classes that are serialized as part of Buildbucket pubsub.
 ///
 /// See https://chromium.googlesource.com/infra/luci/luci-go/+/main/buildbucket/proto/notification.proto#41.
-@JsonSerializable(includeIfNull: false, checked: true)
 @immutable
-final class BuildBucketPubSubUserData {
-  const BuildBucketPubSubUserData({
+sealed class PubSubUserData {
+  const PubSubUserData({
     required this.checkRunId,
-    required this.builderName,
-    required this.commitSha,
-    required this.commitBranch,
     required this.repoOwner,
     required this.repoName,
-    required this.userAgent,
-    this.firestoreTaskDocumentName,
   });
-
-  factory BuildBucketPubSubUserData.fromJson(Map<String, Object?> object) {
-    try {
-      return _$BuildBucketPubSubUserDataFromJson(object);
-    } on CheckedFromJsonException catch (e) {
-      throw FormatException('Invalid UserData object: ${e.message}.\n${e.innerStack}', object.toString());
-    }
-  }
 
   /// Which GitHub check run this build reports status to.
   @JsonKey(name: 'check_run_id')
   final int checkRunId;
+
+  /// The owner of the GitHub repo, i.e. `flutter` or `matanlurey`.
+  @JsonKey(name: 'repo_owner')
+  final String repoOwner;
+
+  /// The name of the GitHub repo, i.e. `flutter` or `packages`.
+  @JsonKey(name: 'repo_name')
+  final String repoName;
+
+  /// Returns a JSON representation of this object.
+  Map<String, Object?> toJson();
+
+  @override
+  @nonVirtual
+  String toString() {
+    return '$runtimeType ${const JsonEncoder.withIndent('  ').convert(toJson())}';
+  }
+}
+
+/// Represents the data passed per presubmit-build.
+@JsonSerializable(includeIfNull: false, checked: true)
+final class PresubmitUserData extends PubSubUserData {
+  const PresubmitUserData({
+    required super.checkRunId,
+    required super.repoOwner,
+    required super.repoName,
+    required this.builderName,
+    required this.commitSha,
+    required this.commitBranch,
+    required this.userAgent,
+  });
+
+  factory PresubmitUserData.fromJson(Map<String, Object?> object) {
+    try {
+      return _$PresubmitUserDataFromJson(object);
+    } on CheckedFromJsonException catch (e) {
+      throw FormatException('Invalid UserData object: ${e.message}.\n${e.innerStack}', object.toString());
+    }
+  }
 
   /// The name of the builder being executed.
   @JsonKey(name: 'builder_name')
@@ -50,25 +75,9 @@ final class BuildBucketPubSubUserData {
   @JsonKey(name: 'commit_branch')
   final String commitBranch;
 
-  /// The owner of the GitHub repo, i.e. `flutter` or `matanlurey`.
-  @JsonKey(name: 'repo_owner')
-  final String repoOwner;
-
-  /// The name of the GitHub repo, i.e. `flutter` or `packages`.
-  @JsonKey(name: 'repo_name')
-  final String repoName;
-
   /// Where this build originated from.
   @JsonKey(name: 'user_agent')
   final String userAgent;
-
-  /// The firestore task document name storing results of this build.
-  @JsonKey(
-    name: 'firestore_task_document_name',
-    fromJson: FirestoreTaskDocumentName._parse,
-    toJson: FirestoreTaskDocumentName._toJson,
-  )
-  final FirestoreTaskDocumentName? firestoreTaskDocumentName;
 
   @override
   int get hashCode {
@@ -80,30 +89,84 @@ final class BuildBucketPubSubUserData {
       repoOwner,
       repoName,
       userAgent,
-      firestoreTaskDocumentName,
     );
   }
 
   @override
   bool operator ==(Object other) {
-    return other is BuildBucketPubSubUserData &&
+    return other is PresubmitUserData &&
         checkRunId == other.checkRunId &&
         builderName == other.builderName &&
         commitSha == other.commitSha &&
         commitBranch == other.commitBranch &&
         repoOwner == other.repoOwner &&
         repoName == other.repoName &&
-        userAgent == other.userAgent &&
+        userAgent == other.userAgent;
+  }
+
+  @override
+  Map<String, Object?> toJson() => _$PresubmitUserDataToJson(this);
+}
+
+/// Represents the data passed per postsubmit-build.
+@JsonSerializable(includeIfNull: false, checked: true)
+final class PostsubmitUserData extends PubSubUserData {
+  const PostsubmitUserData({
+    required super.checkRunId,
+    required super.repoName,
+    required super.repoOwner,
+    required this.taskKey,
+    required this.commitKey,
+    required this.firestoreTaskDocumentName,
+  });
+
+  factory PostsubmitUserData.fromJson(Map<String, Object?> object) {
+    try {
+      return _$PostsubmitUserDataFromJson(object);
+    } on CheckedFromJsonException catch (e) {
+      throw FormatException('Invalid UserData object: ${e.message}.\n${e.innerStack}', object.toString());
+    }
+  }
+
+  @JsonKey(name: 'task_key')
+  final String taskKey;
+
+  @JsonKey(name: 'commit_key')
+  final String commitKey;
+
+  /// The firestore task document name storing results of this build.
+  @JsonKey(
+    name: 'firestore_task_document_name',
+    fromJson: FirestoreTaskDocumentName._parse,
+    toJson: FirestoreTaskDocumentName._toJson,
+  )
+  final FirestoreTaskDocumentName firestoreTaskDocumentName;
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      checkRunId,
+      repoOwner,
+      repoName,
+      taskKey,
+      commitKey,
+      firestoreTaskDocumentName,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PostsubmitUserData &&
+        checkRunId == other.checkRunId &&
+        repoOwner == other.repoOwner &&
+        repoName == other.repoName &&
+        taskKey == other.taskKey &&
+        commitKey == other.commitKey &&
         firestoreTaskDocumentName == other.firestoreTaskDocumentName;
   }
 
-  /// Returns a JSON representation of this object.
-  Map<String, Object?> toJson() => _$BuildBucketPubSubUserDataToJson(this);
-
   @override
-  String toString() {
-    return 'BuildBucketPubSubUserData ${const JsonEncoder.withIndent('  ').convert(toJson())}';
-  }
+  Map<String, Object?> toJson() => _$PostsubmitUserDataToJson(this);
 }
 
 /// Represents the name of a Firestore document.
@@ -119,10 +182,7 @@ final class FirestoreTaskDocumentName {
     }
   }
 
-  static FirestoreTaskDocumentName? _parse(String? documentName) {
-    if (documentName == null) {
-      return null;
-    }
+  static FirestoreTaskDocumentName _parse(String documentName) {
     if (_parseDocumentName.matchAsPrefix(documentName) case final match?) {
       final commitSha = match.group(1)!;
       final taskName = match.group(2)!;

--- a/app_dart/lib/src/service/luci_build_service/user_data.g.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.g.dart
@@ -8,44 +8,74 @@ part of 'user_data.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BuildBucketPubSubUserData _$BuildBucketPubSubUserDataFromJson(Map<String, dynamic> json) => $checkedCreate(
-      'BuildBucketPubSubUserData',
+PresubmitUserData _$PresubmitUserDataFromJson(Map<String, dynamic> json) => $checkedCreate(
+      'PresubmitUserData',
       json,
       ($checkedConvert) {
-        final val = BuildBucketPubSubUserData(
+        final val = PresubmitUserData(
           checkRunId: $checkedConvert('check_run_id', (v) => v as int),
+          repoOwner: $checkedConvert('repo_owner', (v) => v as String),
+          repoName: $checkedConvert('repo_name', (v) => v as String),
           builderName: $checkedConvert('builder_name', (v) => v as String),
           commitSha: $checkedConvert('commit_sha', (v) => v as String),
           commitBranch: $checkedConvert('commit_branch', (v) => v as String),
-          repoOwner: $checkedConvert('repo_owner', (v) => v as String),
-          repoName: $checkedConvert('repo_name', (v) => v as String),
           userAgent: $checkedConvert('user_agent', (v) => v as String),
-          firestoreTaskDocumentName:
-              $checkedConvert('firestore_task_document_name', (v) => FirestoreTaskDocumentName._parse(v as String?)),
         );
         return val;
       },
       fieldKeyMap: const {
         'checkRunId': 'check_run_id',
+        'repoOwner': 'repo_owner',
+        'repoName': 'repo_name',
         'builderName': 'builder_name',
         'commitSha': 'commit_sha',
         'commitBranch': 'commit_branch',
-        'repoOwner': 'repo_owner',
+        'userAgent': 'user_agent'
+      },
+    );
+
+Map<String, dynamic> _$PresubmitUserDataToJson(PresubmitUserData instance) => <String, dynamic>{
+      'check_run_id': instance.checkRunId,
+      'repo_owner': instance.repoOwner,
+      'repo_name': instance.repoName,
+      'builder_name': instance.builderName,
+      'commit_sha': instance.commitSha,
+      'commit_branch': instance.commitBranch,
+      'user_agent': instance.userAgent,
+    };
+
+PostsubmitUserData _$PostsubmitUserDataFromJson(Map<String, dynamic> json) => $checkedCreate(
+      'PostsubmitUserData',
+      json,
+      ($checkedConvert) {
+        final val = PostsubmitUserData(
+          checkRunId: $checkedConvert('check_run_id', (v) => v as int),
+          repoName: $checkedConvert('repo_name', (v) => v as String),
+          repoOwner: $checkedConvert('repo_owner', (v) => v as String),
+          taskKey: $checkedConvert('task_key', (v) => v as String),
+          commitKey: $checkedConvert('commit_key', (v) => v as String),
+          firestoreTaskDocumentName:
+              $checkedConvert('firestore_task_document_name', (v) => FirestoreTaskDocumentName._parse(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'checkRunId': 'check_run_id',
         'repoName': 'repo_name',
-        'userAgent': 'user_agent',
+        'repoOwner': 'repo_owner',
+        'taskKey': 'task_key',
+        'commitKey': 'commit_key',
         'firestoreTaskDocumentName': 'firestore_task_document_name'
       },
     );
 
-Map<String, dynamic> _$BuildBucketPubSubUserDataToJson(BuildBucketPubSubUserData instance) {
+Map<String, dynamic> _$PostsubmitUserDataToJson(PostsubmitUserData instance) {
   final val = <String, dynamic>{
     'check_run_id': instance.checkRunId,
-    'builder_name': instance.builderName,
-    'commit_sha': instance.commitSha,
-    'commit_branch': instance.commitBranch,
     'repo_owner': instance.repoOwner,
     'repo_name': instance.repoName,
-    'user_agent': instance.userAgent,
+    'task_key': instance.taskKey,
+    'commit_key': instance.commitKey,
   };
 
   void writeNotNull(String key, dynamic value) {

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -155,7 +155,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -208,7 +207,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -241,7 +239,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -274,7 +271,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -321,7 +317,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -367,7 +362,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -413,7 +407,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -461,7 +454,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -507,7 +499,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 
@@ -554,7 +545,6 @@ void main() {
     final Map<String, dynamic> userDataMap = {
       'task_key': '${task.key.id}',
       'commit_key': '${task.key.parent?.id}',
-      'firestore_commit_document_name': commit.sha,
       'firestore_task_document_name': taskDocumentName,
     };
 

--- a/app_dart/test/service/luci_build_service/user_data_test.dart
+++ b/app_dart/test/service/luci_build_service/user_data_test.dart
@@ -6,66 +6,9 @@ import 'package:cocoon_service/src/service/luci_build_service/user_data.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('should encode to JSON', () {
-    const userData = BuildBucketPubSubUserData(
-      checkRunId: 1234,
-      builderName: 'Linux_foo',
-      commitSha: 'abc123',
-      commitBranch: 'main',
-      repoOwner: 'repo-owner',
-      repoName: 'repo-name',
-      userAgent: 'UserData Test',
-    );
-    expect(userData.toJson(), {
-      'check_run_id': 1234,
-      'builder_name': 'Linux_foo',
-      'commit_sha': 'abc123',
-      'commit_branch': 'main',
-      'repo_owner': 'repo-owner',
-      'repo_name': 'repo-name',
-      'user_agent': 'UserData Test',
-    });
-  });
-
-  test('should encode to JSON including firestoreTaskDocumentName', () {
-    final userData = BuildBucketPubSubUserData(
-      checkRunId: 1234,
-      builderName: 'Linux_foo',
-      commitSha: 'abc123',
-      commitBranch: 'main',
-      repoOwner: 'repo-owner',
-      repoName: 'repo-name',
-      userAgent: 'UserData Test',
-      firestoreTaskDocumentName: FirestoreTaskDocumentName(
-        commitSha: 'abc123',
-        currentAttempt: 1,
-        taskName: 'Linux_foo',
-      ),
-    );
-    expect(userData.toJson(), {
-      'check_run_id': 1234,
-      'builder_name': 'Linux_foo',
-      'commit_sha': 'abc123',
-      'commit_branch': 'main',
-      'repo_owner': 'repo-owner',
-      'repo_name': 'repo-name',
-      'user_agent': 'UserData Test',
-      'firestore_task_document_name': 'abc123_Linux_foo_1',
-    });
-  });
-
-  test('should decode from JSON', () {
-    expect(
-      BuildBucketPubSubUserData.fromJson(const {
-        'check_run_id': 1234,
-        'builder_name': 'Linux_foo',
-        'commit_sha': 'abc123',
-        'commit_branch': 'main',
-        'repo_owner': 'repo-owner',
-        'repo_name': 'repo-name',
-        'user_agent': 'UserData Test',
-      }),
-      const BuildBucketPubSubUserData(
+  group('PresubmitUserData', () {
+    test('should encode to JSON', () {
+      const userData = PresubmitUserData(
         checkRunId: 1234,
         builderName: 'Linux_foo',
         commitSha: 'abc123',
@@ -73,13 +16,8 @@ void main() {
         repoOwner: 'repo-owner',
         repoName: 'repo-name',
         userAgent: 'UserData Test',
-      ),
-    );
-  });
-
-  test('should decode from JSON including firestoreTaskDocumentName', () {
-    expect(
-      BuildBucketPubSubUserData.fromJson(const {
+      );
+      expect(userData.toJson(), {
         'check_run_id': 1234,
         'builder_name': 'Linux_foo',
         'commit_sha': 'abc123',
@@ -87,53 +25,106 @@ void main() {
         'repo_owner': 'repo-owner',
         'repo_name': 'repo-name',
         'user_agent': 'UserData Test',
-        'firestore_task_document_name': 'abc123_Linux_foo_1',
-      }),
-      BuildBucketPubSubUserData(
+      });
+    });
+
+    test('should decode from JSON', () {
+      expect(
+        PresubmitUserData.fromJson(const {
+          'check_run_id': 1234,
+          'builder_name': 'Linux_foo',
+          'commit_sha': 'abc123',
+          'commit_branch': 'main',
+          'repo_owner': 'repo-owner',
+          'repo_name': 'repo-name',
+          'user_agent': 'UserData Test',
+        }),
+        const PresubmitUserData(
+          checkRunId: 1234,
+          builderName: 'Linux_foo',
+          commitSha: 'abc123',
+          commitBranch: 'main',
+          repoOwner: 'repo-owner',
+          repoName: 'repo-name',
+          userAgent: 'UserData Test',
+        ),
+      );
+    });
+
+    test('should gracefully fail decoding if the format is invalid', () {
+      expect(
+        () => PresubmitUserData.fromJson(const {
+          'check_run_id': 1234,
+          'builder_nameMALFORRMED': 'Linux_foo',
+          'commit_sha': 'abc123',
+          'commit_branch': 'main',
+          'repo_owner': 'repo-owner',
+          'repo_name': 'repo-name',
+          'user_agent': 'UserData Test',
+        }),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('PostsubmitUserData', () {
+    test('should encode to JSON', () {
+      final userData = PostsubmitUserData(
         checkRunId: 1234,
-        builderName: 'Linux_foo',
-        commitSha: 'abc123',
-        commitBranch: 'main',
         repoOwner: 'repo-owner',
         repoName: 'repo-name',
-        userAgent: 'UserData Test',
+        taskKey: 'task-key',
+        commitKey: 'commit-key',
         firestoreTaskDocumentName: FirestoreTaskDocumentName(
           commitSha: 'abc123',
           currentAttempt: 1,
-          taskName: 'Linux_foo',
+          taskName: 'task-name',
         ),
-      ),
-    );
-  });
-
-  test('should gracefully fail decoding if the format is invalid', () {
-    expect(
-      () => BuildBucketPubSubUserData.fromJson(const {
+      );
+      expect(userData.toJson(), {
         'check_run_id': 1234,
-        'builder_nameMALFORRMED': 'Linux_foo',
-        'commit_sha': 'abc123',
-        'commit_branch': 'main',
         'repo_owner': 'repo-owner',
         'repo_name': 'repo-name',
-        'user_agent': 'UserData Test',
-      }),
-      throwsFormatException,
-    );
-  });
+        'task_key': 'task-key',
+        'commit_key': 'commit-key',
+        'firestore_task_document_name': 'abc123_task-name_1',
+      });
+    });
 
-  test('should gracefully fail decoding if the firestoreTaskDocumentName format is invalid', () {
-    expect(
-      () => BuildBucketPubSubUserData.fromJson(const {
-        'check_run_id': 1234,
-        'builder_name': 'Linux_foo',
-        'commit_sha': 'abc123',
-        'commit_branch': 'main',
-        'repo_owner': 'repo-owner',
-        'repo_name': 'repo-name',
-        'user_agent': 'UserData Test',
-        'firestore_task_document_name': 'MALFORMED',
-      }),
-      throwsFormatException,
-    );
+    test('should decode from JSON', () {
+      expect(
+        PostsubmitUserData.fromJson(const {
+          'check_run_id': 1234,
+          'repo_owner': 'repo-owner',
+          'repo_name': 'repo-name',
+          'task_key': 'task-key',
+          'commit_key': 'commit-key',
+          'firestore_task_document_name': 'abc123_task-name_1',
+        }),
+        PostsubmitUserData(
+          checkRunId: 1234,
+          repoOwner: 'repo-owner',
+          repoName: 'repo-name',
+          taskKey: 'task-key',
+          commitKey: 'commit-key',
+          firestoreTaskDocumentName: FirestoreTaskDocumentName(
+            commitSha: 'abc123',
+            currentAttempt: 1,
+            taskName: 'task-name',
+          ),
+        ),
+      );
+    });
+
+    test('should gracefully fail decoding if the format is invalid', () {
+      expect(
+        () => PostsubmitUserData.fromJson(const {
+          'check_run_id': 1234,
+          'repo_owner': 'repo-owner',
+          'repo_name': 'repo-name',
+        }),
+        throwsFormatException,
+      );
+    });
   });
 }

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -733,7 +733,6 @@ void main() {
         'builder_name': 'Linux 1',
         'repo_owner': 'flutter',
         'repo_name': 'packages',
-        'firestore_commit_document_name': '0',
         'firestore_task_document_name': '0_task1_1',
       });
 
@@ -831,7 +830,6 @@ void main() {
         'builder_name': 'Linux 1',
         'repo_owner': 'flutter',
         'repo_name': 'packages',
-        'firestore_commit_document_name': '0',
         'firestore_task_document_name': '0_task1_1',
       });
 
@@ -922,7 +920,6 @@ void main() {
         'builder_name': 'Linux 1',
         'repo_owner': 'flutter',
         'repo_name': 'packages',
-        'firestore_commit_document_name': '0',
         'firestore_task_document_name': '0_task1_1',
       });
     });
@@ -1098,7 +1095,6 @@ void main() {
       expect(userData, <String, dynamic>{
         'commit_key': 'flutter/packages/master/0',
         'task_key': '1',
-        'firestore_commit_document_name': '0',
         'firestore_task_document_name': '0_task1_1',
       });
     });


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/164568.

The only potentially user-visible change is removing `firestore_commit_document_name` which appears unused outside of tests. 

These new `UserData` classes will replace `Map<String, Object?>` in a future PR.