### PR TITLE
Do not treat `no builds were found` as a warning case, we cancel builds aggressively

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -392,14 +392,14 @@ class LuciBuildService {
     );
 
     final Iterable<bbv2.Build> builds = await getTryBuildsByPullRequest(pullRequest: pullRequest);
-    log.info('Found ${builds.length} builds.');
 
     if (builds.isEmpty) {
-      log.warning(
+      log.info(
         'No builds were found for pull request ${pullRequest.base!.repo!.fullName}.',
       );
       return;
     }
+    log.info('Found ${builds.length} builds.');
 
     final List<bbv2.BatchRequest_Request> requests = <bbv2.BatchRequest_Request>[];
     for (bbv2.Build build in builds) {


### PR DESCRIPTION
I.e. often before triggering new builds

This reduces warning+ level spam, such as [here](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2025-03-05T01:31:50.869Z;duration=PT30H;query=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22default%22%0Aseverity%3E%3DWARNING%0Atimestamp%3D%222025-03-05T01:31:52.349Z%22%0AinsertId%3D%22kmk1sf5kqd0p%22?project=flutter-dashboard).