### PR TITLE
Use `master` as both the channel and branch name.

### DIFF
--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -99,7 +99,7 @@ interface class BranchService {
   }) async {
     final results = [
       // Always include master -> HEAD.
-      ReleaseBranch(channel: Config.defaultBranch(slug), reference: 'HEAD'),
+      ReleaseBranch(channel: Config.defaultBranch(slug), reference: 'master'),
     ];
 
     // And then for each of these channels, lookup

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -102,7 +102,7 @@ void main() {
           slug: Config.flutterSlug,
         );
         expect(releaseBranches, [
-          const ReleaseBranch(channel: 'master', reference: 'HEAD'),
+          const ReleaseBranch(channel: 'master', reference: 'master'),
         ]);
       },
     );
@@ -122,7 +122,7 @@ void main() {
         expect(
           releaseBranches,
           unorderedEquals([
-            const ReleaseBranch(channel: 'master', reference: 'HEAD'),
+            const ReleaseBranch(channel: 'master', reference: 'master'),
             const ReleaseBranch(
               channel: 'stable',
               reference: 'flutter-3.29-candidate.0',
@@ -150,7 +150,7 @@ void main() {
         expect(
           releaseBranches,
           unorderedEquals([
-            const ReleaseBranch(channel: 'master', reference: 'HEAD'),
+            const ReleaseBranch(channel: 'master', reference: 'master'),
             const ReleaseBranch(
               channel: 'stable',
               reference: 'flutter-3.29-candidate.0',

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -101,6 +101,12 @@ void main() {
         final releaseBranches = await branchService.getReleaseBranches(
           slug: Config.flutterSlug,
         );
+        // NOTE, master is intentionally used as both the channel and the
+        // reference, because on the frontend, the "channel" moniker is just
+        // ignored, and the "reference" must point to an actual git reference
+        // (HEAD is not sufficient or correct).
+        //
+        // See https://github.com/flutter/flutter/issues/164726.
         expect(releaseBranches, [
           const ReleaseBranch(channel: 'master', reference: 'master'),
         ]);

--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -274,7 +274,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
               .where((Branch b) => b.branch != buildState.currentBranch)
               .map<DropdownMenuItem<String>>((Branch b) {
                 final branchPrefix =
-                    (b.channel != 'HEAD') ? '${b.channel}: ' : '';
+                    (b.channel != 'master') ? '${b.channel}: ' : '';
                 return DropdownMenuItem<String>(
                   value: b.branch,
                   child: Padding(

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -139,7 +139,7 @@ class DevelopmentCocoonService implements CocoonService {
   Future<CocoonResponse<List<Branch>>> fetchFlutterBranches() async {
     final fakeBranches = <Branch>[
       Branch()
-        ..channel = 'HEAD'
+        ..channel = 'master'
         ..branch = 'master',
       Branch()
         ..channel = 'stable'

--- a/dashboard/test/service/appengine_cocoon_test.dart
+++ b/dashboard/test/service/appengine_cocoon_test.dart
@@ -356,7 +356,7 @@ void main() {
             ..branch = 'flutter-3.15-candidate.5'
             ..channel = 'dev',
           Branch()
-            ..branch = 'HEAD'
+            ..branch = 'master'
             ..channel = 'master',
         ]),
       );

--- a/dashboard/test/utils/appengine_cocoon_test_data.dart
+++ b/dashboard/test/utils/appengine_cocoon_test_data.dart
@@ -108,7 +108,7 @@ const String jsonGetBranchesResponse = '''[
     "channel":"dev"
   },
   {
-    "reference":"HEAD",
+    "reference":"master",
     "channel":"master"
   }
 ]''';


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/164726.

It turns out `HEAD`, as defined, did nothing, and was really just ignored (by both the UI and backend), so trying to make it do something broke stuff. I thought about adding a UI regression test, but there isn't (really) a way to know it would work (or not), so settled for a note in a backend regression test.