### PR TITLE
Verified we still want to check for `fuchsia.*` branches.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -263,7 +263,6 @@ class LuciBuildService {
         final branches = await gerritService.branches(
           'flutter-review.googlesource.com',
           'recipes',
-          // TODO(matanlurey): Remove fuchsia.* (https://github.com/flutter/flutter/issues/164593).
           filterRegex: 'flutter-.*|fuchsia.*',
         );
         if (branches.contains(proposedVersion.version)) {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/164593.