### PR TITLE
Move from warning to info for max retries.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -1172,7 +1172,7 @@ class LuciBuildService {
     }
     final retries = task.attempts ?? 1;
     if (retries > config.maxLuciTaskRetries) {
-      log.warning('Max retries reached');
+      log.info('Max retries reached for ${task.taskName}');
       return false;
     }
 


### PR DESCRIPTION
There is no reason to log a warning.