### PR TITLE
Stop ignoring argument type and invalid type error types.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,6 @@ analyzer:
   errors:
     # TODO(matanlurey): Ignore for now, we have a lot of pre-existing violations.
     avoid_dynamic_calls: ignore
-    argument_type_not_assignable: ignore
     comment_references: ignore
     inference_failure_on_collection_literal: ignore
     inference_failure_on_function_invocation: ignore
@@ -19,7 +18,6 @@ analyzer:
     inference_failure_on_untyped_parameter: ignore
     lines_longer_than_80_chars: ignore
     only_throw_errors: ignore
-    return_of_invalid_type: ignore
   exclude:
     - ".dart_tool/**"
     - "**/*.g.dart"

--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -48,14 +48,16 @@ class PrCheckRuns extends Document {
 
   /// The json string of the pullrequest belonging to this document.
   PullRequest get pullRequest => PullRequest.fromJson(
-    json.decode(fields![kPullRequestField]!.stringValue!),
+    json.decode(fields![kPullRequestField]!.stringValue!)
+        as Map<String, Object?>,
   );
 
   /// The head sha at the time this document was created for testing.
   String get sha => fields![kShaField]!.stringValue!;
 
-  RepositorySlug get slug =>
-      RepositorySlug.fromJson(json.decode(fields![kSlugField]!.stringValue!));
+  RepositorySlug get slug => RepositorySlug.fromJson(
+    json.decode(fields![kSlugField]!.stringValue!) as Map<String, Object?>,
+  );
 
   /// Initializes a new document for the list of check_runs in Firestore so we can find it later.
   ///

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -61,7 +61,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     final project = jsonBuildMap['build']['builder']['project'] as String;
     final bucket = jsonBuildMap['build']['builder']['bucket'] as String;
     final builder = jsonBuildMap['build']['builder']['builder'] as String;
-    final buildId = Int64.parseInt(jsonBuildMap['build']['id']);
+    final buildId = Int64.parseInt(jsonBuildMap['build']['id'] as String);
 
     // This should already be covered by the pubsub filter, but adding an additional check
     // to ensure we don't process builds that aren't from dart-internal/flutter.

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -191,7 +191,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       log.info('Updating check status for ${target.getTestName}');
       await githubChecksService.updateCheckStatus(
         build: build,
-        checkRunId: userDataMap['check_run_id'],
+        checkRunId: userDataMap['check_run_id'] as int,
         luciBuildService: scheduler.luciBuildService,
         slug: commit.slug,
       );

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -118,8 +118,8 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
           slug,
           builderName,
           tagSet,
-          commitBranch: userDataMap['commit_branch'],
-          commitSha: userDataMap['commit_sha'],
+          commitBranch: userDataMap['commit_branch'] as String,
+          commitSha: userDataMap['commit_sha'] as String,
         );
         if (currentAttempt < maxAttempt) {
           rescheduled = true;
@@ -133,7 +133,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
         }
       }
       await githubChecksService.updateCheckStatus(
-        checkRunId: userDataMap['check_run_id'],
+        checkRunId: userDataMap['check_run_id'] as int,
         build: build,
         luciBuildService: luciBuildService,
         slug: slug,

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -44,7 +44,9 @@ class CommitService {
   /// https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
   Future<void> handlePushGithubRequest(Map<String, dynamic> pushEvent) async {
     final datastore = datastoreProvider(config.db);
-    final slug = RepositorySlug.full(pushEvent['repository']['full_name']);
+    final slug = RepositorySlug.full(
+      pushEvent['repository']['full_name'] as String,
+    );
     final sha = pushEvent['head_commit']['id'] as String;
     final branch = pushEvent['ref'].split('/')[2] as String;
     final id = '${slug.fullName}/$branch/$sha';
@@ -53,16 +55,16 @@ class CommitService {
       key: key,
       timestamp:
           DateTime.parse(
-            pushEvent['head_commit']['timestamp'],
+            pushEvent['head_commit']['timestamp'] as String,
           ).millisecondsSinceEpoch,
       repository: slug.fullName,
       sha: sha,
-      author: pushEvent['sender']['login'],
-      authorAvatarUrl: pushEvent['sender']['avatar_url'],
+      author: pushEvent['sender']['login'] as String?,
+      authorAvatarUrl: pushEvent['sender']['avatar_url'] as String?,
       // The field has a size of 1500 we need to ensure the commit message
       // is at most 1500 chars long.
       message: truncate(
-        pushEvent['head_commit']['message'],
+        pushEvent['head_commit']['message'] as String,
         1490,
         omission: '...',
       ),

--- a/app_dart/test/model/gerrit/commit_test.dart
+++ b/app_dart/test/model/gerrit/commit_test.dart
@@ -28,7 +28,9 @@ void main() {
       },
       "message": "Roll recipe dependencies (trivial)\\n\\nThis is an automated CL created by the recipe roller."
     }''';
-      final commit = GerritCommit.fromJson(jsonDecode(json));
+      final commit = GerritCommit.fromJson(
+        jsonDecode(json) as Map<String, Object?>,
+      );
       expect(commit.author, isNotNull);
       expect(commit.author!.name, 'recipe-roller');
       expect(commit.author!.time, DateTime(2023, 06, 07, 22, 54, 6));

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1339,7 +1339,8 @@ void main() {
         numberOfPullRequests: 1,
       );
       final jsonMap = json.decode(pushMessage.data!) as Map<String, dynamic>;
-      final jsonSubMap = json.decode(jsonMap['2']) as Map<String, dynamic>;
+      final jsonSubMap =
+          json.decode(jsonMap['2'] as String) as Map<String, dynamic>;
       final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(jsonSubMap);
 
       expect(
@@ -1393,7 +1394,8 @@ void main() {
         numberOfPullRequests: 1,
       );
       final jsonMap = json.decode(pushMessage.data!) as Map<String, dynamic>;
-      final jsonSubMap = json.decode(jsonMap['2']) as Map<String, dynamic>;
+      final jsonSubMap =
+          json.decode(jsonMap['2'] as String) as Map<String, dynamic>;
       final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(jsonSubMap);
 
       final taskDocument = generateFirestoreTask(0);

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -210,7 +210,7 @@ void main() {
       ).thenAnswer((Invocation invocation) async {
         return generateCheckRun(
           invocation.positionalArguments[2].hashCode,
-          name: invocation.positionalArguments[3],
+          name: invocation.positionalArguments[3] as String,
         );
       });
 
@@ -1209,7 +1209,9 @@ targets:
         // Set up mock buildbucket to validate which bucket is requested.
         final mockBuildbucket = MockBuildBucketClient();
         when(mockBuildbucket.batch(any)).thenAnswer((i) async {
-          return FakeBuildBucketClient().batch(i.positionalArguments[0]);
+          return FakeBuildBucketClient().batch(
+            i.positionalArguments[0] as bbv2.BatchRequest,
+          );
         });
         when(
           mockBuildbucket.scheduleBuild(
@@ -1298,7 +1300,7 @@ targets:
           expect(
             await scheduler.processCheckRun(
               cocoon_checks.CheckRunEvent.fromJson(
-                json.decode(checkRunEventFor()),
+                json.decode(checkRunEventFor()) as Map<String, Object?>,
               ),
             ),
             true,
@@ -1337,7 +1339,8 @@ targets:
                 expect(
                   await scheduler.processCheckRunCompletion(
                     cocoon_checks.CheckRunEvent.fromJson(
-                      json.decode(checkRunEventFor(test: ignored)),
+                      json.decode(checkRunEventFor(test: ignored))
+                          as Map<String, Object?>,
                     ),
                   ),
                   isTrue,
@@ -1381,7 +1384,8 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(checkRunEventFor(test: 'Bar bar')),
+                  json.decode(checkRunEventFor(test: 'Bar bar'))
+                      as Map<String, Object?>,
                 ),
               ),
               isFalse,
@@ -1436,7 +1440,8 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(checkRunEventFor(test: 'Bar bar')),
+                  json.decode(checkRunEventFor(test: 'Bar bar'))
+                      as Map<String, Object?>,
                 ),
               ),
               isFalse,
@@ -1497,7 +1502,8 @@ targets:
               expect(
                 await scheduler.processCheckRunCompletion(
                   cocoon_checks.CheckRunEvent.fromJson(
-                    json.decode(checkRunEventFor(test: 'Bar bar')),
+                    json.decode(checkRunEventFor(test: 'Bar bar'))
+                        as Map<String, Object?>,
                   ),
                 ),
                 isTrue,
@@ -1642,9 +1648,8 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(
-                    checkRunEventFor(test: 'Bar bar', sha: 'testSha'),
-                  ),
+                  json.decode(checkRunEventFor(test: 'Bar bar', sha: 'testSha'))
+                      as Map<String, Object?>,
                 ),
               ),
               isTrue,
@@ -1750,9 +1755,8 @@ targets:
             expect(
               await scheduler.processCheckRunCompletion(
                 cocoon_checks.CheckRunEvent.fromJson(
-                  json.decode(
-                    checkRunEventFor(test: 'Bar bar', sha: 'testSha'),
-                  ),
+                  json.decode(checkRunEventFor(test: 'Bar bar', sha: 'testSha'))
+                      as Map<String, Object?>,
                 ),
               ),
               isTrue,
@@ -1856,8 +1860,8 @@ targets:
                 ),
               ).thenAnswer((inv) async {
                 final slug = inv.positionalArguments[1] as RepositorySlug;
-                final sha = inv.positionalArguments[2];
-                final name = inv.positionalArguments[3];
+                final sha = inv.positionalArguments[2] as String;
+                final name = inv.positionalArguments[3] as String?;
                 checkRuns.add(
                   createCheckRun(
                     id: 1,
@@ -1944,8 +1948,8 @@ targets:
               ),
             ).thenAnswer((inv) async {
               final slug = inv.positionalArguments[1] as RepositorySlug;
-              final sha = inv.positionalArguments[2];
-              final name = inv.positionalArguments[3];
+              final sha = inv.positionalArguments[2] as String;
+              final name = inv.positionalArguments[3] as String?;
               checkRuns.add(
                 createCheckRun(
                   id: 1,
@@ -2072,8 +2076,9 @@ targets:
                 await scheduler.processCheckRunCompletion(
                   cocoon_checks.CheckRunEvent.fromJson(
                     json.decode(
-                      checkRunEventFor(test: 'Bar bar', sha: 'testSha'),
-                    ),
+                          checkRunEventFor(test: 'Bar bar', sha: 'testSha'),
+                        )
+                        as Map<String, Object?>,
                   ),
                 ),
                 isTrue,
@@ -2243,7 +2248,8 @@ targets:
               expect(
                 await scheduler.processCheckRunCompletion(
                   cocoon_checks.CheckRunEvent.fromJson(
-                    json.decode(checkRunEventFor(test: 'Bar bar')),
+                    json.decode(checkRunEventFor(test: 'Bar bar'))
+                        as Map<String, Object?>,
                   ),
                 ),
                 isTrue,
@@ -2998,8 +3004,8 @@ targets:
           ),
         ).thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
-          final sha = inv.positionalArguments[2];
-          final name = inv.positionalArguments[3];
+          final sha = inv.positionalArguments[2] as String;
+          final name = inv.positionalArguments[3] as String?;
           checkRuns.add(
             createCheckRun(
               id: 1,
@@ -3152,8 +3158,8 @@ targets:
           ),
         ).thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
-          final sha = inv.positionalArguments[2];
-          final name = inv.positionalArguments[3];
+          final sha = inv.positionalArguments[2] as String;
+          final name = inv.positionalArguments[3] as String?;
           checkRuns.add(
             createCheckRun(
               id: 1,
@@ -3204,12 +3210,13 @@ targets:
 
         final mergeGroupEvent = cocoon_checks.MergeGroupEvent.fromJson(
           json.decode(
-            generateMergeGroupEventString(
-              repository: 'flutter/flutter',
-              action: 'checks_requested',
-              message: 'Implement an amazing feature',
-            ),
-          ),
+                generateMergeGroupEventString(
+                  repository: 'flutter/flutter',
+                  action: 'checks_requested',
+                  message: 'Implement an amazing feature',
+                ),
+              )
+              as Map<String, Object?>,
         );
 
         await scheduler.triggerMergeGroupTargets(
@@ -3311,8 +3318,8 @@ targets:
           ),
         ).thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
-          final sha = inv.positionalArguments[2];
-          final name = inv.positionalArguments[3];
+          final sha = inv.positionalArguments[2] as String;
+          final name = inv.positionalArguments[3] as String?;
           checkRuns.add(
             createCheckRun(
               id: 1,
@@ -3362,12 +3369,13 @@ targets:
 
         final mergeGroupEvent = cocoon_checks.MergeGroupEvent.fromJson(
           json.decode(
-            generateMergeGroupEventString(
-              repository: 'flutter/flutter',
-              action: 'checks_requested',
-              message: 'Implement an amazing feature',
-            ),
-          ),
+                generateMergeGroupEventString(
+                  repository: 'flutter/flutter',
+                  action: 'checks_requested',
+                  message: 'Implement an amazing feature',
+                ),
+              )
+              as Map<String, Object?>,
         );
 
         await scheduler.triggerMergeGroupTargets(
@@ -3456,8 +3464,8 @@ targets:
           ),
         ).thenAnswer((inv) async {
           final slug = inv.positionalArguments[1] as RepositorySlug;
-          final sha = inv.positionalArguments[2];
-          final name = inv.positionalArguments[3];
+          final sha = inv.positionalArguments[2] as String;
+          final name = inv.positionalArguments[3] as String?;
           checkRuns.add(
             createCheckRun(
               id: 1,
@@ -3508,12 +3516,13 @@ targets:
 
         final mergeGroupEvent = cocoon_checks.MergeGroupEvent.fromJson(
           json.decode(
-            generateMergeGroupEventString(
-              repository: 'flutter/flutter',
-              action: 'checks_requested',
-              message: 'Implement an amazing feature',
-            ),
-          ),
+                generateMergeGroupEventString(
+                  repository: 'flutter/flutter',
+                  action: 'checks_requested',
+                  message: 'Implement an amazing feature',
+                ),
+              )
+              as Map<String, Object?>,
         );
 
         await scheduler.triggerMergeGroupTargets(

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -1097,7 +1097,8 @@ Map<String, dynamic> generatePushEvent(
   String message = 'Commit-message',
   String avatarUrl = 'https://fakegithubcontent.com/google_profile',
   String username = 'googledotcom',
-}) => jsonDecode('''
+}) =>
+    jsonDecode('''
 {
   "ref": "refs/heads/$branch",
   "before": "abc123abc123abc123",
@@ -1125,7 +1126,8 @@ Map<String, dynamic> generatePushEvent(
     "full_name": "$organization/$repository"
   }
 }
-''');
+''')
+        as Map<String, Object?>;
 
 PushMessage generateMergeGroupMessage({
   required String repository,

--- a/auto_submit/lib/configuration/repository_configuration.dart
+++ b/auto_submit/lib/configuration/repository_configuration.dart
@@ -117,13 +117,13 @@ class RepositoryConfiguration {
     }
 
     return RepositoryConfiguration(
-      allowConfigOverride: yamlDoc[allowConfigOverrideKey],
-      defaultBranch: yamlDoc[defaultBranchKey],
+      allowConfigOverride: yamlDoc[allowConfigOverrideKey] as bool?,
+      defaultBranch: yamlDoc[defaultBranchKey] as String?,
       autoApprovalAccounts: autoApprovalAccounts,
-      approvingReviews: yamlDoc[approvingReviewsKey],
-      approvalGroup: yamlDoc[approvalGroupKey],
-      runCi: yamlDoc[runCiKey],
-      supportNoReviewReverts: yamlDoc[supportNoReviewRevertKey],
+      approvingReviews: yamlDoc[approvingReviewsKey] as int?,
+      approvalGroup: yamlDoc[approvalGroupKey] as String?,
+      runCi: yamlDoc[runCiKey] as bool?,
+      supportNoReviewReverts: yamlDoc[supportNoReviewRevertKey] as bool?,
       requiredCheckRunsOnRevert: requiredCheckRunsOnRevert,
     );
   }

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -48,7 +48,7 @@ class RepositoryConfigurationManager {
             () async => _getConfiguration(slug),
             config.repositoryConfigurationTtl,
           );
-      final cacheYaml = String.fromCharCodes(cacheValue);
+      final cacheYaml = String.fromCharCodes(cacheValue as Iterable<int>);
       log.info('Converting yaml to RepositoryConfiguration: $cacheYaml');
       return RepositoryConfiguration.fromYaml(cacheYaml);
     } finally {

--- a/auto_submit/lib/service/graphql_service.dart
+++ b/auto_submit/lib/service/graphql_service.dart
@@ -91,7 +91,7 @@ class GraphQlService {
       variables: queryPullRequest.variables,
     );
 
-    return graphQlPullRequest['repository']['pullRequest']['id'];
+    return graphQlPullRequest['repository']['pullRequest']['id'] as String;
   }
 
   /// Puts the given pull request onto the merge queue.

--- a/auto_submit/test/src/service/fake_github_service.dart
+++ b/auto_submit/test/src/service/fake_github_service.dart
@@ -460,7 +460,9 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<Branch> getBranch(RepositorySlug slug, String branchName) async {
-    return Branch.fromJson(json.decode(branchMockData!));
+    return Branch.fromJson(
+      json.decode(branchMockData!) as Map<String, Object?>,
+    );
   }
 
   bool addReviewersToPullRequestMock = true;

--- a/cipd_packages/device_doctor/bin/main.dart
+++ b/cipd_packages/device_doctor/bin/main.dart
@@ -80,7 +80,7 @@ Future<void> main(List<String> args) async {
   final argResults = parser.parse(args);
   _action = argResults[actionFlag] as String?;
   _deviceOS = argResults[deviceOSFlag] as String?;
-  _output = File(argResults[outputFlag] ?? defaultOutputPath);
+  _output = File(argResults[outputFlag] as String? ?? defaultOutputPath);
 
   final deviceDiscovery = DeviceDiscovery(_deviceOS, _output);
 

--- a/cipd_packages/device_doctor/lib/src/android_device.dart
+++ b/cipd_packages/device_doctor/lib/src/android_device.dart
@@ -514,7 +514,7 @@ class AndroidDevice implements Device {
     final packages = <String>[];
 
     // Listen to the stdout and stderr streams
-    const LineSplitter().convert(result.stdout).forEach((data) {
+    const LineSplitter().convert(result.stdout as String).forEach((data) {
       final packageMatch = RegExp(r'package:(.+)$').firstMatch(data);
       if (packageMatch != null) {
         final packageName = packageMatch.group(1);
@@ -550,7 +550,7 @@ class AndroidDevice implements Device {
     final packages = <String>[];
 
     // Listen to the stdout and stderr streams
-    const LineSplitter().convert(result.stdout).forEach((data) {
+    const LineSplitter().convert(result.stdout as String).forEach((data) {
       final packageMatch = RegExp(r'package:(.+)$').firstMatch(data);
       if (packageMatch != null) {
         final packageName = packageMatch.group(1);

--- a/cipd_packages/device_doctor/lib/src/ios_debug_symbol_doctor.dart
+++ b/cipd_packages/device_doctor/lib/src/ios_debug_symbol_doctor.dart
@@ -118,7 +118,7 @@ class RecoverCommand extends Command<bool> {
 
   @override
   Future<bool> run() async {
-    final timeoutSeconds = int.tryParse(argResults!['timeout']);
+    final timeoutSeconds = int.tryParse(argResults!['timeout'] as String);
     if (timeoutSeconds == null) {
       throw ArgumentError(
         'Could not parse an integer from the option --timeout="${argResults!['timeout']}"',

--- a/cipd_packages/device_doctor/test/src/utils.dart
+++ b/cipd_packages/device_doctor/test/src/utils.dart
@@ -25,15 +25,16 @@ class MockProcessManager extends Mock implements ProcessManager {
     bool includeParentEnvironment = true,
     bool runInShell = false,
     ProcessStartMode mode = ProcessStartMode.normal,
-  }) {
+  }) async {
     return super.noSuchMethod(
-      Invocation.method(
-        #start,
-        [command],
-        {#workingDirectory: workingDirectory},
-      ),
-      returnValue: Future<Process>.value(FakeProcess(0)),
-    );
+          Invocation.method(
+            #start,
+            [command],
+            {#workingDirectory: workingDirectory},
+          ),
+          returnValue: Future<Process>.value(FakeProcess(0)),
+        )
+        as Process;
   }
 
   @override
@@ -47,9 +48,10 @@ class MockProcessManager extends Mock implements ProcessManager {
     covariant Encoding? stderrEncoding = systemEncoding,
   }) {
     return super.noSuchMethod(
-      Invocation.method(#runSync, [command]),
-      returnValue: ProcessResult(1, 0, 'abc', 'def'),
-    );
+          Invocation.method(#runSync, [command]),
+          returnValue: ProcessResult(1, 0, 'abc', 'def'),
+        )
+        as ProcessResult;
   }
 
   @override
@@ -61,11 +63,12 @@ class MockProcessManager extends Mock implements ProcessManager {
     bool runInShell = false,
     covariant Encoding? stdoutEncoding = systemEncoding,
     covariant Encoding? stderrEncoding = systemEncoding,
-  }) {
+  }) async {
     return super.noSuchMethod(
-      Invocation.method(#run, [command]),
-      returnValue: Future.value(ProcessResult(1, 0, 'abc', 'def')),
-    );
+          Invocation.method(#run, [command]),
+          returnValue: Future.value(ProcessResult(1, 0, 'abc', 'def')),
+        )
+        as ProcessResult;
   }
 }
 

--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -488,7 +488,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
                             return (commit) {
                               return _schedulePostsubmitBuildForReleaseBranch(
                                 context: context,
-                                commit: commit,
+                                commit: commit as Commit,
                               );
                             };
                           }(),

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -93,7 +93,7 @@ class AppEngineCocoonService implements CocoonService {
     try {
       final jsonResponse = jsonDecode(response.body) as Map<String, dynamic>;
       return CocoonResponse<List<CommitStatus>>.data(
-        _commitStatusesFromJson(jsonResponse['Statuses']),
+        _commitStatusesFromJson(jsonResponse['Statuses'] as List<Object?>),
       );
     } catch (error) {
       return CocoonResponse<List<CommitStatus>>.error(error.toString());
@@ -129,7 +129,9 @@ class AppEngineCocoonService implements CocoonService {
     try {
       final jsonResponse = jsonDecode(response.body) as Map<String, dynamic>;
       return CocoonResponse<List<CommitTasksStatus>>.data(
-        _commitStatusesFromJsonFirestore(jsonResponse['Statuses']),
+        _commitStatusesFromJsonFirestore(
+          jsonResponse['Statuses'] as List<Object?>,
+        ),
       );
     } catch (error) {
       return CocoonResponse<List<CommitTasksStatus>>.error(error.toString());
@@ -330,7 +332,9 @@ class AppEngineCocoonService implements CocoonService {
         CommitStatus()
           ..commit = _commitFromJson(checklist)
           ..branch = _branchFromJson(checklist)!
-          ..tasks.addAll(_tasksFromStagesJson(jsonCommitStatus['Stages'])),
+          ..tasks.addAll(
+            _tasksFromStagesJson(jsonCommitStatus['Stages'] as List<Object?>),
+          ),
       );
     }
 
@@ -352,7 +356,9 @@ class AppEngineCocoonService implements CocoonService {
         CommitTasksStatus()
           ..commit = _commitFromJsonFirestore(jsonCommit)
           ..branch = _branchFromJsonFirestore(jsonCommit)!
-          ..tasks.addAll(_tasksFromJsonFirestore(jsonCommitStatus['Tasks'])),
+          ..tasks.addAll(
+            _tasksFromJsonFirestore(jsonCommitStatus['Tasks'] as List<Object?>),
+          ),
       );
     }
 
@@ -378,7 +384,7 @@ class AppEngineCocoonService implements CocoonService {
           ..key =
               (RootKey()
                 ..child = (Key()..name = jsonChecklist['Key'] as String))
-          ..timestamp = Int64() + checklist['CreateTimestamp']!
+          ..timestamp = Int64() + (checklist['CreateTimestamp']! as Object)
           ..sha = commit['Sha'] as String
           ..author = author['Login'] as String
           ..authorAvatarUrl = author['avatar_url'] as String
@@ -410,7 +416,7 @@ class AppEngineCocoonService implements CocoonService {
     final tasks = <Task>[];
 
     for (final jsonStage in json.cast<Map<String, dynamic>>()) {
-      tasks.addAll(_tasksFromJson(jsonStage['Tasks']));
+      tasks.addAll(_tasksFromJson(jsonStage['Tasks'] as List<Object?>));
     }
 
     return tasks;

--- a/test_utilities/bin/global_test_runner.dart
+++ b/test_utilities/bin/global_test_runner.dart
@@ -16,7 +16,7 @@ Future<Null> main(List<String> rawArgs) async {
   final args = argParser.parse(rawArgs);
 
   // Load tests yaml file.
-  final file = File(args['tests-file']);
+  final file = File(args['tests-file'] as String);
   final doc = loadYaml(file.readAsStringSync());
   // Execute the tests
   final baseDir = normalize(
@@ -30,9 +30,12 @@ Future<Null> main(List<String> rawArgs) async {
   );
   await runShellCommand(<String>[prepareScriptPath], 'prepare environment');
   doc['tasks'].forEach((task) async {
-    final scriptPath = join(baseDir, task['script']);
-    final taskPath = join(baseDir, task['task']);
-    await runShellCommand(<String>[scriptPath, taskPath], task['task']);
+    final scriptPath = join(baseDir, task['script'] as String);
+    final taskPath = join(baseDir, task['task'] as String);
+    await runShellCommand(<String>[
+      scriptPath,
+      taskPath,
+    ], task['task'] as String);
   });
 }
 


### PR DESCRIPTION
More cleanup post unifying formatting and analysis options.

No behavioral changes, all of the `as ___` casts were implicit before and are explicit now.