### PR TITLE
Migrate vacuum stale tasks from datastore to firestore.

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -101,10 +101,10 @@ class FirestoreService {
   ///
   /// The returned commits will be ordered by most recent [Commit.timestamp].
   Future<List<Commit>> queryRecentCommits({
+    required RepositorySlug slug,
     int limit = 100,
     int? timestamp,
     String? branch,
-    required RepositorySlug slug,
   }) async {
     timestamp ??= DateTime.now().millisecondsSinceEpoch;
     branch ??= Config.defaultBranch(slug);
@@ -129,12 +129,22 @@ class FirestoreService {
         .toList();
   }
 
-  /// Queries for recent [Task] by [name].
-  Future<List<Task>> queryRecentTasksByName({
+  /// Queries for recent [Task]s.
+  ///
+  /// Optionally may filter by:
+  /// - [name], which maps to [Task.taskName];
+  /// - [commitSha], which maps to [Task.commitSha];
+  ///
+  /// The default [limit] is 100 tasks.
+  Future<List<Task>> queryRecentTasks({
     int limit = 100,
-    required String name,
+    String? name,
+    String? commitSha,
   }) async {
-    final filterMap = {'$kTaskNameField =': name};
+    final filterMap = {
+      if (name != null) '$kTaskNameField =': name,
+      if (commitSha != null) '$kTaskCommitShaField =': commitSha,
+    };
     final orderMap = {kTaskCreateTimestampField: kQueryOrderDescending};
     final documents = await query(
       kTaskCollectionId,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -229,9 +229,7 @@ class Scheduler {
       final priority = await policy.triggerPriority(
         taskName: task.name!,
         commitSha: commit.sha!,
-        recentTasks: await firestoreService.queryRecentTasksByName(
-          name: task.name!,
-        ),
+        recentTasks: await firestoreService.queryRecentTasks(name: task.name!),
       );
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -66,7 +66,7 @@ void main() {
     db = FakeDatastoreDB();
     mockFirestoreService = MockFirestoreService();
     when(
-      mockFirestoreService.queryRecentTasksByName(
+      mockFirestoreService.queryRecentTasks(
         name: anyNamed('name'),
         limit: anyNamed('limit'),
       ),

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -19,18 +19,6 @@ import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.dart';
 
 void main() {
-  // late FakeConfig config;
-  // late RequestHandlerTester tester;
-  // late VacuumStaleTasks handler;
-  // late _FakeFirestoreService firestoreService;
-
-  // setUp(() {
-  //   firestoreService = _FakeFirestoreService();
-  //   config = FakeConfig(firestoreService: firestoreService);
-  //   tester = RequestHandlerTester();
-  //   handler = VacuumStaleTasks(config: config);
-  // });
-
   late RequestHandlerTester tester;
 
   setUp(() {

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -215,6 +215,7 @@ final class _FakeFirestoreService extends Fake implements FirestoreService {
       commitSha: commit.sha!,
       buildNumber: buildNumber,
       status: status,
+      created: createdAt,
     );
     _tasksByCommitSha.putIfAbsent(commit.sha!, () => {})[task.name!] = task;
     return task;

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -4,10 +4,12 @@
 
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
+import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore;
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
-import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:gcloud/db.dart';
+import 'package:collection/collection.dart';
+import 'package:github/src/common/model/repos.dart';
 import 'package:googleapis/firestore/v1.dart';
+import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -17,107 +19,256 @@ import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.dart';
 
 void main() {
-  group(VacuumStaleTasks, () {
-    late FakeConfig config;
-    late RequestHandlerTester tester;
-    late VacuumStaleTasks handler;
-    late MockFirestoreService mockFirestoreService;
+  // late FakeConfig config;
+  // late RequestHandlerTester tester;
+  // late VacuumStaleTasks handler;
+  // late _FakeFirestoreService firestoreService;
 
-    final commit = generateCommit(1);
+  // setUp(() {
+  //   firestoreService = _FakeFirestoreService();
+  //   config = FakeConfig(firestoreService: firestoreService);
+  //   tester = RequestHandlerTester();
+  //   handler = VacuumStaleTasks(config: config);
+  // });
+
+  late RequestHandlerTester tester;
+
+  setUp(() {
+    tester = RequestHandlerTester();
+  });
+
+  group('precondition checks', () {
+    late MockFirestoreService firestore;
+    late FakeConfig config;
+    late VacuumStaleTasks handler;
 
     setUp(() {
-      mockFirestoreService = MockFirestoreService();
-      config = FakeConfig(firestoreService: mockFirestoreService);
-      config.db.values[commit.key] = commit;
-
-      tester = RequestHandlerTester();
-      handler = VacuumStaleTasks(
-        config: config,
-        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
-      );
+      firestore = MockFirestoreService();
+      config = FakeConfig(firestoreService: firestore);
+      handler = VacuumStaleTasks(config: config);
     });
 
-    test('skips when tasks have a build number', () async {
-      final originalTasks = <Task>[
-        generateTask(
-          1,
-          status: Task.statusInProgress,
-          parent: commit,
-          buildNumber: 123,
+    test('requests commits for each supported repository', () async {
+      when(
+        firestore.queryRecentCommits(
+          slug: captureAnyNamed('slug'),
+          limit: anyNamed('limit'),
         ),
-      ];
-      await config.db.commit(inserts: originalTasks);
+      ).thenAnswer((_) async {
+        // Intentionally do not return any results so we short-circuit.
+        return [];
+      });
 
       await tester.get(handler);
 
-      final tasks = config.db.values.values.whereType<Task>().toList();
-      expect(tasks[0].status, Task.statusInProgress);
+      expect(
+        verify(
+          firestore.queryRecentCommits(
+            slug: captureAnyNamed('slug'),
+            limit: anyNamed('limit'),
+          ),
+        ).captured,
+        config.supportedRepos,
+      );
+    });
+
+    test('requests commits equal to config.backfillerCommitLimit', () async {
+      // Only make a single call
+      config.supportedReposValue = {Config.flutterSlug};
+
+      when(
+        firestore.queryRecentCommits(
+          slug: anyNamed('slug'),
+          limit: captureAnyNamed('limit'),
+        ),
+      ).thenAnswer((_) async {
+        // Intentionally do not return any results so we short-circuit.
+        return [];
+      });
+
+      await tester.get(handler);
+
+      expect(
+        verify(
+          firestore.queryRecentCommits(
+            slug: anyNamed('slug'),
+            limit: captureAnyNamed('limit'),
+          ),
+        ).captured,
+        [config.backfillerCommitLimit],
+      );
+    });
+  });
+
+  group('logic checks', () {
+    const timeoutLimit = Duration(hours: 1);
+
+    late _FakeFirestoreService firestore;
+    late FakeConfig config;
+    late VacuumStaleTasks handler;
+    late DateTime now;
+
+    setUp(() {
+      firestore = _FakeFirestoreService();
+      config = FakeConfig(
+        firestoreService: firestore,
+        supportedReposValue: {Config.flutterSlug},
+      );
+      now = DateTime.now();
+      handler = VacuumStaleTasks(
+        config: config,
+        now: () => now,
+        timeoutLimit: timeoutLimit,
+      );
+    });
+
+    test('resets tasks', () async {
+      final resetEligible = firestore.createTask(
+        firestore.createCommit(),
+        status: Task.statusInProgress,
+        buildNumber: null,
+        createdAt: now.subtract(timeoutLimit),
+      );
+
+      await tester.get(handler);
+
+      expect(
+        firestore.fetchUpdatedTask(resetEligible).status,
+        Task.statusNew,
+        reason: 'Timed-out in-progress tasks without a build number',
+      );
+    });
+
+    group('ignores tasks that are not in progress', () {
+      for (final status in [
+        Task.statusCancelled,
+        Task.statusFailed,
+        Task.statusInfraFailure,
+        Task.statusNew,
+        Task.statusSkipped,
+        Task.statusSucceeded,
+      ]) {
+        test('status=$status', () async {
+          final notInProgress = firestore.createTask(
+            firestore.createCommit(),
+            status: status,
+          );
+
+          await tester.get(handler);
+
+          expect(
+            firestore.fetchUpdatedTask(notInProgress).status,
+            status,
+            reason: 'Only Task.statusInProgress should be reset',
+          );
+        });
+      }
+    });
+
+    test('ignores tasks with an assigned build number', () async {
+      final inProgress = firestore.createTask(
+        firestore.createCommit(),
+        status: Task.statusInProgress,
+        buildNumber: 1234,
+      );
+
+      await tester.get(handler);
+
+      expect(
+        firestore.fetchUpdatedTask(inProgress).status,
+        Task.statusInProgress,
+        reason: 'A task with .buildNumber set should not be reset',
+      );
     });
 
     test(
-      'skips when tasks are not yet old enough to be considered stale',
+      'ignores tasks where the task was created within the timeout limit',
       () async {
-        when(mockFirestoreService.writeViaTransaction(captureAny)).thenAnswer((
-          Invocation invocation,
-        ) {
-          return Future<CommitResponse>.value(CommitResponse());
-        });
-        final originalTasks = <Task>[
-          generateTask(
-            1,
-            status: Task.statusInProgress,
-            parent: commit,
-            created: DateTime.now().subtract(const Duration(minutes: 5)),
-          ),
-        ];
-        await config.db.commit(inserts: originalTasks);
+        final inProgress = firestore.createTask(
+          firestore.createCommit(),
+          status: Task.statusInProgress,
+          createdAt: now.subtract(timeoutLimit - const Duration(minutes: 1)),
+        );
 
         await tester.get(handler);
 
-        final tasks = config.db.values.values.whereType<Task>().toList();
-        expect(tasks[0].status, Task.statusInProgress);
+        expect(
+          firestore.fetchUpdatedTask(inProgress).status,
+          Task.statusInProgress,
+          reason: 'A task within the timeoutlimit should not be reset',
+        );
       },
     );
-
-    test('resets stale task', () async {
-      when(mockFirestoreService.writeViaTransaction(captureAny)).thenAnswer((
-        Invocation invocation,
-      ) {
-        return Future<CommitResponse>.value(CommitResponse());
-      });
-      final originalTasks = <Task>[
-        generateTask(1, status: Task.statusInProgress, parent: commit),
-        generateTask(2, status: Task.statusSucceeded, parent: commit),
-        // Task 3 should be vacuumed
-        generateTask(
-          3,
-          status: Task.statusInProgress,
-          parent: commit,
-          created: DateTime.now().subtract(const Duration(hours: 4)),
-        ),
-      ];
-      final datastore = DatastoreService(config.db, 5);
-      await datastore.insert(originalTasks);
-
-      await tester.get(handler);
-
-      final tasks = config.db.values.values.whereType<Task>().toList();
-      expect(tasks[0].status, Task.statusNew);
-      expect(tasks[2].status, Task.statusNew);
-
-      final captured =
-          verify(mockFirestoreService.writeViaTransaction(captureAny)).captured;
-      expect(captured.length, 1);
-      final commitResponse = captured[0] as List<Write>;
-      expect(commitResponse.length, 2);
-      final taskDocuemnt1 = firestore.Task.fromDocument(
-        taskDocument: commitResponse[0].update!,
-      );
-      final taskDocuemnt2 = firestore.Task.fromDocument(
-        taskDocument: commitResponse[0].update!,
-      );
-      expect(taskDocuemnt1.status, firestore.Task.statusNew);
-      expect(taskDocuemnt2.status, firestore.Task.statusNew);
-    });
   });
+}
+
+final class _FakeFirestoreService extends Fake implements FirestoreService {
+  _FakeFirestoreService();
+  var _counter = 0;
+  final _commits = <firestore.Commit>[];
+  final _tasksByCommitSha = <String, Map<String, firestore.Task>>{};
+
+  @useResult
+  firestore.Commit createCommit() {
+    final commit = generateFirestoreCommit(++_counter);
+    _commits.add(commit);
+    return commit;
+  }
+
+  @useResult
+  firestore.Task createTask(
+    firestore.Commit commit, {
+    required String status,
+    int? buildNumber,
+    DateTime? createdAt,
+  }) {
+    final task = generateFirestoreTask(
+      ++_counter,
+      commitSha: commit.sha!,
+      buildNumber: buildNumber,
+      status: status,
+    );
+    _tasksByCommitSha.putIfAbsent(commit.sha!, () => {})[task.name!] = task;
+    return task;
+  }
+
+  @useResult
+  firestore.Task fetchUpdatedTask(firestore.Task task) {
+    return _tasksByCommitSha[task.commitSha!]![task.name!]!;
+  }
+
+  @override
+  Future<List<firestore.Commit>> queryRecentCommits({
+    required RepositorySlug slug,
+    int limit = 100,
+    int? timestamp,
+    String? branch,
+  }) async {
+    if (timestamp != null) {
+      fail('Unexpected: queryRecentCommits(timestamp: ...)');
+    }
+    if (branch != null) {
+      fail('Unexpected: queryRecentCommits(branch: ...)');
+    }
+    return _commits
+        .where((c) => c.slug == slug)
+        .sortedBy((c) => c.createTimestamp ?? 0)
+        .take(limit)
+        .toList();
+  }
+
+  @override
+  Future<List<firestore.Task>> queryCommitTasks(String commitSha) async {
+    return _tasksByCommitSha[commitSha]?.values.toList() ?? [];
+  }
+
+  @override
+  Future<CommitResponse> writeViaTransaction(List<Write> writes) async {
+    final updating = writes.map((w) => w.update).whereType<firestore.Task>();
+    for (final task in updating) {
+      final tasks = _tasksByCommitSha[task.commitSha]!;
+      tasks[task.name!] = task;
+    }
+    return CommitResponse();
+  }
 }

--- a/app_dart/test/request_handlers/vacuum_github_commits_test.dart
+++ b/app_dart/test/request_handlers/vacuum_github_commits_test.dart
@@ -78,7 +78,7 @@ void main() {
       final tabledataResourceApi = MockTabledataResource();
       mockFirestoreService = MockFirestoreService();
       when(
-        mockFirestoreService.queryRecentTasksByName(
+        mockFirestoreService.queryRecentTasks(
           name: anyNamed('name'),
           limit: anyNamed('limit'),
         ),

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -168,7 +168,7 @@ void main() {
 
       mockFirestoreService = MockFirestoreService();
       when(
-        mockFirestoreService.queryRecentTasksByName(
+        mockFirestoreService.queryRecentTasks(
           name: anyNamed('name'),
           limit: anyNamed('limit'),
         ),

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -1868,31 +1868,33 @@ class MockFirestoreService extends _i1.Mock implements _i14.FirestoreService {
 
   @override
   _i19.Future<List<_i42.Commit>> queryRecentCommits({
+    required _i12.RepositorySlug? slug,
     int? limit = 100,
     int? timestamp,
     String? branch,
-    required _i12.RepositorySlug? slug,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#queryRecentCommits, [], {
+              #slug: slug,
               #limit: limit,
               #timestamp: timestamp,
               #branch: branch,
-              #slug: slug,
             }),
             returnValue: _i19.Future<List<_i42.Commit>>.value(<_i42.Commit>[]),
           )
           as _i19.Future<List<_i42.Commit>>);
 
   @override
-  _i19.Future<List<_i43.Task>> queryRecentTasksByName({
+  _i19.Future<List<_i43.Task>> queryRecentTasks({
     int? limit = 100,
-    required String? name,
+    String? name,
+    String? commitSha,
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#queryRecentTasksByName, [], {
+            Invocation.method(#queryRecentTasks, [], {
               #limit: limit,
               #name: name,
+              #commitSha: commitSha,
             }),
             returnValue: _i19.Future<List<_i43.Task>>.value(<_i43.Task>[]),
           )


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/144733.

Also rewrote the test suite to be understandable by humans.