### PR TITLE
Don't treat `.ci.yaml` validation errors as an `InternalServerError`

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -124,6 +124,9 @@ class GithubWebhookSubscription extends SubscriptionHandler {
               'Failed to process check_run event. checkRunEvent: $checkRunEvent',
             );
           case RecoverableErrorResult(:final message):
+            log.info(
+              'User error state for check_run event ($checkRunEvent): $message',
+            );
             response!.statusCode = HttpStatus.badRequest;
             response!.reasonPhrase = message;
             return Body.empty;

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
@@ -18,6 +19,7 @@ import '../../request_handling/subscription_handler.dart';
 import '../../service/commit_service.dart';
 import '../../service/datastore.dart';
 import '../../service/github_service.dart';
+import '../../service/scheduler/process_check_run_result.dart';
 
 // Filenames which are not actually tests.
 const List<String> kNotActuallyATest = <String>[
@@ -109,10 +111,22 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       case 'check_run':
         final event = jsonDecode(webhook.payload) as Map<String, dynamic>;
         final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(event);
-        if (await scheduler.processCheckRun(checkRunEvent) == false) {
-          throw InternalServerError(
-            'Failed to process check_run event. checkRunEvent: $checkRunEvent',
-          );
+        switch (await scheduler.processCheckRun(checkRunEvent)) {
+          case SuccessResult():
+            break;
+          case InternalErrorResult(
+            :final message,
+            :final error,
+            :final stackTrace,
+          ):
+            log.severe(message, error, stackTrace);
+            throw InternalServerError(
+              'Failed to process check_run event. checkRunEvent: $checkRunEvent',
+            );
+          case RecoverableErrorResult(:final message):
+            response!.statusCode = HttpStatus.badRequest;
+            response!.reasonPhrase = message;
+            return Body.empty;
         }
         break;
       case 'push':

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -1587,11 +1587,9 @@ $stacktrace
                 checkRunEvent.checkRun!.headSha!,
               );
               if (pullRequest == null) {
-                log.warning(
+                return ProcessCheckRunResult.userError(
                   'Asked to reschedule presubmits for unknown sha/PR: ${checkRunEvent.checkRun!.headSha!}',
                 );
-                // TODO(matanlurey): Follow up with jtmcdole on why this was/is a success case.
-                return const ProcessCheckRunResult.success();
               }
 
               final isFusion = await fusionTester.isFusionBasedRef(slug, sha);

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -42,6 +42,7 @@ import 'luci_build_service.dart';
 import 'luci_build_service/engine_artifacts.dart';
 import 'luci_build_service/pending_task.dart';
 import 'scheduler/policy.dart';
+import 'scheduler/process_check_run_result.dart';
 
 /// Scheduler service to validate all commits to supported Flutter repositories.
 ///
@@ -1506,13 +1507,14 @@ $stacktrace
   ///
   /// Relevant APIs:
   ///   https://developer.github.com/v3/checks/runs/#check-runs-and-requested-actions
-  Future<bool> processCheckRun(
+  @useResult
+  Future<ProcessCheckRunResult> processCheckRun(
     cocoon_checks.CheckRunEvent checkRunEvent,
   ) async {
     switch (checkRunEvent.action) {
       case 'completed':
         await processCheckRunCompletion(checkRunEvent);
-        return true;
+        return const ProcessCheckRunResult.success();
 
       case 'rerequested':
         log.fine(
@@ -1588,7 +1590,8 @@ $stacktrace
                 log.warning(
                   'Asked to reschedule presubmits for unknown sha/PR: ${checkRunEvent.checkRun!.headSha!}',
                 );
-                return true;
+                // TODO(matanlurey): Follow up with jtmcdole on why this was/is a success case.
+                return const ProcessCheckRunResult.success();
               }
 
               final isFusion = await fusionTester.isFusionBasedRef(slug, sha);
@@ -1630,11 +1633,10 @@ $stacktrace
                 (target) => checkRunEvent.checkRun!.name == target.value.name,
               );
               if (target == null) {
-                // TODO(matanlurey): Revisit why this is coming up null, it's just mitigation for https://github.com/flutter/flutter/issues/164342 until then.
-                log.warning(
-                  'Could not reschedule checkRun "${checkRunEvent.checkRun!.name}", not found in list of presubmit targets: ${presubmitTargets.map((t) => t.value.name).toList()}',
+                return ProcessCheckRunResult.internalError(
+                  'Could not reschedule checkRun "${checkRunEvent.checkRun!.name}", '
+                  'not found in list of presubmit targets: ${presubmitTargets.map((t) => t.value.name).toList()}',
                 );
-                return true;
               }
               await luciBuildService.scheduleTryBuilds(
                 targets: [target],
@@ -1681,14 +1683,24 @@ $stacktrace
             success = true;
           } on NoBuildFoundException {
             log.warning('No build found to reschedule.');
+          } on FormatException catch (e) {
+            // See https://github.com/flutter/flutter/issues/165018.
+            log.info('CheckName: $name failed due to user error: $e');
+            return ProcessCheckRunResult.userError('$e');
           }
         }
 
         log.fine('CheckName: $name State: $success');
-        return success;
+
+        // TODO(matanlurey): It would be better to early return above where it is not a success.
+        if (!success) {
+          return const ProcessCheckRunResult.internalError(
+            'Not successful. See previous log messages',
+          );
+        }
     }
 
-    return true;
+    return const ProcessCheckRunResult.success();
   }
 
   /// Push [Commit] to BigQuery as part of the infra metrics dashboards.

--- a/app_dart/lib/src/service/scheduler/process_check_run_result.dart
+++ b/app_dart/lib/src/service/scheduler/process_check_run_result.dart
@@ -1,0 +1,92 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:cocoon_service/src/service/scheduler.dart';
+library;
+
+import 'package:meta/meta.dart';
+
+/// Possible results for [Scheduler.processCheckRun].
+@immutable
+sealed class ProcessCheckRunResult {
+  const factory ProcessCheckRunResult.success() = SuccessResult._;
+  const factory ProcessCheckRunResult.userError(String message) =
+      RecoverableErrorResult._;
+  const factory ProcessCheckRunResult.internalError(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) = InternalErrorResult._;
+}
+
+/// Successful.
+final class SuccessResult implements ProcessCheckRunResult {
+  const SuccessResult._();
+
+  @override
+  bool operator ==(Object other) => other is SuccessResult;
+
+  @override
+  int get hashCode => (SuccessResult).hashCode;
+
+  @override
+  String toString() {
+    return 'ProcessCheckResult.success()';
+  }
+}
+
+/// User-recoverable error.
+final class RecoverableErrorResult implements ProcessCheckRunResult {
+  const RecoverableErrorResult._(this.message);
+
+  /// What should be displayed to the user.
+  final String message;
+
+  @override
+  bool operator ==(Object other) {
+    return other is RecoverableErrorResult && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(RecoverableErrorResult, message);
+  }
+
+  @override
+  String toString() {
+    return 'ProcessCheckResult.userError($message)';
+  }
+}
+
+/// Internal error.
+final class InternalErrorResult implements ProcessCheckRunResult {
+  const InternalErrorResult._(this.message, {this.error, this.stackTrace});
+
+  /// What should be displayed to the user.
+  final String message;
+
+  /// Originating error, if any.
+  final Object? error;
+
+  /// Originating stack trace, if any.
+  final StackTrace? stackTrace;
+
+  @override
+  bool operator ==(Object other) {
+    return other is InternalErrorResult &&
+        message == other.message &&
+        error == other.error &&
+        stackTrace == other.stackTrace;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(InternalErrorResult, message, error, stackTrace);
+  }
+
+  @override
+  String toString() {
+    return 'ProcessCheckRunResult.internalError($message, error: $error, stackTrace: $stackTrace)';
+  }
+}

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1308,7 +1308,11 @@ targets:
         );
         expect(
           await scheduler.processCheckRun(checkRunEvent),
-          const ProcessCheckRunResult.success(),
+          isA<RecoverableErrorResult>().having(
+            (e) => e.message,
+            'message',
+            contains('Asked to reschedule presubmits for unknown sha/PR'),
+          ),
         );
         verifyNever(mockGithubChecksUtil.createCheckRun(any, any, any, any));
       });

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -21,6 +21,7 @@ import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart';
 import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart';
+import 'package:cocoon_service/src/service/scheduler/process_check_run_result.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:gcloud/db.dart' as gcloud_db;
 import 'package:gcloud/db.dart';
@@ -865,7 +866,10 @@ targets:
         final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           checkRunEventJson,
         );
-        expect(await scheduler.processCheckRun(checkRunEvent), true);
+        expect(
+          await scheduler.processCheckRun(checkRunEvent),
+          const ProcessCheckRunResult.success(),
+        );
         verify(
           mockGithubChecksUtil.createCheckRun(
             any,
@@ -975,7 +979,10 @@ targets:
           final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
             checkRunEventJson,
           );
-          expect(await scheduler.processCheckRun(checkRunEvent), true);
+          expect(
+            await scheduler.processCheckRun(checkRunEvent),
+            const ProcessCheckRunResult.success(),
+          );
           verify(
             mockGithubChecksUtil.createCheckRun(
               any,
@@ -1063,7 +1070,10 @@ targets:
         final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           checkRunEventJson,
         );
-        expect(await scheduler.processCheckRun(checkRunEvent), true);
+        expect(
+          await scheduler.processCheckRun(checkRunEvent),
+          const ProcessCheckRunResult.success(),
+        );
         verifyNever(
           mockGithubChecksUtil.createCheckRun(
             any,
@@ -1134,7 +1144,10 @@ targets:
         checkrun['name'] = checkrun['check_run']['name'] = 'Linux A';
         final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(checkrun);
 
-        expect(await scheduler.processCheckRun(checkRunEvent), true);
+        expect(
+          await scheduler.processCheckRun(checkRunEvent),
+          const ProcessCheckRunResult.success(),
+        );
 
         verify(
           callbacks.findPullRequestForSha(any, checkRunEvent.checkRun!.headSha),
@@ -1252,7 +1265,10 @@ targets:
         final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
           jsonDecode(checkRunString) as Map<String, dynamic>,
         );
-        expect(await scheduler.processCheckRun(checkRunEvent), true);
+        expect(
+          await scheduler.processCheckRun(checkRunEvent),
+          const ProcessCheckRunResult.success(),
+        );
         verify(
           mockGithubChecksUtil.createCheckRun(any, any, any, any),
         ).called(1);
@@ -1290,7 +1306,10 @@ targets:
           findPullRequestForSha: callbacks.findPullRequestForSha,
           httpClientProvider: () => httpClient,
         );
-        expect(await scheduler.processCheckRun(checkRunEvent), true);
+        expect(
+          await scheduler.processCheckRun(checkRunEvent),
+          const ProcessCheckRunResult.success(),
+        );
         verifyNever(mockGithubChecksUtil.createCheckRun(any, any, any, any));
       });
 
@@ -1303,7 +1322,7 @@ targets:
                 json.decode(checkRunEventFor()) as Map<String, Object?>,
               ),
             ),
-            true,
+            const ProcessCheckRunResult.success(),
           );
         });
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165018.

This splits the possible result states of `processCheckRuns` into:

- Success (previously: `true`)
- User error (previously: `false`), where we don't log an exception/error but return a `400` to the user
- Internal error (previously: `false`), where we log an exception/stack trace and return a `500` to the user