### PR TITLE
Use `Config.defaultBranch` for tip-of-tree `.ci.yaml`.

### DIFF
--- a/app_dart/lib/src/service/scheduler/ci_yaml_fetcher.dart
+++ b/app_dart/lib/src/service/scheduler/ci_yaml_fetcher.dart
@@ -111,10 +111,7 @@ final class _CiYamlFetcher extends CiYamlFetcher {
     bool validate = false,
   }) async {
     final isFusion = await _fusionTester.isFusionBasedRef(slug, commitSha);
-    final totCommit = await _fetchTipOfTreeCommit(
-      slug: slug,
-      commitBranch: commitBranch,
-    );
+    final totCommit = await _fetchTipOfTreeCommit(slug: slug);
     final totYaml = await _getCiYaml(
       slug: totCommit.slug,
       commitSha: totCommit.sha!,
@@ -219,12 +216,11 @@ final class _CiYamlFetcher extends CiYamlFetcher {
   /// (without `bringup: true`) are not added to the build.
   Future<firestore.Commit> _fetchTipOfTreeCommit({
     required RepositorySlug slug,
-    required String commitBranch,
   }) async {
     final firestore = await _config.createFirestoreService();
     final recentCommits = await firestore.queryRecentCommits(
       slug: slug,
-      branch: commitBranch,
+      branch: Config.defaultBranch(slug),
       limit: 1,
     );
     if (recentCommits.length != 1) {

--- a/app_dart/test/service/scheduler/ci_yaml_fetcher_test.dart
+++ b/app_dart/test/service/scheduler/ci_yaml_fetcher_test.dart
@@ -10,6 +10,7 @@ import 'package:cocoon_service/ci_yaml.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as firestore;
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
+import 'package:github/github.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:logging/logging.dart';
@@ -62,17 +63,6 @@ void main() {
       1,
       sha: 'bf58e0e6dffbfd759a3b2b5c56a2b5b115506c91',
     );
-    when(
-      // ignore: discarded_futures
-      firestoreService.queryRecentCommits(
-        slug: anyNamed('slug'),
-        limit: argThat(equals(1), named: 'limit'),
-        timestamp: argThat(isNull, named: 'timestamp'),
-        branch: anyNamed('branch'),
-      ),
-    ).thenAnswer((_) async {
-      return [totCommit];
-    });
 
     ciYamlFetcher = CiYamlFetcher(
       cache: cache,
@@ -86,6 +76,23 @@ void main() {
   tearDown(() {
     printOnFailure(logs.join('\n'));
   });
+
+  void mockFillFirestore({
+    required RepositorySlug slug,
+    required String branch,
+  }) {
+    when(
+      // ignore: discarded_futures
+      firestoreService.queryRecentCommits(
+        slug: argThat(equals(slug), named: 'slug'),
+        limit: argThat(equals(1), named: 'limit'),
+        timestamp: argThat(isNull, named: 'timestamp'),
+        branch: argThat(equals(branch), named: 'branch'),
+      ),
+    ).thenAnswer((_) async {
+      return [totCommit];
+    });
+  }
 
   test('fetches the root .ci.yaml for a repository (GitHub)', () async {
     httpClient = MockClient((request) async {
@@ -104,6 +111,8 @@ void main() {
 
       fail('Should not occur. Unexpected request: ${request.url}');
     });
+
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     final ciYaml = await ciYamlFetcher.getCiYaml(
       slug: Config.flutterSlug,
@@ -144,6 +153,8 @@ void main() {
       fail('Should not occur. Unexpected request: ${request.url}');
     });
 
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
+
     final ciYaml = await ciYamlFetcher.getCiYaml(
       slug: Config.flutterSlug,
       commitSha: currentSha,
@@ -175,6 +186,8 @@ void main() {
       fail('Should not occur. Unexpected request: ${request.url}');
     });
 
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
+
     final ciYaml = await ciYamlFetcher.getCiYamlByDatastoreCommit(
       generateCommit(1, sha: currentSha),
       validate: true,
@@ -203,6 +216,8 @@ void main() {
 
       fail('Should not occur. Unexpected request: ${request.url}');
     });
+
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
       generateFirestoreCommit(1, sha: currentSha),
@@ -238,6 +253,8 @@ void main() {
 
       fail('Should not occur. Unexpected request: ${request.url}');
     });
+
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     await expectLater(
       ciYamlFetcher.getCiYaml(
@@ -280,6 +297,8 @@ void main() {
       fail('Should not occur. Unexpected request: ${request.url}');
     });
 
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
+
     final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
       generateFirestoreCommit(1, sha: currentSha),
       validate: true,
@@ -288,6 +307,45 @@ void main() {
     expect(
       ciYaml.targets().map((t) => t.value.name),
       unorderedEquals(['Linux A', 'Linux B']),
+    );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/165433.
+  test('fetches ToT .ci.yaml from the default branch only', () async {
+    httpClient = MockClient((request) async {
+      if (request.url.host != 'raw.githubusercontent.com') {
+        fail('Unexpected host: ${request.url}');
+      }
+
+      // Extract the URL request ($slug/$ref/$file);
+      final [owner, repository, ref, ...path] = request.url.pathSegments;
+      expect('$owner/$repository', Config.flutterSlug.fullName);
+      expect(p.joinAll(path), kCiYamlPath);
+
+      if (ref == totSha || ref == currentSha) {
+        return http.Response(singleCiYaml, HttpStatus.ok);
+      }
+
+      fail('Should not occur. Unexpected request: ${request.url}');
+    });
+
+    mockFillFirestore(
+      slug: Config.flutterSlug,
+      branch: Config.defaultBranch(Config.flutterSlug),
+    );
+
+    final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
+      generateFirestoreCommit(
+        1,
+        sha: currentSha,
+        branch: 'flutter-0.42-candidate.0',
+      ),
+      validate: true,
+    );
+
+    expect(
+      ciYaml.targets().map((t) => t.value.name),
+      unorderedEquals(['Linux A']),
     );
   });
 
@@ -315,6 +373,8 @@ void main() {
       }, HttpStatus.ok);
     });
 
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
+
     final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
       generateFirestoreCommit(1, sha: currentSha),
       validate: true,
@@ -337,6 +397,8 @@ void main() {
     httpClient = MockClient((_) async {
       return http.Response('', HttpStatus.ok);
     });
+
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     await expectLater(
       ciYamlFetcher.getCiYaml(
@@ -367,6 +429,8 @@ targets:
       - B
           ''', HttpStatus.ok);
     });
+
+    mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     await expectLater(
       ciYamlFetcher.getCiYaml(


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165433.

I believe this restores the [logic we had before](https://github.com/flutter/cocoon/pull/4333/files#diff-44d26c271d034096ac3f0506b7400724ed6dd135aaff3b443ef628880a21457e) that I accidentally broke. 