### PR TITLE
Finish migrating public calls from`package:logging`.

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -5,17 +5,14 @@
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/server.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
 import 'package:gcloud/db.dart';
-import 'package:logging/logging.dart';
 
 Future<void> main() async {
-  log = Logger('app_dart');
   await withAppEngineServices(() async {
     useLoggingPackageAdaptor();
 

--- a/app_dart/lib/src/foundation/github_checks_util.dart
+++ b/app_dart/lib/src/foundation/github_checks_util.dart
@@ -138,7 +138,7 @@ class GithubChecksUtil {
       },
       retryIf: (_) => true,
       onRetry: (e) {
-        log2.warn(
+        log.warn(
           'createCheckRun fails for slug: ${slug.fullName}, sha: $sha, name: $name.',
           e,
         );

--- a/app_dart/lib/src/foundation/utils.dart
+++ b/app_dart/lib/src/foundation/utils.dart
@@ -86,7 +86,7 @@ class FusionTester {
     final cacheKey = '${slug.fullName}/$sha';
     final cacheHit = _isFusionMap[cacheKey];
     if (cacheHit != null) {
-      log2.info('isFusionRef: cache hit for $cacheKey = $cacheHit');
+      log.info('isFusionRef: cache hit for $cacheKey = $cacheHit');
       return cacheHit;
     }
     final isFusion =
@@ -106,7 +106,7 @@ class FusionTester {
     RetryOptions retryOptions,
   ) async {
     if (slug != Config.flutterSlug) {
-      log2.debug('isFusionRef: not a fusion ref - wrong slug($slug)');
+      log.debug('isFusionRef: not a fusion ref - wrong slug($slug)');
       return false;
     }
     try {
@@ -129,22 +129,22 @@ class FusionTester {
         ),
       ]);
       if (files.any((contents) => contents.isEmpty)) {
-        log2.debug(
+        log.debug(
           'isFusionRef: not a fusion ref - DEPS or engine/src/.gn is empty',
         );
         return false;
       }
 
-      log2.debug('isFusionRef: fusion ref - ');
+      log.debug('isFusionRef: fusion ref - ');
       return true;
     } on NotFoundException catch (e) {
-      log2.debug(
+      log.debug(
         "isFusionRef: 'DEPS' or 'engine/src/.gn' not found a fusion ref.",
         e,
       );
       return false;
     } catch (e) {
-      log2.warn('isFusionRef: unknown error while testing', e);
+      log.warn('isFusionRef: unknown error while testing', e);
       rethrow;
     }
   }
@@ -194,7 +194,7 @@ Future<String> githubFileContent(
     if (e is! HttpException && e is! NotFoundException) {
       rethrow;
     }
-    log2.warn('Failed to fetch $githubUrl, falling back to $gobUrl', e);
+    log.warn('Failed to fetch $githubUrl, falling back to $gobUrl', e);
     await retryOptions.retry(() async {
       content = String.fromCharCodes(
         base64Decode(
@@ -215,7 +215,7 @@ FutureOr<String> getUrl(
   HttpClientProvider httpClientProvider, {
   Duration timeout = const Duration(seconds: 5),
 }) async {
-  log2.info('Making HTTP GET request for $url');
+  log.info('Making HTTP GET request for $url');
   final client = httpClientProvider();
   try {
     final response = await client.get(url).timeout(timeout);
@@ -225,7 +225,7 @@ FutureOr<String> getUrl(
     } else if (response.statusCode == HttpStatus.notFound) {
       throw NotFoundException('HTTP ${response.statusCode}: $url');
     } else {
-      log2.warn('HTTP ${response.statusCode}: $url');
+      log.warn('HTTP ${response.statusCode}: $url');
       throw HttpException('HTTP ${response.statusCode}: $url');
     }
   } finally {
@@ -262,12 +262,12 @@ Future<List<Target>> getTargetsToRun(
   Iterable<Target> targets,
   FilesChanged filesChanged,
 ) async {
-  log2.info('Getting targets to run from diff.');
+  log.info('Getting targets to run from diff.');
 
   // If we were not able to determine what files were changed run all targets.
   switch (filesChanged) {
     case InconclusiveFilesChanged(:final pullRequestNumber, :final reason):
-      log2.info('Running all targets on PR#$pullRequestNumber: $reason');
+      log.info('Running all targets on PR#$pullRequestNumber: $reason');
       return [...targets];
     case SuccessfulFilesChanged(:final pullRequestNumber, :final filesChanged):
       final targetsToRun = <Target>[];
@@ -288,7 +288,7 @@ Future<List<Target>> getTargetsToRun(
         }
       }
 
-      log2.info(
+      log.info(
         'Running a subset of targets on PR#$pullRequestNumber: ${targetsToRun.map((t) => t.value.name).join(', ')}',
       );
 
@@ -324,7 +324,7 @@ Future<void> insertBigquery(
   try {
     await tabledataResourceApi.insertAll(request, projectId, dataset, table);
   } on ApiRequestError catch (e) {
-    log2.warn('Failed to add to BigQuery', e);
+    log.warn('Failed to add to BigQuery', e);
   }
 }
 

--- a/app_dart/lib/src/model/appengine/commit.dart
+++ b/app_dart/lib/src/model/appengine/commit.dart
@@ -45,7 +45,7 @@ class Commit extends Model<String> {
     required DatastoreService datastore,
     required Key<String> key,
   }) async {
-    log2.debug('Looking up commit by key with id: ${key.id}');
+    log.debug('Looking up commit by key with id: ${key.id}');
     return datastore.lookupByValue<Commit>(key);
   }
 

--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -82,7 +82,7 @@ class Task extends Model<int> {
       ..filter('name =', name);
     final tasks = await query.run().toList();
     if (tasks.length != 1) {
-      log2.error('Found ${tasks.length} entries for builder $name');
+      log.error('Found ${tasks.length} entries for builder $name');
       throw InternalServerError(
         'Expected to find 1 task for $name, but found ${tasks.length}',
       );
@@ -99,7 +99,7 @@ class Task extends Model<int> {
     required Key<String> commitKey,
     required int id,
   }) {
-    log2.debug('Looking up key...');
+    log.debug('Looking up key...');
     final key = Key<int>(commitKey, Task, id);
     return datastore.lookupByValue<Task>(key);
   }
@@ -136,24 +136,24 @@ class Task extends Model<int> {
     DatastoreService datastore, {
     String? customName,
   }) async {
-    log2.debug('Creating task from buildbucket result: ${build.toString()}');
+    log.debug('Creating task from buildbucket result: ${build.toString()}');
     // Example: Getting "flutter" from "mirrors/flutter".
     final repository = build.input.gitilesCommit.project.split('/')[1];
-    log2.debug('Repository: $repository');
+    log.debug('Repository: $repository');
 
     // Example: Getting "stable" from "refs/heads/stable".
     final branch = build.input.gitilesCommit.ref.split('/')[2];
-    log2.debug('Branch: $branch');
+    log.debug('Branch: $branch');
 
     final hash = build.input.gitilesCommit.id;
-    log2.debug('Hash: $hash');
+    log.debug('Hash: $hash');
 
     final slug = RepositorySlug('flutter', repository);
-    log2.debug('Slug: ${slug.toString()}');
+    log.debug('Slug: ${slug.toString()}');
 
     final startTime = build.startTime.toDateTime().millisecondsSinceEpoch;
     final endTime = build.endTime.toDateTime().millisecondsSinceEpoch;
-    log2.debug('Start/end time (ms): $startTime, $endTime');
+    log.debug('Start/end time (ms): $startTime, $endTime');
 
     final id = '${slug.fullName}/$branch/$hash';
     final commitKey = datastore.db.emptyKey.append<String>(Commit, id: id);

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -162,7 +162,7 @@ class CiStaging extends Document {
       // is an OK response to have. All fields should have been written at creation time.
       recordedConclusion = fields[checkRun]?.stringValue;
       if (recordedConclusion == null) {
-        log2.info(
+        log.info(
           '$logCrumb: $checkRun not present in doc for $transaction / $doc',
         );
         await docRes.rollback(
@@ -203,7 +203,7 @@ class CiStaging extends Document {
       // Only rollback the "failed" counter if this is a successful test run,
       // i.e. the test failed, the user requested a rerun, and now it passes.
       if (recordedConclusion == kFailureValue && conclusion == kSuccessValue) {
-        log2.info(
+        log.info(
           '$logCrumb: conclusion flipped to positive - assuming test was re-run',
         );
         if (failed == 0) {
@@ -217,7 +217,7 @@ class CiStaging extends Document {
       if ((recordedConclusion == kScheduledValue ||
               recordedConclusion == kSuccessValue) &&
           conclusion == kFailureValue) {
-        log2.info('$logCrumb: test failed');
+        log.info('$logCrumb: test failed');
         valid = true;
         failed = failed + 1;
       }
@@ -226,7 +226,7 @@ class CiStaging extends Document {
       checkRunGuard = fields[kCheckRunGuardField]?.stringValue;
 
       // All checks pass. "valid" is only set to true if there was a change in either the remaining or failed count.
-      log2.info(
+      log.info(
         '$logCrumb: setting remaining to $remaining, failed to $failed, and changing $recordedConclusion',
       );
       fields[checkRun] = Value(stringValue: conclusion);
@@ -235,7 +235,7 @@ class CiStaging extends Document {
     } on DetailedApiRequestError catch (e, stack) {
       if (e.status == 404) {
         // An attempt to read a document not in firestore should not be retried.
-        log2.info('$logCrumb: staging document not found for $transaction');
+        log.info('$logCrumb: staging document not found for $transaction');
         await docRes.rollback(
           RollbackRequest(transaction: transaction),
           kDatabase,
@@ -279,7 +279,7 @@ $stack
       writes: documentsToWrites([doc], exists: true),
     );
     final response = await docRes.commit(commitRequest, kDatabase);
-    log2.info(
+    log.info(
       '$logCrumb: results = ${response.writeResults?.map((e) => e.toJson())}',
     );
     return StagingConclusion(
@@ -346,10 +346,10 @@ For CI stage $stage:
         kCollectionId,
         documentId: documentIdFor(slug: slug, sha: sha, stage: stage),
       );
-      log2.info('$logCrumb: document created');
+      log.info('$logCrumb: document created');
       return newDoc;
     } catch (e) {
-      log2.warn('$logCrumb: failed to create document', e);
+      log.warn('$logCrumb: failed to create document', e);
       rethrow;
     }
   }

--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -96,10 +96,10 @@ class PrCheckRuns extends Document {
         kDocumentParent,
         kCollectionId,
       );
-      log2.info('$logCrumb: document created');
+      log.info('$logCrumb: document created');
       return newDoc;
     } catch (e) {
-      log2.warn('$logCrumb: failed to create document', e);
+      log.warn('$logCrumb: failed to create document', e);
       rethrow;
     }
   }
@@ -111,9 +111,9 @@ class PrCheckRuns extends Document {
     String checkRunName,
   ) async {
     final filterMap = <String, Object>{'$checkRunName =': '$checkRunId'};
-    log2.info('findDocumentFor($filterMap): finding prCheckRuns document');
+    log.info('findDocumentFor($filterMap): finding prCheckRuns document');
     final docs = await firestoreService.query(kCollectionId, filterMap);
-    log2.info('findDocumentFor($filterMap): found: $docs');
+    log.info('findDocumentFor($filterMap): found: $docs');
     return PrCheckRuns.fromDocument(docs.first).pullRequest;
   }
 
@@ -123,11 +123,9 @@ class PrCheckRuns extends Document {
     String sha,
   ) async {
     final filterMap = <String, Object>{'sha =': sha};
-    log2.info(
-      'findPullRequestForSha($filterMap): finding prCheckRuns document',
-    );
+    log.info('findPullRequestForSha($filterMap): finding prCheckRuns document');
     final docs = await firestoreService.query(kCollectionId, filterMap);
-    log2.info('findPullRequestForSha($filterMap): found: $docs');
+    log.info('findPullRequestForSha($filterMap): found: $docs');
     if (docs.isEmpty) return null;
     return PrCheckRuns.fromDocument(docs.first).pullRequest;
   }

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -45,7 +45,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     final datastore = datastoreProvider(config.db);
 
     if (message.data == null) {
-      log2.info('no data in message');
+      log.info('no data in message');
       return Body.empty;
     }
 
@@ -54,7 +54,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     final jsonBuildMap = json.decode(message.data!) as Map<String, dynamic>;
 
     if (jsonBuildMap['build'] == null) {
-      log2.info('no build information in message');
+      log.info('no build information in message');
       return Body.empty;
     }
 
@@ -66,7 +66,7 @@ class DartInternalSubscription extends SubscriptionHandler {
     // This should already be covered by the pubsub filter, but adding an additional check
     // to ensure we don't process builds that aren't from dart-internal/flutter.
     if (project != 'dart-internal' || bucket != 'flutter') {
-      log2.info('Ignoring build not from dart-internal/flutter bucket');
+      log.info('Ignoring build not from dart-internal/flutter bucket');
       return Body.empty;
     }
 
@@ -77,38 +77,38 @@ class DartInternalSubscription extends SubscriptionHandler {
       r'(Linux|Mac|Windows)\s+(engine_release_builder|packaging_release_builder|flutter_release_builder)',
     );
     if (!regex.hasMatch(builder)) {
-      log2.info('Ignoring builder that is not a release builder');
+      log.info('Ignoring builder that is not a release builder');
       return Body.empty;
     }
 
-    log2.info('Creating build request object with build id $buildId');
+    log.info('Creating build request object with build id $buildId');
 
     final getBuildRequest = bbv2.GetBuildRequest(id: buildId);
 
-    log2.info('Calling buildbucket api to get build data for build $buildId');
+    log.info('Calling buildbucket api to get build data for build $buildId');
 
     final existingBuild = await buildBucketClient.getBuild(getBuildRequest);
 
-    log2.info(
+    log.info(
       'Got back existing builder with name: ${existingBuild.builder.builder}',
     );
 
-    log2.info('Checking for existing task in datastore');
+    log.info('Checking for existing task in datastore');
     final existingTask = await datastore.getTaskFromBuildbucketBuild(
       existingBuild,
     );
 
     late Task taskToInsert;
     if (existingTask != null) {
-      log2.info('Updating Task from existing Build');
+      log.info('Updating Task from existing Build');
       existingTask.updateFromBuildbucketBuild(existingBuild);
       taskToInsert = existingTask;
     } else {
-      log2.info('Creating Task from Buildbucket result');
+      log.info('Creating Task from Buildbucket result');
       taskToInsert = await Task.fromBuildbucketBuild(existingBuild, datastore);
     }
 
-    log2.info('Inserting Task into the datastore: ${taskToInsert.toString()}');
+    log.info('Inserting Task into the datastore: ${taskToInsert.toString()}');
     await datastore.insert(<Task>[taskToInsert]);
     try {
       final firestoreService = await config.createFirestoreService();
@@ -119,7 +119,7 @@ class DartInternalSubscription extends SubscriptionHandler {
         kDatabase,
       );
     } catch (e) {
-      log2.warn('Failed to insert dart internal task into firestore', e);
+      log.warn('Failed to insert dart internal task into firestore', e);
     }
 
     return Body.forJson(taskToInsert.toString());

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -93,14 +93,14 @@ class GithubWebhookSubscription extends SubscriptionHandler {
   @override
   Future<Body> post() async {
     if (message.data == null || message.data!.isEmpty) {
-      log2.warn('GitHub webhook message was empty. No-oping');
+      log.warn('GitHub webhook message was empty. No-oping');
       return Body.empty;
     }
 
     final webhook = pb.GithubWebhookMessage.fromJson(message.data!);
 
-    log2.info('Processing ${webhook.event}');
-    log2.debug(webhook.payload);
+    log.info('Processing ${webhook.event}');
+    log.debug(webhook.payload);
     switch (webhook.event) {
       case 'pull_request':
         await _handlePullRequest(webhook.payload);
@@ -119,12 +119,12 @@ class GithubWebhookSubscription extends SubscriptionHandler {
             :final error,
             :final stackTrace,
           ):
-            log2.error(message, error, stackTrace);
+            log.error(message, error, stackTrace);
             throw InternalServerError(
               'Failed to process check_run event. checkRunEvent: $checkRunEvent',
             );
           case RecoverableErrorResult(:final message):
-            log2.info(
+            log.info(
               'User error state for check_run event ($checkRunEvent): $message',
             );
             response!.statusCode = HttpStatus.badRequest;
@@ -155,7 +155,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         // dart-internal builds that are triggered by the initial branch
         // creation have an associated commit.
         if (candidateBranchRegex.hasMatch(createEvent.ref!)) {
-          log2.debug(
+          log.debug(
             'Branch ${createEvent.ref} is a candidate branch, creating new '
             'commit in the datastore',
           );
@@ -186,7 +186,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     final slug = pr.base!.repo!.slug();
     if (!config.supportedRepos.contains(slug)) {
-      log2.warn(
+      log.warn(
         '$crumb: asked to handle unsupported repo $slug for ${pr.htmlUrl}',
       );
       throw const InternalServerError('Unsupported repository');
@@ -195,7 +195,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     // See the API reference:
     // https://developer.github.com/v3/activity/events/types/#pullrequestevent
     // which unfortunately is a bit light on explanations.
-    log2.info('$crumb: processing $eventAction for ${pr.htmlUrl}');
+    log.info('$crumb: processing $eventAction for ${pr.htmlUrl}');
     switch (eventAction) {
       case 'closed':
         await _processPullRequestClosed(pullRequestEvent);
@@ -217,7 +217,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         await _tryReleaseApproval(pullRequestEvent);
         break;
       case 'labeled':
-        log2.info(
+        log.info(
           '$crumb: PR labels = [${pr.labels?.map((label) => '"${label.name}"').join(', ')}]',
         );
         await _processLabels(pr);
@@ -282,21 +282,21 @@ class GithubWebhookSubscription extends SubscriptionHandler {
 
     // See the API reference:
     // https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group
-    log2.info('Processing $action for merge queue @ $headSha');
+    log.info('Processing $action for merge queue @ $headSha');
     switch (action) {
       // A merge group (a group of PRs to be tested a merged together) was
       // created and Github is requesting checks to be performed before merging
       // into the main branch. Cocoon should kick off CI jobs needed to verify
       // the PR group.
       case 'checks_requested':
-        log2.info('Checks requests for merge queue @ $headSha');
+        log.info('Checks requests for merge queue @ $headSha');
 
         if (!await _shaExistsInGob(slug, headSha)) {
           throw InternalServerError(
             '$slug/$headSha was not found on GoB. Failing so this event can be retried',
           );
         }
-        log2.info(
+        log.info(
           '$slug/$headSha was found on GoB mirror. Scheduling merge group tasks',
         );
         await scheduler.triggerMergeGroupTargets(
@@ -308,15 +308,15 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       // stopped to save CI resources, as Github will no longer merge this group
       // into the main branch.
       case 'destroyed':
-        log2.info(
+        log.info(
           'Merge group destroyed for $slug/$headSha because it was $reason.',
         );
         if (reason == 'invalidated' || reason == 'dequeued') {
           await scheduler.cancelDestroyedMergeGroupTargets(headSha: headSha);
         } else if (reason == 'merged') {
-          log2.info('Merge group for $slug/$headSha was merged successfully.');
+          log.info('Merge group for $slug/$headSha was merged successfully.');
         } else {
-          log2.warn(
+          log.warn(
             'Unrecognized reason for merge group destroyed event: $reason',
           );
         }
@@ -376,7 +376,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     final pr = pullRequestEvent.pullRequest!;
     final slug = pullRequestEvent.repository!.slug();
 
-    log2.info(
+    log.info(
       'Scheduling tasks if mergeable(${pr.mergeable}): owner=${slug.owner} repo=${slug.name} and pr=${pr.number}',
     );
 
@@ -447,7 +447,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     );
 
     if (pr.merged!) {
-      log2.debug('Pull request ${pr.number} was closed and merged.');
+      log.debug('Pull request ${pr.number} was closed and merged.');
 
       // To avoid polluting the repo with temporary revert branches, delete the
       // branch after the reverted PR is merged.
@@ -467,7 +467,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       final isRevertPullRequest =
           pr.labels?.any((label) => label.name == Config.revertOfLabel) == true;
       if (isRevertPullRequest) {
-        log2.info(
+        log.info(
           'Revert merged successfully, deleting branch ${pr.head!.ref!}',
         );
         final slug = pullRequestEvent.repository!.slug();
@@ -476,7 +476,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
       }
 
       if (await _commitExistsInGob(pr)) {
-        log2.debug(
+        log.debug(
           'Merged commit was found on GoB mirror. Scheduling postsubmit tasks...',
         );
         return scheduler.addPullRequest(pr);
@@ -538,7 +538,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
     }
 
     final slug = pr.base!.repo!.slug();
-    log2.info(
+    log.info(
       'Applying framework repo labels for: owner=${slug.owner} repo=${slug.name} isFusion=$isFusion and pr=${pr.number}',
     );
 
@@ -989,11 +989,11 @@ The "Merge" button is also unlocked. To bypass presubmits as well as the tree st
       '$PullRequestLabelProcessor($slug/pull/$prNumber)';
 
   void logInfo(Object? message) {
-    log2.info('$logCrumb: $message');
+    log.info('$logCrumb: $message');
   }
 
   void logSevere(Object? message, {Object? error, StackTrace? stackTrace}) {
-    log2.error('$logCrumb: $message', error, stackTrace);
+    log.error('$logCrumb: $message', error, stackTrace);
   }
 
   Future<void> processLabels() async {

--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -36,7 +36,7 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
     final quotaLimit = quotaUsage['limit'] as int;
     const githubQuotaUsageSLO = 0.5;
     if (remainingQuota < githubQuotaUsageSLO * quotaLimit) {
-      log2.warn(
+      log.warn(
         'Remaining GitHub quota is $remainingQuota, which is less than quota'
         'usage SLO ${githubQuotaUsageSLO * quotaLimit} '
         '(${githubQuotaUsageSLO * 100}% of the limit $quotaLimit)).',

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -55,7 +55,7 @@ class GithubWebhook extends RequestHandler<Body> {
         pb.GithubWebhookMessage.create()
           ..event = event
           ..payload = requestString;
-    log2.debug('$message');
+    log.debug('$message');
     await pubsub.publish(topic, message.writeToJsonMap());
 
     return Body.empty;

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -53,7 +53,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
   @override
   Future<Body> post() async {
     if (message.data == null) {
-      log2.info('no data in message');
+      log.info('no data in message');
       return Body.empty;
     }
 
@@ -71,34 +71,34 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       userDataMap =
           json.decode(String.fromCharCodes(pubSubCallBack.userData))
               as Map<String, dynamic>;
-      log2.info('User data was not base64 encoded.');
+      log.info('User data was not base64 encoded.');
     } on FormatException {
       userDataMap = UserData.decodeUserDataBytes(pubSubCallBack.userData);
-      log2.info('Decoding base64 encoded user data.');
+      log.info('Decoding base64 encoded user data.');
     }
 
     // collect userData
     if (userDataMap.isEmpty) {
-      log2.info('User data is empty');
+      log.info('User data is empty');
       return Body.empty;
     }
 
-    log2.debug('userData=$userDataMap');
+    log.debug('userData=$userDataMap');
 
     if (!buildsPubSub.hasBuild()) {
-      log2.warn('No build was found in message.');
+      log.warn('No build was found in message.');
       return Body.empty;
     }
 
     final build = buildsPubSub.build;
 
     // Note that result is no longer present in the output.
-    log2.debug('Updating buildId=${build.id} for result=${build.status}');
+    log.debug('Updating buildId=${build.id} for result=${build.status}');
 
     // Add build fields that are stored in a separate compressed buffer.
     build.mergeFromBuffer(ZLibCodec().decode(buildsPubSub.buildLargeFields));
 
-    log2.info('build ${build.toProto3Json()}');
+    log.info('build ${build.toProto3Json()}');
 
     final rawTaskKey = userDataMap['task_key'] as String?;
     final rawCommitKey = userDataMap['commit_key'] as String?;
@@ -117,7 +117,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     );
     Task? task;
     firestore.Task? firestoreTask;
-    log2.info(
+    log.info(
       'Looking up task document $kDatabase/documents/${firestore.kTaskCollectionId}/$taskDocumentName...',
     );
     final taskId = int.parse(rawTaskKey!);
@@ -128,13 +128,13 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
       documentName:
           '$kDatabase/documents/${firestore.kTaskCollectionId}/$taskDocumentName',
     );
-    log2.info('Found $firestoreTask');
+    log.info('Found $firestoreTask');
 
     if (_shouldUpdateTask(build, firestoreTask)) {
       final oldTaskStatus = firestoreTask.status;
       firestoreTask.updateFromBuild(build);
 
-      log2.info('Updated firestore task $firestoreTask');
+      log.info('Updated firestore task $firestoreTask');
 
       task.updateFromBuildbucketBuild(build);
       await datastore.insert(<Task>[task]);
@@ -143,11 +143,11 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
         BatchWriteRequest(writes: writes),
         kDatabase,
       );
-      log2.debug(
+      log.debug(
         'Updated datastore from $oldTaskStatus to ${firestoreTask.status}',
       );
     } else {
-      log2.debug(
+      log.debug(
         'skip processing for build with status scheduled or task with status '
         'finished.',
       );
@@ -166,7 +166,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     if (!postsubmitTargets.any(
       (element) => element.value.name == firestoreTask!.taskName,
     )) {
-      log2.warn(
+      log.warn(
         'Target ${firestoreTask.taskName} has been deleted from TOT. Skip '
         'updating.',
       );
@@ -178,7 +178,7 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
     if (firestoreTask.status == firestore.Task.statusFailed ||
         firestoreTask.status == firestore.Task.statusInfraFailure ||
         firestoreTask.status == firestore.Task.statusCancelled) {
-      log2.debug('Trying to auto-retry...');
+      log.debug('Trying to auto-retry...');
       final retried = await scheduler.luciBuildService.checkRerunBuilder(
         commit: commit,
         target: target,
@@ -187,13 +187,13 @@ class PostsubmitLuciSubscription extends SubscriptionHandler {
         taskDocument: firestoreTask,
         firestoreService: firestoreService,
       );
-      log2.info('Retried: $retried');
+      log.info('Retried: $retried');
     }
 
     // Only update GitHub checks if target is not bringup
     if (target.value.bringup == false &&
         config.postsubmitSupportedRepos.contains(target.slug)) {
-      log2.info('Updating check status for ${target.getTestName}');
+      log.info('Updating check status for ${target.getTestName}');
       await githubChecksService.updateCheckStatus(
         build: build,
         checkRunId: userDataMap['check_run_id'] as int,

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -57,7 +57,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
   @override
   Future<Body> post() async {
     if (message.data == null) {
-      log2.info('no data in message');
+      log.info('no data in message');
       return Body.empty;
     }
 
@@ -69,7 +69,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     final buildsPubSub = pubSubCallBack.buildPubsub;
 
     if (!buildsPubSub.hasBuild()) {
-      log2.info('no build information in message');
+      log.info('no build information in message');
       return Body.empty;
     }
 
@@ -81,18 +81,18 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     final builderName = build.builder.builder;
     final tagSet = BuildTags.fromStringPairs(build.tags);
 
-    log2.info('Available tags: $tagSet');
+    log.info('Available tags: $tagSet');
 
     // Skip status update if we can not get the sha tag.
     if (tagSet.buildTags.whereType<BuildSetBuildTag>().isEmpty) {
-      log2.warn('Buildset tag not included, skipping Status Updates');
+      log.warn('Buildset tag not included, skipping Status Updates');
       return Body.empty;
     }
 
-    log2.info('Setting status (${build.status}) for $builderName');
+    log.info('Setting status (${build.status}) for $builderName');
 
     if (!pubSubCallBack.hasUserData()) {
-      log2.info('No user data was found in this request');
+      log.info('No user data was found in this request');
       return Body.empty;
     }
 
@@ -101,10 +101,10 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
       userDataMap =
           json.decode(String.fromCharCodes(pubSubCallBack.userData))
               as Map<String, dynamic>;
-      log2.info('User data was not base64 encoded.');
+      log.info('User data was not base64 encoded.');
     } on FormatException {
       userDataMap = UserData.decodeUserDataBytes(pubSubCallBack.userData);
-      log2.info('Decoding base64 encoded user data.');
+      log.info('Decoding base64 encoded user data.');
     }
 
     if (userDataMap.containsKey('repo_owner') &&
@@ -126,7 +126,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
         );
         if (currentAttempt < maxAttempt) {
           rescheduled = true;
-          log2.info('Rerunning failed task: $builderName');
+          log.info('Rerunning failed task: $builderName');
           await luciBuildService.reschedulePresubmitBuild(
             builderName: builderName,
             build: build,
@@ -143,7 +143,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
         rescheduled: rescheduled,
       );
     } else {
-      log2.info('This repo does not support checks API');
+      log.info('This repo does not support checks API');
     }
     return Body.empty;
   }
@@ -191,13 +191,13 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
     // Do not block on the target not found.
     if (!targets.any((element) => element.value.name == builderName)) {
       // do not reschedule
-      log2.warn(
+      log.warn(
         'Did not find builder with name: $builderName in ciYaml for '
         '${commit.sha}',
       );
       final availableBuilderList =
           ciYaml.presubmitTargets().map((Target e) => e.value.name).toList();
-      log2.warn('ciYaml presubmit targets found: $availableBuilderList');
+      log.warn('ciYaml presubmit targets found: $availableBuilderList');
       return 1;
     }
 

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -37,7 +37,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   Future<Body> get() async {
     if (authContext!.clientContext.isDevelopmentEnvironment) {
       // Don't push GitHub status from the local dev server.
-      log2.debug('GitHub statuses are not pushed from local dev environments');
+      log.debug('GitHub statuses are not pushed from local dev environments');
       return Body.empty;
     }
 
@@ -59,7 +59,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
       config,
     );
     await _updatePRs(slug, status.githubStatus, datastore, firestoreService);
-    log2.debug('All the PRs for $repository have been updated with $status');
+    log.debug('All the PRs for $repository have been updated with $status');
 
     return Body.empty;
   }
@@ -79,7 +79,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     )) {
       // Tree status only affects the default branch - which github should filter for.. but check for a whoopsie.
       if (pr.base!.ref != Config.defaultBranch(slug)) {
-        log2.warn(
+        log.warn(
           'when asked for PRs for ${Config.defaultBranch(slug)} - github '
           'returns something else: $pr',
         );
@@ -102,7 +102,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
               ? GithubBuildStatus.statusNeutral
               : realStatus;
       if (githubBuildStatus.status != status) {
-        log2.log(
+        log.log(
           severity: hasEmergencyLabel ? Severity.warning : Severity.debug,
           'Updating status of ${slug.fullName}#${pr.number} from '
           '${githubBuildStatus.status} to $status',
@@ -132,7 +132,7 @@ class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
           );
           githubBuildStatuses.add(githubBuildStatus);
         } catch (e) {
-          log2.error(
+          log.error(
             'Failed to post status update to ${slug.fullName}#${pr.number}',
             e,
           );

--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -80,7 +80,7 @@ class RerunProdTask extends ApiRequestHandler<Body> {
     final slug = RepositorySlug('flutter', repo);
 
     if (taskName == 'all') {
-      log2.info(
+      log.info(
         'Attempting to reset all failed prod tasks for $commitSha in $repo...',
       );
       final commitKey = Commit.createKey(
@@ -95,7 +95,7 @@ class RerunProdTask extends ApiRequestHandler<Body> {
         if (!Task.taskFailStatusSet.contains(task.status)) {
           continue;
         }
-        log2.info('Resetting failed task ${task.name}');
+        log.info('Resetting failed task ${task.name}');
         futures.add(
           _rerun(
             datastore: datastore,
@@ -110,7 +110,7 @@ class RerunProdTask extends ApiRequestHandler<Body> {
       }
       await Future.wait(futures);
     } else {
-      log2.info(
+      log.info(
         'Attempting to reset prod task "$taskName" for $commitSha in $repo...',
       );
       await _rerun(
@@ -125,7 +125,7 @@ class RerunProdTask extends ApiRequestHandler<Body> {
       );
     }
 
-    log2.info('$taskName reset initiated successfully.');
+    log.info('$taskName reset initiated successfully.');
 
     return Body.empty;
   }

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -109,8 +109,8 @@ class BatchBackfiller extends RequestHandler {
     // Get the number of targets to be backfilled in each cycle.
     backfill = getFilteredBackfill(backfill);
 
-    log2.debug('Backfilling ${backfill.length} builds');
-    log2.debug(backfill.map((tuple) => tuple.first.value.name).toString());
+    log.debug('Backfilling ${backfill.length} builds');
+    log.debug(backfill.map((tuple) => tuple.first.value.name).toString());
 
     // Update tasks status as in progress to avoid duplicate scheduling.
     final backfillTasks = backfill.map((tuple) => tuple.second.task).toList();
@@ -118,7 +118,7 @@ class BatchBackfiller extends RequestHandler {
       await datastore.withTransaction<void>((transaction) async {
         transaction.queueMutations(inserts: backfillTasks);
         await transaction.commit();
-        log2.debug(
+        log.debug(
           'Updated ${backfillTasks.length} tasks: '
           '${backfillTasks.map((e) => e.name).toList()} when backfilling.',
         );
@@ -127,7 +127,7 @@ class BatchBackfiller extends RequestHandler {
       try {
         await updateTaskDocuments(backfillTasks);
       } catch (e) {
-        log2.warn(
+        log.warn(
           'Failed to update batch backfilled task documents in Firestore',
           e,
         );
@@ -137,7 +137,7 @@ class BatchBackfiller extends RequestHandler {
       // Schedule after db updates to avoid duplicate scheduling when db update fails.
       await _scheduleWithRetries(backfill);
     } catch (e) {
-      log2.error('Failed to update tasks when backfilling', e);
+      log.error('Failed to update tasks when backfilling', e);
     }
   }
 
@@ -212,7 +212,7 @@ class BatchBackfiller extends RequestHandler {
                   .where((element) => element.isNotEmpty)
                   .toList()
                   .length;
-          log2.info(
+          log.info(
             'Backfill fails and retry backfilling $nonEmptyListLenght targets.',
           );
           backfill = _updateBackfill(backfill, pendingTasks);
@@ -222,7 +222,7 @@ class BatchBackfiller extends RequestHandler {
         }
       }, retryIf: (Exception e) => e is InternalServerError);
     } catch (e) {
-      log2.error(
+      log.error(
         'Failed to backfill ${backfill.length} targets due to error',
         e,
       );

--- a/app_dart/lib/src/request_handlers/scheduler/scheduler_request_subscription.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/scheduler_request_subscription.dart
@@ -43,12 +43,12 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
   @override
   Future<Body> post() async {
     if (message.data == null) {
-      log2.info('no data in message');
+      log.info('no data in message');
       throw const BadRequestException('no data in message');
     }
 
     // final String data = message.data!;
-    log2.debug('attempting to read message ${message.data}');
+    log.debug('attempting to read message ${message.data}');
 
     final batchRequest = bbv2.BatchRequest.create();
 
@@ -57,7 +57,7 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
       jsonDecode(message.data!) as Map<String, dynamic>,
     );
 
-    log2.info(
+    log.info(
       'Read the following data: ${batchRequest.toProto3Json().toString()}',
     );
 
@@ -88,7 +88,7 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
         }
       }, retryIf: (Exception e) => e is InternalServerError);
     } catch (e) {
-      log2.warn(
+      log.warn(
         'Failed to schedule builds on exception: $unscheduledWarning.',
         e,
       );
@@ -117,7 +117,7 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
       if (url == null ||
           pathSegments.length != 2 ||
           int.tryParse(checkRunId ?? '') == null) {
-        log2.warn('missing url / github_checkrun for $builder');
+        log.warn('missing url / github_checkrun for $builder');
         continue;
       }
 
@@ -154,7 +154,7 @@ ${errors.isEmpty ? 'unknown' : errors.map((t) => t.trim()).join('\n')}
   /// Returns [List<bbv2.BatchRequest_Request>] of requests that need to be retried.
   Future<({List<bbv2.BatchRequest_Request> retries, List<String> errors})>
   _sendBatchRequest(bbv2.BatchRequest request) async {
-    log2.info('Sending batch request for ${request.toProto3Json().toString()}');
+    log.info('Sending batch request for ${request.toProto3Json().toString()}');
 
     final errors = <String>[];
 
@@ -162,14 +162,14 @@ ${errors.isEmpty ? 'unknown' : errors.map((t) => t.trim()).join('\n')}
     try {
       response = await buildBucketClient.batch(request);
     } catch (e) {
-      log2.error('Exception making batch Requests.', e);
+      log.error('Exception making batch Requests.', e);
       rethrow;
     }
 
-    log2.info(
+    log.info(
       'Made ${request.requests.length} and received ${response.responses.length}',
     );
-    log2.info('Responses: ${response.responses}');
+    log.info('Responses: ${response.responses}');
 
     final retry = <bbv2.BatchRequest_Request>[...request.requests];
     for (final batchResponseResponse in response.responses) {
@@ -180,7 +180,7 @@ ${errors.isEmpty ? 'unknown' : errors.map((t) => t.trim()).join('\n')}
               batchResponseResponse.scheduleBuild.builder,
         );
       } else {
-        log2.warn(
+        log.warn(
           'Response does not have schedule build: $batchResponseResponse',
         );
         errors.add('$batchResponseResponse');
@@ -188,7 +188,7 @@ ${errors.isEmpty ? 'unknown' : errors.map((t) => t.trim()).join('\n')}
 
       if (batchResponseResponse.hasError() &&
           batchResponseResponse.error.code != 0) {
-        log2.info('Non-zero grpc code: $batchResponseResponse');
+        log.info('Non-zero grpc code: $batchResponseResponse');
       }
     }
 

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -83,7 +83,7 @@ class VacuumStaleTasks extends RequestHandler<Body> {
         }
       }
     }
-    log2.info('Vacuuming stale tasks: $tasksToBeReset');
+    log.info('Vacuuming stale tasks: $tasksToBeReset');
     await datastore.insert(tasksToBeReset);
 
     await updateTaskDocuments(tasksToBeReset);

--- a/app_dart/lib/src/request_handlers/trigger_workflow.dart
+++ b/app_dart/lib/src/request_handlers/trigger_workflow.dart
@@ -47,7 +47,7 @@ class TriggerWorkflow extends ApiRequestHandler<Body> {
       body: json.encode({'ref': ref}),
     );
     if (response.statusCode != 204 || response.body.isNotEmpty) {
-      log2.warn(
+      log.warn(
         'trigger-workflow($ref, $workflow): failed; ${response.statusCode} / '
         '${response.body}',
       );

--- a/app_dart/lib/src/request_handlers/update_task_status.dart
+++ b/app_dart/lib/src/request_handlers/update_task_status.dart
@@ -79,7 +79,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
         task.isTestFlaky!,
       );
     } catch (e) {
-      log2.warn('Failed to update task in Firestore', e);
+      log.warn('Failed to update task in Firestore', e);
     }
     return UpdateTaskStatusResponse(task);
   }
@@ -93,7 +93,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final sha = (requestData![gitShaParam] as String).trim();
     final taskName = requestData![builderNameParam] as String?;
     final documentName = '$kDatabase/documents/tasks/${sha}_${taskName}_1';
-    log2.info('getting firestore document: $documentName');
+    log.info('getting firestore document: $documentName');
     final initialTasks = await firestoreService.queryCommitTasks(sha);
     // Targets the latest task. This assumes only one task is running at any time.
     final firestoreTask = initialTasks
@@ -126,9 +126,9 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     final builderName = requestData![builderNameParam] as String?;
     final query = datastore.db.query<Task>(ancestorKey: commitKey);
     final initialTasks = await query.run().toList();
-    log2.debug('Found ${initialTasks.length} tasks for commit');
+    log.debug('Found ${initialTasks.length} tasks for commit');
     final tasks = <Task>[];
-    log2.debug('Searching for task with builderName=$builderName');
+    log.debug('Searching for task with builderName=$builderName');
     for (var task in initialTasks) {
       if (task.builderName == builderName || task.name == builderName) {
         tasks.add(task);
@@ -136,7 +136,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
     }
 
     if (tasks.length != 1) {
-      log2.error('Found ${tasks.length} entries for builder $builderName');
+      log.error('Found ${tasks.length} entries for builder $builderName');
       throw InternalServerError(
         'Expected to find 1 task for $builderName, but found ${tasks.length}',
       );
@@ -154,7 +154,7 @@ class UpdateTaskStatus extends ApiRequestHandler<UpdateTaskStatusResponse> {
 
     final id = 'flutter/flutter/$gitBranch/$gitSha';
     final commitKey = datastore.db.emptyKey.append<String>(Commit, id: id);
-    log2.debug('Constructed commit key=$id');
+    log.debug('Constructed commit key=$id');
     // Return the official key from Datastore for task lookups.
     final commit = await config.db.lookupValue<Commit>(commitKey);
     return commit.key;

--- a/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
@@ -74,7 +74,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
     final queryAfter = DateTime.now().subtract(const Duration(days: 1));
     final queryBefore = DateTime.now().subtract(const Duration(minutes: 3));
     try {
-      log2.debug(
+      log.debug(
         'Listing commit for slug: $slug branch: $branch and msSinceEpoch: '
         '${queryAfter.millisecondsSinceEpoch}',
       );
@@ -83,7 +83,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
         branch,
         queryAfter.millisecondsSinceEpoch,
       );
-      log2.debug('Retrieved ${commits.length} commits from GitHub');
+      log.debug('Retrieved ${commits.length} commits from GitHub');
       // Do not try to add recent commits as they may already be processed
       // by cocoon, which can cause race conditions.
       commits =
@@ -95,7 +95,7 @@ class VacuumGithubCommits extends ApiRequestHandler<Body> {
               )
               .toList();
     } on gh.GitHubError catch (e) {
-      log2.error('Failed retriving commits from GitHub', e);
+      log.error('Failed retriving commits from GitHub', e);
     }
 
     return _toDatastoreCommit(slug, commits, datastore, branch);

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -115,7 +115,7 @@ class AuthenticationProvider {
       if (verifyTokenResponse.statusCode != HttpStatus.ok) {
         /// Google Auth API returns a message in the response body explaining why
         /// the request failed. Such as "Invalid Token".
-        log2.debug(
+        log.debug(
           'Token verification failed: ${verifyTokenResponse.statusCode}; '
           '${verifyTokenResponse.body}',
         );
@@ -143,7 +143,7 @@ class AuthenticationProvider {
     // Authenticate as a signed-in Google account via OAuth id token.
     final clientId = await config.oauthClientId;
     if (token.audience != clientId && !token.email!.endsWith('@google.com')) {
-      log2.warn(
+      log.warn(
         'Possible forged token: "${token.audience}" (expected "$clientId")',
       );
       throw const Unauthenticated('Invalid ID token');

--- a/app_dart/lib/src/request_handling/pubsub.dart
+++ b/app_dart/lib/src/request_handling/pubsub.dart
@@ -34,7 +34,7 @@ class PubSub {
       request,
       fullTopicName,
     );
-    log2.info('pubsub response messageId=${response.messageIds}');
+    log.info('pubsub response messageId=${response.messageIds}');
     return response.messageIds!;
   }
 }

--- a/app_dart/lib/src/request_handling/pubsub_authentication.dart
+++ b/app_dart/lib/src/request_handling/pubsub_authentication.dart
@@ -48,7 +48,7 @@ class PubsubAuthenticationProvider extends AuthenticationProvider {
 
     final clientContext = clientContextProvider();
 
-    log2.debug('Authenticating as pubsub message');
+    log.debug('Authenticating as pubsub message');
     return authenticateIdToken(idToken, clientContext: clientContext);
   }
 

--- a/app_dart/lib/src/request_handling/request_handler.dart
+++ b/app_dart/lib/src/request_handling/request_handler.dart
@@ -57,7 +57,7 @@ abstract class RequestHandler<T extends Body> {
           } on HttpStatusException {
             rethrow;
           } catch (e, s) {
-            log2.error('Internal server error', e, s);
+            log.error('Internal server error', e, s);
             throw InternalServerError('$e\n$s');
           }
         } on HttpStatusException catch (error) {

--- a/app_dart/lib/src/request_handling/subscription_handler.dart
+++ b/app_dart/lib/src/request_handling/subscription_handler.dart
@@ -87,7 +87,7 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
       return;
     }
 
-    log2.info('Request body: ${utf8.decode(body)}');
+    log.info('Request body: ${utf8.decode(body)}');
     PubSubPushMessage? pubSubPushMessage;
     if (body.isNotEmpty) {
       try {
@@ -108,7 +108,7 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
       throw const BadRequestException('Failed to get message');
     }
 
-    log2.debug(pubSubPushMessage.toString());
+    log.debug(pubSubPushMessage.toString());
 
     final messageId = pubSubPushMessage.message!.messageId!;
 
@@ -137,17 +137,17 @@ abstract class SubscriptionHandler extends RequestHandler<Body> {
       ttl: const Duration(days: 1),
     );
 
-    log2.info('Processing message $messageId');
+    log.info('Processing message $messageId');
     await runZoned<Future<void>>(
       () async => super.service(
         request,
         onError: (e) async {
-          log2.warn(
+          log.warn(
             'Failed to process $message. (${e.statusCode}) ${e.message}',
             e,
           );
           await cache.purge(subscriptionName, messageId);
-          log2.info('Purged write lock from cache');
+          log.info('Purged write lock from cache');
         },
       ),
       zoneValues: <RequestKey<dynamic>, Object?>{

--- a/app_dart/lib/src/request_handling/swarming_authentication.dart
+++ b/app_dart/lib/src/request_handling/swarming_authentication.dart
@@ -53,7 +53,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
     final clientContext = clientContextProvider();
 
     if (swarmingToken != null) {
-      log2.debug('Authenticating as swarming task');
+      log.debug('Authenticating as swarming task');
       return authenticateAccessToken(
         swarmingToken,
         clientContext: clientContext,
@@ -78,7 +78,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
     // Authenticate as a signed-in Google account via OAuth id token.
     final client = httpClientProvider();
     try {
-      log2.debug('Sending token request to Google OAuth');
+      log.debug('Sending token request to Google OAuth');
       final verifyTokenResponse = await client.get(
         Uri.https('oauth2.googleapis.com', '/tokeninfo', <String, String>{
           'access_token': accessToken,
@@ -89,7 +89,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
         /// Google Auth API returns a message in the response body explaining why
         /// the request failed. Such as "Invalid Token".
         final body = verifyTokenResponse.body;
-        log2.warnJson(
+        log.warnJson(
           'Token verification failed: ${verifyTokenResponse.statusCode}; $body',
         );
         throw const Unauthenticated('Invalid access token');
@@ -101,7 +101,7 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
           json.decode(verifyTokenResponse.body) as Map<String, dynamic>,
         );
       } on FormatException {
-        log2.warn('Failed to decode token JSON: ${verifyTokenResponse.body}');
+        log.warn('Failed to decode token JSON: ${verifyTokenResponse.body}');
         throw InternalServerError(
           'Invalid JSON: "${verifyTokenResponse.body}"',
         );
@@ -113,12 +113,12 @@ class SwarmingAuthenticationProvider extends AuthenticationProvider {
       }
 
       if (token.email == Config.frobAccount) {
-        log2.debug('Authenticating as FRoB request');
+        log.debug('Authenticating as FRoB request');
         return AuthenticatedContext(clientContext: clientContext);
       }
 
-      log2.debug(verifyTokenResponse.body);
-      log2.warn('${token.email} is not allowed');
+      log.debug(verifyTokenResponse.body);
+      log.warn('${token.email} is not allowed');
       throw Unauthenticated('${token.email} is not allowed');
     } finally {
       client.close();

--- a/app_dart/lib/src/service/branch_service.dart
+++ b/app_dart/lib/src/service/branch_service.dart
@@ -54,14 +54,14 @@ interface class BranchService {
       filterRegex: branch,
     )).contains(branch)) {
       // subString is a regex, and can return multiple matches
-      log2.warn('$branch already exists for $recipesSlug');
+      log.warn('$branch already exists for $recipesSlug');
       throw BadRequestException('$branch already exists');
     }
     final recipeCommits = await _gerritService.commits(
       recipesSlug,
       Config.defaultBranch(recipesSlug),
     );
-    log2.info('$recipesSlug commits: $recipeCommits');
+    log.info('$recipesSlug commits: $recipeCommits');
     final engineCommit = await _retryOptions.retry(() async {
       // This attempts to regenerate the OAuth token, which is why it isn't stored as a dependency.
       final githubService = await _config.createDefaultGitHubService();
@@ -70,12 +70,12 @@ interface class BranchService {
         engineSha,
       );
     }, retryIf: (Exception e) => e is gh.GitHubError);
-    log2.info('${Config.flutterSlug} commit: $engineCommit');
+    log.info('${Config.flutterSlug} commit: $engineCommit');
     final branchTime = engineCommit.commit?.committer?.date;
     if (branchTime == null) {
       throw BadRequestException('$engineSha has no commit time');
     }
-    log2.info('Searching for a recipe commit before $branchTime');
+    log.info('Searching for a recipe commit before $branchTime');
     for (var recipeCommit in recipeCommits) {
       final recipeTime = recipeCommit.author?.time;
 
@@ -109,7 +109,7 @@ interface class BranchService {
         branchName: channel,
       );
       if (reference == null) {
-        log2.warn('Could not resolve release branch for "$channel"');
+        log.warn('Could not resolve release branch for "$channel"');
         continue;
       }
       results.add(ReleaseBranch(channel: channel, reference: reference));
@@ -135,7 +135,7 @@ interface class BranchService {
       );
       return content.trim();
     } catch (e, s) {
-      log2.error('Could not fetch release version file', e, s);
+      log.error('Could not fetch release version file', e, s);
       return null;
     }
   }

--- a/app_dart/lib/src/service/build_bucket_client.dart
+++ b/app_dart/lib/src/service/build_bucket_client.dart
@@ -70,7 +70,7 @@ class BuildBucketClient {
     final url = Uri.parse('$buildBucketUri$path');
     final token = await accessTokenService?.createAccessToken();
 
-    log2.info('Making bbv2 request with path: $url and body: $request');
+    log.info('Making bbv2 request with path: $url and body: $request');
 
     final response = await httpClient.post(
       url,
@@ -83,8 +83,8 @@ class BuildBucketClient {
       },
     );
 
-    log2.info('bbv2 request returned response code ${response.statusCode}');
-    log2.info('bbv2 request response body: ${response.body}');
+    log.info('bbv2 request returned response code ${response.statusCode}');
+    log.info('bbv2 request response body: ${response.body}');
 
     if (response.statusCode < 300) {
       return response.body.substring(kRpcResponseGarbage.length);
@@ -147,7 +147,7 @@ class BuildBucketClient {
     if (response.responses.length != request.requests.length) {
       throw BatchRequestException('Failed to execute all requests');
     }
-    log2.info('Batch response matches request size.');
+    log.info('Batch response matches request size.');
     return response;
   }
 

--- a/app_dart/lib/src/service/cache_service.dart
+++ b/app_dart/lib/src/service/cache_service.dart
@@ -112,7 +112,7 @@ class CacheService {
     } catch (e) {
       // If the last retry is unsuccessful on an exception we do not want to die
       // here.
-      log2.warn('Unable to retrieve value for $key from cache.', e);
+      log.warn('Unable to retrieve value for $key from cache.', e);
       value = null;
     }
 

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -33,7 +33,7 @@ class CommitService {
     final datastore = datastoreProvider(config.db);
     final slug = RepositorySlug.full(createEvent.repository!.fullName);
     final branch = createEvent.ref!;
-    log2.info(
+    log.info(
       'Creating commit object for branch $branch in repository ${slug.fullName}',
     );
     final commit = await _createCommitFromBranchEvent(datastore, slug, branch);
@@ -106,10 +106,10 @@ class CommitService {
     final firestoreService = await config.createFirestoreService();
     final datastore = datastoreProvider(config.db);
     try {
-      log2.info('Checking for existing commit in the datastore');
+      log.info('Checking for existing commit in the datastore');
       await datastore.lookupByValue<Commit>(commit.key);
     } on KeyNotFoundException {
-      log2.info('Commit does not exist in datastore, inserting into datastore');
+      log.info('Commit does not exist in datastore, inserting into datastore');
       await datastore.insert(<Commit>[commit]);
       try {
         final commitDocument = firestore.commitToCommitDocument(commit);
@@ -119,7 +119,7 @@ class CommitService {
           kDatabase,
         );
       } catch (e) {
-        log2.warn('Failed to insert new branched commit in Firestore', e);
+        log.warn('Failed to insert new branched commit in Firestore', e);
       }
     }
   }

--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -453,13 +453,13 @@ class Config {
     final response = await http.post(githubAccessTokensUri, headers: headers);
     final jsonBody = jsonDecode(response.body) as Map<String, dynamic>;
     if (jsonBody.containsKey('token') == false) {
-      log2.warn(response.body);
+      log.warn(response.body);
       throw Exception(
         'generateGitHubToken failed to get token from Github for repo=${slug.fullName}',
       );
     }
     final token = jsonBody['token'] as String;
-    log2.debug('Generated a new GitHub token for ${slug.fullName}');
+    log.debug('Generated a new GitHub token for ${slug.fullName}');
     return Uint8List.fromList(token.codeUnits);
   }
 

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -320,21 +320,21 @@ class DatastoreService {
     bbv2.Build build, {
     String? customName,
   }) async {
-    log2.debug(
+    log.debug(
       'Generating commit key from buildbucket build: ${build.toString()}',
     );
 
     final repository = build.input.gitilesCommit.project.split('/')[1];
-    log2.debug('Repository: $repository');
+    log.debug('Repository: $repository');
 
     final branch = build.input.gitilesCommit.ref.split('/')[2];
-    log2.debug('Branch: $branch');
+    log.debug('Branch: $branch');
 
     final hash = build.input.gitilesCommit.id;
-    log2.debug('Hash: $hash');
+    log.debug('Hash: $hash');
 
     final slug = RepositorySlug('flutter', repository);
-    log2.debug('Slug: ${slug.toString()}');
+    log.debug('Slug: ${slug.toString()}');
 
     final id = '${slug.fullName}/$branch/$hash';
     final commitKey = db.emptyKey.append<String>(Commit, id: id);
@@ -346,7 +346,7 @@ class DatastoreService {
         name: customName ?? build.builder.builder,
       );
     } on InternalServerError catch (e) {
-      log2.warn('Failed to find an existing task for the buildbucket build', e);
+      log.warn('Failed to find an existing task for the buildbucket build', e);
       return null;
     }
   }

--- a/app_dart/lib/src/service/gerrit_service.dart
+++ b/app_dart/lib/src/service/gerrit_service.dart
@@ -115,10 +115,10 @@ class GerritService {
       host: '${slug.owner}-review.googlesource.com',
       path: 'projects/$projectName/commits/$commitId',
     );
-    log2.info('Gerrit get-commit url: $url');
+    log.info('Gerrit get-commit url: $url');
 
     final response = await _get(url);
-    log2.info('Gob commit response for commit $commitId: ${response.body}');
+    log.info('Gob commit response for commit $commitId: ${response.body}');
     if (!_responseIsAcceptable(response)) return null;
 
     final jsonBody = _stripXssToken(response.body);
@@ -143,17 +143,17 @@ class GerritService {
     String branchName,
     String revision,
   ) async {
-    log2.info('Creating branch $branchName at $revision');
+    log.info('Creating branch $branchName at $revision');
     final url = Uri.https(
       '${slug.owner}-review.googlesource.com',
       'projects/${slug.name}/branches/$branchName',
     );
     final response = await _put(url, body: revision) as Map<String, dynamic>;
-    log2.info('$response');
+    log.info('$response');
     if (response['revision'] != revision) {
       throw const InternalServerError('Failed to create branch');
     }
-    log2.info('Created branch $branchName');
+    log.info('Created branch $branchName');
   }
 
   Future<dynamic> _getJson(Uri url) async {
@@ -188,11 +188,11 @@ class GerritService {
         'Gerrit returned ${response.statusCode} which is not 200 or 202',
       );
     }
-    log2.info('Sent PUT to $url');
-    log2.info(response.body);
+    log.info('Sent PUT to $url');
+    log.info(response.body);
     // Remove XSS token
     final jsonBody = _stripXssToken(response.body);
-    log2.info(jsonBody);
+    log.info(jsonBody);
     return jsonDecode(jsonBody);
   }
 

--- a/app_dart/lib/src/service/github_checks_service.dart
+++ b/app_dart/lib/src/service/github_checks_service.dart
@@ -48,7 +48,7 @@ class GithubChecksService {
     bool rescheduled = false,
   }) async {
     var status = statusForResult(build.status);
-    log2.info('status for build ${build.id} is ${status.value}');
+    log.info('status for build ${build.id} is ${status.value}');
 
     // Only `id` and `name` in the CheckRun are needed.
     // Instead of making an API call to get the details of each check run, we
@@ -66,7 +66,7 @@ class GithubChecksService {
         (terminalStatuses.contains(build.status))
             ? conclusionForResult(build.status)
             : null;
-    log2.info(
+    log.info(
       'conclusion for build ${build.id} is ${(conclusion != null) ? conclusion.value : null}',
     );
 
@@ -74,7 +74,7 @@ class GithubChecksService {
     github.CheckRunOutput? output;
     // If status has completed with failure then provide more details.
     if (taskFailed(build.status)) {
-      log2.info(
+      log.info(
         'failed presubmit task, ${build.id} has failed, status = ${build.status.toString()}',
       );
       if (rescheduled) {
@@ -98,7 +98,7 @@ class GithubChecksService {
           title: checkRun.name!,
           summary: getGithubSummary(buildbucketBuild.summaryMarkdown),
         );
-        log2.debug(
+        log.debug(
           'Updating check run with output: [${output.toJson().toString()}]',
         );
       }

--- a/app_dart/lib/src/service/luci_build_service/user_data.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.dart
@@ -24,7 +24,7 @@ sealed class PubSubUserData {
       jsonObject = json.decode(utf8.decode(bytes)) as Map<String, dynamic>;
     } on FormatException {
       // TODO(matanlurey): Remove legacy cases. https://github.com/flutter/flutter/issues/164568.
-      log2.warn(
+      log.warn(
         'Expected JSON encoding. See https://github.com/flutter/flutter/issues/164568.',
       );
       final encodedBytes = String.fromCharCodes(bytes);

--- a/app_dart/lib/src/service/scheduler/policy.dart
+++ b/app_dart/lib/src/service/scheduler/policy.dart
@@ -34,7 +34,7 @@ final class GuaranteedPolicy implements SchedulerPolicy {
       (Task t) => t.taskName == taskName && t.commitSha == commitSha,
     );
     if (recentTasks.isEmpty) {
-      log2.warn(
+      log.warn(
         '$taskName is newly added, triggerring builds regardless of policy',
       );
       return LuciBuildService.kDefaultPriority;
@@ -75,7 +75,7 @@ final class BatchPolicy implements SchedulerPolicy {
       (Task t) => t.taskName == taskName && t.commitSha == commitSha,
     );
     if (recentTasks.length < kBatchSize) {
-      log2.warn(
+      log.warn(
         '$taskName has less than $kBatchSize, skip scheduling to wait for '
         'ci.yaml roll.',
       );

--- a/app_dart/test/foundation/utils_test.dart
+++ b/app_dart/test/foundation/utils_test.dart
@@ -99,14 +99,14 @@ void main() {
         ]);
 
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             contains(
               logThat(message: anything, severity: equals(Severity.info)),
             ),
           ),
         );
-        expect(log2, hasNoWarningsOrHigher);
+        expect(log, hasNoWarningsOrHigher);
       });
 
       test('falls back to git on borg', () async {
@@ -194,7 +194,7 @@ void main() {
         // It will request from GitHub 3 times, fallback to GoB, then fail.
         expect(retry, 6);
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             containsAll([
               logThat(

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -852,7 +852,7 @@ void main() {
       await tester.post(webhook);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           containsAll([
             logThat(message: equals('Processing pull_request')),
@@ -2836,7 +2836,7 @@ void foo() {
         await pullRequestLabelProcessor.processLabels();
 
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             containsAll([
               logThat(
@@ -2890,7 +2890,7 @@ void foo() {
           await pullRequestLabelProcessor.processLabels();
 
           expect(
-            log2,
+            log,
             bufferedLoggerOf(
               containsAll([
                 logThat(
@@ -2923,7 +2923,7 @@ void foo() {
           await pullRequestLabelProcessor.processLabels();
 
           expect(
-            log2,
+            log,
             bufferedLoggerOf(
               containsAll([
                 logThat(
@@ -3146,7 +3146,7 @@ void foo() {
       ).called(1);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           containsAllInOrder([
             logThat(message: equals('Processing merge_group')),
@@ -3270,7 +3270,7 @@ void foo() {
       ]);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           containsAllInOrder([
             logThat(message: equals('Processing merge_group')),
@@ -3350,7 +3350,7 @@ void foo() {
       ]);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           containsAllInOrder([
             logThat(message: equals('Processing merge_group')),
@@ -3403,7 +3403,7 @@ void foo() {
       await tester.post(webhook);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           containsAllInOrder([
             logThat(message: equals('Processing merge_group')),

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
-import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
@@ -14,7 +13,6 @@ import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:googleapis/firestore/v1.dart';
-import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -41,28 +39,12 @@ void main() {
   late MockGithubChecksUtil mockGithubChecksUtil;
   late FakeScheduler scheduler;
   late FakeCiYamlFetcher ciYamlFetcher;
-  late List<String> logs;
 
   firestore.Task? firestoreTask;
   firestore_commit.Commit? firestoreCommit;
   late int attempt;
 
   setUp(() async {
-    logs = [];
-    log = Logger.detached('postsubmit_luci_subscription_test');
-    log.onRecord.listen((r) {
-      final buffer = StringBuffer(r.message);
-      if (r.error case final error?) {
-        buffer.writeln();
-        buffer.writeln('$error');
-      }
-      if (r.stackTrace case final stackTrace?) {
-        buffer.writeln();
-        buffer.writeln('$stackTrace');
-      }
-      logs.add('$buffer');
-    });
-
     firestoreTask = null;
     attempt = 0;
     mockGithubChecksUtil = MockGithubChecksUtil();
@@ -138,10 +120,6 @@ void main() {
     );
     request = FakeHttpRequest();
     tester = SubscriptionTester(request: request);
-  });
-
-  tearDown(() {
-    printOnFailure('LOGGER BUFFER:\n${logs.join('\n')}');
   });
 
   test('throws exception when task document name is not in message', () async {

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:cocoon_common_test/cocoon_common_test.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_server_test/mocks.dart';
 import 'package:cocoon_server_test/test_logging.dart';
@@ -20,7 +21,6 @@ import 'package:googleapis/firestore/v1.dart';
 import 'package:graphql/client.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:retry/retry.dart';
 import 'package:test/test.dart';
@@ -52,8 +52,6 @@ void main() {
     late MockClient mockHttpClient;
     late RepositorySlug slug;
     late RetryOptions retryOptions;
-
-    final records = <LogRecord>[];
 
     setUp(() {
       clientContext = FakeClientContext();
@@ -103,8 +101,6 @@ void main() {
 
       slug = RepositorySlug('flutter', 'flutter');
       checkRuns.clear();
-      records.clear();
-      log.onRecord.listen(records.add);
     });
 
     group('in development environment', () {
@@ -250,14 +246,7 @@ void main() {
           prsFromGitHub = <PullRequest>[];
           final body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
         });
 
         test(
@@ -281,16 +270,7 @@ void main() {
 
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             // Should not apply labels or make comments
             verifyNever(
@@ -324,16 +304,7 @@ void main() {
             githubGoldStatus = newGithubGoldStatus(slug, pr, '', '', '');
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             // Should not apply labels or make comments
             verifyNever(
@@ -383,14 +354,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -439,14 +403,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -528,16 +485,7 @@ void main() {
             verifyNever(
               mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
             );
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             // Should not apply labels or make comments
             verifyNever(
@@ -578,16 +526,7 @@ void main() {
             verifyNever(
               mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
             );
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             // Should not apply labels or make comments
             verifyNever(
@@ -626,14 +565,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -665,14 +597,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -720,16 +645,7 @@ void main() {
             verifyNever(
               mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
             );
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             // Should not apply labels, should comment to update
             verifyNever(
@@ -780,14 +696,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -831,14 +740,7 @@ void main() {
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           // Should not apply labels or make comments
           verifyNever(
@@ -880,14 +782,7 @@ void main() {
           expect(body, same(Body.empty));
           expect(status.updates, 1);
           expect(status.status, GithubGoldStatusUpdate.statusRunning);
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           final captured =
               verify(
@@ -959,14 +854,7 @@ void main() {
           expect(body, same(Body.empty));
           expect(status.updates, 1);
           expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           final captured =
               verify(
@@ -1039,14 +927,7 @@ void main() {
           expect(body, same(Body.empty));
           expect(status.updates, 1);
           expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           final captured =
               verify(
@@ -1139,14 +1020,7 @@ void main() {
           expect(body, same(Body.empty));
           expect(status.updates, 1);
           expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
 
           final captured =
               verify(
@@ -1234,16 +1108,7 @@ void main() {
             expect(body, same(Body.empty));
             expect(status.updates, 1);
             expect(status.status, GithubGoldStatusUpdate.statusRunning);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             final captured =
                 verify(
@@ -1343,16 +1208,7 @@ void main() {
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
             expect(status.updates, 1);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             final captured =
                 verify(
@@ -1452,16 +1308,7 @@ void main() {
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
             expect(status.updates, 1);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             final captured =
                 verify(
@@ -1575,16 +1422,7 @@ void main() {
             expect(body, same(Body.empty));
             expect(status.updates, 1);
             expect(status.status, GithubGoldStatusUpdate.statusCompleted);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             final captured =
                 verify(
@@ -1660,16 +1498,7 @@ void main() {
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
             expect(status.updates, 0);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
             verifyNever(
               mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
             );
@@ -1732,16 +1561,7 @@ void main() {
             final body = await tester.get<Body>(handler);
             expect(body, same(Body.empty));
             expect(status.updates, 0);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
             verifyNever(
               mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
             );
@@ -1786,16 +1606,7 @@ void main() {
             expect(body, same(Body.empty));
             expect(status.updates, 1);
             expect(status.status, GithubGoldStatusUpdate.statusRunning);
-            expect(
-              records.where(
-                (LogRecord record) => record.level == Level.WARNING,
-              ),
-              isEmpty,
-            );
-            expect(
-              records.where((LogRecord record) => record.level == Level.SEVERE),
-              isEmpty,
-            );
+            expect(log, hasNoWarningsOrHigher);
 
             final captured =
                 verify(
@@ -1920,14 +1731,7 @@ void main() {
             githubGoldStatusNext!.status,
             GithubGoldStatusUpdate.statusCompleted,
           );
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
         },
       );
 
@@ -1965,14 +1769,7 @@ void main() {
           final body = await tester.get<Body>(handler);
           expect(body, same(Body.empty));
           expect(status.updates, 0);
-          expect(
-            records.where((LogRecord record) => record.level == Level.WARNING),
-            isEmpty,
-          );
-          expect(
-            records.where((LogRecord record) => record.level == Level.SEVERE),
-            isEmpty,
-          );
+          expect(log, hasNoWarningsOrHigher);
           verifyNever(
             mockFirestoreService.batchWriteDocuments(captureAny, captureAny),
           );

--- a/app_dart/test/request_handling/api_request_handler_test.dart
+++ b/app_dart/test/request_handling/api_request_handler_test.dart
@@ -27,17 +27,12 @@ void main() {
     setUpAll(() async {
       server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       server.listen((HttpRequest request) {
-        final spec = ZoneSpecification(
-          print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
-            log.fine(line);
-          },
-        );
         runZoned<dynamic>(() {
           return ss.fork(() {
             ss.register(#appengine.logging, log);
             return handler.service(request);
           });
-        }, zoneSpecification: spec);
+        });
       });
     });
 
@@ -67,7 +62,7 @@ void main() {
       final response = await issueRequest();
       expect(response.statusCode, HttpStatus.unauthorized);
       expect(await utf8.decoder.bind(response).join(), 'Not authenticated');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('empty request body yields empty requestData', () async {
@@ -77,7 +72,7 @@ void main() {
       expect(response.headers.value('X-Test-RequestData'), '{}');
       expect(response.statusCode, HttpStatus.ok);
       expect(await response.toList(), isEmpty);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('JSON request body yields valid requestData', () async {
@@ -87,7 +82,7 @@ void main() {
       expect(response.headers.value('X-Test-RequestData'), '{param1: value1}');
       expect(response.statusCode, HttpStatus.ok);
       expect(await response.toList(), isEmpty);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('non-JSON request body yields HTTP ok', () async {
@@ -97,7 +92,7 @@ void main() {
       expect(response.headers.value('X-Test-RequestBody'), '[97, 98, 99]');
       expect(response.headers.value('X-Test-RequestData'), '{}');
       expect(await response.toList(), isEmpty);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('can access authContext', () async {
@@ -105,7 +100,7 @@ void main() {
       final response = await issueRequest();
       expect(response.headers.value('X-Test-IsDev'), 'true');
       expect(response.statusCode, HttpStatus.ok);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test(
@@ -126,7 +121,7 @@ void main() {
           body: '{"param1":"value1","param2":"value2","extra":"yes"}',
         );
         expect(response.statusCode, HttpStatus.ok);
-        expect(log2, bufferedLoggerOf(isEmpty));
+        expect(log, bufferedLoggerOf(isEmpty));
       },
     );
   });

--- a/app_dart/test/request_handling/authentication_test.dart
+++ b/app_dart/test/request_handling/authentication_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:cocoon_common_test/cocoon_common_test.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/model/appengine/allowed_account.dart';
@@ -12,7 +13,6 @@ import 'package:cocoon_service/src/request_handling/authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
@@ -94,13 +94,11 @@ void main() {
         httpClient = MockClient(
           (_) async => http.Response('Not JSON!', HttpStatus.ok),
         );
-        final records = <LogRecord>[];
-        log.onRecord.listen(records.add);
         await expectLater(
           auth.tokenInfo(request),
           throwsA(isA<InternalServerError>()),
         );
-        expect(records, isEmpty);
+        expect(log, bufferedLoggerOf(isEmpty));
       });
 
       test('fails if token verification yields forged token', () async {

--- a/app_dart/test/request_handling/request_handler_test.dart
+++ b/app_dart/test/request_handling/request_handler_test.dart
@@ -61,7 +61,7 @@ void main() {
       expect(response.statusCode, HttpStatus.methodNotAllowed);
       response = await issuePost();
       expect(response.statusCode, HttpStatus.methodNotAllowed);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('empty body yields empty HTTP response body', () async {
@@ -69,7 +69,7 @@ void main() {
       final response = await issueGet();
       expect(response.statusCode, HttpStatus.ok);
       expect(await response.toList(), isEmpty);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('string body yields string HTTP response body', () async {
@@ -77,7 +77,7 @@ void main() {
       final response = await issueGet();
       expect(response.statusCode, HttpStatus.ok);
       expect(await utf8.decoder.bind(response).join(), 'Hello world');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('JsonBody yields JSON HTTP response body', () async {
@@ -85,7 +85,7 @@ void main() {
       final response = await issueGet();
       expect(response.statusCode, HttpStatus.ok);
       expect(await utf8.decoder.bind(response).join(), '{"key":"value"}');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('throwing HttpException yields corresponding HTTP status', () async {
@@ -93,7 +93,7 @@ void main() {
       final response = await issueGet();
       expect(response.statusCode, HttpStatus.badRequest);
       expect(await utf8.decoder.bind(response).join(), 'Bad request');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test(
@@ -107,7 +107,7 @@ void main() {
           contains('error message'),
         );
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             equals([
               logThat(
@@ -128,7 +128,7 @@ void main() {
       handler = AccessesRequestAndResponseDirectly();
       final response = await issueGet();
       expect(response.headers.value('X-Test-Path'), '/path');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('may implement both GET and POST', () async {
@@ -139,7 +139,7 @@ void main() {
       response = await issuePost();
       expect(response.headers.value('X-Test-Get'), isNull);
       expect(response.headers.value('X-Test-Post'), 'true');
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
 
     test('may implement only POST', () async {
@@ -148,7 +148,7 @@ void main() {
       expect(response.statusCode, HttpStatus.methodNotAllowed);
       response = await issuePost();
       expect(response.statusCode, HttpStatus.ok);
-      expect(log2, bufferedLoggerOf(isEmpty));
+      expect(log, bufferedLoggerOf(isEmpty));
     });
   });
 }

--- a/app_dart/test/service/branch_service_test.dart
+++ b/app_dart/test/service/branch_service_test.dart
@@ -150,7 +150,7 @@ void main() {
           ]),
         );
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             contains(
               logThat(

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -592,7 +592,7 @@ void main() {
             ),
           );
 
-          expect(log2, isNot(loggedFallingBackToDefaultRecipe));
+          expect(log, isNot(loggedFallingBackToDefaultRecipe));
 
           final scheduleBuild =
               pubsub.messages.first['requests'].first['scheduleBuild']
@@ -616,7 +616,7 @@ void main() {
             ),
           );
 
-          expect(log2, isNot(loggedFallingBackToDefaultRecipe));
+          expect(log, isNot(loggedFallingBackToDefaultRecipe));
 
           final scheduleBuild =
               pubsub.messages.first['requests'].first['scheduleBuild']
@@ -643,7 +643,7 @@ void main() {
             ),
           );
 
-          expect(log2, loggedFallingBackToDefaultRecipe);
+          expect(log, loggedFallingBackToDefaultRecipe);
 
           final scheduleBuild =
               pubsub.messages.first['requests'].first['scheduleBuild']
@@ -672,7 +672,7 @@ void main() {
           ),
         );
 
-        expect(log2, isNot(loggedFallingBackToDefaultRecipe));
+        expect(log, isNot(loggedFallingBackToDefaultRecipe));
 
         final scheduleBuild =
             pubsub.messages.first['requests'].first['scheduleBuild']

--- a/auto_submit/bin/server.dart
+++ b/auto_submit/bin/server.dart
@@ -13,8 +13,6 @@ import 'package:auto_submit/requests/github_webhook.dart';
 import 'package:auto_submit/requests/readiness_check.dart';
 import 'package:auto_submit/service/config.dart';
 import 'package:auto_submit/service/secrets.dart';
-import 'package:cocoon_server/logging.dart';
-import 'package:logging/logging.dart';
 import 'package:neat_cache/neat_cache.dart';
 import 'package:shelf_router/shelf_router.dart';
 
@@ -22,7 +20,6 @@ import 'package:shelf_router/shelf_router.dart';
 const int kCacheSize = 1024;
 
 Future<void> main() async {
-  log = Logger('auto_submit');
   await withAppEngineServices(() async {
     useLoggingPackageAdaptor();
 

--- a/auto_submit/lib/action/git_cli_revert_method.dart
+++ b/auto_submit/lib/action/git_cli_revert_method.dart
@@ -73,7 +73,7 @@ class GitCliRevertMethod implements RevertMethod {
       branch = await githubService.getBranch(slug, gitRevertBranchName.branch);
     }, retryIf: (Exception e) => e is NotFoundException);
 
-    log2.info(
+    log.info(
       'found branch ${slug.fullName}/${branch!.name}, safe to create revert request of ${pullRequestToRevert.number!}.',
     );
 
@@ -95,7 +95,7 @@ class GitCliRevertMethod implements RevertMethod {
           prToRevertBody: pullRequestToRevert.body,
         ).format;
 
-    log2.info(
+    log.info(
       'Attempting to create pull request with ${slug.fullName}/${gitRevertBranchName.branch}.',
     );
     final revertPullRequest = await githubService.createPullRequest(
@@ -107,7 +107,7 @@ class GitCliRevertMethod implements RevertMethod {
       body: formatter.revertPrBody,
     );
 
-    log2.info(
+    log.info(
       'pull request number is: ${slug.fullName}/${revertPullRequest.number}',
     );
 

--- a/auto_submit/lib/configuration/repository_configuration_manager.dart
+++ b/auto_submit/lib/configuration/repository_configuration_manager.dart
@@ -49,7 +49,7 @@ class RepositoryConfigurationManager {
             config.repositoryConfigurationTtl,
           );
       final cacheYaml = String.fromCharCodes(cacheValue as Iterable<int>);
-      log2.info('Converting yaml to RepositoryConfiguration: $cacheYaml');
+      log.info('Converting yaml to RepositoryConfiguration: $cacheYaml');
       return RepositoryConfiguration.fromYaml(cacheYaml);
     } finally {
       _mutex.release();
@@ -60,7 +60,7 @@ class RepositoryConfigurationManager {
   /// bytes.
   Future<List<int>> _getConfiguration(RepositorySlug slug) async {
     // Read the org level configuraiton file first.
-    log2.info('Getting org level configuration.');
+    log.info('Getting org level configuration.');
     // Get the Org level configuration.
     final orgSlug = RepositorySlug(slug.owner, orgRepository);
     var githubService = await config.createGithubService(orgSlug);
@@ -78,14 +78,14 @@ class RepositoryConfigurationManager {
       globalRepositoryConfiguration.defaultBranch = await githubService
           .getDefaultBranch(slug);
     }
-    log2.info(
+    log.info(
       'Default branch was found to be ${globalRepositoryConfiguration.defaultBranch} for ${slug.fullName}.',
     );
 
     // If the override flag is set to true we check the pull request's
     // repository to collect any values that will override the global config.
     if (globalRepositoryConfiguration.allowConfigOverride) {
-      log2.info(
+      log.info(
         'Override is set, collecting and merging local repository configuration.',
       );
       githubService = await config.createGithubService(slug);
@@ -105,7 +105,7 @@ class RepositoryConfigurationManager {
         );
         return mergedRepositoryConfiguration.toString().codeUnits;
       } on GitHubError catch (e) {
-        log2.warn(
+        log.warn(
           'Configuration override was set but no local repository '
           'configuration file was found in ${slug.fullName}, using global '
           'configuration.',

--- a/auto_submit/lib/git/git_repository_manager.dart
+++ b/auto_submit/lib/git/git_repository_manager.dart
@@ -104,7 +104,7 @@ class GitRepositoryManager {
 
   /// Delete the repository managed by this instance.
   Future<void> deleteRepository() async {
-    log2.info('Deleting clone directory $targetCloneDirectory');
+    log.info('Deleting clone directory $targetCloneDirectory');
     if (Directory(targetCloneDirectory).existsSync()) {
       Directory(targetCloneDirectory).deleteSync(recursive: true);
     }

--- a/auto_submit/lib/helpers.dart
+++ b/auto_submit/lib/helpers.dart
@@ -22,7 +22,7 @@ Future<void> serveHandler(Handler handler) async {
     InternetAddress.anyIPv4, // Allows external connections
     port,
   );
-  log2.info('Serving at http://${server.address.host}:${server.port}');
+  log.info('Serving at http://${server.address.host}:${server.port}');
 
   await terminateRequestFuture();
 
@@ -42,7 +42,7 @@ class LoggingHandler {
     try {
       return await _delegate(request);
     } catch (e, s) {
-      log2.error('Uncaught exception in HTTP handler', e, s);
+      log.error('Uncaught exception in HTTP handler', e, s);
       rethrow;
     }
   }
@@ -68,7 +68,7 @@ Future<void> terminateRequestFuture() {
   StreamSubscription? sigIntSub, sigTermSub;
 
   Future<void> signalHandler(ProcessSignal signal) async {
-    log2.info('Received signal $signal - closing');
+    log.info('Received signal $signal - closing');
 
     final subCopy = sigIntSub;
     if (subCopy != null) {

--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -38,7 +38,7 @@ class PubSub {
       request,
       fullTopicName,
     );
-    log2.info('pubsub response messageId=${response.messageIds}');
+    log.info('pubsub response messageId=${response.messageIds}');
   }
 
   /// Pulls messages from the server.

--- a/auto_submit/lib/requests/check_pull_request.dart
+++ b/auto_submit/lib/requests/check_pull_request.dart
@@ -50,10 +50,10 @@ class CheckPullRequest extends CheckRequest {
       pubSubBatchSize,
     );
 
-    log2.info('$crumb: pulled message batch of size ${messages.length}');
+    log.info('$crumb: pulled message batch of size ${messages.length}');
 
     if (messages.isEmpty) {
-      log2.info('$crumb: nothing to do, exiting.');
+      log.info('$crumb: nothing to do, exiting.');
       return Response.ok('$crumb: nothing to do, exiting.');
     }
 
@@ -89,7 +89,7 @@ class CheckPullRequest extends CheckRequest {
     for (var message in messages) {
       assert(message.message != null);
       assert(message.message!.data != null);
-      log2.info(
+      log.info(
         '$crumb: processing message: '
         'id = ${message.message?.messageId}, '
         'ackId = ${message.ackId}, '
@@ -98,7 +98,7 @@ class CheckPullRequest extends CheckRequest {
 
       final messageData = message.message!.data!;
       final requestBodyJson = String.fromCharCodes(base64.decode(messageData));
-      log2.info('$crumb: request JSON = $requestBodyJson');
+      log.info('$crumb: request JSON = $requestBodyJson');
 
       final requestBody = json.decode(requestBodyJson) as Map<String, Object?>;
       final pullRequest = PullRequest.fromJson(requestBody);
@@ -111,7 +111,7 @@ class CheckPullRequest extends CheckRequest {
         // of the PR and decide to submit it or not based on all the labels set
         // on it. So the message is deduplicated but still ackowledged so it is
         // not delivered again.
-        log2.info('$crumb: deduplicated pull request #${pullRequest.number}');
+        log.info('$crumb: deduplicated pull request #${pullRequest.number}');
         await pubsub.acknowledge(pubSubSubscription, message.ackId!);
         continue;
       } else {
@@ -132,7 +132,7 @@ class CheckPullRequest extends CheckRequest {
   ) async {
     final crumb =
         '$CheckPullRequest(${pullRequest.repo?.fullName}/${pullRequest.number})';
-    log2.info('$crumb: Processing PR: ${pullRequest.toJson()}');
+    log.info('$crumb: Processing PR: ${pullRequest.toJson()}');
 
     try {
       final approver = approverProvider(config);
@@ -150,7 +150,7 @@ class CheckPullRequest extends CheckRequest {
       // Because each message is acked individually, the successful ones will
       // be acked, and the failed ones will not, and will be retried by pubsub
       // later according to the retry policy set up in Cocoon.
-      log2.error(
+      log.error(
         '''$crumb: failed to process message.
 
 Pull request: https://github.com/${pullRequest.repo?.fullName}/${pullRequest.number}

--- a/auto_submit/lib/requests/check_revert_request.dart
+++ b/auto_submit/lib/requests/check_revert_request.dart
@@ -48,18 +48,18 @@ class CheckRevertRequest extends CheckRequest {
       pubSubBatchSize,
     );
     if (messageList.isEmpty) {
-      log2.info('No messages are pulled.');
+      log.info('No messages are pulled.');
       return Response.ok('No messages are pulled.');
     }
 
-    log2.info('Processing ${messageList.length} messages');
+    log.info('Processing ${messageList.length} messages');
 
     final validationService = RevertRequestValidationService(config);
 
     final futures = <Future<void>>[];
 
     for (var message in messageList) {
-      log2.info('${message.toJson()}');
+      log.info('${message.toJson()}');
       assert(message.message != null);
       assert(message.message!.data != null);
       final messageData = message.message!.data!;
@@ -71,29 +71,29 @@ class CheckRevertRequest extends CheckRequest {
       final githubPullRequestEvent = GithubPullRequestEvent.fromJson(rawBody);
       final pullRequest = githubPullRequestEvent.pullRequest!;
 
-      log2.info('Processing message ackId: ${message.ackId}');
-      log2.info('Processing mesageId: ${message.message!.messageId}');
-      log2.info('Processing PR: $rawBody');
+      log.info('Processing message ackId: ${message.ackId}');
+      log.info('Processing mesageId: ${message.message!.messageId}');
+      log.info('Processing PR: $rawBody');
       if (processingLog.contains(pullRequest.number) ||
           githubPullRequestEvent.action != 'labeled') {
         // Ack duplicate.
-        log2.info('Ack the duplicated message : ${message.ackId!}.');
-        log2.info('duplicate pull request #${pullRequest.number}');
+        log.info('Ack the duplicated message : ${message.ackId!}.');
+        log.info('duplicate pull request #${pullRequest.number}');
         await pubsub.acknowledge(pubSubSubscription, message.ackId!);
         continue;
       } else {
         // Use the auto approval as we do not want to allow non bot reverts to
         // be processed throught the service.
-        log2.info('new pull request #${pullRequest.number}');
+        log.info('new pull request #${pullRequest.number}');
         if (pullRequest.labels!.any((element) => element.name == 'revert of')) {
           final approver = approverProvider(config);
-          log2.info(
+          log.info(
             'Checking auto approval of "revert of" pull request: $rawBody',
           );
           await approver.autoApproval(pullRequest);
         } else {
           // These should be closed requests that do not need to be reviewed.
-          log2.info('Processing "revert" request : ${pullRequest.number}.');
+          log.info('Processing "revert" request : ${pullRequest.number}.');
         }
         processingLog.add(pullRequest.number!);
       }

--- a/auto_submit/lib/requests/github_webhook.dart
+++ b/auto_submit/lib/requests/github_webhook.dart
@@ -36,7 +36,7 @@ class GithubWebhook extends RequestHandler {
   @override
   Future<Response> post(Request request) async {
     final reqHeader = request.headers;
-    log2.info('Header: $reqHeader');
+    log.info('Header: $reqHeader');
 
     final gitHubEvent = request.headers[GithubWebhook.eventTypeHeader];
 
@@ -48,7 +48,7 @@ class GithubWebhook extends RequestHandler {
         await request.read().expand((bodyBytes) => bodyBytes).toList();
     final hmacSignature = request.headers[GithubWebhook.signatureHeader];
     if (!await _validateRequest(hmacSignature, requestBytes)) {
-      log2.info('User is forbidden');
+      log.info('User is forbidden');
       throw const Forbidden();
     }
 
@@ -83,7 +83,7 @@ class GithubWebhook extends RequestHandler {
 
     // Check for revert label first.
     if (hasRevertLabel) {
-      log2.info('Found pull request with the revert label.');
+      log.info('Found pull request with the revert label.');
       await pubsub.publish(
         config.pubsubRevertRequestTopic,
         GithubPullRequestEvent(
@@ -93,7 +93,7 @@ class GithubWebhook extends RequestHandler {
         ),
       );
     } else if (hasAutosubmit) {
-      log2.info('Found pull request with autosubmit label.');
+      log.info('Found pull request with autosubmit label.');
       await pubsub.publish(config.pubsubPullRequestTopic, pullRequest);
     }
 

--- a/auto_submit/lib/server/authenticated_request_handler.dart
+++ b/auto_submit/lib/server/authenticated_request_handler.dart
@@ -29,7 +29,7 @@ abstract class AuthenticatedRequestHandler extends RequestHandler {
     try {
       await cronAuthProvider.authenticate(request);
     } on Unauthenticated catch (error) {
-      log2.info('Authenticate error: $error');
+      log.info('Authenticate error: $error');
       return Response.forbidden(error.toString());
     }
     return super.run(request);

--- a/auto_submit/lib/service/approver_service.dart
+++ b/auto_submit/lib/service/approver_service.dart
@@ -40,17 +40,17 @@ class ApproverService {
       github.RepositorySlug.full(pullRequest.base!.repo!.fullName),
     );
 
-    log2.info(
+    log.info(
       'Determining auto approval of $author on ${slug.fullName}/$prNumber.',
     );
 
     // If there are auto_approvers let them approve the pull request.
     if (!approvalAccounts.contains(author)) {
-      log2.info(
+      log.info(
         'Auto-review ignored for $author on ${slug.fullName}/$prNumber.',
       );
     } else {
-      log2.info('Auto approval detected on ${slug.fullName}/$prNumber.');
+      log.info('Auto approval detected on ${slug.fullName}/$prNumber.');
       await _approve(pullRequest, author);
     }
   }
@@ -80,6 +80,6 @@ class ApproverService {
       'APPROVE',
     );
     await botClient.pullRequests.createReview(slug, review);
-    log2.info('Review for ${slug.fullName}/${pullRequest.number} complete');
+    log.info('Review for ${slug.fullName}/${pullRequest.number} complete');
   }
 }

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -238,7 +238,7 @@ class Config {
     final installData = json.decode(response.body) as Map<String, dynamic>;
     final installationId = installData['id']?.toString();
     if (installationId == null) {
-      log2.warn(
+      log.warn(
         'Failed to get ID from Github '
         '(response code ${response.statusCode}):\n${response.body}',
       );
@@ -279,7 +279,7 @@ class Config {
   }
 
   Future<Uint8List> _generateGithubToken(RepositorySlug slug) async {
-    log2.info('Generating new GitHub token');
+    log.info('Generating new GitHub token');
     final jwt = await _generateGithubJwt();
     final headers = <String, String>{
       'Authorization': 'Bearer $jwt',
@@ -295,7 +295,7 @@ class Config {
     final jsonBody = jsonDecode(response.body) as Map<String, dynamic>;
     final token = jsonBody['token'] as String?;
     if (token == null) {
-      log2.warn(
+      log.warn(
         'Failed to get token from Github '
         '(response code ${response.statusCode}):\n${response.body}',
       );
@@ -305,7 +305,7 @@ class Config {
         uri: githubAccessTokensUri,
       );
     }
-    log2.info('Successfully generated new GitHub token');
+    log.info('Successfully generated new GitHub token');
     return Uint8List.fromList(token.codeUnits);
   }
 

--- a/auto_submit/lib/service/discord_notification.dart
+++ b/auto_submit/lib/service/discord_notification.dart
@@ -28,7 +28,7 @@ class DiscordNotification {
       body: jsonMessageString,
     );
 
-    log2.info('discord webhook status: ${response.statusCode}');
-    log2.info('discord webhook response body: ${response.body}');
+    log.info('discord webhook status: ${response.statusCode}');
+    log.info('discord webhook response body: ${response.body}');
   }
 }

--- a/auto_submit/lib/service/github_service.dart
+++ b/auto_submit/lib/service/github_service.dart
@@ -305,7 +305,7 @@ class GithubService {
       pullRequest.base!.sha!,
     );
     if (comparison.behindBy! >= _kBehindToT) {
-      log2.info(
+      log.info(
         'The current branch is behind by ${comparison.behindBy} commits.',
       );
       final headSha = pullRequest.head!.sha!;

--- a/auto_submit/lib/service/graphql_service.dart
+++ b/auto_submit/lib/service/graphql_service.dart
@@ -45,7 +45,7 @@ class GraphQlService {
     );
 
     if (queryResult.hasException) {
-      log2.error('GraphQL query failed', queryResult.exception);
+      log.error('GraphQL query failed', queryResult.exception);
       throw const BadRequestException('GraphQL query failed');
     }
     return queryResult.data!;
@@ -66,7 +66,7 @@ class GraphQlService {
     );
 
     if (queryResult.hasException) {
-      log2.error('GraphQL mutate failed', queryResult.exception);
+      log.error('GraphQL mutate failed', queryResult.exception);
       throw const BadRequestException('GraphQL mutate failed');
     }
     return queryResult.data!;
@@ -109,7 +109,7 @@ class GraphQlService {
       jump: jump,
     );
 
-    log2.info(
+    log.info(
       'Attempting to enqueue ${slug.fullName}/$pullRequestNumber '
       'with these variables: ${enqueueMutation.variables}',
     );

--- a/auto_submit/lib/service/pull_request_validation_service.dart
+++ b/auto_submit/lib/service/pull_request_validation_service.dart
@@ -50,7 +50,7 @@ class PullRequestValidationService extends ValidationService {
         pubsub: pubsub,
       );
     } else {
-      log2.info(
+      log.info(
         'Should not process ${messagePullRequest.toJson()}, and ack the message.',
       );
       await pubsub.acknowledge(subscription, ackId);
@@ -81,7 +81,7 @@ class PullRequestValidationService extends ValidationService {
     // the merge queue merge it, or kick it out of the merge queue.
     if (pullRequest.isMergeQueueEnabled) {
       if (result.repository!.pullRequest!.isInMergeQueue) {
-        log2.info(
+        log.info(
           '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',
         );
         await pubsub.acknowledge(subscription, ackId);
@@ -133,11 +133,11 @@ class _PullRequestValidationProcessor {
   String get logCrumb => 'PullRequestValidation($slug/pull/$prNumber)';
 
   void logInfo(Object? message) {
-    log2.info('$logCrumb: $message');
+    log.info('$logCrumb: $message');
   }
 
   void logSevere(Object? message) {
-    log2.error('$logCrumb: $message');
+    log.error('$logCrumb: $message');
   }
 
   Future<void> process() async {

--- a/auto_submit/lib/service/revert_request_validation_service.dart
+++ b/auto_submit/lib/service/revert_request_validation_service.dart
@@ -90,7 +90,7 @@ class RevertRequestValidationService extends ValidationService {
         break;
       // Do not process.
       case RevertProcessMethod.none:
-        log2.info(
+        log.info(
           'Should not process ${messagePullRequest.toJson()}, and ack the message.',
         );
         await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
@@ -123,12 +123,12 @@ class RevertRequestValidationService extends ValidationService {
       slug,
       issueNumber,
     );
-    log2.info(
+    log.info(
       'Found ${pullRequestComments.length} comments for issue ${slug.fullName}/$issueNumber',
     );
     for (var prComment in pullRequestComments) {
       final commentBody = prComment.body;
-      log2.info(
+      log.info(
         'Processing comment on ${slug.fullName}/$issueNumber: $commentBody',
       );
       if (commentBody != null && regExp.hasMatch(commentBody)) {
@@ -176,7 +176,7 @@ class RevertRequestValidationService extends ValidationService {
       final message =
           '''Time to revert pull request ${slug.fullName}/${messagePullRequest.number} has elapsed.
           You need to open the revert manually and process as a regular pull request.''';
-      log2.info(message);
+      log.info(message);
       await githubService.createComment(
         slug,
         messagePullRequest.number!,
@@ -187,7 +187,7 @@ class RevertRequestValidationService extends ValidationService {
         messagePullRequest.number!,
         Config.kRevertLabel,
       );
-      log2.info(
+      log.info(
         'Should not process ${messagePullRequest.toJson()}, and ack the message.',
       );
       await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
@@ -204,7 +204,7 @@ class RevertRequestValidationService extends ValidationService {
           '''A reason for requesting a revert of ${slug.fullName}/${messagePullRequest.number} could
       not be found or the reason was not properly formatted. Begin a comment with **'Reason for revert:'** to tell the bot why
       this issue is being reverted.''';
-      log2.info(message);
+      log.info(message);
       await githubService.createComment(
         slug,
         messagePullRequest.number!,
@@ -215,7 +215,7 @@ class RevertRequestValidationService extends ValidationService {
         messagePullRequest.number!,
         Config.kRevertLabel,
       );
-      log2.info(
+      log.info(
         'Should not process ${messagePullRequest.toJson()}, and ack the message.',
       );
       await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
@@ -233,14 +233,14 @@ class RevertRequestValidationService extends ValidationService {
                 messagePullRequest,
               )
               as github.PullRequest;
-      log2.info(
+      log.info(
         'Created revert pull request ${slug.fullName}/${pullRequest.number}.',
       );
       // This will come through this service again for processing.
       await githubService.addLabels(slug, pullRequest.number!, [
         Config.kRevertOfLabel,
       ]);
-      log2.info('Assigning new revert issue to $sender');
+      log.info('Assigning new revert issue to $sender');
       await githubService.addAssignee(slug, pullRequest.number!, [sender]);
       // TODO (ricardoamador) create a better solution than this to stop processing
       // the revert requests. Maybe change the label after the revert has occurred.
@@ -255,7 +255,7 @@ class RevertRequestValidationService extends ValidationService {
     } catch (e, s) {
       final message =
           'Unable to create the revert pull request due to ${e.toString()}';
-      log2.error(message, e, s);
+      log.error(message, e, s);
       await githubService.createComment(
         slug,
         messagePullRequest.number!,
@@ -289,7 +289,7 @@ class RevertRequestValidationService extends ValidationService {
     // the merge queue merge it, or kick it out of the merge queue.
     if (pullRequest.isMergeQueueEnabled) {
       if (result.repository!.pullRequest!.isInMergeQueue) {
-        log2.info(
+        log.info(
           '${slug.fullName}/$prNumber is already in the merge queue. Skipping.',
         );
         await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
@@ -310,7 +310,7 @@ class RevertRequestValidationService extends ValidationService {
         'Repository configuration does not support review-less revert pull requests. Please assign at least two reviewers to this pull request.',
       );
       // We do not want to continue processing this issue.
-      log2.info('Ack the processed message : $ackId.');
+      log.info('Ack the processed message : $ackId.');
       await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
       return;
     }
@@ -328,7 +328,7 @@ class RevertRequestValidationService extends ValidationService {
     /// Runs all the validation defined in the service.
     /// If the runCi flag is false then we need a way to not run the ciSuccessful validation.
     for (var validation in validations) {
-      log2.info(
+      log.info(
         '${slug.fullName}/$prNumber running validation ${validation.name}',
       );
       validationsMap[validation.name] = await validation.validate(
@@ -348,16 +348,16 @@ class RevertRequestValidationService extends ValidationService {
             'auto label is removed for ${slug.fullName}/$prNumber, due to $commmentMessage';
         await githubService.removeLabel(slug, prNumber, Config.kRevertOfLabel);
         await githubService.createComment(slug, prNumber, message);
-        log2.info(message);
+        log.info(message);
         shouldReturn = true;
       }
     }
 
     if (shouldReturn) {
-      log2.info(
+      log.info(
         'The pr ${slug.fullName}/$prNumber with message: $ackId should be acknowledged due to validation failure.',
       );
-      log2.info(
+      log.info(
         'The pr ${slug.fullName}/$prNumber is not feasible for merge and message: $ackId is acknowledged.',
       );
       await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
@@ -367,7 +367,7 @@ class RevertRequestValidationService extends ValidationService {
     // If PR has some failures to ignore temporarily do nothing and continue.
     for (final MapEntry(:key, :value) in validationsMap.entries) {
       if (!value.result && value.action == Action.IGNORE_TEMPORARILY) {
-        log2.info(
+        log.info(
           'Temporarily ignoring processing of ${slug.fullName}/$prNumber due to $key failing validation.',
         );
         return;
@@ -385,7 +385,7 @@ class RevertRequestValidationService extends ValidationService {
           'auto label is removed for ${slug.fullName}/$prNumber, ${processed.message}.';
       await githubService.removeLabel(slug, prNumber, Config.kRevertOfLabel);
       await githubService.createComment(slug, prNumber, message);
-      log2.info(message);
+      log.info(message);
     } else {
       // Need to add the discord notification here.
       final discordNotification = await discordNotificationClient;
@@ -394,10 +394,10 @@ class RevertRequestValidationService extends ValidationService {
         jsonEncode(discordMessage.toJson()),
       );
 
-      log2.info(
+      log.info(
         'Pull Request ${slug.fullName}/$prNumber was ${processed.method.pastTenseLabel} successfully!',
       );
-      log2.info(
+      log.info(
         'Attempting to insert a pull request record into the database for $prNumber',
       );
       await insertPullRequestRecord(
@@ -407,7 +407,7 @@ class RevertRequestValidationService extends ValidationService {
       );
     }
 
-    log2.info('Ack the processed message : $ackId.');
+    log.info('Ack the processed message : $ackId.');
     await pubsub.acknowledge(config.pubsubRevertRequestSubscription, ackId);
   }
 

--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -108,7 +108,7 @@ ${pullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
     } catch (e, s) {
       final message =
           'Failed to enqueue ${slug.fullName}/${restPullRequest.number} with $e';
-      log2.error(message, e, s);
+      log.error(message, e, s);
       return (result: false, message: message, method: SubmitMethod.enqueue);
     }
 
@@ -141,13 +141,13 @@ ${pullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
       if (result != null && !merged) {
         final message =
             'Failed to merge ${slug.fullName}/$number with ${result?.message}';
-        log2.error(message);
+        log.error(message);
         return (result: false, message: message, method: SubmitMethod.merge);
       }
     } catch (e, s) {
       // Catch graphql client init exceptions.
       final message = 'Failed to merge ${slug.fullName}/$number with $e';
-      log2.error(message, e, s);
+      log.error(message, e, s);
       return (result: false, message: message, method: SubmitMethod.merge);
     }
 
@@ -187,7 +187,7 @@ ${pullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
         pullRequestRecord: pullRequestRecord,
       );
     } on BigQueryException catch (e) {
-      log2.error(
+      log.error(
         'Failed to insert pull request record into BigQuery for pull request '
         '${slug.fullName}/${pullRequest.number} due to',
         e,
@@ -233,7 +233,7 @@ Future<github.PullRequestMerge> _processMergeInternal({
 }) async {
   // This is retryable so to guard against token expiration we get a fresh
   // client each time.
-  log2.info('Attempting to merge ${slug.fullName}/$number.');
+  log.info('Attempting to merge ${slug.fullName}/$number.');
   final gitHubService = await config.createGithubService(slug);
   final pullRequestMerge = await gitHubService.mergePullRequest(
     slug,

--- a/auto_submit/lib/validations/approval.dart
+++ b/auto_submit/lib/validations/approval.dart
@@ -40,7 +40,7 @@ class Approval extends Validation {
     var message = '';
     var action = Action.REMOVE_LABEL;
     if (repositoryConfiguration.autoApprovalAccounts.contains(author)) {
-      log2.info(
+      log.info(
         'PR ${slug.fullName}/${messagePullRequest.number} approved for roller account: $author',
       );
       return ValidationResult(true, Action.REMOVE_LABEL, '');
@@ -61,7 +61,7 @@ class Approval extends Validation {
       await approver.computeApproval();
       approved = approver.approved;
 
-      log2.info(
+      log.info(
         'PR ${slug.fullName}/${messagePullRequest.number} approved $approved, approvers: ${approver.approvers}, remaining approvals: ${approver.remainingReviews}, request authors: ${approver.changeRequestAuthors}',
       );
 
@@ -160,7 +160,7 @@ class Approver {
     // reverse chronological order.
     for (var review in reviews.reversed) {
       if (review.author!.login == author) {
-        log2.info('Author cannot review own pull request.');
+        log.info('Author cannot review own pull request.');
         continue;
       }
 

--- a/auto_submit/lib/validations/ci_successful.dart
+++ b/auto_submit/lib/validations/ci_successful.dart
@@ -60,7 +60,7 @@ class CiSuccessful extends Validation {
     if (baseBranch == targetBranch) {
       // Only validate tree status where base branch is the default branch.
       if (!isTreeStatusReporting(slug, prNumber, statuses)) {
-        log2.warn(
+        log.warn(
           'Statuses were not ready for ${slug.fullName}/$prNumber, sha: $commit.',
         );
         return ValidationResult(
@@ -70,7 +70,7 @@ class CiSuccessful extends Validation {
         );
       }
     } else {
-      log2.info(
+      log.info(
         'Target branch is $baseBranch for ${slug.fullName}/$prNumber, skipping tree status check.',
       );
     }
@@ -156,7 +156,7 @@ class CiSuccessful extends Validation {
       return false;
     }
     const treeStatusName = 'tree-status';
-    log2.info(
+    log.info(
       '${slug.fullName}/$prNumber: Validating tree status for ${slug.name}/tree-status, statuses: $statuses',
     );
 
@@ -185,7 +185,7 @@ class CiSuccessful extends Validation {
     Set<FailureDetail> failures,
     bool allSuccess,
   ) {
-    log2.info('Validating name: ${slug.name}/$prNumber, statuses: $statuses');
+    log.info('Validating name: ${slug.name}/$prNumber, statuses: $statuses');
 
     final staleStatuses = <ContextNode>[];
     for (var status in statuses) {
@@ -212,7 +212,7 @@ class CiSuccessful extends Validation {
       }
     }
     if (staleStatuses.isNotEmpty) {
-      log2.warn(
+      log.warn(
         'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleStatuses.map((e) => e.context).toList()}',
       );
     }
@@ -233,7 +233,7 @@ class CiSuccessful extends Validation {
     bool allSuccess,
     Author author,
   ) {
-    log2.info('Validating name: ${slug.name}/$prNumber, checkRuns: $checkRuns');
+    log.info('Validating name: ${slug.name}/$prNumber, checkRuns: $checkRuns');
 
     final staleCheckRuns = <github.CheckRun>[];
     for (var checkRun in checkRuns) {
@@ -252,7 +252,7 @@ class CiSuccessful extends Validation {
         continue;
       } else if (checkRun.status == github.CheckRunStatus.completed) {
         // checkrun has failed.
-        log2.info('${slug.name}/$prNumber: CheckRun $name failed.');
+        log.info('${slug.name}/$prNumber: CheckRun $name failed.');
         failures.add(FailureDetail(name!, checkRun.detailsUrl as String));
       } else if (checkRun.status == github.CheckRunStatus.queued) {
         if (prState == PullRequestState.open &&
@@ -264,7 +264,7 @@ class CiSuccessful extends Validation {
       allSuccess = false;
     }
     if (staleCheckRuns.isNotEmpty) {
-      log2.warn(
+      log.warn(
         'Pull request https://github.com/${slug.fullName}/pull/$prNumber from ${slug.name} repo auto roller has been running over ${Config.kGitHubCheckStaleThreshold} hours due to: ${staleCheckRuns.map((e) => e.name).toList()}',
       );
     }

--- a/auto_submit/lib/validations/mergeable.dart
+++ b/auto_submit/lib/validations/mergeable.dart
@@ -24,7 +24,7 @@ class Mergeable extends Validation {
     final slug = messagePullRequest.base!.repo!.slug();
     final mergeableState = result.repository!.pullRequest!.mergeable!;
 
-    log2.info(
+    log.info(
       '${slug.name}/$pullRequestNumber has mergeable state $mergeableState',
     );
 

--- a/auto_submit/lib/validations/required_check_runs.dart
+++ b/auto_submit/lib/validations/required_check_runs.dart
@@ -54,7 +54,7 @@ class RequiredCheckRuns extends Validation {
         }, retryIf: (Exception e) => e is RetryableException);
       }
     } catch (e, s) {
-      log2.warn('Required check has not completed in time', e, s);
+      log.warn('Required check has not completed in time', e, s);
       checksCompleted = false;
     }
 

--- a/auto_submit/test/requests/check_pull_request_test.dart
+++ b/auto_submit/test/requests/check_pull_request_test.dart
@@ -239,7 +239,7 @@ void main() {
         await checkPullRequest.get();
 
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             contains(
               logThat(
@@ -339,7 +339,7 @@ void main() {
       expect(pubsub.messagesQueue.length, 0);
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           contains(
             logThat(

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -17,7 +17,6 @@ import 'package:cocoon_server_test/test_logging.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/bigquery/v2.dart';
 import 'package:graphql/client.dart';
-import 'package:logging/logging.dart';
 import 'package:mockito/mockito.dart';
 import 'package:retry/retry.dart';
 import 'package:test/test.dart';
@@ -41,10 +40,6 @@ void main() {
 
   late MockJobsResource jobsResource;
   late FakeBigqueryService bigqueryService;
-
-  setUpAll(() {
-    log = Logger('auto_submit');
-  });
 
   setUp(() {
     githubGraphQLClient = FakeGraphQLClient();
@@ -740,7 +735,7 @@ This is the second line in a paragraph.''');
       );
 
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           contains(
             logThat(

--- a/auto_submit/test/service/revert_request_validation_service_test.dart
+++ b/auto_submit/test/service/revert_request_validation_service_test.dart
@@ -1424,7 +1424,7 @@ void main() {
 
       // Expectations
       expect(
-        log2,
+        log,
         bufferedLoggerOf(
           contains(
             logThat(

--- a/auto_submit/test/validations/ci_successful_test.dart
+++ b/auto_submit/test/validations/ci_successful_test.dart
@@ -532,7 +532,7 @@ void main() {
         );
 
         expect(
-          log2,
+          log,
           bufferedLoggerOf(
             contains(
               logThat(
@@ -554,7 +554,7 @@ void main() {
           failures,
           allSuccess,
         );
-        expect(log2, hasNoWarningsOrHigher);
+        expect(log, hasNoWarningsOrHigher);
       },
     );
   });

--- a/packages/cocoon_server/lib/logging.dart
+++ b/packages/cocoon_server/lib/logging.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/logging.dart' show log, log2;
+export 'src/logging.dart' show log;

--- a/packages/cocoon_server/lib/src/logging.dart
+++ b/packages/cocoon_server/lib/src/logging.dart
@@ -8,32 +8,29 @@ import 'package:cocoon_common/src/internal.dart' as internal;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
-// Used to access the symbol `self`.
-import 'logging.dart' as self;
-
 /// A root application logger using the interface in `package:logging`.
 ///
-/// This is being migrated to [log2], which uses a new interface. See
+/// This is being migrated to [log], which uses a new interface. See
 /// [#164652](https://github.com/flutter/flutter/issues/164652).
-Logger log = Logger.root..level = Level.ALL;
+final _rootLegacyLogger = Logger.root..level = Level.ALL;
 
 /// A root application logger using the interface in `package:cocoon_common`.
-LogSink get log2 => _log2;
-LogSink _log2 = const DuringMigrationLogSink();
+LogSink get log => _log;
+LogSink _log = const DuringMigrationLogSink();
 
-/// Changes the default implementation of [log2].
+/// Changes the default implementation of [log].
 ///
 /// This can all be called in a testing environment.
 void overrideLog2ForTesting(LogSink logSink) {
   if (!internal.assertionsEnabled) {
     throw StateError('Can only use in a test or local development');
   }
-  _log2 = logSink;
+  _log = logSink;
 }
 
 /// A narrow shim on top of [LogSink] that delegates to [log].
 ///
-/// Used as the default implementation of [log2]. See
+/// Used as the default implementation of [log]. See
 /// [#164652](https://github.com/flutter/flutter/issues/164652).
 @visibleForTesting
 final class DuringMigrationLogSink with LogSink {
@@ -58,6 +55,6 @@ final class DuringMigrationLogSink with LogSink {
     Object? error,
     StackTrace? trace,
   }) {
-    self.log.log(_toLevel(severity), message, error, trace);
+    _rootLegacyLogger.log(_toLevel(severity), message, error, trace);
   }
 }

--- a/packages/cocoon_server/test/logging_test.dart
+++ b/packages/cocoon_server/test/logging_test.dart
@@ -11,12 +11,8 @@ void main() {
   late List<pkg_logging.LogRecord> logs;
 
   setUp(() {
-    final logger = pkg_logging.Logger.detached('logging_test');
-    log = logger;
-    logger.level = pkg_logging.Level.ALL;
-
     logs = [];
-    logger.onRecord.listen(logs.add);
+    pkg_logging.Logger.root.onRecord.listen(logs.add);
   });
 
   group('log2 maps Severity -> Level', () {
@@ -34,7 +30,7 @@ void main() {
 
     for (final MapEntry(key: severity, value: level) in expected.entries) {
       test('$severity -> $level', () {
-        log2.log('test', severity: Severity.unknown);
+        log.log('test', severity: Severity.unknown);
 
         expect(logs, [
           isA<pkg_logging.LogRecord>().having(
@@ -48,7 +44,7 @@ void main() {
   });
 
   test('includes message', () {
-    log2.log('hello world');
+    log.log('hello world');
 
     expect(logs, [
       isA<pkg_logging.LogRecord>().having(
@@ -61,7 +57,7 @@ void main() {
 
   test('includes error', () {
     final error = StateError('Example error');
-    log2.log('with error', error: error);
+    log.log('with error', error: error);
 
     expect(logs, [
       isA<pkg_logging.LogRecord>().having((e) => e.error, 'error', same(error)),
@@ -70,7 +66,7 @@ void main() {
 
   test('includes stack trace', () {
     final trace = StackTrace.current;
-    log2.log('with error', trace: trace);
+    log.log('with error', trace: trace);
 
     expect(logs, [
       isA<pkg_logging.LogRecord>().having(

--- a/packages/cocoon_server_test/lib/test_logging.dart
+++ b/packages/cocoon_server_test/lib/test_logging.dart
@@ -7,7 +7,7 @@ import 'package:cocoon_common/cocoon_common.dart';
 import 'package:cocoon_server/src/logging.dart' as internal;
 import 'package:test_api/scaffolding.dart';
 
-/// Overrides [internal.log2] to use a [BufferedLogger] per-test instance.
+/// Overrides [internal.log] to use a [BufferedLogger] per-test instance.
 ///
 /// Note that by using this method, [internal.log], the production root logger
 /// instance (https://github.com/flutter/flutter/issues/164652) is no longer
@@ -48,9 +48,9 @@ void useTestLoggerPerTest() {
   });
 }
 
-/// Clears [internal.log2].
+/// Clears [internal.log].
 ///
 /// Use this method judiciously, and instead write tighter test cases.
 void clearTestLogger() {
-  (internal.log2 as BufferedLogger).clear();
+  (internal.log as BufferedLogger).clear();
 }

--- a/packages/cocoon_server_test/test/test_logging_test.dart
+++ b/packages/cocoon_server_test/test/test_logging_test.dart
@@ -11,6 +11,6 @@ void main() {
   useTestLoggerPerTest();
 
   test('should create a BufferedLogger in every test instance', () {
-    expect(log2, isA<BufferedLogger>());
+    expect(log, isA<BufferedLogger>());
   });
 }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/164652.

Summary of changes:
- Rename `log2` back to `log`
- Hide `log` (it's really just `Logger.root`)
- Change the entrypoints
- Make some final updates to tests still using `package:logging`

Now `package:logging` is just used as an implementation detail to map to `package:appengine`.

In a follow-up PR we can switch to using `io.stderr` and support structured logging.