### PR TITLE
Include skipped tasks in `rerun-prod-task`.

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -198,36 +198,36 @@ class Task extends Model<int> {
   }
 
   /// The task was cancelled.
-  static const String statusCancelled = 'Cancelled';
+  static const statusCancelled = 'Cancelled';
 
   /// The task is yet to be run.
-  static const String statusNew = 'New';
+  static const statusNew = 'New';
 
   /// The task failed to run due to an unexpected issue.
-  static const String statusInfraFailure = 'Infra Failure';
+  static const statusInfraFailure = 'Infra Failure';
 
   /// The task is currently running.
-  static const String statusInProgress = 'In Progress';
+  static const statusInProgress = 'In Progress';
 
   /// The task was run successfully.
-  static const String statusSucceeded = 'Succeeded';
+  static const statusSucceeded = 'Succeeded';
 
   /// The task failed to run successfully.
-  static const String statusFailed = 'Failed';
+  static const statusFailed = 'Failed';
 
   /// The task was skipped or canceled while running.
   ///
   /// This status is only used by LUCI tasks.
-  static const String statusSkipped = 'Skipped';
+  static const statusSkipped = 'Skipped';
 
-  static const Set<String> taskFailStatusSet = <String>{
+  static const taskFailStatusSet = {
     Task.statusInfraFailure,
     Task.statusFailed,
     Task.statusCancelled,
   };
 
   /// The list of legal values for the [status] property.
-  static const List<String> legalStatusValues = <String>[
+  static const legalStatusValues = {
     statusCancelled,
     statusFailed,
     statusInfraFailure,
@@ -235,15 +235,15 @@ class Task extends Model<int> {
     statusNew,
     statusSkipped,
     statusSucceeded,
-  ];
+  };
 
-  static const List<String> finishedStatusValues = <String>[
+  static const finishedStatusValues = {
     statusCancelled,
     statusFailed,
     statusInfraFailure,
     statusSkipped,
     statusSucceeded,
-  ];
+  };
 
   /// The key of the commit that owns this task.
   @ModelKeyProperty(propertyName: 'ChecklistKey')

--- a/dashboard/lib/build_dashboard_page.dart
+++ b/dashboard/lib/build_dashboard_page.dart
@@ -514,6 +514,7 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
       idToken: await buildState.authService.idToken,
       branch: buildState.currentBranch,
       repo: buildState.currentRepo,
+      include: {TaskBox.statusSkipped},
     );
     if (!context.mounted) {
       return;

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -196,6 +196,7 @@ class AppEngineCocoonService implements CocoonService {
     required String commitSha,
     required String repo,
     required String branch,
+    Iterable<String>? include,
   }) async {
     if (idToken == null || idToken.isEmpty) {
       return const CocoonResponse<bool>.error('Sign in to trigger reruns');
@@ -211,6 +212,7 @@ class AppEngineCocoonService implements CocoonService {
         'repo': repo,
         'commit': commitSha,
         'task': taskName,
+        if (include != null) 'include': include.join(','),
       }),
     );
 
@@ -229,10 +231,12 @@ class AppEngineCocoonService implements CocoonService {
     required String commitSha,
     required String repo,
     required String branch,
+    Iterable<String>? include,
   }) async {
     return rerunTask(
       idToken: idToken,
       taskName: 'all',
+      include: include,
       commitSha: commitSha,
       repo: repo,
       branch: branch,

--- a/dashboard/lib/service/cocoon.dart
+++ b/dashboard/lib/service/cocoon.dart
@@ -65,6 +65,7 @@ abstract class CocoonService {
     required String commitSha,
     required String repo,
     required String branch,
+    Iterable<String>? include,
   });
 
   /// Force update Cocoon to get the latest commits.

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -154,6 +154,7 @@ class DevelopmentCocoonService implements CocoonService {
     required String commitSha,
     required String repo,
     required String branch,
+    Iterable<String>? include,
   }) async {
     return const CocoonResponse<void>.error(
       'Unable to schedule against fake data. Try building the app to use prod data.',

--- a/dashboard/test/build_dashboard_page_test.dart
+++ b/dashboard/test/build_dashboard_page_test.dart
@@ -942,11 +942,12 @@ void main() {
           idToken: '1234567890',
           branch: 'flutter-release',
           repo: 'flutter',
+          include: {TaskBox.statusSkipped},
         ),
       ).thenAnswer((_) async => const CocoonResponse.data(null));
-      final tooltip =
-          tester.firstWidget(find.byKey(const ValueKey('schedulePostsubmit')))
-              as Tooltip;
+      final tooltip = tester.firstWidget<Tooltip>(
+        find.byKey(const ValueKey('schedulePostsubmit')),
+      );
       await tester.tap(find.byWidget(tooltip.child!));
     });
   });

--- a/dashboard/test/service/appengine_cocoon_test.dart
+++ b/dashboard/test/service/appengine_cocoon_test.dart
@@ -179,6 +179,49 @@ void main() {
       );
     });
 
+    test('should treat rerunCommit as task=all', () async {
+      service = AppEngineCocoonService(
+        client: MockClient((request) async {
+          return Response('${request.url.toString()}|${request.body}', 500);
+        }),
+      );
+
+      final response = await service.rerunCommit(
+        idToken: 'fakeAccessToken',
+        repo: 'flutter',
+        commitSha: 'abc123',
+        branch: 'master',
+      );
+      expect(
+        response.error,
+        endsWith(
+          'api/rerun-prod-task|{"branch":"master","repo":"flutter","commit":"abc123","task":"all"}',
+        ),
+      );
+    });
+
+    test('should include statuses with rerunCommit', () async {
+      service = AppEngineCocoonService(
+        client: MockClient((request) async {
+          return Response('${request.url.toString()}|${request.body}', 500);
+        }),
+      );
+
+      final response = await service.rerunCommit(
+        idToken: 'fakeAccessToken',
+        repo: 'flutter',
+        commitSha: 'abc123',
+        branch: 'master',
+        include: ['Foolish', 'Dashing'],
+      );
+      expect(
+        response.error,
+        endsWith(
+          'api/rerun-prod-task|{"branch":"master","repo":"flutter","commit":"abc123","task":"all","include":"Foolish,Dashing"}',
+        ),
+      );
+    });
+
     test(
       'should set error in response if bad status code is returned',
       () async {

--- a/dashboard/test/utils/mocks.mocks.dart
+++ b/dashboard/test/utils/mocks.mocks.dart
@@ -369,6 +369,7 @@ class MockCocoonService extends _i1.Mock implements _i3.CocoonService {
     required String? commitSha,
     required String? repo,
     required String? branch,
+    Iterable<String>? include,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#rerunCommit, [], {
@@ -376,6 +377,7 @@ class MockCocoonService extends _i1.Mock implements _i3.CocoonService {
               #commitSha: commitSha,
               #repo: repo,
               #branch: branch,
+              #include: include,
             }),
             returnValue: _i6.Future<_i3.CocoonResponse<void>>.value(
               _FakeCocoonResponse_2<void>(
@@ -385,6 +387,7 @@ class MockCocoonService extends _i1.Mock implements _i3.CocoonService {
                   #commitSha: commitSha,
                   #repo: repo,
                   #branch: branch,
+                  #include: include,
                 }),
               ),
             ),


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165572.

This allows re-running tasks that otherwise would not be re-run, but behind a flag (argument) that otherwise is not set.

Included validation/tests on both the frontend and backend.