### PR TITLE
Run `/api/vacuum-github-commits` at most once at a time

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -157,15 +157,12 @@ Server createServer({
       config: config,
       authenticationProvider: swarmingAuthProvider,
     ),
+
     '/api/vacuum-github-commits': VacuumGithubCommits(
       config: config,
       authenticationProvider: authProvider,
       scheduler: scheduler,
-    ),
-    '/api/v2/vacuum-github-commits': VacuumGithubCommits(
-      config: config,
-      authenticationProvider: authProvider,
-      scheduler: scheduler,
+      cache: cache,
     ),
 
     /// Temporary API to trigger a dispatch-able workflow from Cocoon.

--- a/app_dart/lib/src/request_handling/single_execution_request_handler.dart
+++ b/app_dart/lib/src/request_handling/single_execution_request_handler.dart
@@ -1,0 +1,113 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cocoon_server/logging.dart';
+import 'package:meta/meta.dart';
+
+import '../service/cache_service.dart';
+import 'api_request_handler.dart';
+import 'body.dart';
+
+/// A class that services an HTTP `GET` request that discards new requests.
+///
+/// [Scheduling jobs with `cron.yaml`][1] reads:
+/// > Only a single instance of a job should run at any time. The Cron service
+/// > is designed to provide "at least once" delivery; that is, if a job is
+/// > scheduled, App Engine sends the job request at least one time. In some
+/// > rare circumstances, it is possible for multiple instances of the same job
+/// > to be requested, therefore, your request handler should be idempotent, and
+/// > your code should ensure that there are no harmful side-effects if this
+/// > occurs.
+///
+/// [1]: https://cloud.google.com/appengine/docs/flexible/scheduling-jobs-with-cron-yaml
+abstract class SingleExecutionRequestHandler extends ApiRequestHandler {
+  @visibleForTesting
+  static const subCacheName = 'SingleExecutionRequestHandler';
+
+  @visibleForTesting
+  static const xAppengineCron = 'X-Appengine-Cron';
+
+  const SingleExecutionRequestHandler({
+    required super.config,
+    required super.authenticationProvider,
+    required CacheService cache,
+    @visibleForTesting DateTime Function() now = DateTime.now,
+  }) : _cache = cache,
+       _now = now;
+
+  final CacheService _cache;
+  final DateTime Function() _now;
+
+  /// Whether to disallow access from non-`cron.yaml` jobs.
+  ///
+  /// See <https://cloud.google.com/appengine/docs/flexible/scheduling-jobs-with-cron-yaml#securing_urls_for_cron>.
+  bool get allowOnlyAppEngineCronAccess => true;
+
+  /// The maximum amount of time this task might concievably run.
+  ///
+  /// After [maxExecutionTime], the "lock" is removed and subsequent requests
+  /// still invoke [get], even if (somehow) an existing handler is still
+  /// processing a job.
+  ///
+  /// At most 60 minutes (cron tasks cannot run longer than 60 minutes), but
+  /// often shorter, such as the duration set in the root `cron.yaml` file. For
+  /// example a task that is executed every 5 minutes might have a max execution
+  /// time of 5 minutes.
+  @protected
+  Duration get maxExecutionTime => const Duration(minutes: 60);
+
+  /// Name of the cache key used for this handler.
+  @protected
+  String get cacheKey => '$runtimeType';
+
+  @override
+  @nonVirtual
+  Future<Body> get() async {
+    if (allowOnlyAppEngineCronAccess &&
+        request!.headers.value(xAppengineCron) != 'true') {
+      response!.statusCode = HttpStatus.unauthorized;
+      return Body.empty;
+    }
+
+    // Lookup if this task is already executing.
+    final isExecuting = await _cache.getOrCreateWithLocking(
+      subCacheName,
+      cacheKey,
+      createFn: null,
+    );
+    if (isExecuting != null) {
+      // Skip running this task.
+      final started = DateTime.fromMillisecondsSinceEpoch(
+        isExecuting.buffer.asUint64List().first,
+      );
+      log.info(
+        'Ignoring request to $runtimeType, already running since ${started.toIso8601String()}.',
+      );
+      response!.statusCode = HttpStatus.accepted;
+    } else {
+      // Mark the task as running.
+      try {
+        final now = Uint64List(1)..[0] = _now().millisecondsSinceEpoch;
+        await _cache.setWithLocking(
+          subCacheName,
+          cacheKey,
+          now.buffer.asUint8List(),
+          ttl: maxExecutionTime,
+        );
+        log.debug('Starting $runtimeType');
+        await run();
+      } finally {
+        log.debug('Completed $runtimeType');
+        await _cache.purge(subCacheName, cacheKey);
+      }
+    }
+    return Body.empty;
+  }
+
+  /// Provide the batch function that executes conditionally.
+  Future<void> run();
+}

--- a/app_dart/test/request_handling/single_execution_request_handler_test.dart
+++ b/app_dart/test/request_handling/single_execution_request_handler_test.dart
@@ -1,0 +1,237 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/request_handling/single_execution_request_handler.dart';
+import 'package:cocoon_service/src/service/cache_service.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+import '../src/datastore/fake_config.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_authentication.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  late FakeConfig config;
+  late FakeAuthenticationProvider authenticationProvider;
+  late CacheService cache;
+  late ApiRequestHandlerTester tester;
+
+  setUp(() {
+    config = FakeConfig();
+    authenticationProvider = FakeAuthenticationProvider();
+    cache = CacheService(inMemory: true);
+    tester = ApiRequestHandlerTester();
+  });
+
+  test('refuses a non-cron.yaml scheduled task', () async {
+    final handler = _TestHandler(
+      () => fail('Should not run'),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+    );
+
+    await tester.get(handler);
+
+    expect(tester.response.statusCode, HttpStatus.unauthorized);
+  });
+
+  test('allows a non-cron.yaml scheduled task', () async {
+    final handler = _TestHandler(
+      expectAsync0(() async {}),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+      allowOnlyAppEngineCronAccess: false,
+    );
+
+    await tester.get(handler);
+
+    expect(tester.response.statusCode, HttpStatus.ok);
+  });
+
+  test('allows a cron.yaml scheduled task (authorized)', () async {
+    final handler = _TestHandler(
+      expectAsync0(() async {}),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+      allowOnlyAppEngineCronAccess: true,
+    );
+
+    tester.request!.headers.add(
+      SingleExecutionRequestHandler.xAppengineCron,
+      'true',
+    );
+    await tester.get(handler);
+
+    expect(tester.response.statusCode, HttpStatus.ok);
+  });
+
+  test('blocks re-entry while executing', () async {
+    final completer = Completer<void>();
+    final handler = _TestHandler(
+      expectAsync0(() {
+        return completer.future;
+      }),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+      allowOnlyAppEngineCronAccess: false,
+    );
+
+    // Make a first request, which will block.
+    final blocking = ApiRequestHandlerTester();
+    final executing = blocking.get(handler);
+    await pumpEventQueue();
+
+    // Make a second request.
+    await tester.get(handler);
+    expect(tester.response.statusCode, HttpStatus.accepted);
+
+    completer.complete();
+    await executing;
+  });
+
+  test('allows re-running', () async {
+    final handler = _TestHandler(
+      expectAsync0(() async {}, count: 2),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+      allowOnlyAppEngineCronAccess: false,
+    );
+
+    // Make a first request, which will succeed.
+    await tester.get(handler);
+    expect(tester.response.statusCode, HttpStatus.ok);
+
+    // Make a second request, which will succeed.
+    await tester.get(handler);
+    expect(tester.response.statusCode, HttpStatus.ok);
+  });
+
+  test('stores the current DateTime as the cache value', () async {
+    final completer = Completer<void>();
+    final stickyNow = DateTime.now();
+    final handler = _TestHandler(
+      expectAsync0(() {
+        return completer.future;
+      }),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: cache,
+      allowOnlyAppEngineCronAccess: false,
+      cacheKey: 'test-cache-key',
+      now: () => stickyNow,
+    );
+
+    final waiting = tester.get(handler);
+    await pumpEventQueue();
+
+    final value = await cache.getOrCreate(
+      SingleExecutionRequestHandler.subCacheName,
+      'test-cache-key',
+      createFn: null,
+    );
+    expect(
+      value!.buffer.asUint64List().first,
+      stickyNow.millisecondsSinceEpoch,
+    );
+
+    completer.complete();
+    await expectLater(waiting, completes);
+
+    expect(
+      await cache.getOrCreate(
+        SingleExecutionRequestHandler.subCacheName,
+        'test-cache-key',
+        createFn: null,
+      ),
+      isNull,
+    );
+  });
+
+  test('stores a TTL', () async {
+    final capture = _FakeCapturingCache();
+    final handler = _TestHandler(
+      expectAsync0(() async {}),
+      config: config,
+      authenticationProvider: authenticationProvider,
+      cache: capture,
+      allowOnlyAppEngineCronAccess: false,
+      maxExecutionTime: const Duration(seconds: 42),
+    );
+
+    await tester.get(handler);
+    expect(capture.capturedTtl, const Duration(seconds: 42));
+  });
+}
+
+final class _FakeCapturingCache extends Fake implements CacheService {
+  Duration? capturedTtl;
+
+  @override
+  Future<void> purge(String subcacheName, String key) async {}
+
+  @override
+  Future<Uint8List?> getOrCreateWithLocking(
+    String subcacheName,
+    String key, {
+    required Future<Uint8List> Function()? createFn,
+    Duration ttl = const Duration(minutes: 1),
+  }) async {
+    return null;
+  }
+
+  @override
+  Future<Uint8List?> setWithLocking(
+    String subcacheName,
+    String key,
+    Uint8List? value, {
+    Duration ttl = const Duration(minutes: 1),
+  }) async {
+    capturedTtl = ttl;
+    return null;
+  }
+}
+
+final class _TestHandler extends SingleExecutionRequestHandler {
+  _TestHandler(
+    this._run, {
+    required super.config,
+    required super.authenticationProvider,
+    required super.cache,
+    super.now,
+    bool? allowOnlyAppEngineCronAccess,
+    Duration? maxExecutionTime,
+    String? cacheKey,
+  }) : _cacheKey = cacheKey,
+       _allowOnlyAppEngineCronAccess = allowOnlyAppEngineCronAccess,
+       _maxExecutionTime = maxExecutionTime;
+
+  @override
+  bool get allowOnlyAppEngineCronAccess =>
+      _allowOnlyAppEngineCronAccess ?? super.allowOnlyAppEngineCronAccess;
+  final bool? _allowOnlyAppEngineCronAccess;
+
+  @override
+  Duration get maxExecutionTime => _maxExecutionTime ?? super.maxExecutionTime;
+  final Duration? _maxExecutionTime;
+
+  @override
+  String get cacheKey => _cacheKey ?? super.cacheKey;
+  final String? _cacheKey;
+
+  @override
+  Future<void> run() => _run();
+  final Future<void> Function() _run;
+}

--- a/app_dart/test/service/github_service_test.dart
+++ b/app_dart/test/service/github_service_test.dart
@@ -22,7 +22,6 @@ void main() {
   late RepositorySlug slug;
 
   const branch = 'master';
-  const lastCommitTimestampMills = 100;
 
   const authorName = 'Jane Doe';
   const authorEmail = 'janedoe@example.com';
@@ -78,7 +77,7 @@ void main() {
     final commits = await githubService.listBranchedCommits(
       slug,
       branch,
-      lastCommitTimestampMills,
+      since: DateTime.now().subtract(const Duration(days: 1)),
     );
     expect(commits, hasLength(1));
     final commit = commits.single;

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -11,7 +11,7 @@ import 'package:github/github.dart';
 /// A fake GithubService implementation.
 class FakeGithubService implements GithubService {
   FakeGithubService({GitHub? client}) : github = client ?? MockGitHub();
-  late List<RepositoryCommit> Function(String, int) listCommitsBranch;
+  late List<RepositoryCommit> Function(String, DateTime) listCommitsBranch;
   late List<PullRequest> Function(String?) listPullRequestsBranch;
 
   @override
@@ -20,10 +20,10 @@ class FakeGithubService implements GithubService {
   @override
   Future<List<RepositoryCommit>> listBranchedCommits(
     RepositorySlug slug,
-    String branch,
-    int? lastCommitTimestampMills,
-  ) async {
-    return listCommitsBranch(branch, lastCommitTimestampMills ?? 0);
+    String branch, {
+    required DateTime since,
+  }) async {
+    return listCommitsBranch(branch, since);
   }
 
   final List<(RepositorySlug, String)> deletedBranches = [];

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -2791,15 +2791,15 @@ class MockGithubService extends _i1.Mock implements _i16.GithubService {
   @override
   _i19.Future<List<_i12.RepositoryCommit>> listBranchedCommits(
     _i12.RepositorySlug? slug,
-    String? branch,
-    int? lastCommitTimestampMills,
-  ) =>
+    String? branch, {
+    required DateTime? since,
+  }) =>
       (super.noSuchMethod(
-            Invocation.method(#listBranchedCommits, [
-              slug,
-              branch,
-              lastCommitTimestampMills,
-            ]),
+            Invocation.method(
+              #listBranchedCommits,
+              [slug, branch],
+              {#since: since},
+            ),
             returnValue: _i19.Future<List<_i12.RepositoryCommit>>.value(
               <_i12.RepositoryCommit>[],
             ),

--- a/cron.yaml
+++ b/cron.yaml
@@ -4,7 +4,7 @@
 #   gcloud app deploy --project flutter-dashboard cron.yaml
 cron:
 - description: retrieve missing commits
-  url: /api/v2/vacuum-github-commits
+  url: /api/vacuum-github-commits
   schedule: every 6 hours
 
 - description: vacuum stale tasks

--- a/dashboard/tool/update_goldens_from_luci.dart
+++ b/dashboard/tool/update_goldens_from_luci.dart
@@ -1,0 +1,15 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+void main(List<String> args) async {
+  if (args.length != 1) {
+    io.stderr.writeln(
+      'Usage: dart run tool/update_goldens_from_luci.dart <flutter/cocoon PR#>',
+    );
+    io.exitCode = 1;
+    return;
+  }
+}


### PR DESCRIPTION
🚫 Blocked. Needs Redis transaction support (https://github.com/flutter/flutter/issues/165687).

---

Attempt on mitigating https://github.com/flutter/flutter/issues/165612.

If we receive an additional request while one is already running, we can ignore subsequent requests.

It's not clear this solves https://github.com/flutter/flutter/issues/165612, so if it doesn't we can either adjust it (like, "run this at most ___ times in __" as part of the logic, instead of pending tasks), or remove the `SingleExecutionRequestHandler` part and just keep the (small) refactors.

(If we like this, we could make it the base class for the other Cron-type APIs)