### PR TITLE
Leave a comment instead of check run.

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -1360,21 +1360,20 @@ $s
         testsToRun: _FlutterRepoTestsToRun.engineTestsAndFrameworkTests,
       );
     } catch (error, stacktrace) {
-      await githubChecksService.githubChecksUtil.createCheckRun(
-        config,
+      final githubService = await config.createDefaultGitHubService();
+      await githubService.createComment(
         slug,
-        pullRequest.head!.sha!,
-        'CI Caught Failure',
-        conclusion: CheckRunConclusion.failure,
-        output: CheckRunOutput(
-          title: 'CI Caught Failure',
-          summary: 'A critical error occurred, preventing further CI testing.',
-          text: '''
-This check run indicates a failure in the CI process that stopped further tests from running.  We need to investigate to determine the root cause.
+        issueNumber: pullRequest.number!,
+        body: '''
+CI had a failure that stopped further tests from running.  We need to investigate to determine the root cause.
+
+SHA at time of execution: $sha.
 
 Possible causes:
 * **Configuration Changes:** The `.ci.yaml` file might have been modified between the creation of this pull request and the start of this test run. This can lead to ci yaml validation errors.
 * **Infrastructure Issues:** Problems with the CI environment itself (e.g., quota) could have caused the failure.
+
+A blank commit, or merging to head, will be required to resume running CI for this PR.
 
 **Error Details:**
 
@@ -1388,7 +1387,6 @@ Stack trace:
 $stacktrace
 ```
 ''',
-        ),
       );
     }
   }

--- a/dashboard/tool/update_goldens_from_luci.dart
+++ b/dashboard/tool/update_goldens_from_luci.dart
@@ -1,0 +1,15 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+void main(List<String> args) async {
+  if (args.length != 1) {
+    io.stderr.writeln(
+      'Usage: dart run tool/update_goldens_from_luci.dart <flutter/cocoon PR#>',
+    );
+    io.exitCode = 1;
+    return;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165662.

The check run was cute but it now means we need to filter out re-run attempts on it.

Given we'll probably move away from check runs (and use a dashboard), this seems fine?