### PR TITLE
Raise limit to `1000` framework-only files and modern release branches.

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -353,7 +353,7 @@ class Config {
   };
 
   /// The maximum [gh.PullRequest.changedFilesCount] to consider a PR for a "framework-only" CI optimization.
-  int get maxFilesChangedForSkippingEnginePhase => 29;
+  int get maxFilesChangedForSkippingEnginePhase => 1000;
 
   /// Max retries for Luci builder with infra failure.
   int get maxLuciTaskRetries => 2;

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -548,15 +548,10 @@ class Scheduler {
     // support this optimization.
     //
     // So, to avoid making it impossible to create a release branch, or to
-    // update the existing release branch (i.e. hot fixes), we only apply the
-    // optimization on the "master" branch.
-    //
-    // In theory, many moons from now when maintained release branches are
-    // guaranteed to include the flutter/recipes change we could remove this
-    // check.
-    final refuseLogPrefix =
-        'Refusing to skip engine builds for PR#$prNumber branch';
-    if (prBranch != Config.defaultBranch(Config.flutterSlug)) {
+    // or to update the existing release branch (i.e. hot fixes), we skip this
+    // optimziation on that specific branch.
+    final refuseLogPrefix = 'Refusing to skip engine builds for PR#$prNumber';
+    if (prBranch == 'flutter-3.29-candidate.0') {
       log.info(
         '$refuseLogPrefix: $prBranch (not ${Config.defaultBranch(Config.flutterSlug)} branch)',
       );

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -3609,15 +3609,17 @@ targets:
       });
 
       test(
-        'still runs engine builds (>= 30 files in changedFilesCount)',
+        'still runs engine builds (>=X files in changedFilesCount)',
         () async {
           fakeFusion.isFusion = (_, _) => true;
           getFilesChanged.cannedFiles = [
             // Irrelevant, never called.
           ];
+          config.maxFilesChangedForSkippingEnginePhaseValue = 1000;
+
           final pullRequest = generatePullRequest(
             authorLogin: 'joe-flutter',
-            changedFilesCount: 30,
+            changedFilesCount: config.maxFilesChangedForSkippingEnginePhase,
           );
 
           await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
@@ -3653,7 +3655,7 @@ targets:
       });
 
       // Regression test for https://github.com/flutter/flutter/issues/162403.
-      test('engine builds still run for release branches', () async {
+      test('engine builds still run for flutter-3.29-candidate.0', () async {
         fakeFusion.isFusion = (_, _) => true;
         getFilesChanged.cannedFiles = ['packages/flutter/lib/material.dart'];
         final pullRequest = generatePullRequest(


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/161462.

It turns out @jtmcdole  had _accidentally_ fixes fixed by using our `GithubService` wrapper while refactoring, meaning `PaginationHelper` has been used this _entire_ time, and we have been getting the full list of files (since https://github.com/flutter/cocoon/pull/4191 at least), so this can actually be lifted.

In addition, we can just gate the optimization on a specific release branch (to speed up beta/new stables).