### PR TITLE
Collate tasks correctly for `/api/get-status`.

### DIFF
--- a/app_dart/lib/src/model/firestore/commit_tasks_status.dart
+++ b/app_dart/lib/src/model/firestore/commit_tasks_status.dart
@@ -58,7 +58,7 @@ class CommitTasksStatus {
     }
 
     // Sort build numbers, and return.
-    final fullTasks = fullTasksMap.values.toList();
+    final fullTasks = [...fullTasksMap.values];
     for (final fullTask in fullTasks) {
       fullTask.buildList.sort();
     }

--- a/app_dart/lib/src/model/firestore/commit_tasks_status.dart
+++ b/app_dart/lib/src/model/firestore/commit_tasks_status.dart
@@ -30,21 +30,39 @@ class CommitTasksStatus {
   ///
   /// Note we use the lastest run as the `task`, surfacing on the dashboard.
   List<FullTask> collateTasksByTaskName() {
+    // Create an initial map of { task-name -> FullTask(latestTask, []) }
     final fullTasksMap = <String, FullTask>{};
-    for (var task in tasks) {
-      if (!fullTasksMap.containsKey(task.taskName)) {
-        if (task.buildNumber == null) {
-          fullTasksMap[task.taskName!] = FullTask(task, <int>[]);
+    for (final task in tasks) {
+      final FullTask taskToAddBuildNumber;
+      // If task.taskName already exists
+      if (fullTasksMap[task.taskName!] case final fullTask?) {
+        // If this task is newer than the existing task, use the new task
+        if (task.attempts! > fullTask.task.attempts!) {
+          taskToAddBuildNumber = FullTask(task, fullTask.buildList);
         } else {
-          fullTasksMap[task.taskName!] = FullTask(task, <int>[
-            task.buildNumber!,
-          ]);
+          // Otherwise, just reference the existing (newer) task
+          taskToAddBuildNumber = fullTask;
         }
-      } else if (fullTasksMap.containsKey(task.taskName)) {
-        fullTasksMap[task.taskName]!.buildList.add(task.buildNumber!);
+      } else {
+        // Otherwise, use this task as the latest task (so far)
+        taskToAddBuildNumber = FullTask(task, []);
       }
+
+      // If the task has a build number, add it to the list
+      if (task.buildNumber case final buildNumber?) {
+        taskToAddBuildNumber.buildList.add(buildNumber);
+      }
+
+      // And store it for the next loop
+      fullTasksMap[task.taskName!] = taskToAddBuildNumber;
     }
-    return fullTasksMap.entries.map((entry) => entry.value).toList();
+
+    // Sort build numbers, and return.
+    final fullTasks = fullTasksMap.values.toList();
+    for (final fullTask in fullTasks) {
+      fullTask.buildList.sort();
+    }
+    return fullTasks;
   }
 }
 

--- a/app_dart/test/model/firestore/commit_tasks_status_test.dart
+++ b/app_dart/test/model/firestore/commit_tasks_status_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/commit_tasks_status.dart';
+import 'package:test/test.dart';
+
+import '../../src/utilities/entity_generators.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  group('collateTasksByTaskName', () {
+    test('surfaces the latest task as FullTask.task', () {
+      final status = CommitTasksStatus(generateFirestoreCommit(1), [
+        generateFirestoreTask(1, attempts: 2, buildNumber: 1002),
+        generateFirestoreTask(1, attempts: 3, buildNumber: 1003),
+        generateFirestoreTask(1, attempts: 1, buildNumber: 1001),
+      ]);
+
+      final collate = status.collateTasksByTaskName();
+      expect(collate, [
+        isA<FullTask>()
+            .having((t) => t.task.taskName, 'task.taskName', 'task1')
+            .having((t) => t.task.attempts, 'task.attempts', 3)
+            .having((t) => t.buildList, 'buildList', [1001, 1002, 1003]),
+      ]);
+    });
+
+    test('skips null build numbers', () {
+      final status = CommitTasksStatus(generateFirestoreCommit(1), [
+        generateFirestoreTask(1, attempts: 2, buildNumber: 1002),
+        generateFirestoreTask(1, attempts: 3, buildNumber: null),
+        generateFirestoreTask(1, attempts: 1, buildNumber: 1001),
+      ]);
+
+      final collate = status.collateTasksByTaskName();
+      expect(collate, [
+        isA<FullTask>()
+            .having((t) => t.task.taskName, 'task.taskName', 'task1')
+            .having((t) => t.task.attempts, 'task.attempts', 3)
+            .having((t) => t.buildList, 'buildList', [1001, 1002]),
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165828.

I assumed `CommitTasksStatus.collateTasks()` worked, but it never did 😢 .

Fixed it, and added some trivial tests to catch the obvious null-check bugs that were crashing.