### PR TITLE
Attempt 2 - Stop using the (external) field names of Task outside of the Task class 

### DIFF
--- a/app_dart/lib/src/model/firestore/commit_tasks_status.dart
+++ b/app_dart/lib/src/model/firestore/commit_tasks_status.dart
@@ -73,9 +73,19 @@ class FullTask {
   final Task task;
   final List<int> buildList;
 
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'Task': task.facade,
+  Map<String, Object?> toJson() {
+    return {
+      'Task': {
+        'DocumentName': task.name,
+        'TaskName': task.taskName,
+        'CommitSha': task.commitSha,
+        'CreateTimestamp': task.createTimestamp,
+        'StartTimestamp': task.startTimestamp,
+        'EndTimestamp': task.endTimestamp,
+        'Status': task.status,
+        'Bringup': task.bringup,
+        'TestFlaky': task.testFlaky,
+      },
       'BuildList': buildList.join(','),
     };
   }

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -107,8 +107,9 @@ class DartInternalSubscription extends SubscriptionHandler {
     await datastore.insert(<Task>[taskToInsert]);
     try {
       final firestoreService = await config.createFirestoreService();
-      final taskDocument = firestore.taskToDocument(taskToInsert);
-      final writes = documentsToWrites([taskDocument]);
+      final writes = documentsToWrites([
+        firestore.Task.fromDatastore(taskToInsert),
+      ]);
       await firestoreService.batchWriteDocuments(
         BatchWriteRequest(writes: writes),
         kDatabase,

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -146,8 +146,9 @@ class BatchBackfiller extends RequestHandler {
     if (tasks.isEmpty) {
       return;
     }
-    final taskDocuments = tasks.map(firestore.taskToDocument).toList();
-    final writes = documentsToWrites(taskDocuments, exists: true);
+    final writes = documentsToWrites([
+      ...tasks.map(firestore.Task.fromDatastore),
+    ], exists: true);
     final firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);
   }

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -113,8 +113,9 @@ class VacuumStaleTasks extends RequestHandler<Body> {
     if (tasks.isEmpty) {
       return;
     }
-    final taskDocuments = tasks.map(firestore.taskToDocument).toList();
-    final writes = documentsToWrites(taskDocuments, exists: true);
+    final writes = documentsToWrites([
+      ...tasks.map(firestore.Task.fromDatastore),
+    ], exists: true);
     final firestoreService = await config.createFirestoreService();
     await firestoreService.writeViaTransaction(writes);
   }

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -135,30 +135,28 @@ class FirestoreService {
     int limit = 100,
     required String name,
   }) async {
-    final filterMap = {'$kTaskNameField =': name};
-    final orderMap = {kTaskCreateTimestampField: kQueryOrderDescending};
+    final filterMap = {'${Task.fieldBringup} =': name};
+    final orderMap = {Task.fieldCreateTimestamp: kQueryOrderDescending};
     final documents = await query(
       kTaskCollectionId,
       filterMap,
       orderMap: orderMap,
     );
-    return documents.map((d) => Task.fromDocument(taskDocument: d)).toList();
+    return [...documents.map(Task.fromDocument)];
   }
 
   /// Returns all tasks running against the speificed [commitSha].
   Future<List<Task>> queryCommitTasks(String commitSha) async {
-    final filterMap = <String, Object>{'$kTaskCommitShaField =': commitSha};
+    final filterMap = <String, Object>{'${Task.fieldCommitSha} =': commitSha};
     final orderMap = <String, String>{
-      kTaskCreateTimestampField: kQueryOrderDescending,
+      Task.fieldCreateTimestamp: kQueryOrderDescending,
     };
     final documents = await query(
       kTaskCollectionId,
       filterMap,
       orderMap: orderMap,
     );
-    return documents
-        .map((Document document) => Task.fromDocument(taskDocument: document))
-        .toList();
+    return [...documents.map(Task.fromDocument)];
   }
 
   /// Queries the last updated Gold status for the [slug] and [prNumber].

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -135,7 +135,7 @@ class FirestoreService {
     int limit = 100,
     required String name,
   }) async {
-    final filterMap = {'${Task.fieldBringup} =': name};
+    final filterMap = {'${Task.fieldName} =': name};
     final orderMap = {Task.fieldCreateTimestamp: kQueryOrderDescending};
     final documents = await query(
       kTaskCollectionId,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -285,9 +285,8 @@ class Scheduler {
       repositoryPath: commit.repository!,
       sha: commit.sha!,
     );
-    final taskDocuments = firestore.targetsToTaskDocuments(commit, targets);
     final writes = documentsToWrites([
-      ...taskDocuments,
+      ...[...tasks.map(firestore.Task.fromDatastore)],
       commitDocument,
     ], exists: false);
     // TODO(keyonghan): remove try catch logic after validated to work.

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_server_test/test_logging.dart';
-import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:cocoon_service/src/service/luci_build_service/firestore_task_document_name.dart';
@@ -22,14 +21,18 @@ void main() {
 
   group('Task', () {
     test('disallows illegal status', () {
-      final task = Task();
+      final task = Task.fromDocument(
+        Document()
+          ..name = 'name'
+          ..fields = {},
+      );
       expect(() => task.setStatus('unknown'), throwsArgumentError);
     });
 
     test('creates task document correctly from task data model', () async {
       final task = generateTask(1);
       final commitSha = task.commitKey!.id!.split('/').last;
-      final taskDocument = taskToDocument(task);
+      final taskDocument = Task.fromDatastore(task);
       expect(
         taskDocument.name,
         '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${task.name}_${task.attempts}',
@@ -42,49 +45,6 @@ void main() {
       expect(taskDocument.status, task.status);
       expect(taskDocument.testFlaky, task.isTestFlaky);
       expect(taskDocument.commitSha, commitSha);
-    });
-
-    test('creates task documents correctly from targets', () async {
-      final commit = generateCommit(1);
-      final targets = <Target>[
-        generateTarget(1, platform: 'Mac'),
-        generateTarget(2, platform: 'Linux'),
-      ];
-      final taskDocuments = targetsToTaskDocuments(commit, targets);
-      expect(taskDocuments.length, 2);
-      expect(
-        taskDocuments[0].name,
-        '$kDatabase/documents/$kTaskCollectionId/${commit.sha}_${targets[0].value.name}_$kTaskInitialAttempt',
-      );
-      expect(
-        taskDocuments[0].fields![kTaskCreateTimestampField]!.integerValue,
-        commit.timestamp.toString(),
-      );
-      expect(
-        taskDocuments[0].fields![kTaskEndTimestampField]!.integerValue,
-        '0',
-      );
-      expect(taskDocuments[0].fields![kTaskBringupField]!.booleanValue, false);
-      expect(
-        taskDocuments[0].fields![kTaskNameField]!.stringValue,
-        targets[0].value.name,
-      );
-      expect(
-        taskDocuments[0].fields![kTaskStartTimestampField]!.integerValue,
-        '0',
-      );
-      expect(
-        taskDocuments[0].fields![kTaskStatusField]!.stringValue,
-        Task.statusNew,
-      );
-      expect(
-        taskDocuments[0].fields![kTaskTestFlakyField]!.booleanValue,
-        false,
-      );
-      expect(
-        taskDocuments[0].fields![kTaskCommitShaField]!.stringValue,
-        commit.sha,
-      );
     });
 
     group('updateFromBuild', () {
@@ -170,24 +130,6 @@ void main() {
       expect(task.status, Task.statusNew);
       expect(task.testFlaky, false);
     });
-  });
-
-  test('task facade', () {
-    final taskDocument = generateFirestoreTask(1);
-    final expectedResult = <String, dynamic>{
-      kTaskDocumentName: taskDocument.name,
-      kTaskCommitSha: taskDocument.commitSha,
-      kTaskCreateTimestamp: taskDocument.createTimestamp,
-      kTaskStartTimestamp: taskDocument.startTimestamp,
-      kTaskEndTimestamp: taskDocument.endTimestamp,
-      kTaskTaskName: taskDocument.taskName,
-      kTaskAttempts: taskDocument.attempts,
-      kTaskBringup: taskDocument.bringup,
-      kTaskTestFlaky: taskDocument.testFlaky,
-      kTaskBuildNumber: taskDocument.buildNumber,
-      kTaskStatus: taskDocument.status,
-    };
-    expect(taskDocument.facade, expectedResult);
   });
 }
 

--- a/app_dart/test/request_handlers/dart_internal_subscription_test.dart
+++ b/app_dart/test/request_handlers/dart_internal_subscription_test.dart
@@ -191,7 +191,7 @@ void main() {
     final batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final insertedTaskDocument = firestore.Task.fromDocument(
-      taskDocument: batchWriteRequest.writes![0].update!,
+      batchWriteRequest.writes![0].update!,
     );
     expect(insertedTaskDocument.taskName, expectedTask.name);
   });
@@ -280,7 +280,7 @@ void main() {
     final batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final insertedTaskDocument = firestore.Task.fromDocument(
-      taskDocument: batchWriteRequest.writes![0].update!,
+      batchWriteRequest.writes![0].update!,
     );
     expect(insertedTaskDocument.status, expectedTask.status);
   });

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -354,9 +354,7 @@ void main() {
     final batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final insertedTaskDocument = batchWriteRequest.writes![0].update!;
-    final resultTask = firestore.Task.fromDocument(
-      taskDocument: insertedTaskDocument,
-    );
+    final resultTask = firestore.Task.fromDocument(insertedTaskDocument);
     expect(resultTask.status, firestore.Task.statusInProgress);
     expect(resultTask.attempts, 2);
   });
@@ -412,9 +410,7 @@ void main() {
     final batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final insertedTaskDocument = batchWriteRequest.writes![0].update!;
-    final resultTask = firestore.Task.fromDocument(
-      taskDocument: insertedTaskDocument,
-    );
+    final resultTask = firestore.Task.fromDocument(insertedTaskDocument);
     expect(resultTask.status, firestore.Task.statusInProgress);
     expect(resultTask.attempts, 2);
   });
@@ -472,9 +468,7 @@ void main() {
       final batchWriteRequest = captured[0] as BatchWriteRequest;
       expect(batchWriteRequest.writes!.length, 1);
       final insertedTaskDocument = batchWriteRequest.writes![0].update!;
-      final resultTask = firestore.Task.fromDocument(
-        taskDocument: insertedTaskDocument,
-      );
+      final resultTask = firestore.Task.fromDocument(insertedTaskDocument);
       expect(resultTask.status, firestore.Task.statusInProgress);
       expect(resultTask.attempts, 2);
     },

--- a/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
+++ b/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
@@ -254,7 +254,7 @@ void main() {
       final commitResponse = captured[0] as List<Write>;
       expect(commitResponse.length, 1);
       final taskDocuemnt = firestore.Task.fromDocument(
-        taskDocument: commitResponse[0].update!,
+        commitResponse[0].update!,
       );
       expect(taskDocuemnt.status, firestore.Task.statusInProgress);
     });

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -134,10 +134,10 @@ void main() {
       final commitResponse = captured[0] as List<Write>;
       expect(commitResponse.length, 2);
       final taskDocuemnt1 = firestore.Task.fromDocument(
-        taskDocument: commitResponse[0].update!,
+        commitResponse[0].update!,
       );
       final taskDocuemnt2 = firestore.Task.fromDocument(
-        taskDocument: commitResponse[0].update!,
+        commitResponse[0].update!,
       );
       expect(taskDocuemnt1.status, firestore.Task.statusNew);
       expect(taskDocuemnt2.status, firestore.Task.statusNew);

--- a/app_dart/test/src/utilities/entity_generators.dart
+++ b/app_dart/test/src/utilities/entity_generators.dart
@@ -78,7 +78,7 @@ Task generateTask(
   key: (parent ?? generateCommit(i)).key.append(Task, id: i),
   attempts: attempts,
   isFlaky: isFlaky,
-  builderName: builderName,
+  builderName: builderName ?? name ?? 'task$i',
   buildNumber: buildNumber,
   buildNumberList: buildNumber != null ? '$buildNumber' : null,
   createTimestamp: created?.millisecondsSinceEpoch ?? 0,
@@ -98,33 +98,18 @@ firestore.Task generateFirestoreTask(
   DateTime? ended,
   String? commitSha,
 }) {
-  final taskName = name ?? 'task$i';
-  final sha = commitSha ?? 'testSha';
-  final task =
-      firestore.Task()
-        ..name = '${sha}_${taskName}_$attempts'
-        ..fields = <String, Value>{
-          firestore.kTaskCreateTimestampField: Value(
-            integerValue: (created?.millisecondsSinceEpoch ?? 0).toString(),
-          ),
-          firestore.kTaskStartTimestampField: Value(
-            integerValue: (started?.millisecondsSinceEpoch ?? 0).toString(),
-          ),
-          firestore.kTaskEndTimestampField: Value(
-            integerValue: (ended?.millisecondsSinceEpoch ?? 0).toString(),
-          ),
-          firestore.kTaskBringupField: Value(booleanValue: bringup),
-          firestore.kTaskTestFlakyField: Value(booleanValue: testFlaky),
-          firestore.kTaskStatusField: Value(stringValue: status),
-          firestore.kTaskNameField: Value(stringValue: taskName),
-          firestore.kTaskCommitShaField: Value(stringValue: sha),
-        };
-  if (buildNumber != null) {
-    task.fields![firestore.kTaskBuildNumberField] = Value(
-      integerValue: buildNumber.toString(),
-    );
-  }
-  return task;
+  return firestore.Task(
+    builderName: name ?? 'task$i',
+    currentAttempt: attempts,
+    commitSha: commitSha ?? 'testSha',
+    bringup: bringup,
+    buildNumber: buildNumber,
+    createTimestamp: created?.millisecondsSinceEpoch ?? 0,
+    startTimestamp: started?.millisecondsSinceEpoch ?? 0,
+    endTimestamp: ended?.millisecondsSinceEpoch ?? 0,
+    status: status,
+    testFlaky: testFlaky,
+  );
 }
 
 firestore_commit.Commit generateFirestoreCommit(


### PR DESCRIPTION
Reverts (fixing-forward) https://github.com/flutter/cocoon/pull/4399.

This time we use `fieldName` instead of `fieldBringup`.