### PR TITLE
Avoid retrying deleted branches in the Merge Queue handler

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -294,10 +294,13 @@ class GithubWebhookSubscription extends SubscriptionHandler {
             final githubService = await config.createGithubService(slug);
             try {
               await githubService.getReference(slug, mergeGroup.headRef);
+              log.info(
+                '$slug/$headSha was not found on GoB, but was found on GitHub.',
+              );
             } on github.NotFound {
               final message =
                   '$slug/$headSha was not found on GoB and appears deleted on '
-                  'github.';
+                  'GitHub.';
               log.info(message);
               return ProcessCheckRunResult.missingEntity(message);
             }

--- a/app_dart/test/src/service/fake_github_service.dart
+++ b/app_dart/test/src/service/fake_github_service.dart
@@ -120,9 +120,10 @@ class FakeGithubService implements GithubService {
     return <String>['abc/def'];
   }
 
+  GitReference Function() getReferenceValue = GitReference.new;
   @override
   Future<GitReference> getReference(RepositorySlug slug, String ref) async {
-    return GitReference();
+    return getReferenceValue();
   }
 
   @override

--- a/app_dart/test/src/utilities/webhook_generators.dart
+++ b/app_dart/test/src/utilities/webhook_generators.dart
@@ -1136,7 +1136,10 @@ PushMessage generateMergeGroupMessage({
   required String repository,
   required String action,
   required String message,
+  DateTime? publishTime,
   String? reason,
+  String? headSha,
+  String? headRef,
 }) {
   if (action == 'destroyed' &&
       !MergeGroupEvent.destroyReasons.contains(reason)) {
@@ -1152,24 +1155,35 @@ PushMessage generateMergeGroupMessage({
       message: message,
       repository: repository,
       reason: reason,
+      headSha: headSha,
+      headRef: headRef,
     ),
   );
-  return PushMessage(data: webhookMessage.writeToJson(), messageId: 'abc123');
+  publishTime ??= DateTime.now();
+  return PushMessage(
+    data: webhookMessage.writeToJson(),
+    messageId: 'abc123',
+    publishTime: publishTime.toUtc().toIso8601String(),
+  );
 }
 
 String generateMergeGroupEventString({
   required String action,
   required String message,
   required String repository,
+  String? headSha,
+  String? headRef,
   String? reason,
 }) {
+  headSha ??= 'c9affbbb12aa40cb3afbe94b9ea6b119a256bebf';
+  headRef ??= 'refs/heads/gh-readonly-queue/main/pr-15-$headSha';
   return '''
 {
 "action": "$action",
 ${reason != null ? '"reason": "$reason",' : ''}
 "merge_group": {
-  "head_sha": "c9affbbb12aa40cb3afbe94b9ea6b119a256bebf",
-  "head_ref": "refs/heads/gh-readonly-queue/main/pr-15-172355550dde5881b0269972ea4cbe5a6d0561bc",
+  "head_sha": "$headSha",
+  "head_ref": "$headRef",
   "base_sha": "172355550dde5881b0269972ea4cbe5a6d0561bc",
   "base_ref": "refs/heads/main",
   "head_commit": {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/166078.

Part 2 of https://github.com/flutter/cocoon/pull/4393.

Before we were returning `5xx` class errors to Cloud PubSub, which means "retry". After this PR, for PRs that are >= 15 minutes old, we check and see "was the corresponding branch deleted", and if it was, we return a `4xx` class error, which will discard the Cloud PubSub message instead.

This reduces the amount of indefinite hops that happens from Cocoon <> Cloud PubSub.