### PR TITLE
Handle duplicate gold patchsets.

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -320,12 +320,13 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
         );
       }
       final patchsets = jsonResponseTriage['patchsets'] as List<dynamic>;
+      // Note: there can be multiple patchsets with the same id, ensure that
+      // all are collected.
       var untriaged = 0;
       for (var i = 0; i < patchsets.length; i++) {
         final patchset = patchsets[i] as Map<String, dynamic>;
         if (patchset['patchset_id'] == pr.head!.sha) {
-          untriaged = patchset['new_untriaged_images'] as int;
-          break;
+          untriaged += patchset['new_untriaged_images'] as int;
         }
       }
 

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -409,7 +409,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '2'
@@ -421,7 +420,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '3'
@@ -466,7 +464,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -478,7 +475,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -518,7 +514,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = 'Task Name'
@@ -579,7 +574,6 @@ void main() {
                     Commit()
                       ..author = 'Cast'
                       ..branch = 'master',
-
                 tasks: [
                   Task()
                     ..status = 'Succeeded'
@@ -606,7 +600,6 @@ void main() {
                     Commit()
                       ..author = 'Cast'
                       ..branch = 'master',
-
                 tasks: [
                   Task()
                     ..status = 'Succeeded'
@@ -638,7 +631,6 @@ void main() {
                     Commit()
                       ..author = 'Cast'
                       ..branch = 'master',
-
                 tasks: [
                   Task()
                     ..status = 'Succeeded'
@@ -665,7 +657,6 @@ void main() {
                     Commit()
                       ..author = 'Cast'
                       ..branch = 'master',
-
                 tasks: [
                   Task()
                     ..status = 'Succeeded'
@@ -709,7 +700,6 @@ void main() {
                       Commit()
                         ..author = 'Cast'
                         ..branch = 'master',
-
                   tasks: [taskA3],
                 ),
                 CommitStatus(
@@ -717,7 +707,6 @@ void main() {
                       Commit()
                         ..author = 'Cast'
                         ..branch = 'master',
-
                   tasks: [taskB1],
                 ),
               ],
@@ -752,7 +741,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -776,7 +764,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -805,7 +792,6 @@ void main() {
             Commit()
               ..author = 'Author'
               ..branch = 'master',
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -834,7 +820,6 @@ void main() {
             (Commit()
               ..author = 'Author'
               ..branch = 'master'),
-
         tasks: [
           Task()
             ..builderName = '1'
@@ -926,7 +911,6 @@ Future<void> expectTaskBoxColorWithMessage(
                         Commit()
                           ..author = 'Mathilda'
                           ..branch = 'master',
-
                     tasks: [Task()..status = message],
                   ),
                 ],

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -49,7 +49,6 @@ class TestGrid extends StatelessWidget {
                   ..author = 'Fats Domino'
                   ..sha = '24e8c0a2'
                   ..branch = 'master'),
-
             tasks: [task],
           ),
         ],


### PR DESCRIPTION
Gold can return multiple patchsets for the same commit. We need to sum the untriaged images of all of them, otherwise based on the exact ordering we can miss golden diffs.