### PR TITLE
Move `commit_tasks_status`, explain `documentId` path Firestore models

### DIFF
--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -22,6 +22,10 @@ import '../../service/firestore.dart';
 ///       remaining: int >= 0
 ///       [*fields]: string {scheduled, success, failure, skipped}
 /// ```
+///
+/// Note that the document ID fields are _synthetic_, that is, there is no
+/// cooresponding concrete field on the document itself. We should probably fix
+/// that (https://github.com/flutter/flutter/issues/166229).
 class CiStaging extends Document {
   /// Firestore collection for the staging documents.
   static const kCollectionId = 'ciStaging';

--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'task.dart';
+library;
+
 import 'dart:io';
 
 import 'package:github/github.dart';
@@ -12,6 +15,17 @@ import '../../../cocoon_service.dart';
 import '../../service/firestore.dart';
 import 'base.dart';
 
+/// Representation of each commit (row) on https://flutter-dashboard.appspot.com/#/build.
+///
+/// Provides enough information to render a build status without querying GitHub
+/// for commit information, and is a (non-enforced) parent document of [Task],
+/// where each [Commit] has many tasks associated by [Task.commitSha].
+///
+/// This documents layout is currently:
+/// ```
+///  /projects/flutter-dashboard/databases/cocoon/commits/
+///    document: <this.sha>
+/// ```
 final class Commit extends Document with AppDocument<Commit> {
   static const collectionId = 'commits';
   static const fieldAvatar = 'avatar';

--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -16,8 +16,13 @@ const String kGithubBuildStatusStatusField = 'status';
 const String kGithubBuildStatusUpdateTimeMillisField = 'updateTimeMillis';
 const String kGithubBuildStatusUpdatesField = 'updates';
 
-/// Class that represents an update having been posted to a GitHub PR on the
-/// status of the Flutter build.
+/// A update having been posted to a GitHub PR on the status of the build.
+///
+/// This documents layout is currently:
+/// ```
+///  /projects/flutter-dashboard/databases/cocoon/commits/
+///    document: <this.head>
+/// ```
 class GithubBuildStatus extends Document {
   /// Lookup [GithubBuildStatus] from Firestore.
   ///

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -16,6 +16,13 @@ const String kGithubGoldStatusDescriptionField = 'description';
 const String kGithubGoldStatusUpdatesField = 'updates';
 const String kGithubGoldStatusRepositoryField = 'repository';
 
+/// A update having been posted to a GitHub PR on the status of the build.
+///
+/// This documents layout is currently:
+/// ```
+///  /projects/flutter-dashboard/databases/cocoon/commits/
+///    document: <this.slug.owner>_<this.slug.name>_<this.prNumber>
+/// ```
 class GithubGoldStatus extends Document {
   /// Lookup [GithubGoldStatus] from Firestore.
   ///

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'commit.dart';
+library;
+
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:googleapis/firestore/v1.dart' hide Status;
 import 'package:path/path.dart' as p;
@@ -15,6 +18,23 @@ import 'base.dart';
 
 const String kTaskCollectionId = 'tasks';
 
+/// Representation of each task (column) per _row_ on https://flutter-dashboard.appspot.com/#/build.
+///
+/// Provides enough information to render a build status without querying LUCI,
+/// and is also used to do some light analysis-based tasks (based on recent
+/// tasks). Each [commitSha] is associated with a [Commit.sha].
+///
+/// This documents layout is currently:
+/// ```
+///  /projects/flutter-dashboard/databases/cocoon/commits/
+///    document: <this.commitSha>_<this.taskName>_<attempts>
+/// ```
+///
+/// Note that the [attempts] field is _synthetic_, that is, there is no
+/// cooresponding concrete field on the document itself. We should probably fix
+/// that (https://github.com/flutter/flutter/issues/166229).
+///
+/// See also: [FirestoreTaskDocumentName].
 final class Task extends Document with AppDocument<Task> {
   static const fieldBringup = 'bringup';
   static const fieldBuildNumber = 'buildNumber';

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -9,10 +9,10 @@ import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
-import '../service/build_status_provider/commit_tasks_status.dart';
 import '../request_handling/body.dart';
 import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
+import '../service/build_status_provider/commit_tasks_status.dart';
 import '../service/config.dart';
 
 /// Returns [List<String>] of the commit shas that had all passing tests.

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
-import '../model/firestore/commit_tasks_status.dart';
+import '../service/build_status_provider/commit_tasks_status.dart';
 import '../request_handling/body.dart';
 import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -8,11 +8,11 @@ import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../model/firestore/commit.dart';
-import '../model/firestore/commit_tasks_status.dart';
 import '../model/firestore/task.dart';
 import '../request_handling/body.dart';
 import '../request_handling/request_handler.dart';
 import '../service/build_status_provider.dart';
+import '../service/build_status_provider/commit_tasks_status.dart';
 import '../service/config.dart';
 
 @immutable

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -8,9 +8,9 @@ import 'package:github/github.dart';
 import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';
-import '../model/firestore/commit_tasks_status.dart';
 import '../model/firestore/github_build_status.dart';
 import '../model/firestore/task.dart';
+import 'build_status_provider/commit_tasks_status.dart';
 
 /// Branches that are used to calculate the tree status.
 const Set<String> defaultBranches = <String>{

--- a/app_dart/lib/src/service/build_status_provider/commit_tasks_status.dart
+++ b/app_dart/lib/src/service/build_status_provider/commit_tasks_status.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'commit.dart';
-import 'task.dart';
+import '../../model/firestore/commit.dart';
+import '../../model/firestore/task.dart';
 
 /// Class that holds the status for all tasks corresponding to a particular
 /// commit.

--- a/app_dart/test/request_handlers/get_green_commits_test.dart
+++ b/app_dart/test/request_handlers/get_green_commits_test.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
-import 'package:cocoon_service/src/model/firestore/commit_tasks_status.dart';
+import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -6,8 +6,8 @@ import 'dart:convert';
 
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart';
-import 'package:cocoon_service/src/model/firestore/commit_tasks_status.dart';
 import 'package:cocoon_service/src/request_handlers/get_status.dart';
+import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;

--- a/app_dart/test/service/commit_tasks_status_test.dart
+++ b/app_dart/test/service/commit_tasks_status_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_server_test/test_logging.dart';
-import 'package:cocoon_service/src/model/firestore/commit_tasks_status.dart';
+import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:test/test.dart';
 
 import '../../src/utilities/entity_generators.dart';

--- a/app_dart/test/service/commit_tasks_status_test.dart
+++ b/app_dart/test/service/commit_tasks_status_test.dart
@@ -6,7 +6,7 @@ import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:test/test.dart';
 
-import '../../src/utilities/entity_generators.dart';
+import '../src/utilities/entity_generators.dart';
 
 void main() {
   useTestLoggerPerTest();

--- a/app_dart/test/src/service/fake_build_status_provider.dart
+++ b/app_dart/test/src/service/fake_build_status_provider.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_service/src/model/firestore/commit_tasks_status.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
+import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/166229.

This makes it easier to remember where these models are stored in a NoSQL path than looking it up each time on Firebase. Also moved a "model" that was not actually serialized and stored in Firestore out of the `model` directory.