### PR TITLE
Ignore `<Document>.name` when inserting a new document.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -571,11 +571,12 @@ class LuciBuildService {
         datastore = datastore,
       );
       tags.addOrReplace(CurrentAttemptBuildTag(attemptNumber: newAttempt));
-    } catch (e) {
+    } catch (e, s) {
       log.error(
         'updating task ${taskDocument.taskName} of commit '
         '${taskDocument.commitSha}. Skipping rescheduling.',
         e,
+        s,
       );
       return;
     }
@@ -1097,11 +1098,12 @@ class LuciBuildService {
         datastore = datastore,
       );
       buildTags.add(CurrentAttemptBuildTag(attemptNumber: newAttempt));
-    } catch (e) {
+    } catch (e, s) {
       log.error(
         'Updating task ${taskDocument.taskName} of commit '
         '${taskDocument.commitSha} failure. Skipping rescheduling.',
         e,
+        s,
       );
       return false;
     }
@@ -1146,6 +1148,7 @@ class LuciBuildService {
     final newAttempt = int.parse(taskDocument.name!.split('_').last) + 1;
     taskDocument.resetAsRetry(attempt: newAttempt);
     taskDocument.setStatus(firestore.Task.statusInProgress);
+
     await firestoreService.insert(taskDocument);
 
     return newAttempt;

--- a/packages/cocoon_server/lib/firestore.dart
+++ b/packages/cocoon_server/lib/firestore.dart
@@ -130,8 +130,16 @@ base class Firestore {
   @useResult
   Future<g.Document?> tryInsertByPath(String path, g.Document document) async {
     try {
+      // TODO(matanlurey): Make this an error instead of stripping it off.
+      // Document.name cannot be set on an inserted path, but some documents
+      // use ".name" as a synthetic field (i.e. Task.attempts) where it would
+      // be cumbersome and error-prone to remember to sometimes clear the name.
+      //
+      // See https://github.com/flutter/flutter/issues/166229.
+      final clone = g.Document(fields: {...?document.fields});
+      assert(clone.name == null, 'Name must be null for new documents');
       return await _api.projects.databases.documents.createDocument(
-        document,
+        clone,
         resolvePath('documents'),
         p.dirname(path),
         documentId: p.basename(path),

--- a/packages/cocoon_server/test/firestore_test.dart
+++ b/packages/cocoon_server/test/firestore_test.dart
@@ -97,9 +97,9 @@ void main() {
     );
   });
 
-  test('should insert a document by path', () async {
-    final expected = g.Document();
-    final created = g.Document();
+  test('should insert a document by path, and ignore document.name', () async {
+    final expected = g.Document(fields: {});
+    final created = g.Document(fields: {}, name: 'Should be stripped');
     when(
       mockDocumentsResource.createDocument(
         any,
@@ -109,10 +109,12 @@ void main() {
       ),
     ).thenAnswer((i) async {
       expect(i.positionalArguments, [
-        created,
+        isA<g.Document>()
+            .having((d) => d.name, 'name', isNull)
+            .having((d) => d.fields, 'fields', expected.fields),
         'projects/project-id/databases/database-id/documents',
         'tasks',
-      ]);
+      ], reason: '${expected.fields}');
       expect(i.namedArguments, containsPair(#documentId, 'new-task'));
       return expected;
     });


### PR DESCRIPTION
Fixes a regression due to https://github.com/flutter/cocoon/pull/4398, which is over a week ago and does not revert cleanly.

The underlying issue is https://github.com/flutter/flutter/issues/166229, where we are trying to derive fields from `document.name` (such as `<Task>.attempts`), which in turn causes contortions for insertion logic (we want to _start_ with an existing Task, and then edit the attempt number, and then insert the new task).