### PR TITLE
Remove usages of Commit().. across dashboard.

### DIFF
--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -282,19 +282,15 @@ class AppEngineCocoonService implements CocoonService {
 
   Commit _commitFromJson(Map<String, Object?> commit) {
     final author = commit['Author'] as Map<String, dynamic>;
-
-    final result =
-        Commit()
-          ..timestamp = Int64() + (commit['CreateTimestamp']!)
-          ..sha = commit['Sha'] as String
-          ..author = author['Login'] as String
-          ..authorAvatarUrl = author['avatar_url'] as String
-          ..repository = commit['FlutterRepositoryPath'] as String
-          ..branch = commit['Branch'] as String;
-    if (commit['Message'] != null) {
-      result.message = commit['Message'] as String;
-    }
-    return result;
+    return Commit(
+      timestamp: Int64() + (commit['CreateTimestamp']!),
+      sha: commit['Sha'] as String,
+      author: author['Login'] as String,
+      authorAvatarUrl: author['avatar_url'] as String,
+      repository: commit['FlutterRepositoryPath'] as String,
+      branch: commit['Branch'] as String,
+      message: commit['Message'] as String?,
+    );
   }
 
   List<Task> _tasksFromJson(List<Object?> json) {

--- a/dashboard/lib/service/dev_cocoon.dart
+++ b/dashboard/lib/service/dev_cocoon.dart
@@ -304,18 +304,20 @@ class DevelopmentCocoonService implements CocoonService {
     final author = random.nextInt(_authors.length);
     final message = commitTimestamp % 37 + author;
     final messageInc = _messagePrimes[message % _messagePrimes.length];
-    return Commit()
-      ..author = _authors[author]
-      ..authorAvatarUrl =
-          'https://avatars2.githubusercontent.com/u/${2148558 + author}?v=4'
-      ..message = List<String>.generate(
+    return Commit(
+      author: _authors[author],
+      authorAvatarUrl:
+          'https://avatars2.githubusercontent.com/u/'
+          '${2148558 + author}?v=4',
+      message: List<String>.generate(
         6,
         (int i) => _words[(message + i * messageInc) % _words.length],
-      ).join(' ')
-      ..repository = 'flutter/$repo'
-      ..sha = commitSha
-      ..timestamp = Int64(commitTimestamp)
-      ..branch = branch;
+      ).join(' '),
+      repository: 'flutter/$repo',
+      sha: commitSha,
+      timestamp: Int64(commitTimestamp),
+      branch: branch,
+    );
   }
 
   static const Map<String, int> _repoTaskCount = <String, int>{

--- a/dashboard/test/service/appengine_cocoon_test.dart
+++ b/dashboard/test/service/appengine_cocoon_test.dart
@@ -31,14 +31,14 @@ void main() {
       final statuses = await service.fetchCommitStatuses(repo: 'flutter');
 
       final expectedStatus = CommitStatus(
-        commit:
-            Commit()
-              ..timestamp = Int64(123456789)
-              ..sha = 'ShaShankHash'
-              ..author = 'ShaSha'
-              ..authorAvatarUrl = 'https://flutter.dev'
-              ..repository = 'flutter/cocoon'
-              ..branch = 'master',
+        commit: Commit(
+          timestamp: Int64(123456789),
+          sha: 'ShaShankHash',
+          author: 'ShaSha',
+          authorAvatarUrl: 'https://flutter.dev',
+          repository: 'flutter/cocoon',
+          branch: 'master',
+        ),
         tasks: [
           Task(
             createTimestamp: Int64(1569353940885),

--- a/dashboard/test/utils/generate_commit_for_tests.dart
+++ b/dashboard/test/utils/generate_commit_for_tests.dart
@@ -1,0 +1,31 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter_dashboard/model/commit.pb.dart';
+
+import 'generate_task_for_tests.dart' show utc$2020_9_1_12_30;
+export 'generate_task_for_tests.dart' show utc$2020_9_1_12_30;
+
+/// Generates a [Commit] for use in a test fixture.
+Commit generateCommitForTest({
+  DateTime? timestamp,
+  String author = 'author',
+  String avatarUrl = '',
+  String sha = 'abc123',
+  String branch = 'master',
+  String message = 'Commit message',
+  String repository = 'flutter/flutter',
+}) {
+  timestamp ??= utc$2020_9_1_12_30;
+  return Commit(
+    timestamp: Int64(timestamp.millisecondsSinceEpoch),
+    sha: sha,
+    author: author,
+    authorAvatarUrl: avatarUrl,
+    branch: branch,
+    message: message,
+    repository: repository,
+  );
+}

--- a/dashboard/test/widgets/commit_box_test.dart
+++ b/dashboard/test/widgets/commit_box_test.dart
@@ -14,17 +14,17 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 
 import '../utils/fake_flutter_app_icons.dart';
 import '../utils/fake_url_launcher.dart';
+import '../utils/generate_commit_for_tests.dart';
 import '../utils/golden.dart';
 
 void main() {
-  final expectedCommit =
-      Commit()
-        ..author = 'AuthoryMcAuthor Face'
-        ..authorAvatarUrl =
-            'https://avatars2.githubusercontent.com/u/2148558?v=4'
-        ..message = 'commit message\n\nreview comments'
-        ..repository = 'flutter/cocoon'
-        ..sha = 'ShaShankRedemption';
+  final expectedCommit = generateCommitForTest(
+    author: 'AuthoryMcAuthor Face',
+    avatarUrl: 'https://avatars2.githubusercontent.com/u/2148558?v=4',
+    message: 'commit message\n\nreview comments',
+    repository: 'flutter/cocoon',
+    sha: 'ShaShankRedemption',
+  );
   final shortSha = expectedCommit.sha.substring(0, 7);
   final Widget basicApp = MaterialApp(
     theme: ThemeData(useMaterial3: false),

--- a/dashboard/test/widgets/task_grid_test.dart
+++ b/dashboard/test/widgets/task_grid_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_app_icons/flutter_app_icons_platform_interface.dart';
 import 'package:flutter_dashboard/logic/task_grid_filter.dart';
-import 'package:flutter_dashboard/model/commit.pb.dart';
 import 'package:flutter_dashboard/service/dev_cocoon.dart';
 import 'package:flutter_dashboard/src/rpc_model/commit_status.dart';
 import 'package:flutter_dashboard/state/build.dart';
@@ -22,6 +21,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../utils/fake_build.dart';
 import '../utils/fake_flutter_app_icons.dart';
+import '../utils/generate_commit_for_tests.dart';
 import '../utils/generate_task_for_tests.dart';
 import '../utils/golden.dart';
 import '../utils/mocks.dart';
@@ -394,10 +394,7 @@ void main() {
 
     final statusesWithSkips = [
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -406,10 +403,7 @@ void main() {
         ],
       ),
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -418,10 +412,7 @@ void main() {
         ],
       ),
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -463,10 +454,7 @@ void main() {
 
     final statuses = [
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -475,10 +463,7 @@ void main() {
         ],
       ),
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -515,10 +500,7 @@ void main() {
     await precacheTaskIcons(tester);
     final commitStatuses = <CommitStatus>[
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(),
         tasks: [
           generateTaskForTest(
             status: TaskBox.statusSucceeded,
@@ -576,10 +558,7 @@ void main() {
             ),
             commitStatuses: [
               CommitStatus(
-                commit:
-                    Commit()
-                      ..author = 'Cast'
-                      ..branch = 'master',
+                commit: generateCommitForTest(author: 'Cast'),
                 tasks: [
                   generateTaskForTest(
                     status: TaskBox.statusSucceeded,
@@ -603,10 +582,7 @@ void main() {
             ),
             commitStatuses: [
               CommitStatus(
-                commit:
-                    Commit()
-                      ..author = 'Cast'
-                      ..branch = 'master',
+                commit: generateCommitForTest(author: 'Cast'),
                 tasks: [
                   generateTaskForTest(
                     status: TaskBox.statusSucceeded,
@@ -635,10 +611,7 @@ void main() {
             ),
             commitStatuses: [
               CommitStatus(
-                commit:
-                    Commit()
-                      ..author = 'Cast'
-                      ..branch = 'master',
+                commit: generateCommitForTest(author: 'Cast'),
                 tasks: [
                   generateTaskForTest(
                     status: TaskBox.statusSucceeded,
@@ -662,10 +635,7 @@ void main() {
             ),
             commitStatuses: [
               CommitStatus(
-                commit:
-                    Commit()
-                      ..author = 'Cast'
-                      ..branch = 'master',
+                commit: generateCommitForTest(author: 'Cast'),
                 tasks: [generateTaskForTest(status: TaskBox.statusSucceeded)],
               ),
             ],
@@ -689,10 +659,7 @@ void main() {
               ),
               commitStatuses: [
                 CommitStatus(
-                  commit:
-                      Commit()
-                        ..author = 'Cast'
-                        ..branch = 'master',
+                  commit: generateCommitForTest(author: 'Cast'),
                   tasks: [
                     generateTaskForTest(
                       status: TaskBox.statusSucceeded,
@@ -702,10 +669,7 @@ void main() {
                   ],
                 ),
                 CommitStatus(
-                  commit:
-                      Commit()
-                        ..author = 'Cast'
-                        ..branch = 'master',
+                  commit: generateCommitForTest(author: 'Cast'),
                   tasks: [
                     generateTaskForTest(
                       status: TaskBox.statusSucceeded,
@@ -742,20 +706,14 @@ void main() {
     await precacheTaskIcons(tester);
     final statuses = [
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(author: 'Cast'),
         tasks: [
           for (final status in TaskBox.statusColor.keys)
             generateTaskForTest(status: status, builderName: 'task_$status'),
         ],
       ),
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(author: 'Cast'),
         tasks: [
           for (final status in TaskBox.statusColor.keys)
             generateTaskForTest(
@@ -766,10 +724,7 @@ void main() {
         ],
       ),
       CommitStatus(
-        commit:
-            Commit()
-              ..author = 'Author'
-              ..branch = 'master',
+        commit: generateCommitForTest(author: 'Cast'),
         tasks: [
           for (final status in TaskBox.statusColor.keys)
             generateTaskForTest(
@@ -780,10 +735,7 @@ void main() {
         ],
       ),
       CommitStatus(
-        commit:
-            (Commit()
-              ..author = 'Author'
-              ..branch = 'master'),
+        commit: generateCommitForTest(author: 'Cast'),
         tasks: [
           for (final status in TaskBox.statusColor.keys)
             generateTaskForTest(
@@ -866,10 +818,7 @@ Future<void> expectTaskBoxColorWithMessage(
                 ),
                 commitStatuses: <CommitStatus>[
                   CommitStatus(
-                    commit:
-                        Commit()
-                          ..author = 'Mathilda'
-                          ..branch = 'master',
+                    commit: generateCommitForTest(author: 'Mathilda'),
                     tasks: [generateTaskForTest(status: message)],
                   ),
                 ],

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_dashboard/logic/task_grid_filter.dart';
-import 'package:flutter_dashboard/model/commit.pb.dart';
 import 'package:flutter_dashboard/model/task.pb.dart';
 import 'package:flutter_dashboard/src/rpc_model.dart';
 import 'package:flutter_dashboard/state/build.dart';
@@ -20,6 +19,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 import '../utils/fake_build.dart';
+import '../utils/generate_commit_for_tests.dart';
 import '../utils/generate_task_for_tests.dart';
 import '../utils/golden.dart';
 import '../utils/task_icons.dart';
@@ -632,11 +632,10 @@ final class _TestGrid extends StatelessWidget {
         buildState: buildState,
         commitStatuses: <CommitStatus>[
           CommitStatus(
-            commit:
-                (Commit()
-                  ..author = 'Fats Domino'
-                  ..sha = '24e8c0a2'
-                  ..branch = 'master'),
+            commit: generateCommitForTest(
+              author: 'Fats Domino',
+              sha: '24e8c0a2',
+            ),
             tasks: [task],
           ),
         ],


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/165025.

When we remove `commit.proto`, it will be a nightmare to change all mutable properties to a constructor call.

Nearly all of these happen in tests, so let's just change them now.