### PR TITLE
Add synthetic fields that are missing from Firestore.

### DIFF
--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -2,9 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'task.dart';
+library;
+
 import 'package:cocoon_server/logging.dart';
+import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 import '../../service/firestore.dart';
 import 'base.dart';
@@ -45,26 +51,28 @@ final class CiStagingId extends AppDocumentId<CiStaging> {
 /// This document layout is currently:
 /// ```
 ///  /projects/flutter-dashboard/databases/cocoon/ciStaging/
-///     document: <owner>_<repo>_<sha>_<stage>
+///     document: <this.slug.owner>_<this.slug.repo>_<this.sha>_<this.stage>
 ///       total: int >= 0
 ///       remaining: int >= 0
 ///       [*fields]: string {scheduled, success, failure, skipped}
 /// ```
-///
-/// Note that the document ID fields are _synthetic_, that is, there is no
-/// cooresponding concrete field on the document itself. We should probably fix
-/// that (https://github.com/flutter/flutter/issues/166229).
 final class CiStaging extends Document with AppDocument<CiStaging> {
   /// Firestore collection for the staging documents.
-  static const kCollectionId = 'ciStaging';
+  static const _collectionId = 'ciStaging';
+
   static const kRemainingField = 'remaining';
   static const kTotalField = 'total';
   static const kFailedField = 'failed_count';
   static const kCheckRunGuardField = 'check_run_guard';
 
-  static const kScheduledValue = 'scheduled';
-  static final kSuccessValue = CheckRunConclusion.success.value!;
-  static final kFailureValue = CheckRunConclusion.failure.value!;
+  @visibleForTesting
+  static const fieldRepoFullPath = 'repository';
+
+  @visibleForTesting
+  static const fieldCommitSha = 'commit_sha';
+
+  @visibleForTesting
+  static const fieldStage = 'stage';
 
   static AppDocumentId<CiStaging> documentIdFor({
     required RepositorySlug slug,
@@ -77,7 +85,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
 
   /// Description of the document in Firestore.
   static final metadata = AppDocumentMetadata<CiStaging>(
-    collectionId: kCollectionId,
+    collectionId: _collectionId,
     fromDocument: CiStaging.fromDocument,
   );
 
@@ -89,7 +97,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
   }) {
     // Document names cannot cannot have '/' in the document id.
     final docId = documentIdFor(slug: slug, sha: sha, stage: stage);
-    return '$kDocumentParent/$kCollectionId/${docId.documentId}';
+    return '$kDocumentParent/$_collectionId/${docId.documentId}';
   }
 
   /// Lookup [Commit] from Firestore.
@@ -110,6 +118,42 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
       ..fields = {...?other.fields}
       ..createTime = other.createTime
       ..updateTime = other.updateTime;
+  }
+
+  /// The repository that this stage is recorded for.
+  RepositorySlug get slug {
+    // TODO(matanlurey): Simplify this when existing documents are backfilled.
+    if (fields![fieldRepoFullPath]?.stringValue case final repoFullPath?) {
+      return RepositorySlug.full(repoFullPath);
+    }
+
+    // Read it from the document name.
+    final [owner, repo, _, _] = p.posix.basename(name!).split('_');
+    return RepositorySlug(owner, repo);
+  }
+
+  /// Which commit this stage is recorded for.
+  String get sha {
+    // TODO(matanlurey): Simplify this when existing documents are backfilled.
+    if (fields![fieldCommitSha]?.stringValue case final sha?) {
+      return sha;
+    }
+
+    // Read it from the document name.
+    final [_, _, sha, _] = p.posix.basename(name!).split('_');
+    return sha;
+  }
+
+  /// The stage of the CI process.
+  CiStage? get stage {
+    // TODO(matanlurey): Simplify this when existing documents are backfilled.
+    if (fields![fieldStage]?.stringValue case final stageName?) {
+      return CiStage.values.firstWhereOrNull((e) => e.name == stageName);
+    }
+
+    // Read it from the document name.
+    final [_, _, _, stageName] = p.posix.basename(name!).split('_');
+    return CiStage.values.firstWhereOrNull((e) => e.name == stageName);
   }
 
   /// The remaining number of checks in this staging.
@@ -136,7 +180,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
     required String sha,
     required CiStage stage,
     required String checkRun,
-    required String conclusion,
+    required TaskConclusion conclusion,
   }) async {
     final changeCrumb = '${slug.owner}_${slug.name}_$sha';
     final logCrumb =
@@ -163,7 +207,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
     var total = -1;
     var valid = false;
     String? checkRunGuard;
-    String? recordedConclusion;
+    TaskConclusion? recordedConclusion;
 
     late final Document doc;
 
@@ -203,7 +247,9 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
 
       // We will have check_runs scheduled after the engine was built successfully, so missing the checkRun field
       // is an OK response to have. All fields should have been written at creation time.
-      recordedConclusion = fields[checkRun]?.stringValue;
+      if (fields[checkRun]?.stringValue case final name?) {
+        recordedConclusion = TaskConclusion.fromName(name);
+      }
       if (recordedConclusion == null) {
         log.info(
           '$logCrumb: $checkRun not present in doc for $transaction / $doc',
@@ -233,8 +279,8 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
       //   recordedConclusion == failure && conclusion == success: down (-1)
       //   recordedConclusion != failure && conclusion == failure: up (+1)
       // So if the test existed and either remaining or failed_count is changed; the response is valid.
-      if (recordedConclusion == kScheduledValue &&
-          conclusion != kScheduledValue) {
+      if (recordedConclusion == TaskConclusion.scheduled &&
+          conclusion != TaskConclusion.scheduled) {
         // Guard against going negative and log enough info so we can debug.
         if (remaining == 0) {
           throw '$logCrumb: field "$kRemainingField" is already zero for $transaction / ${doc.fields}';
@@ -245,7 +291,8 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
 
       // Only rollback the "failed" counter if this is a successful test run,
       // i.e. the test failed, the user requested a rerun, and now it passes.
-      if (recordedConclusion == kFailureValue && conclusion == kSuccessValue) {
+      if (recordedConclusion == TaskConclusion.failure &&
+          conclusion == TaskConclusion.success) {
         log.info(
           '$logCrumb: conclusion flipped to positive - assuming test was re-run',
         );
@@ -257,9 +304,9 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
       }
 
       // Only increment the "failed" counter if the new conclusion flips from positive or neutral to failure.
-      if ((recordedConclusion == kScheduledValue ||
-              recordedConclusion == kSuccessValue) &&
-          conclusion == kFailureValue) {
+      if ((recordedConclusion == TaskConclusion.scheduled ||
+              recordedConclusion == TaskConclusion.success) &&
+          conclusion == TaskConclusion.failure) {
         log.info('$logCrumb: test failed');
         valid = true;
         failed = failed + 1;
@@ -272,7 +319,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
       log.info(
         '$logCrumb: setting remaining to $remaining, failed to $failed, and changing $recordedConclusion',
       );
-      fields[checkRun] = Value(stringValue: conclusion);
+      fields[checkRun] = Value(stringValue: conclusion.name);
       fields[kRemainingField] = Value(integerValue: '$remaining');
       fields[kFailedField] = Value(integerValue: '$failed');
     } on DetailedApiRequestError catch (e, stack) {
@@ -345,7 +392,9 @@ For CI stage $stage:
   Pending: $remaining
   Failed: $failed
 '''
-              : 'Attempted to transition the state of check run $checkRun from "$recordedConclusion" to "$conclusion".',
+              : ''
+                  'Attempted to transition the state of check run $checkRun '
+                  'from "${recordedConclusion.name}" to "${conclusion.name}".',
     );
   }
 
@@ -372,7 +421,11 @@ For CI stage $stage:
       kRemainingField: Value(integerValue: '${tasks.length}'),
       kFailedField: Value(integerValue: '0'),
       kCheckRunGuardField: Value(stringValue: checkRunGuard),
-      for (final task in tasks) task: Value(stringValue: kScheduledValue),
+      fieldRepoFullPath: Value(stringValue: slug.fullName),
+      fieldCommitSha: Value(stringValue: sha),
+      fieldStage: Value(stringValue: stage.name),
+      for (final task in tasks)
+        task: Value(stringValue: TaskConclusion.scheduled.name),
     };
 
     final document = Document(fields: fields);
@@ -386,7 +439,7 @@ For CI stage $stage:
       final newDoc = await databasesDocumentsResource.createDocument(
         document,
         kDocumentParent,
-        kCollectionId,
+        _collectionId,
         documentId:
             documentIdFor(
               slug: slug,
@@ -401,6 +454,37 @@ For CI stage $stage:
       rethrow;
     }
   }
+}
+
+/// Represents the conclusion of a [Task] within a [CiStaging] document.
+enum TaskConclusion {
+  /// An unknown task conclusion.
+  unknown,
+
+  /// A task is scheduled to run.
+  scheduled,
+
+  /// A task was completed as a success.
+  success,
+
+  /// A task was completed as a failure.
+  failure;
+
+  /// Returns a [TaskConclusion] from a [name].
+  factory TaskConclusion.fromName(String? name) {
+    for (final value in TaskConclusion.values) {
+      if (value.name == name) {
+        return value;
+      }
+    }
+    return TaskConclusion.unknown;
+  }
+
+  /// Whether the task is completed or not.
+  bool get isComplete => this != scheduled;
+
+  /// Whether the task is a success or not.
+  bool get isSuccess => this == success;
 }
 
 /// Well-defined stages in the build infrastructure.

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -72,7 +72,7 @@ final class GetGreenCommits extends RequestHandler<Body> {
 
   bool everyNonFlakyTaskSucceed(CommitTasksStatus status) {
     return status.tasks
-        .where((task) => !task.testFlaky!)
+        .where((task) => !task.testFlaky)
         .every((nonFlakyTask) => nonFlakyTask.status == Task.statusSucceeded);
   }
 }

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -130,7 +130,7 @@ final class _SerializableTask {
       'CreateTimestamp': task.task.createTimestamp,
       'StartTimestamp': task.task.startTimestamp,
       'EndTimestamp': task.task.endTimestamp,
-      'Attempts': task.task.attempts,
+      'Attempts': task.task.currentAttempt,
       'Flaky': task.task.bringup,
       'Status': task.task.status,
       'BuildNumberList': task.buildList.join(','),

--- a/app_dart/lib/src/service/build_status_provider.dart
+++ b/app_dart/lib/src/service/build_status_provider.dart
@@ -77,17 +77,17 @@ interface class BuildStatusService {
         final taskInProgress = tasksInProgress[task.taskName] ?? true;
 
         if (isRelevantToLatestStatus && taskInProgress) {
-          if (task.bringup! || _isSuccessful(task)) {
+          if (task.bringup || _isSuccessful(task)) {
             /// This task no longer needs to be checked to see if it causing
             /// the build status to fail.
-            tasksInProgress[task.taskName!] = false;
+            tasksInProgress[task.taskName] = false;
           } else if (_isFailed(task) || _isRerunning(task)) {
-            failedTasks.add(task.taskName!);
+            failedTasks.add(task.taskName);
 
             /// This task no longer needs to be checked to see if its causing
             /// the build status to fail since its been
             /// added to the failedTasks list.
-            tasksInProgress[task.taskName!] = false;
+            tasksInProgress[task.taskName] = false;
           }
         }
       }
@@ -106,7 +106,7 @@ interface class BuildStatusService {
     final tasks = <String, bool>{};
 
     for (var task in statuses.first.tasks) {
-      tasks[task.taskName!] = true;
+      tasks[task.taskName] = true;
     }
     return tasks;
   }
@@ -145,7 +145,7 @@ interface class BuildStatusService {
   }
 
   bool _isRerunning(Task task) {
-    return task.attempts! > 1 &&
+    return task.currentAttempt > 1 &&
         (task.status == Task.statusInProgress || task.status == Task.statusNew);
   }
 }

--- a/app_dart/lib/src/service/build_status_provider/commit_tasks_status.dart
+++ b/app_dart/lib/src/service/build_status_provider/commit_tasks_status.dart
@@ -35,9 +35,9 @@ class CommitTasksStatus {
     for (final task in tasks) {
       final FullTask taskToAddBuildNumber;
       // If task.taskName already exists
-      if (fullTasksMap[task.taskName!] case final fullTask?) {
+      if (fullTasksMap[task.taskName] case final fullTask?) {
         // If this task is newer than the existing task, use the new task
-        if (task.attempts! > fullTask.task.attempts!) {
+        if (task.currentAttempt > fullTask.task.currentAttempt) {
           taskToAddBuildNumber = FullTask(task, fullTask.buildList);
         } else {
           // Otherwise, just reference the existing (newer) task
@@ -54,7 +54,7 @@ class CommitTasksStatus {
       }
 
       // And store it for the next loop
-      fullTasksMap[task.taskName!] = taskToAddBuildNumber;
+      fullTasksMap[task.taskName] = taskToAddBuildNumber;
     }
 
     // Sort build numbers, and return.

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -1144,13 +1144,13 @@ class LuciBuildService {
     await datastore.insert(<Task>[task]);
 
     // Updates task status in Firestore.
-    final newAttempt = int.parse(taskDocument.name!.split('_').last) + 1;
+    final newAttempt = taskDocument.currentAttempt + 1;
     taskDocument.resetAsRetry(attempt: newAttempt);
     taskDocument.setStatus(firestore.Task.statusInProgress);
     await firestoreService.insert(
       firestore.Task.documentIdFor(
-        commitSha: taskDocument.commitSha!,
-        taskName: taskDocument.taskName!,
+        commitSha: taskDocument.commitSha,
+        taskName: taskDocument.taskName,
         currentAttempt: newAttempt,
       ),
       taskDocument,
@@ -1169,7 +1169,7 @@ class LuciBuildService {
     if (!firestore.Task.taskFailStatusSet.contains(task.status)) {
       return false;
     }
-    final retries = task.attempts ?? 1;
+    final retries = task.currentAttempt;
     if (retries > config.maxLuciTaskRetries) {
       log.info('Max retries reached for ${task.taskName}');
       return false;
@@ -1177,7 +1177,7 @@ class LuciBuildService {
 
     final currentCommit = await firestore_commit.Commit.fromFirestoreBySha(
       firestoreService,
-      sha: task.commitSha!,
+      sha: task.commitSha,
     );
     final commitList = await firestoreService.queryRecentCommits(
       limit: 1,

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -74,7 +74,7 @@ class Scheduler {
 
   Future<StagingConclusion> Function({
     required String checkRun,
-    required String conclusion,
+    required TaskConclusion conclusion,
     required FirestoreService firestoreService,
     required String sha,
     required RepositorySlug slug,
@@ -1017,12 +1017,12 @@ $s
     final name = checkRun.name;
     final sha = checkRun.headSha;
     final slug = checkRunEvent.repository?.slug();
-    final conclusion = checkRun.conclusion;
+    final conclusion = TaskConclusion.fromName(checkRun.conclusion);
 
     if (name == null ||
         sha == null ||
         slug == null ||
-        conclusion == null ||
+        conclusion == TaskConclusion.unknown ||
         kCheckRunsToIgnore.contains(name)) {
       return true;
     }
@@ -1396,7 +1396,7 @@ $stacktrace
     required String sha,
     required CiStage stage,
     required String name,
-    required String conclusion,
+    required TaskConclusion conclusion,
   }) async {
     final logCrumb = 'checkCompleted($name, $slug, $sha, $conclusion)';
     final documentName = CiStaging.documentNameFor(

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -216,7 +216,7 @@ void main() {
     );
 
     expect(firestoreTask!.status, firestore.Task.statusInProgress);
-    expect(firestoreTask!.attempts, 1);
+    expect(firestoreTask!.currentAttempt, 1);
     expect(await tester.post(handler), Body.empty);
     expect(firestoreTask!.status, firestore.Task.statusInProgress);
   });
@@ -344,7 +344,7 @@ void main() {
     );
 
     expect(firestoreTask!.status, firestore.Task.statusFailed);
-    expect(firestoreTask!.attempts, 1);
+    expect(firestoreTask!.currentAttempt, 1);
     expect(await tester.post(handler), Body.empty);
 
     final savedTask = firestore.Task.fromDocument(
@@ -353,7 +353,7 @@ void main() {
       ),
     );
     expect(savedTask.status, firestore.Task.statusInProgress);
-    expect(savedTask.attempts, 2);
+    expect(savedTask.currentAttempt, 2);
   });
 
   test('on canceled builds auto-rerun the build if they timed out', () async {
@@ -397,7 +397,7 @@ void main() {
     );
 
     expect(firestoreTask!.status, firestore.Task.statusInfraFailure);
-    expect(firestoreTask!.attempts, 1);
+    expect(firestoreTask!.currentAttempt, 1);
     expect(await tester.post(handler), Body.empty);
 
     final savedTask = firestore.Task.fromDocument(
@@ -406,7 +406,7 @@ void main() {
       ),
     );
     expect(savedTask.status, firestore.Task.statusInProgress);
-    expect(savedTask.attempts, 2);
+    expect(savedTask.currentAttempt, 2);
   });
 
   test(
@@ -461,7 +461,7 @@ void main() {
         ),
       );
       expect(savedTask.status, firestore.Task.statusInProgress);
-      expect(savedTask.attempts, 2);
+      expect(savedTask.currentAttempt, 2);
     },
   );
 

--- a/app_dart/test/service/commit_tasks_status_test.dart
+++ b/app_dart/test/service/commit_tasks_status_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(collate, [
         isA<FullTask>()
             .having((t) => t.task.taskName, 'task.taskName', 'task1')
-            .having((t) => t.task.attempts, 'task.attempts', 3)
+            .having((t) => t.task.currentAttempt, 'task.attempts', 3)
             .having((t) => t.buildList, 'buildList', [1001, 1002, 1003]),
       ]);
     });
@@ -39,7 +39,7 @@ void main() {
       expect(collate, [
         isA<FullTask>()
             .having((t) => t.task.taskName, 'task.taskName', 'task1')
-            .having((t) => t.task.attempts, 'task.attempts', 3)
+            .having((t) => t.task.currentAttempt, 'task.attempts', 3)
             .having((t) => t.buildList, 'buildList', [1001, 1002]),
       ]);
     });

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1412,7 +1412,7 @@ void main() {
 
       final taskDocument = generateFirestoreTask(0);
       final task = generateTask(0);
-      expect(taskDocument.attempts, 1);
+      expect(taskDocument.currentAttempt, 1);
       expect(task.attempts, 1);
       await service.reschedulePostsubmitBuildUsingCheckRunEvent(
         checkRunEvent,
@@ -1423,7 +1423,7 @@ void main() {
         datastore: datastore,
         firestoreService: firestoreService,
       );
-      expect(taskDocument.attempts, 2);
+      expect(taskDocument.currentAttempt, 2);
       expect(task.attempts, 2);
       expect(pubsub.messages.length, 1);
     });
@@ -1979,9 +1979,9 @@ void main() {
           final oldTask = generateFirestoreTask(1, attempts: 2);
           await firestoreService.insert(
             firestore.Task.documentIdFor(
-              commitSha: oldTask.commitSha!,
-              taskName: oldTask.taskName!,
-              currentAttempt: oldTask.attempts!,
+              commitSha: oldTask.commitSha,
+              taskName: oldTask.taskName,
+              currentAttempt: oldTask.currentAttempt,
             ),
             oldTask,
           );
@@ -2100,7 +2100,7 @@ void main() {
         buildNumber: 1,
       );
       final target = generateTarget(1);
-      expect(firestoreTask!.attempts, 1);
+      expect(firestoreTask!.currentAttempt, 1);
       final rerunFlag = await service.checkRerunBuilder(
         commit: totCommit,
         task: task,
@@ -2110,7 +2110,7 @@ void main() {
         taskDocument: firestoreTask!,
       );
       expect(rerunFlag, isTrue);
-      expect(firestoreTask!.attempts, 2);
+      expect(firestoreTask!.currentAttempt, 2);
 
       final savedTask = firestore.Task.fromDocument(
         await firestoreService.api.getByPath(
@@ -2118,7 +2118,7 @@ void main() {
         ),
       );
       expect(savedTask.status, firestore.Task.statusInProgress);
-      expect(savedTask.attempts, 2);
+      expect(savedTask.currentAttempt, 2);
     });
   });
 

--- a/app_dart/test/service/scheduler/policy_test.dart
+++ b/app_dart/test/service/scheduler/policy_test.dart
@@ -71,8 +71,8 @@ void main() {
       final task = generateFirestoreTask(4);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: allPending,
         ),
         isNull,
@@ -83,8 +83,8 @@ void main() {
       final task = generateFirestoreTask(7);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: latestAllPending,
         ),
         LuciBuildService.kDefaultPriority,
@@ -95,8 +95,8 @@ void main() {
       final task = generateFirestoreTask(7);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: latestFailed,
         ),
         LuciBuildService.kRerunPriority,
@@ -109,8 +109,8 @@ void main() {
         final task = generateFirestoreTask(7);
         expect(
           await policy.triggerPriority(
-            taskName: task.taskName!,
-            commitSha: task.commitSha!,
+            taskName: task.taskName,
+            commitSha: task.commitSha,
             recentTasks: failedWithRunning,
           ),
           isNull,
@@ -122,8 +122,8 @@ void main() {
       final task = generateFirestoreTask(7);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: latestFinishedButRestPending,
         ),
         isNull,
@@ -134,8 +134,8 @@ void main() {
       final task = generateFirestoreTask(7);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: latestPending,
         ),
         isNull,
@@ -162,8 +162,8 @@ void main() {
       final task = generateFirestoreTask(2);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: pending,
         ),
         LuciBuildService.kDefaultPriority,
@@ -174,8 +174,8 @@ void main() {
       final task = generateFirestoreTask(2);
       expect(
         await policy.triggerPriority(
-          taskName: task.taskName!,
-          commitSha: task.commitSha!,
+          taskName: task.taskName,
+          commitSha: task.commitSha,
           recentTasks: latestFailed,
         ),
         LuciBuildService.kRerunPriority,

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1413,7 +1413,10 @@ targets:
                   named: 'stage',
                 ),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                conclusion: argThat(equals('success'), named: 'conclusion'),
+                conclusion: argThat(
+                  equals(TaskConclusion.success),
+                  named: 'conclusion',
+                ),
               ),
             ).called(1);
 
@@ -1469,7 +1472,10 @@ targets:
                   named: 'stage',
                 ),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                conclusion: argThat(equals('success'), named: 'conclusion'),
+                conclusion: argThat(
+                  equals(TaskConclusion.success),
+                  named: 'conclusion',
+                ),
               ),
             ).called(1);
 
@@ -1534,7 +1540,10 @@ targets:
                     named: 'stage',
                   ),
                   checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                  conclusion: argThat(equals('success'), named: 'conclusion'),
+                  conclusion: argThat(
+                    equals(TaskConclusion.success),
+                    named: 'conclusion',
+                  ),
                 ),
               ).called(1);
 
@@ -1677,7 +1686,10 @@ targets:
                   named: 'stage',
                 ),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                conclusion: argThat(equals('success'), named: 'conclusion'),
+                conclusion: argThat(
+                  equals(TaskConclusion.success),
+                  named: 'conclusion',
+                ),
               ),
             ).called(1);
 
@@ -1777,7 +1789,10 @@ targets:
                   named: 'stage',
                 ),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                conclusion: argThat(equals('success'), named: 'conclusion'),
+                conclusion: argThat(
+                  equals(TaskConclusion.success),
+                  named: 'conclusion',
+                ),
               ),
             ).called(1);
 
@@ -1790,7 +1805,10 @@ targets:
                 sha: 'testSha',
                 stage: argThat(equals(CiStage.fusionTests), named: 'stage'),
                 checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                conclusion: argThat(equals('success'), named: 'conclusion'),
+                conclusion: argThat(
+                  equals(TaskConclusion.success),
+                  named: 'conclusion',
+                ),
               ),
             ).called(1);
 
@@ -2080,7 +2098,10 @@ targets:
                     named: 'stage',
                   ),
                   checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                  conclusion: argThat(equals('success'), named: 'conclusion'),
+                  conclusion: argThat(
+                    equals(TaskConclusion.success),
+                    named: 'conclusion',
+                  ),
                 ),
               ).called(1);
 
@@ -2096,7 +2117,10 @@ targets:
                   sha: 'testSha',
                   stage: argThat(equals(CiStage.fusionTests), named: 'stage'),
                   checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                  conclusion: argThat(equals('success'), named: 'conclusion'),
+                  conclusion: argThat(
+                    equals(TaskConclusion.success),
+                    named: 'conclusion',
+                  ),
                 ),
               ).called(1);
 
@@ -2247,7 +2271,10 @@ targets:
                     named: 'stage',
                   ),
                   checkRun: argThat(equals('Bar bar'), named: 'checkRun'),
-                  conclusion: argThat(equals('success'), named: 'conclusion'),
+                  conclusion: argThat(
+                    equals(TaskConclusion.success),
+                    named: 'conclusion',
+                  ),
                 ),
               ).called(1);
 

--- a/app_dart/test/src/utilities/mocks.dart
+++ b/app_dart/test/src/utilities/mocks.dart
@@ -86,7 +86,7 @@ abstract class Callbacks {
     required String sha,
     required CiStage stage,
     required String checkRun,
-    required String conclusion,
+    required TaskConclusion conclusion,
   });
 
   // ignore: unreachable_from_main

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -6142,7 +6142,7 @@ class MockCallbacks extends _i1.Mock implements _i50.Callbacks {
     required String? sha,
     required _i25.CiStage? stage,
     required String? checkRun,
-    required String? conclusion,
+    required _i25.TaskConclusion? conclusion,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#markCheckRunConclusion, [], {


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/166229.

After this PR, _new_ documents inserted store each field explicitly, instead of relying on the hack-y "store the field delimited by `_` in `name` and parse it".  This allows us to do queries, both for administrative purposes, and for business logic, and, once we backfill, simplify some of our logic (for example, we won't need special keys, and can use the default Firestore unique keys).

(We should probably do the backfill on like, the weekend)