### PR TITLE
[Triage bot] Do not report private things to Discord

### DIFF
--- a/triage_bot/lib/engine.dart
+++ b/triage_bot/lib/engine.dart
@@ -815,7 +815,8 @@ class Engine {
   }
 
   Future<void> _updateDiscordFromWebhook(String event, dynamic payload) async {
-    if (GitHubSettings.knownBots.contains(payload.sender.login.toString())) {
+    if (GitHubSettings.knownBots.contains(payload.sender.login.toString())
+    || payload.repository.private.toBoolean()) {
       return;
     }
     switch (event) {


### PR DESCRIPTION
This is not the code that is the deployed triage bot, @Hixie says it has diverged from the one he has running.
If we do end up deploying our own instance of this triage bot, which also posts to Discord, we don't want to fall into the same issue we had the other day. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
