### PR TITLE
Add new (unused) APIs to the shared Firestore layer.

### DIFF
--- a/packages/cocoon_server/lib/src/firestore_batch.dart
+++ b/packages/cocoon_server/lib/src/firestore_batch.dart
@@ -1,0 +1,68 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport '../firestore.dart';
+library;
+
+import 'package:googleapis/firestore/v1.dart' as g;
+import 'package:meta/meta.dart';
+
+import 'firestore_clone.dart';
+
+/// Possible writes to make using [Firestore.tryBatchWrite].
+@immutable
+sealed class BatchWriteOperation {
+  BatchWriteOperation(g.Document document)
+    : _document = cloneFirestoreDocument(document);
+
+  /// An operation to update an existing document.
+  factory BatchWriteOperation.update(g.Document doc) = BatchUpdateOperation._;
+
+  /// An operation to insert a new document.
+  factory BatchWriteOperation.insert(g.Document doc) = BatchInsertOperation._;
+
+  /// An operation to update an existing, _or_ insert a new document.
+  factory BatchWriteOperation.upsert(g.Document doc) = BatchUpsertOperation._;
+
+  final g.Document _document;
+  g.Precondition get _precondition;
+}
+
+@internal
+g.Write internalToFirestoreWrite(
+  BatchWriteOperation operation, {
+  required String documentPath,
+}) {
+  return g.Write(
+    currentDocument: operation._precondition,
+    update: cloneFirestoreDocument(operation._document, name: documentPath),
+  );
+}
+
+/// Updates an _existing_ document.
+@visibleForTesting
+final class BatchUpdateOperation extends BatchWriteOperation {
+  BatchUpdateOperation._(super._document);
+
+  @override
+  g.Precondition get _precondition => g.Precondition(exists: true);
+}
+
+/// Inserts a _non-existent_ document.
+@visibleForTesting
+final class BatchInsertOperation extends BatchWriteOperation {
+  BatchInsertOperation._(super._document);
+
+  @override
+  g.Precondition get _precondition => g.Precondition(exists: false);
+}
+
+/// Updates an _existing_ document, or inserts it if it did not already exist.
+@visibleForTesting
+final class BatchUpsertOperation extends BatchWriteOperation {
+  BatchUpsertOperation._(super._document);
+
+  @override
+  g.Precondition get _precondition => g.Precondition(exists: null);
+}

--- a/packages/cocoon_server/lib/src/firestore_clone.dart
+++ b/packages/cocoon_server/lib/src/firestore_clone.dart
@@ -1,0 +1,21 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:googleapis/firestore/v1.dart' as g;
+import 'package:meta/meta.dart';
+
+/// Creates a shallow-ish clone of [other].
+///
+/// The underlying [g.Document.fields] has each key-value copied (meaning that
+/// changes _to_ the Map istelf are not reflected), but the underlying [g.Value]
+/// is not deep-copied, assuming that it is not mutated directly.
+@internal
+g.Document cloneFirestoreDocument(g.Document other, {String? name}) {
+  return g.Document(
+    name: name ?? other.name,
+    fields: {...?other.fields},
+    createTime: other.createTime,
+    updateTime: other.updateTime,
+  );
+}

--- a/packages/cocoon_server_test/lib/fake_firestore.dart
+++ b/packages/cocoon_server_test/lib/fake_firestore.dart
@@ -2,8 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:cocoon_server/firestore.dart';
-import 'package:collection/collection.dart';
+// ignore: implementation_imports
+import 'package:cocoon_server/src/firestore_batch.dart';
+// ignore: implementation_imports
+import 'package:cocoon_server/src/firestore_clone.dart';
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:http/testing.dart';
 
@@ -20,53 +25,100 @@ final class FakeFirestore extends Firestore {
          g.FirestoreApi(MockClient((_) => throw UnimplementedError())),
        );
 
+  /// Documents stored in memory.
+  ///
+  /// This list is unmodifiable.
+  late final List<g.Document> documents = UnmodifiableListView(_documents);
+
   final _documents = <g.Document>[];
   final DateTime Function() _now;
 
   static g.Document _clone(g.Document document) {
-    return g.Document()
-      ..name = document.name
-      ..fields = document.fields
-      ..createTime = document.createTime
-      ..updateTime = document.updateTime;
+    // ignore: invalid_use_of_internal_member
+    return cloneFirestoreDocument(document);
   }
 
-  g.Document? _getReferenceByPath(String path) {
-    return _documents.firstWhereOrNull((d) {
-      if (d.name case final name?) {
-        return name.endsWith(path);
+  int? _getDocumentIndexbyPath(String path) {
+    for (var i = 0; i < _documents.length; i++) {
+      if (_documents[i].name case final name? when name.endsWith(path)) {
+        return i;
       }
-      return false;
-    });
+    }
+    return null;
   }
 
   @override
   Future<g.Document?> tryGetByPath(String path) async {
-    final result = _getReferenceByPath(path);
-    return result == null ? null : _clone(result);
+    final index = _getDocumentIndexbyPath(path);
+    return index == null ? null : _clone(_documents[index]);
   }
 
   @override
   Future<g.Document?> tryInsertByPath(String path, g.Document document) async {
-    final existing = _getReferenceByPath(path);
-    if (existing != null) {
+    if (_getDocumentIndexbyPath(path) != null) {
       return null;
     }
 
     final inserted = _clone(document);
-    inserted.name = resolvePath(path);
+    inserted.name = resolveDocumentsPath(path);
     inserted.updateTime = inserted.updateTime = _now().toIso8601String();
     _documents.add(inserted);
     return _clone(inserted);
   }
 
   @override
-  Future<List<bool>> tryInsertAll(Map<String, g.Document> documents) async {
-    final results = <bool>[];
-    for (final MapEntry(key: path, value: document) in documents.entries) {
-      final inserted = await tryInsertByPath(path, document);
-      results.add(inserted != null);
+  Future<g.Document?> tryUpdateByPath(String path, g.Document document) async {
+    final index = _getDocumentIndexbyPath(path);
+    if (index == null) {
+      return null;
     }
+
+    final updates = _clone(_documents[index]);
+    updates.fields = {...?document.fields};
+    updates.updateTime = _now().toIso8601String();
+    _documents[index] = updates;
+    return _clone(updates);
+  }
+
+  @override
+  Future<g.Document> upsertByPath(String path, g.Document document) {
+    final index = _getDocumentIndexbyPath(path);
+    if (index == null) {
+      return insertByPath(path, document);
+    } else {
+      return updateByPath(path, document);
+    }
+  }
+
+  @override
+  Future<List<bool>> tryBatchWrite(
+    Map<String, BatchWriteOperation> writes,
+  ) async {
+    final results = List.filled(writes.length, false);
+
+    var i = 0;
+    for (final MapEntry(key: path, value: write) in writes.entries) {
+      // ignore: invalid_use_of_internal_member
+      final op = internalToFirestoreWrite(
+        write,
+        documentPath: resolveDocumentsPath(path),
+      );
+      switch (write) {
+        // ignore: invalid_use_of_visible_for_testing_member
+        case BatchInsertOperation():
+          results[i] = (await tryInsertByPath(path, op.update!)) != null;
+        // ignore: invalid_use_of_visible_for_testing_member
+        case BatchUpdateOperation():
+          results[i] = (await tryUpdateByPath(path, op.update!)) != null;
+        // ignore: invalid_use_of_visible_for_testing_member
+        case BatchUpsertOperation():
+          await upsertByPath(path, op.update!);
+          results[i] = true;
+      }
+
+      i++;
+    }
+
     return results;
   }
 }

--- a/packages/cocoon_server_test/test/fake_firestore_test.dart
+++ b/packages/cocoon_server_test/test/fake_firestore_test.dart
@@ -39,13 +39,114 @@ void main() {
     );
   });
 
-  test('inserts multiple documents successfully', () async {
-    final result = await firestore.tryInsertAll({
-      'tasks/task-1': g.Document(
-        fields: {'gold_coins': g.Value(integerValue: '1')},
+  test('upserts a document', () async {
+    final task = await firestore.upsertByPath(
+      'tasks/existing-task',
+      g.Document(fields: {'gold_coins': g.Value(integerValue: '1001')}),
+    );
+
+    task.fields!['gold_coins'] = g.Value(integerValue: '2002');
+    final _ = await firestore.upsertByPath('tasks/existing-task', task);
+
+    await expectLater(
+      firestore.tryGetByPath('tasks/existing-task'),
+      completion(
+        isA<g.Document>().having(
+          (d) => jsonDecode(jsonEncode(d.toJson()))['fields'],
+          'toJson()',
+          {
+            'gold_coins': {'integerValue': '2002'},
+          },
+        ),
       ),
-      'tasks/task-2': g.Document(
-        fields: {'gold_coins': g.Value(integerValue: '2')},
+    );
+  });
+
+  test('upserts multiple documents', () async {
+    await expectLater(
+      firestore.tryBatchWrite({
+        'tasks/task-1': BatchWriteOperation.upsert(
+          g.Document(fields: {'gold_coins': g.Value(integerValue: '1001')}),
+        ),
+        'tasks/task-2': BatchWriteOperation.upsert(
+          g.Document(fields: {'gold_coins': g.Value(integerValue: '2002')}),
+        ),
+      }),
+      completion([true, true]),
+    );
+
+    await expectLater(
+      firestore.tryGetByPath('tasks/task-1'),
+      completion(
+        isA<g.Document>().having(
+          (d) => jsonDecode(jsonEncode(d.toJson()))['fields'],
+          'toJson()',
+          {
+            'gold_coins': {'integerValue': '1001'},
+          },
+        ),
+      ),
+    );
+
+    await expectLater(
+      firestore.tryGetByPath('tasks/task-2'),
+      completion(
+        isA<g.Document>().having(
+          (d) => jsonDecode(jsonEncode(d.toJson()))['fields'],
+          'toJson()',
+          {
+            'gold_coins': {'integerValue': '2002'},
+          },
+        ),
+      ),
+    );
+
+    await expectLater(
+      firestore.tryBatchWrite({
+        'tasks/task-1': BatchWriteOperation.upsert(
+          g.Document(fields: {'gold_coins': g.Value(integerValue: '3003')}),
+        ),
+        'tasks/task-2': BatchWriteOperation.upsert(
+          g.Document(fields: {'gold_coins': g.Value(integerValue: '4004')}),
+        ),
+      }),
+      completion([true, true]),
+    );
+
+    await expectLater(
+      firestore.tryGetByPath('tasks/task-1'),
+      completion(
+        isA<g.Document>().having(
+          (d) => jsonDecode(jsonEncode(d.toJson()))['fields'],
+          'toJson()',
+          {
+            'gold_coins': {'integerValue': '3003'},
+          },
+        ),
+      ),
+    );
+
+    await expectLater(
+      firestore.tryGetByPath('tasks/task-2'),
+      completion(
+        isA<g.Document>().having(
+          (d) => jsonDecode(jsonEncode(d.toJson()))['fields'],
+          'toJson()',
+          {
+            'gold_coins': {'integerValue': '4004'},
+          },
+        ),
+      ),
+    );
+  });
+
+  test('inserts multiple documents successfully', () async {
+    final result = await firestore.tryBatchWrite({
+      'tasks/task-1': BatchWriteOperation.insert(
+        g.Document(fields: {'gold_coins': g.Value(integerValue: '1')}),
+      ),
+      'tasks/task-2': BatchWriteOperation.insert(
+        g.Document(fields: {'gold_coins': g.Value(integerValue: '2')}),
       ),
     });
 
@@ -83,12 +184,12 @@ void main() {
       g.Document(fields: {'gold_coins': g.Value(integerValue: '1001')}),
     );
 
-    final result = await firestore.tryInsertAll({
-      'tasks/existing-task': g.Document(
-        fields: {'gold_coins': g.Value(integerValue: '1')},
+    final result = await firestore.tryBatchWrite({
+      'tasks/existing-task': BatchWriteOperation.insert(
+        g.Document(fields: {'gold_coins': g.Value(integerValue: '1')}),
       ),
-      'tasks/new-task': g.Document(
-        fields: {'gold_coins': g.Value(integerValue: '2')},
+      'tasks/new-task': BatchWriteOperation.insert(
+        g.Document(fields: {'gold_coins': g.Value(integerValue: '2')}),
       ),
     });
 


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/165931.

This is _part of_ https://github.com/flutter/cocoon/pull/4407, which needs to get split and landed in a few smaller PRs (the last couple of days have taught me that we just really can't rely on our own test coverage and the PRs need to be more targeted/smaller, even if it means landing unused code first, and then change the prod code second, like in this PR).

