### PR TITLE
Parse `currentAttempt`  from `documentId`, not `name`.

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -309,15 +309,8 @@ final class Task extends Document with AppDocument<Task> {
     }
 
     // Read the attempts from the document name.
-    final taskId = TaskId.tryParse(name!);
-    if (taskId != null) {
-      return taskId.currentAttempt;
-    }
-
-    // TODO(matanlurey): Figure out what documentIds do not parse.
-    // Fallback to the code that existed before using TaskId.parse.
-    log.warn('Failed to TaskId.parse($name)');
-    return int.parse(name!.split('_').last);
+    final documentId = p.basename(name!);
+    return TaskId.parse(documentId).currentAttempt;
   }
 
   ///


### PR DESCRIPTION
Fixes:

```txt
Failed to TaskId.parse(projects/flutter-dashboard/databases/cocoon/documents/tasks/a22e3fec6e55f26dac9ec543c9c715b4334e8db4_Mac_arm64 run_release_test_macos_1)
```