### PR TITLE
Implement fakes of `FirestoreService` except `documentsResource()`

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -217,7 +217,7 @@ mixin FirestoreQueries {
 }
 
 class FirestoreService with FirestoreQueries {
-  /// Creates a [BigqueryService] using Google API authentication.
+  /// Creates a [FirestoreService] using Google API authentication.
   static Future<FirestoreService> from(GoogleAuthProvider authProvider) async {
     final client = await authProvider.createClient(
       scopes: const [FirestoreApi.datastoreScope],

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_server/google_auth_provider.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';
 import '../model/firestore/commit.dart';
@@ -42,63 +43,26 @@ final kFieldMapRegExp = RegExp(
   '(${kRelationMapping.keys.join("|")})',
 );
 
-class FirestoreService {
-  /// Creates a [BigqueryService] using Google API authentication.
-  static Future<FirestoreService> from(GoogleAuthProvider authProvider) async {
-    final client = await authProvider.createClient(
-      scopes: const [FirestoreApi.datastoreScope],
-      baseClient: FirestoreBaseClient(
-        projectId: Config.flutterGcpProjectId,
-        databaseId: Config.flutterGcpFirestoreDatabase,
-      ),
-    );
-    return FirestoreService._(client);
-  }
-
-  const FirestoreService._(this._client);
-  final http.Client _client;
-
-  /// Return a [ProjectsDatabasesDocumentsResource] with an authenticated [client]
-  Future<ProjectsDatabasesDocumentsResource> documentResource() async {
-    return FirestoreApi(_client).projects.databases.documents;
-  }
-
-  /// Gets a document based on name.
-  Future<Document> getDocument(String name) async {
-    final databasesDocumentsResource = await documentResource();
-    return databasesDocumentsResource.get(name);
-  }
-
-  /// Batch writes documents to Firestore.
+@visibleForTesting
+mixin FirestoreQueries {
+  /// Wrapper to simplify Firestore query.
   ///
-  /// It does not apply the write operations atomically and can apply them out of order.
-  /// Each write succeeds or fails independently.
-  ///
-  /// https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/batchWrite
-  Future<BatchWriteResponse> batchWriteDocuments(
-    BatchWriteRequest request,
-    String database,
-  ) async {
-    final databasesDocumentsResource = await documentResource();
-    return databasesDocumentsResource.batchWrite(request, database);
-  }
-
-  /// Writes [writes] to Firestore within a transaction.
-  ///
-  /// This is an atomic operation: either all writes succeed or all writes fail.
-  Future<CommitResponse> writeViaTransaction(List<Write> writes) async {
-    final databasesDocumentsResource = await documentResource();
-    final beginTransactionRequest = BeginTransactionRequest(
-      options: TransactionOptions(readWrite: ReadWrite()),
-    );
-    final beginTransactionResponse = await databasesDocumentsResource
-        .beginTransaction(beginTransactionRequest, kDatabase);
-    final commitRequest = CommitRequest(
-      transaction: beginTransactionResponse.transaction,
-      writes: writes,
-    );
-    return databasesDocumentsResource.commit(commitRequest, kDatabase);
-  }
+  /// The [filterMap] follows format:
+  ///   {
+  ///     'fieldInt =': 1,
+  ///     'fieldString =': 'string',
+  ///     'fieldBool =': true,
+  ///   }
+  /// Note
+  ///   1. the space in the key, which will be used to retrieve the field name and operator.
+  ///   2. the value could be any type, like int, string, bool, etc.
+  Future<List<Document>> query(
+    String collectionId,
+    Map<String, Object> filterMap, {
+    int? limit,
+    Map<String, String>? orderMap,
+    String compositeFilterOp = kCompositeFilterOpAnd,
+  });
 
   /// Queries for recent commits.
   ///
@@ -250,9 +214,68 @@ class FirestoreService {
       return githubBuildStatuses.single;
     }
   }
+}
+
+class FirestoreService with FirestoreQueries {
+  /// Creates a [BigqueryService] using Google API authentication.
+  static Future<FirestoreService> from(GoogleAuthProvider authProvider) async {
+    final client = await authProvider.createClient(
+      scopes: const [FirestoreApi.datastoreScope],
+      baseClient: FirestoreBaseClient(
+        projectId: Config.flutterGcpProjectId,
+        databaseId: Config.flutterGcpFirestoreDatabase,
+      ),
+    );
+    return FirestoreService._(client);
+  }
+
+  const FirestoreService._(this._client);
+  final http.Client _client;
+
+  /// Return a [ProjectsDatabasesDocumentsResource] with an authenticated [client]
+  Future<ProjectsDatabasesDocumentsResource> documentResource() async {
+    return FirestoreApi(_client).projects.databases.documents;
+  }
+
+  /// Gets a document based on name.
+  Future<Document> getDocument(String name) async {
+    final databasesDocumentsResource = await documentResource();
+    return databasesDocumentsResource.get(name);
+  }
+
+  /// Batch writes documents to Firestore.
+  ///
+  /// It does not apply the write operations atomically and can apply them out of order.
+  /// Each write succeeds or fails independently.
+  ///
+  /// https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/batchWrite
+  Future<BatchWriteResponse> batchWriteDocuments(
+    BatchWriteRequest request,
+    String database,
+  ) async {
+    final databasesDocumentsResource = await documentResource();
+    return databasesDocumentsResource.batchWrite(request, database);
+  }
+
+  /// Writes [writes] to Firestore within a transaction.
+  ///
+  /// This is an atomic operation: either all writes succeed or all writes fail.
+  Future<CommitResponse> writeViaTransaction(List<Write> writes) async {
+    final databasesDocumentsResource = await documentResource();
+    final beginTransactionRequest = BeginTransactionRequest(
+      options: TransactionOptions(readWrite: ReadWrite()),
+    );
+    final beginTransactionResponse = await databasesDocumentsResource
+        .beginTransaction(beginTransactionRequest, kDatabase);
+    final commitRequest = CommitRequest(
+      transaction: beginTransactionResponse.transaction,
+      writes: writes,
+    );
+    return databasesDocumentsResource.commit(commitRequest, kDatabase);
+  }
 
   /// Returns Firestore [Value] based on corresponding object type.
-  Value getValueFromFilter(Object comparisonOject) {
+  Value _getValueFromFilter(Object comparisonOject) {
     if (comparisonOject is int) {
       return Value(integerValue: comparisonOject.toString());
     } else if (comparisonOject is bool) {
@@ -262,7 +285,7 @@ class FirestoreService {
   }
 
   /// Generates Firestore query filter based on "human" read conditions.
-  Filter generateFilter(
+  Filter _generateFilter(
     Map<String, Object> filterMap,
     String compositeFilterOp,
   ) {
@@ -277,7 +300,7 @@ class FirestoreService {
         throw ArgumentError("Invalid filter comparison in '$filterString'.");
       }
 
-      final value = getValueFromFilter(comparisonOject);
+      final value = _getValueFromFilter(comparisonOject);
       filters.add(
         Filter(
           fieldFilter: FieldFilter(
@@ -293,7 +316,7 @@ class FirestoreService {
     );
   }
 
-  List<Order>? generateOrders(Map<String, String>? orderMap) {
+  List<Order>? _generateOrders(Map<String, String>? orderMap) {
     if (orderMap == null || orderMap.isEmpty) {
       return null;
     }
@@ -306,17 +329,7 @@ class FirestoreService {
     return orders;
   }
 
-  /// Wrapper to simplify Firestore query.
-  ///
-  /// The [filterMap] follows format:
-  ///   {
-  ///     'fieldInt =': 1,
-  ///     'fieldString =': 'string',
-  ///     'fieldBool =': true,
-  ///   }
-  /// Note
-  ///   1. the space in the key, which will be used to retrieve the field name and operator.
-  ///   2. the value could be any type, like int, string, bool, etc.
+  @override
   Future<List<Document>> query(
     String collectionId,
     Map<String, Object> filterMap, {
@@ -328,8 +341,8 @@ class FirestoreService {
     final from = <CollectionSelector>[
       CollectionSelector(collectionId: collectionId),
     ];
-    final filter = generateFilter(filterMap, compositeFilterOp);
-    final orders = generateOrders(orderMap);
+    final filter = _generateFilter(filterMap, compositeFilterOp);
+    final orders = _generateOrders(orderMap);
     final runQueryRequest = RunQueryRequest(
       structuredQuery: StructuredQuery(
         from: from,
@@ -342,11 +355,11 @@ class FirestoreService {
       runQueryRequest,
       kDocumentParent,
     );
-    return documentsFromQueryResponse(runQueryResponseElements);
+    return _documentsFromQueryResponse(runQueryResponseElements);
   }
 
   /// Retrieve documents based on query response.
-  List<Document> documentsFromQueryResponse(
+  List<Document> _documentsFromQueryResponse(
     List<RunQueryResponseElement> runQueryResponseElements,
   ) {
     final documents = <Document>[];

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -2,29 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cocoon_server_test/google_auth_provider.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:googleapis/firestore/v1.dart';
-import 'package:http/testing.dart';
 import 'package:test/test.dart';
-
-import '../src/utilities/entity_generators.dart';
 
 void main() {
   useTestLoggerPerTest();
-
-  final alwaysThrowsHttpClient = MockClient((_) async {
-    throw UnimplementedError();
-  });
-
-  late FirestoreService firestoreService;
-
-  setUp(() async {
-    firestoreService = await FirestoreService.from(
-      FakeGoogleAuthProvider.withFixedClient(alwaysThrowsHttpClient),
-    );
-  });
 
   test('creates writes correctly from documents', () async {
     final documents = <Document>[
@@ -41,139 +25,5 @@ void main() {
     expect(writes.length, documents.length);
     expect(writes[0].update, documents[0]);
     expect(writes[0].currentDocument!.exists, false);
-  });
-
-  group('getValueFromFilter', () {
-    test('int object', () async {
-      const Object intValue = 1;
-      expect(firestoreService.getValueFromFilter(intValue).integerValue, '1');
-    });
-
-    test('string object', () async {
-      const Object stringValue = 'string';
-      expect(
-        firestoreService.getValueFromFilter(stringValue).stringValue,
-        'string',
-      );
-    });
-
-    test('bool object', () async {
-      const Object boolValue = true;
-      expect(firestoreService.getValueFromFilter(boolValue).booleanValue, true);
-    });
-  });
-
-  group('generateFilter', () {
-    test('a composite filter with a single field filter', () async {
-      final filterMap = <String, Object>{'intField =': 1};
-      const compositeFilterOp = kCompositeFilterOpAnd;
-      final filter = firestoreService.generateFilter(
-        filterMap,
-        compositeFilterOp,
-      );
-      expect(filter.compositeFilter, isNotNull);
-      final filters = filter.compositeFilter!.filters!;
-      expect(filters.length, 1);
-      expect(
-        filters[0].fieldFilter!.field!.fieldPath,
-        '`intField`',
-        reason: 'field escaped properly',
-      );
-      expect(filters[0].fieldFilter!.value!.integerValue, '1');
-      expect(filters[0].fieldFilter!.op, kFieldFilterOpEqual);
-    });
-
-    test('accepts complex field names', () async {
-      final filterMap = <String, Object>{
-        'this is my field      !=': 'there are many like it ',
-      };
-      const compositeFilterOp = kCompositeFilterOpAnd;
-      final filter = firestoreService.generateFilter(
-        filterMap,
-        compositeFilterOp,
-      );
-      expect(filter.compositeFilter, isNotNull);
-      final filters = filter.compositeFilter!.filters!;
-      expect(filters.length, 1);
-      expect(
-        filters[0].fieldFilter!.field!.fieldPath,
-        '`this is my field`',
-        reason: 'field escaped properly',
-      );
-      expect(
-        filters[0].fieldFilter!.value!.stringValue,
-        'there are many like it ',
-      );
-      expect(filters[0].fieldFilter!.op, kFieldFilterOpNotEqual);
-    });
-
-    test('a composite filter with multiple field filters', () async {
-      final filterMap = <String, Object>{
-        'intField =': 1,
-        'stringField =': 'string',
-      };
-      const compositeFilterOp = kCompositeFilterOpAnd;
-      final filter = firestoreService.generateFilter(
-        filterMap,
-        compositeFilterOp,
-      );
-      expect(filter.fieldFilter, isNull);
-      expect(filter.compositeFilter, isNotNull);
-      final filters = filter.compositeFilter!.filters!;
-      expect(filters.length, 2);
-      expect(
-        filters[0].fieldFilter!.field!.fieldPath,
-        '`intField`',
-        reason: 'field escaped properly',
-      );
-      expect(filters[0].fieldFilter!.value!.integerValue, '1');
-      expect(filters[0].fieldFilter!.op, kFieldFilterOpEqual);
-      expect(filters[1].fieldFilter!.field!.fieldPath, '`stringField`');
-      expect(filters[1].fieldFilter!.value!.stringValue, 'string');
-      expect(filters[1].fieldFilter!.op, kFieldFilterOpEqual);
-    });
-  });
-
-  group('documentsFromQueryResponse', () {
-    late List<RunQueryResponseElement> runQueryResponseElements;
-    test('when null document returns', () async {
-      runQueryResponseElements = <RunQueryResponseElement>[
-        RunQueryResponseElement(),
-      ];
-      final documents = firestoreService.documentsFromQueryResponse(
-        runQueryResponseElements,
-      );
-      expect(documents.isEmpty, true);
-    });
-
-    test('when non-null document returns', () async {
-      final githubGoldStatus = generateFirestoreGithubGoldStatus(1);
-      runQueryResponseElements = <RunQueryResponseElement>[
-        RunQueryResponseElement(document: githubGoldStatus),
-      ];
-      final documents = firestoreService.documentsFromQueryResponse(
-        runQueryResponseElements,
-      );
-      expect(documents.length, 1);
-      expect(documents[0].name, githubGoldStatus.name);
-    });
-  });
-
-  group('generateOrders', () {
-    Map<String, String>? orderMap;
-    test('when there is no orderMap', () async {
-      orderMap = null;
-      final orders = firestoreService.generateOrders(orderMap);
-      expect(orders, isNull);
-    });
-
-    test('when there is non-null orderMap', () async {
-      orderMap = <String, String>{'createTimestamp': kQueryOrderDescending};
-      final orders = firestoreService.generateOrders(orderMap);
-      expect(orders!.length, 1);
-      final resultOrder = orders[0];
-      expect(resultOrder.direction, kQueryOrderDescending);
-      expect(resultOrder.field!.fieldPath, 'createTimestamp');
-    });
   });
 }

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:math';
 
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/firestore.dart';

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -1,0 +1,391 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:math';
+
+import 'package:cocoon_service/src/service/config.dart';
+import 'package:cocoon_service/src/service/firestore.dart';
+import 'package:googleapis/firestore/v1.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../utilities/mocks.dart';
+
+abstract base class _FakeInMemoryFirestoreService
+    with FirestoreQueries
+    implements FirestoreService {
+  /// Every document currently stored in the fake.
+  Iterable<Document> get documents => _documents.values;
+  final _documents = <String, Document>{};
+
+  @protected
+  String get expectedProjectId => Config.flutterGcpProjectId;
+
+  @protected
+  String get expectedDatabaseId => Config.flutterGcpFirestoreDatabase;
+
+  void _assertExpectedDatabase(String database) {
+    final parts = p.posix.split(database);
+    if (parts.length != 4) {
+      fail('Unexpected database: "$database"');
+    }
+    final [pLiteral, pName, dLiteral, dName] = parts;
+    if (pLiteral != 'projects' || dLiteral != 'databases') {
+      fail('Unexpected database: "$database"');
+    }
+    if (pName != expectedProjectId || dName != expectedDatabaseId) {
+      fail('Unexpected database: "$database"');
+    }
+  }
+
+  final _random = Random();
+  String _generateUniqueId() {
+    const length = 20;
+    const chars =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        'abcdefghijklmnopqrstuvwxyz'
+        '0123456789';
+    final buffer = StringBuffer();
+
+    for (var i = 0; i < length; i++) {
+      final randomIndex = _random.nextInt(chars.length);
+      buffer.write(chars[randomIndex]);
+    }
+
+    final result = buffer.toString();
+    if (_documents.containsKey(result)) {
+      return _generateUniqueId();
+    }
+
+    return result;
+  }
+
+  DateTime _now() => DateTime.now();
+
+  Document _clone(Document other) {
+    return Document(
+      name: other.name,
+      fields: {...?other.fields},
+      createTime: other.createTime,
+      updateTime: other.updateTime,
+    );
+  }
+
+  /// Returns the document specified by [documentName].
+  ///
+  /// If the document does not exist, returns `null`.
+  Document? tryPeekDocument(String documentName) {
+    final document = _documents[documentName];
+    return document == null ? null : _clone(document);
+  }
+
+  /// Returns the document that ends with [relativePath].
+  ///
+  /// The document must exist.
+  Document peekDocumentByPath(String relativePath) {
+    final documentName = p.posix.join(
+      'projects',
+      expectedProjectId,
+      'databases',
+      expectedDatabaseId,
+      'documents',
+      relativePath,
+    );
+    final existingDocument = tryPeekDocument(documentName);
+    if (existingDocument == null) {
+      fail('No document "$documentName" found');
+    }
+    return existingDocument;
+  }
+
+  /// Stores a [document].
+  ///
+  /// Note that this method bypasses normal database conventions, and is
+  /// intended to represent changes to the database that happen _before_ a test
+  /// runs, or as a side-effect not covered in a test.
+  ///
+  /// Either [Document.name] or [name] must be set, or this method fails.
+  ///
+  /// If [created] is set, it is used, otherwise [DateTime.now] is used for
+  /// a new document, and the _prevous_ [Document.createTime] is used for a
+  /// pre-existing document.
+  ///
+  /// If [updated] is set, it is used, otherwise [DateTime.now] is used.
+  ///
+  /// Returns `true` if a new document was inserted, and `false` if updated.
+  bool putDocument(
+    Document document, {
+    String? name,
+    DateTime? created,
+    DateTime? updated,
+  }) {
+    name ??= document.name;
+    if (name == null) {
+      throw ArgumentError.value(document, 'document', 'name must be set');
+    }
+    if (_failOnWrite[name] case final exception?) {
+      throw exception;
+    }
+    final existing = tryPeekDocument(name);
+    if (existing == null) {
+      _documents[name] = Document(
+        name: name,
+        fields: {...?document.fields},
+        createTime: (created ?? _now()).toUtc().toIso8601String(),
+        updateTime: (updated ?? _now()).toUtc().toIso8601String(),
+      );
+      return true;
+    }
+    _documents[name] = Document(
+      name: name,
+      fields: {...?document.fields},
+      createTime: created?.toUtc().toIso8601String() ?? existing.createTime,
+      updateTime: (updated ?? _now()).toUtc().toIso8601String(),
+    );
+    return false;
+  }
+
+  final _failOnWrite = <String, Exception>{};
+
+  /// Instructs the fake to throw an exception if [document] is written.
+  void failOnWrite(Document document, [DetailedApiRequestError? exception]) {
+    if (document.name == null) {
+      fail('Missing "name" field');
+    }
+    _failOnWrite[document.name!] =
+        exception ??
+        DetailedApiRequestError(500, 'Used failOnWrite(${document.name})');
+  }
+
+  @override
+  Future<BatchWriteResponse> batchWriteDocuments(
+    BatchWriteRequest request,
+    String database,
+  ) async {
+    _assertExpectedDatabase(database);
+    return BatchWriteResponse(
+      status: _batchWriteSync(request.writes ?? const []),
+    );
+  }
+
+  /// Same as [batchWriteDocuments], but does not yield the microtask loop.
+  List<Status> _batchWriteSync(List<Write> writes) {
+    final response = <Status>[];
+    for (final write in writes) {
+      final document = write.update;
+      if (document == null) {
+        response.add(Status(code: 3, message: 'Missing "update" field'));
+        continue;
+      }
+      switch (write.currentDocument) {
+        // Must find an existing document to update.
+        case final p? when p.exists == true:
+          final name = document.name;
+          if (name == null) {
+            response.add(Status(code: 3, message: 'Missing "name" field'));
+            continue;
+          }
+          final existing = tryPeekDocument(name);
+          if (existing == null) {
+            response.add(Status(code: 9, message: '"$name" does not exist'));
+            continue;
+          }
+          putDocument(document);
+
+        // Must not find an existing document and insert.
+        case final p? when p.exists == false:
+          final name = document.name ?? _generateUniqueId();
+          if (tryPeekDocument(name) != null) {
+            response.add(Status(code: 9, message: '"$name" already exists'));
+            continue;
+          }
+          putDocument(document, name: name);
+
+        // Upsert: update if existing and insert if missing.
+        default:
+          final name = document.name ?? _generateUniqueId();
+          putDocument(document, name: name);
+      }
+      response.add(Status(code: 0));
+    }
+    return response;
+  }
+
+  @override
+  Future<Document> getDocument(String name) async {
+    final result = tryPeekDocument(name);
+    if (result == null) {
+      throw DetailedApiRequestError(
+        HttpStatus.notFound,
+        'Document "$name" not found',
+      );
+    }
+    return result;
+  }
+
+  @override
+  Future<CommitResponse> writeViaTransaction(List<Write> writes) async {
+    // Poor man's write-only transaction:
+    //
+    // 1. Store a copy of the existing documents.
+    // 2. Attempt to make writes
+    // 3. If any write would fail (non-0 status), restore.
+    //
+    // We have to make some assumptions here to make this easier to reason
+    // about compared to prod code, namely we assume each Write uniquely
+    // writes to a document, i.e. there are not multiple writes each writing
+    // to the same document.
+    final beforeTransaction = _documents.map((k, v) => MapEntry(k, _clone(v)));
+    final result = _batchWriteSync(writes);
+    if (result.any((r) => r.code != 0)) {
+      _documents
+        ..clear()
+        ..addAll(beforeTransaction);
+      throw DetailedApiRequestError(500, 'The transaction was aborted');
+    }
+
+    final updated = _now().toUtc().toIso8601String();
+    return CommitResponse(
+      commitTime: updated,
+      writeResults: List.generate(
+        writes.length,
+        (_) => WriteResult(updateTime: updated),
+      ),
+    );
+  }
+
+  @override
+  Future<List<Document>> query(
+    String collectionId,
+    Map<String, Object> filterMap, {
+    int? limit,
+    Map<String, String>? orderMap,
+    String compositeFilterOp = kCompositeFilterOpAnd,
+  }) async {
+    var results = documents.where((document) {
+      final collection = p.basename(p.dirname(document.name!));
+      return collectionId == collection;
+    });
+
+    results = results.where((document) {
+      return _matchesFilter(document.fields!, filterMap);
+    });
+
+    if (limit != null) {
+      results = results.take(limit);
+    }
+
+    if (compositeFilterOp != kCompositeFilterOpAnd) {
+      throw UnimplementedError('compositeFilterOp: $compositeFilterOp');
+    }
+
+    var sorted = [...results];
+
+    if (orderMap != null) {
+      if (orderMap.values.any((v) => v != kQueryOrderDescending)) {
+        throw UnimplementedError('orderMap: ${[...orderMap.values]}');
+      }
+
+      sorted.sort((a, b) {
+        for (final fieldName in orderMap.keys) {
+          final aField = a.fields?[fieldName];
+          final bField = b.fields?[fieldName];
+          if (aField == null) {
+            return -1;
+          }
+          if (bField == null) {
+            return 1;
+          }
+
+          final result = _compareValues(aField, bField);
+          if (result != 0) {
+            return result;
+          }
+        }
+
+        return 0;
+      });
+    }
+
+    if (limit != null) {
+      sorted = [...sorted.take(limit)];
+    }
+
+    return sorted;
+  }
+
+  static bool _matchesFilter(
+    Map<String, Value> fields,
+    Map<String, Object> filters,
+  ) {
+    for (final MapEntry(key: fieldAndOp, value: value) in filters.entries) {
+      final [...fieldParts, operator] = fieldAndOp.split(' ');
+      final fieldName = fieldParts.join(' ');
+      final fieldValue = fields[fieldName];
+      if (fieldValue == null) {
+        return false;
+      }
+      final result = _compare(fieldValue, value);
+      if (result == null) {
+        return false;
+      }
+      final matched = switch (operator) {
+        '=' => result == 0,
+        '!=' => result != 0,
+        '<' => result < 0,
+        '<=' => result <= 0,
+        '>' => result > 0,
+        '>=' => result >= 0,
+        _ => throw UnimplementedError('"$operator" operator'),
+      };
+
+      if (!matched) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  static int? _compare(Value fieldValue, Object rawValue) {
+    return switch (rawValue) {
+      final String v => fieldValue.stringValue?.compareTo(v),
+      final int v => int.tryParse(fieldValue.integerValue ?? '')?.compareTo(v),
+      _ => throw UnimplementedError('"${rawValue.runtimeType}" filter'),
+    };
+  }
+
+  static int _compareValues(Value a, Value b) {
+    if (a.stringValue case final string?) {
+      return string.compareTo(b.stringValue!);
+    }
+    if (a.integerValue case final integer?) {
+      return int.parse(integer).compareTo(int.parse(b.integerValue!));
+    }
+    throw UnimplementedError('${a.toJson()}');
+  }
+}
+
+/// A partial fake implementation of [FirestoreService].
+///
+/// For methods that are implemented by [_FakeInMemoryFirestoreService],
+/// operates as an in-memory fake, with writes/reads flowing through the API,
+/// which is an in-memory database simulation.
+///
+/// For other methods, they delegate to [mock], which can be manipulated at
+/// test runtime similar to any other mock (i.e. `when(firestore.mock)`).
+///
+/// The awkwardness will be removed after
+/// https://github.com/flutter/flutter/issues/165931.
+final class FakeFirestoreService extends _FakeInMemoryFirestoreService {
+  /// A mock [FirestoreService] for legacy methods that don't faked-out APIs.
+  final mock = MockFirestoreService();
+
+  @override
+  Future<ProjectsDatabasesDocumentsResource> documentResource() {
+    return mock.documentResource();
+  }
+}

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -41,21 +41,15 @@ abstract base class _FakeInMemoryFirestoreService
     }
   }
 
-  final _random = Random();
+  final alphabet = ('ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+              'abcdefghijklmnopqrstuvwxyz'
+              '0123456789' *
+          32)
+      .split('');
+
   String _generateUniqueId() {
-    const length = 20;
-    const chars =
-        'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        'abcdefghijklmnopqrstuvwxyz'
-        '0123456789';
-    final buffer = StringBuffer();
+    final result = (alphabet..shuffle()).take(20).join('');
 
-    for (var i = 0; i < length; i++) {
-      final randomIndex = _random.nextInt(chars.length);
-      buffer.write(chars[randomIndex]);
-    }
-
-    final result = buffer.toString();
     if (_documents.containsKey(result)) {
       return _generateUniqueId();
     }

--- a/app_dart/test/src/service/fake_firestore_service_test.dart
+++ b/app_dart/test/src/service/fake_firestore_service_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:test/test.dart';
@@ -9,6 +10,8 @@ import 'package:test/test.dart';
 import 'fake_firestore_service.dart';
 
 void main() {
+  useTestLoggerPerTest();
+
   late FakeFirestoreService firestore;
 
   setUp(() {

--- a/app_dart/test/src/service/fake_firestore_service_test.dart
+++ b/app_dart/test/src/service/fake_firestore_service_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'fake_firestore_service.dart';
+
+void main() {
+  late FakeFirestoreService firestore;
+
+  setUp(() {
+    firestore = FakeFirestoreService();
+  });
+
+  // FIXME: Write tests.
+  // FIXME: Add support for boolean type.
+  // FIXME: Hope that my 8 PRs today don't have to be reverted on a Friday.
+}

--- a/app_dart/test/src/service/fake_firestore_service_test.dart
+++ b/app_dart/test/src/service/fake_firestore_service_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_service/src/service/firestore.dart';
+import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:test/test.dart';
 
 import 'fake_firestore_service.dart';
@@ -13,7 +15,778 @@ void main() {
     firestore = FakeFirestoreService();
   });
 
-  // FIXME: Write tests.
-  // FIXME: Add support for boolean type.
-  // FIXME: Hope that my 8 PRs today don't have to be reverted on a Friday.
+  group('tryPeekDocument', () {
+    test('returns null if the document does not exist', () {
+      expect(
+        firestore.tryPeekDocumentByPath('messages', 'does-not-exist'),
+        isNull,
+      );
+    });
+
+    test('returns a clone of a matching document', () {
+      final newDoc = firestore.putDocument(
+        g.Document(
+          fields: {'Hello': g.Value(stringValue: 'World')},
+          name: firestore.resolveDocumentName('messages', 'greeting'),
+        ),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(newDoc.name!),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+
+      newDoc.fields!['Hello'] = g.Value(stringValue: 'Changed');
+
+      expect(
+        firestore.tryPeekDocumentByName(newDoc.name!),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+        reason: 'Should have returned a clone that is not changed',
+      );
+    });
+  });
+
+  test('failOnWrite forces a 500 error', () {
+    final blockDoc = g.Document(
+      fields: {'Hello': g.Value(stringValue: 'World')},
+      name: firestore.resolveDocumentName('messages', 'greeting'),
+    );
+
+    firestore.failOnWrite(blockDoc);
+
+    expect(
+      () => firestore.putDocument(blockDoc),
+      throwsA(
+        isA<g.DetailedApiRequestError>().having((e) => e.status, 'status', 500),
+      ),
+    );
+  });
+
+  group('batchWriteDocuments', () {
+    const expectedDatabase = 'projects/flutter-dashboard/databases/cocoon';
+
+    group('must match expected database', () {
+      test('bad projectId', () async {
+        await expectLater(
+          firestore.batchWriteDocuments(
+            g.BatchWriteRequest(),
+            'projects/unexpected-project-id/databases/cocoon',
+          ),
+          throwsA(isStateError),
+        );
+      });
+
+      test('bad databaseId', () async {
+        await expectLater(
+          firestore.batchWriteDocuments(
+            g.BatchWriteRequest(),
+            'projects/flutter-dashboard/databases/unexpected-database-id',
+          ),
+          throwsA(isStateError),
+        );
+      });
+
+      test('bad overall format', () async {
+        await expectLater(
+          firestore.batchWriteDocuments(
+            g.BatchWriteRequest(),
+            'projectZ/flutter-dashboard/databaseS/cocoon',
+          ),
+          throwsA(isStateError),
+        );
+      });
+    });
+
+    test('requires "update"', () async {
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(writes: [g.Write()]),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code != 0)),
+      );
+    });
+
+    test('requires "name"', () async {
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(writes: [g.Write(update: g.Document())]),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code != 0)),
+      );
+    });
+
+    test('updates an existing document if it exists', () async {
+      final existingDoc = g.Document(
+        name: firestore.resolveDocumentName('collection-id', 'document-id'),
+      );
+      firestore.putDocument(existingDoc);
+
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(
+          writes: [
+            g.Write(
+              currentDocument: g.Precondition(exists: true),
+              update: g.Document(
+                name: existingDoc.name,
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+          ],
+        ),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code == 0)),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(existingDoc.name!),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+    });
+
+    test('fails to update a document that does not exist', () async {
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(
+          writes: [
+            g.Write(
+              currentDocument: g.Precondition(exists: true),
+              update: g.Document(
+                name: firestore.resolveDocumentName(
+                  'collection-id',
+                  'document-id',
+                ),
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+          ],
+        ),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code != 0)),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'document-id'),
+        ),
+        isNull,
+      );
+    });
+
+    test('inserts a new document if it does not exist', () async {
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(
+          writes: [
+            g.Write(
+              currentDocument: g.Precondition(exists: false),
+              update: g.Document(
+                name: firestore.resolveDocumentName(
+                  'collection-id',
+                  'document-id',
+                ),
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+          ],
+        ),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code == 0)),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'document-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+    });
+
+    test('fails to insert a new document if already exists', () async {
+      final existingDoc = g.Document(
+        name: firestore.resolveDocumentName('collection-id', 'document-id'),
+      );
+      firestore.putDocument(existingDoc);
+
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(
+          writes: [
+            g.Write(
+              currentDocument: g.Precondition(exists: false),
+              update: g.Document(
+                name: firestore.resolveDocumentName(
+                  'collection-id',
+                  'document-id',
+                ),
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+          ],
+        ),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code != 0)),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'document-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          isNull,
+        ),
+      );
+    });
+
+    test('updates existing document and inserts a new document', () async {
+      final existingDoc = g.Document(
+        name: firestore.resolveDocumentName('collection-id', 'existing-id'),
+      );
+      firestore.putDocument(existingDoc);
+
+      final response = await firestore.batchWriteDocuments(
+        g.BatchWriteRequest(
+          writes: [
+            g.Write(
+              update: g.Document(
+                name: firestore.resolveDocumentName(
+                  'collection-id',
+                  'existing-id',
+                ),
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+            g.Write(
+              update: g.Document(
+                name: firestore.resolveDocumentName('collection-id', 'new-id'),
+                fields: {'Hello': g.Value(stringValue: 'World')},
+              ),
+            ),
+          ],
+        ),
+        expectedDatabase,
+      );
+
+      expect(
+        response.status,
+        allOf(isNotEmpty, everyElement((g.Status status) => status.code == 0)),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'existing-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'new-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+    });
+  });
+
+  group('writeViaTransaction', () {
+    test('writes successfully', () async {
+      final existingDoc = g.Document(
+        name: firestore.resolveDocumentName('collection-id', 'existing-id'),
+      );
+      firestore.putDocument(existingDoc);
+
+      await firestore.writeViaTransaction([
+        g.Write(
+          update: g.Document(
+            name: firestore.resolveDocumentName('collection-id', 'existing-id'),
+            fields: {'Hello': g.Value(stringValue: 'World')},
+          ),
+        ),
+        g.Write(
+          update: g.Document(
+            name: firestore.resolveDocumentName('collection-id', 'new-id'),
+            fields: {'Hello': g.Value(stringValue: 'World')},
+          ),
+        ),
+      ]);
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'existing-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'new-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          'World',
+        ),
+      );
+    });
+
+    test('aborts and does not apply writes', () async {
+      final existingDoc = g.Document(
+        name: firestore.resolveDocumentName('collection-id', 'existing-id'),
+      );
+      firestore.putDocument(existingDoc);
+
+      await expectLater(
+        firestore.writeViaTransaction([
+          g.Write(
+            // This will fail
+            currentDocument: g.Precondition(exists: false),
+            update: g.Document(
+              name: firestore.resolveDocumentName(
+                'collection-id',
+                'existing-id',
+              ),
+              fields: {'Hello': g.Value(stringValue: 'World')},
+            ),
+          ),
+          g.Write(
+            update: g.Document(
+              name: firestore.resolveDocumentName('collection-id', 'new-id'),
+              fields: {'Hello': g.Value(stringValue: 'World')},
+            ),
+          ),
+        ]),
+        throwsA(
+          isA<g.DetailedApiRequestError>().having(
+            (e) => e.status,
+            'status',
+            500,
+          ),
+        ),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'existing-id'),
+        ),
+        isA<g.Document>().having(
+          (d) => d.fields?['Hello']?.stringValue,
+          "['Hello']?.stringValue",
+          isNull,
+        ),
+      );
+
+      expect(
+        firestore.tryPeekDocumentByName(
+          firestore.resolveDocumentName('collection-id', 'new-id'),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('query', () {
+    group('filter', () {
+      group('bool', () {
+        setUp(() {
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '1'),
+              fields: {'is_flaky': g.Value(booleanValue: true)},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '2'),
+              fields: {'is_flaky': g.Value(booleanValue: false)},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '3'),
+              fields: {'is_flaky': g.Value(booleanValue: null)},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '4'),
+              fields: {},
+            ),
+          );
+        });
+
+        test('== true', () async {
+          final query = await firestore.query('items', {'is_flaky =': true});
+          expect(query.map((q) => q.name), [endsWith('1')]);
+        });
+
+        test('!= true', () async {
+          final query = await firestore.query('items', {'is_flaky !=': true});
+          expect(query.map((q) => q.name), [
+            endsWith('2'),
+            endsWith('3'),
+            endsWith('4'),
+          ]);
+        });
+
+        test('== false', () async {
+          final query = await firestore.query('items', {'is_flaky =': false});
+          expect(query.map((q) => q.name), [endsWith('2')]);
+        });
+
+        test('!= false', () async {
+          final query = await firestore.query('items', {'is_flaky !=': false});
+          expect(query.map((q) => q.name), [
+            endsWith('1'),
+            endsWith('3'),
+            endsWith('4'),
+          ]);
+        });
+      });
+
+      group('string', () {
+        setUp(() {
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '1'),
+              fields: {'task': g.Value(stringValue: 'Eat')},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '2'),
+              fields: {'task': g.Value(stringValue: 'Sleep')},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '3'),
+              fields: {'task': g.Value(stringValue: null)},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '4'),
+              fields: {},
+            ),
+          );
+        });
+
+        test('== "Eat"', () async {
+          final query = await firestore.query('items', {'task =': 'Eat'});
+          expect(query.map((q) => q.name), [endsWith('1')]);
+        });
+
+        test('!= Eat', () async {
+          final query = await firestore.query('items', {'task !=': 'Eat'});
+          expect(query.map((q) => q.name), [
+            endsWith('2'),
+            endsWith('3'),
+            endsWith('4'),
+          ]);
+        });
+
+        test('> Eat', () async {
+          final query = await firestore.query('items', {'task >': 'Eat'});
+          expect(query.map((q) => q.name), [endsWith('2')]);
+        });
+
+        test('>= Eat', () async {
+          final query = await firestore.query('items', {'task >=': 'Eat'});
+          expect(query.map((q) => q.name), [endsWith('1'), endsWith('2')]);
+        });
+      });
+
+      group('int', () {
+        setUp(() {
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '1'),
+              fields: {'calories': g.Value(integerValue: '200')},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '2'),
+              fields: {'calories': g.Value(integerValue: '500')},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '3'),
+              fields: {'calories': g.Value(integerValue: null)},
+            ),
+          );
+
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '4'),
+              fields: {},
+            ),
+          );
+        });
+
+        test('== 200', () async {
+          final query = await firestore.query('items', {'calories =': 200});
+          expect(query.map((q) => q.name), [endsWith('1')]);
+        });
+
+        test('!= 200', () async {
+          final query = await firestore.query('items', {'calories !=': 200});
+          expect(query.map((q) => q.name), [
+            endsWith('2'),
+            endsWith('3'),
+            endsWith('4'),
+          ]);
+        });
+
+        test('> 200', () async {
+          final query = await firestore.query('items', {'calories >': 200});
+          expect(query.map((q) => q.name), [endsWith('2')]);
+        });
+
+        test('>= 200', () async {
+          final query = await firestore.query('items', {'calories >=': 200});
+          expect(query.map((q) => q.name), [endsWith('1'), endsWith('2')]);
+        });
+      });
+
+      test('multiple filters', () async {
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '1'),
+            fields: {
+              'is_spicy': g.Value(booleanValue: true),
+              'calories': g.Value(integerValue: '200'),
+            },
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '2'),
+            fields: {
+              'is_spicy': g.Value(booleanValue: false),
+              'calories': g.Value(integerValue: '500'),
+            },
+          ),
+        );
+
+        final query = await firestore.query('items', {
+          'calories >=': 200,
+          'is_spicy =': true,
+        });
+        expect(query.map((q) => q.name), [endsWith('1')]);
+      });
+    });
+
+    group('limit', () {
+      setUp(() {
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '1'),
+            fields: {'number': g.Value(integerValue: '1')},
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '2'),
+            fields: {'number': g.Value(integerValue: '2')},
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '3'),
+            fields: {'number': g.Value(integerValue: '3')},
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '4'),
+            fields: {'number': g.Value(integerValue: '4')},
+          ),
+        );
+      });
+
+      test('unspecified', () async {
+        final query = await firestore.query('items', {'number >=': 1});
+        expect(query.map((q) => q.name), [
+          endsWith('1'),
+          endsWith('2'),
+          endsWith('3'),
+          endsWith('4'),
+        ]);
+      });
+
+      test('> total items', () async {
+        final query = await firestore.query('items', {
+          'number >=': 1,
+        }, limit: 100);
+        expect(query.map((q) => q.name), [
+          endsWith('1'),
+          endsWith('2'),
+          endsWith('3'),
+          endsWith('4'),
+        ]);
+      });
+
+      test('< total items', () async {
+        final query = await firestore.query('items', {
+          'number >=': 1,
+        }, limit: 2);
+        expect(query.map((q) => q.name), [endsWith('1'), endsWith('2')]);
+      });
+    });
+
+    group('order', () {
+      test('unordered', () async {
+        for (var i = 4; i >= 1; i--) {
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '$i'),
+              fields: {'alpha': g.Value(integerValue: '$i')},
+            ),
+          );
+        }
+
+        final query = await firestore.query('items', {}, orderMap: {});
+
+        expect(query.map((q) => q.name), [
+          endsWith('4'),
+          endsWith('3'),
+          endsWith('2'),
+          endsWith('1'),
+        ]);
+      });
+
+      test('1 field', () async {
+        for (var i = 4; i >= 1; i--) {
+          firestore.putDocument(
+            g.Document(
+              name: firestore.resolveDocumentName('items', '$i'),
+              fields: {'alpha': g.Value(integerValue: '$i')},
+            ),
+          );
+        }
+
+        final query = await firestore.query(
+          'items',
+          {},
+          orderMap: {'alpha': kQueryOrderDescending},
+        );
+
+        expect(query.map((q) => q.name), [
+          endsWith('4'),
+          endsWith('3'),
+          endsWith('2'),
+          endsWith('1'),
+        ]);
+      });
+
+      test('2 fields', () async {
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '1'),
+            fields: {
+              'alpha': g.Value(integerValue: '1'),
+              'beta': g.Value(integerValue: '1'),
+            },
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '2'),
+            fields: {
+              'alpha': g.Value(integerValue: '1'),
+              'beta': g.Value(integerValue: '2'),
+            },
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '3'),
+            fields: {
+              'alpha': g.Value(integerValue: '2'),
+              'beta': g.Value(integerValue: '3'),
+            },
+          ),
+        );
+
+        final query = await firestore.query(
+          'items',
+          {},
+          orderMap: {
+            'alpha': kQueryOrderDescending,
+            'beta': kQueryOrderDescending,
+          },
+        );
+
+        expect(query.map((q) => q.name), [
+          endsWith('3'),
+          endsWith('2'),
+          endsWith('1'),
+        ]);
+      });
+    });
+  });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165931.

A basic in-memory implementation of Firestore in-so-far it supports `FirestoreService`.

For more advanced use-cases, i.e. `documentsResource().any.possible.api()`, mocking is still required, but for much of our API surface, it now _really_ reads, writes, and updates to an in-memory database that supports queries, filtering, ordering, and a (very basic) transaction.

We can move more code from `.documentsResource()` to `service.something()`, and ensure those are supported by the fake. In a follow-up PR we can start using this in our own tests where appropriate.

No production code changes.