### PR TITLE
Log `message.data` for `dart-internal-build-results-sub`.

### DIFF
--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -90,7 +90,10 @@ final class DartInternalSubscription extends SubscriptionHandler {
         );
       }
     } catch (e) {
-      log.warn('[dart_internal_166535] bbv2.BuildV2PubSub not compatible', e);
+      log.warn(
+        '[dart_internal_166535] bbv2.BuildV2PubSub not compatible\n${message.data}',
+        e,
+      );
     }
 
     // This should already be covered by the pubsub filter, but adding an additional check


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/166535#issuecomment-2779593051.