### PR TITLE
Simplify `src/model/firestore`, `AppDocument` is-a `Document`.

### DIFF
--- a/app_dart/lib/src/model/firestore/base.dart
+++ b/app_dart/lib/src/model/firestore/base.dart
@@ -95,9 +95,48 @@ final class AppDocumentMetadata<T extends AppDocument<T>> {
 
 /// Provides methods across [g.Document] sub-types in `model/firestore/*.dart`.
 @internal
-mixin AppDocument<T extends AppDocument<T>> on g.Document {
+abstract class AppDocument<T extends AppDocument<T>> implements g.Document {
+  AppDocument([g.Document? from])
+    : _fields = from?.fields ?? {},
+      name = from?.name,
+      createTime = from?.createTime,
+      updateTime = from?.updateTime;
+
+  @override
+  Map<String, g.Value> get fields => _fields;
+
+  @override
+  set fields(Map<String, g.Value>? fields) {
+    _fields.clear();
+    if (fields != null) {
+      _fields.addAll(fields);
+    }
+  }
+
+  final Map<String, g.Value> _fields;
+
+  @override
+  String? name;
+
+  @override
+  String? updateTime;
+
+  @override
+  String? createTime;
+
+  @override
+  Map<String, dynamic> toJson() {
+    // Copied from [g.Document.toJson].
+    return {
+      'fields': fields,
+      if (createTime != null) 'createTime': createTime!,
+      if (name != null) 'name': name!,
+      if (updateTime != null) 'updateTime': updateTime!,
+    };
+  }
+
   Map<String, Object?> _fieldsToJson() {
-    return fields!.map((k, v) => MapEntry(k, _valueToJson(v)));
+    return _fields.map((k, v) => MapEntry(k, _valueToJson(v)));
   }
 
   /// Metadata that informs other parts of the app about how to use this entity.

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -56,7 +56,7 @@ final class CiStagingId extends AppDocumentId<CiStaging> {
 ///       remaining: int >= 0
 ///       [*fields]: string {scheduled, success, failure, skipped}
 /// ```
-final class CiStaging extends Document with AppDocument<CiStaging> {
+final class CiStaging extends AppDocument<CiStaging> {
   /// Firestore collection for the staging documents.
   static const _collectionId = 'ciStaging';
 
@@ -123,7 +123,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
   /// The repository that this stage is recorded for.
   RepositorySlug get slug {
     // TODO(matanlurey): Simplify this when existing documents are backfilled.
-    if (fields![fieldRepoFullPath]?.stringValue case final repoFullPath?) {
+    if (fields[fieldRepoFullPath]?.stringValue case final repoFullPath?) {
       return RepositorySlug.full(repoFullPath);
     }
 
@@ -135,7 +135,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
   /// Which commit this stage is recorded for.
   String get sha {
     // TODO(matanlurey): Simplify this when existing documents are backfilled.
-    if (fields![fieldCommitSha]?.stringValue case final sha?) {
+    if (fields[fieldCommitSha]?.stringValue case final sha?) {
       return sha;
     }
 
@@ -147,7 +147,7 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
   /// The stage of the CI process.
   CiStage? get stage {
     // TODO(matanlurey): Simplify this when existing documents are backfilled.
-    if (fields![fieldStage]?.stringValue case final stageName?) {
+    if (fields[fieldStage]?.stringValue case final stageName?) {
       return CiStage.values.firstWhereOrNull((e) => e.name == stageName);
     }
 
@@ -157,16 +157,16 @@ final class CiStaging extends Document with AppDocument<CiStaging> {
   }
 
   /// The remaining number of checks in this staging.
-  int get remaining => int.parse(fields![kRemainingField]!.integerValue!);
+  int get remaining => int.parse(fields[kRemainingField]!.integerValue!);
 
   /// The total number of checks in this staging.
-  int get total => int.parse(fields![kTotalField]!.integerValue!);
+  int get total => int.parse(fields[kTotalField]!.integerValue!);
 
   /// The total number of failing checks.
-  int get failed => int.parse(fields![kFailedField]!.integerValue!);
+  int get failed => int.parse(fields[kFailedField]!.integerValue!);
 
   /// The check_run to complete when this stage is closed.
-  String get checkRunGuard => fields![kCheckRunGuardField]!.stringValue!;
+  String get checkRunGuard => fields[kCheckRunGuardField]!.stringValue!;
 
   /// Mark a [checkRun] for a given [stage] with [conclusion].
   ///

--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -26,7 +26,7 @@ import 'base.dart';
 ///  /projects/flutter-dashboard/databases/cocoon/commits/
 ///    document: <this.sha>
 /// ```
-final class Commit extends Document with AppDocument<Commit> {
+final class Commit extends AppDocument<Commit> {
   static const collectionId = 'commits';
   static const fieldAvatar = 'avatar';
   static const fieldBranch = 'branch';
@@ -114,32 +114,32 @@ final class Commit extends Document with AppDocument<Commit> {
   /// The timestamp (in milliseconds since the Epoch) of when the commit
   /// landed.
   int get createTimestamp =>
-      int.parse(fields![fieldCreateTimestamp]!.integerValue!);
+      int.parse(fields[fieldCreateTimestamp]!.integerValue!);
 
   /// The SHA1 hash of the commit.
-  String get sha => fields![fieldSha]!.stringValue!;
+  String get sha => fields[fieldSha]!.stringValue!;
 
   /// The GitHub username of the commit author.
-  String get author => fields![fieldAuthor]!.stringValue!;
+  String get author => fields[fieldAuthor]!.stringValue!;
 
   /// URL of the [author]'s profile image / avatar.
   ///
   /// The bytes loaded from the URL are expected to be encoded image bytes.
-  String get avatar => fields![fieldAvatar]!.stringValue!;
+  String get avatar => fields[fieldAvatar]!.stringValue!;
 
   /// The commit message.
   ///
   /// This may be null, since we didn't always load/store this property in
   /// the datastore, so historical entries won't have this information.
-  String get message => fields![fieldMessage]!.stringValue!;
+  String get message => fields[fieldMessage]!.stringValue!;
 
   /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
-  String get repositoryPath => fields![fieldRepositoryPath]!.stringValue!;
+  String get repositoryPath => fields[fieldRepositoryPath]!.stringValue!;
 
   /// The branch of the commit.
-  String get branch => fields![fieldBranch]!.stringValue!;
+  String get branch => fields[fieldBranch]!.stringValue!;
 
   /// [RepositorySlug] of where this commit exists.
   RepositorySlug get slug => RepositorySlug.full(repositoryPath);

--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -25,7 +25,7 @@ const String kGithubBuildStatusUpdatesField = 'updates';
 ///    document: <this.head>
 /// ```
 /*final - TODO(matanlurey): Can't add because of MockFirestoreService. */
-class GithubBuildStatus extends Document with AppDocument<GithubBuildStatus> {
+class GithubBuildStatus extends AppDocument<GithubBuildStatus> {
   static AppDocumentId<GithubBuildStatus> documentIdFor({
     required String headSha,
   }) {
@@ -68,43 +68,42 @@ class GithubBuildStatus extends Document with AppDocument<GithubBuildStatus> {
   static const String statusNeutral = 'neutral';
 
   int? get prNumber =>
-      int.parse(fields![kGithubBuildStatusPrNumberField]!.integerValue!);
+      int.parse(fields[kGithubBuildStatusPrNumberField]!.integerValue!);
 
   /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
   String? get repository =>
-      fields![kGithubBuildStatusRepositoryField]!.stringValue!;
+      fields[kGithubBuildStatusRepositoryField]!.stringValue!;
 
   /// [RepositorySlug] of where this commit exists.
   RepositorySlug get slug => RepositorySlug.full(repository!);
 
-  String? get head => fields![kGithubBuildStatusHeadField]!.stringValue!;
+  String? get head => fields[kGithubBuildStatusHeadField]!.stringValue!;
 
-  String? get status => fields![kGithubBuildStatusStatusField]!.stringValue!;
+  String? get status => fields[kGithubBuildStatusStatusField]!.stringValue!;
 
   /// The last time when the status is updated for the PR.
-  int? get updateTimeMillis => int.parse(
-    fields![kGithubBuildStatusUpdateTimeMillisField]!.integerValue!,
-  );
+  int? get updateTimeMillis =>
+      int.parse(fields[kGithubBuildStatusUpdateTimeMillisField]!.integerValue!);
 
   int? get updates =>
-      int.parse(fields![kGithubBuildStatusUpdatesField]!.integerValue!);
+      int.parse(fields[kGithubBuildStatusUpdatesField]!.integerValue!);
 
   String setStatus(String status) {
-    fields![kGithubBuildStatusStatusField] = Value(stringValue: status);
+    fields[kGithubBuildStatusStatusField] = Value(stringValue: status);
     return status;
   }
 
   int setUpdates(int updates) {
-    fields![kGithubBuildStatusUpdatesField] = Value(
+    fields[kGithubBuildStatusUpdatesField] = Value(
       integerValue: updates.toString(),
     );
     return updates;
   }
 
   int setUpdateTimeMillis(int updateTimeMillis) {
-    fields![kGithubBuildStatusUpdateTimeMillisField] = Value(
+    fields[kGithubBuildStatusUpdateTimeMillisField] = Value(
       integerValue: updateTimeMillis.toString(),
     );
     return updateTimeMillis;

--- a/app_dart/lib/src/model/firestore/github_build_status.dart
+++ b/app_dart/lib/src/model/firestore/github_build_status.dart
@@ -67,27 +67,27 @@ class GithubBuildStatus extends AppDocument<GithubBuildStatus> {
 
   static const String statusNeutral = 'neutral';
 
-  int? get prNumber =>
+  int get prNumber =>
       int.parse(fields[kGithubBuildStatusPrNumberField]!.integerValue!);
 
   /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
-  String? get repository =>
+  String get repository =>
       fields[kGithubBuildStatusRepositoryField]!.stringValue!;
 
   /// [RepositorySlug] of where this commit exists.
-  RepositorySlug get slug => RepositorySlug.full(repository!);
+  RepositorySlug get slug => RepositorySlug.full(repository);
 
-  String? get head => fields[kGithubBuildStatusHeadField]!.stringValue!;
+  String get head => fields[kGithubBuildStatusHeadField]!.stringValue!;
 
-  String? get status => fields[kGithubBuildStatusStatusField]!.stringValue!;
+  String get status => fields[kGithubBuildStatusStatusField]!.stringValue!;
 
   /// The last time when the status is updated for the PR.
-  int? get updateTimeMillis =>
+  int get updateTimeMillis =>
       int.parse(fields[kGithubBuildStatusUpdateTimeMillisField]!.integerValue!);
 
-  int? get updates =>
+  int get updates =>
       int.parse(fields[kGithubBuildStatusUpdatesField]!.integerValue!);
 
   String setStatus(String status) {

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -76,17 +76,17 @@ class GithubGoldStatus extends AppDocument<GithubGoldStatus> {
 
   static const String statusRunning = 'pending';
 
-  int? get prNumber =>
+  int get prNumber =>
       int.parse(fields[kGithubGoldStatusPrNumberField]!.integerValue!);
 
-  String? get head => fields[kGithubGoldStatusHeadField]!.stringValue!;
+  String get head => fields[kGithubGoldStatusHeadField]!.stringValue!;
 
-  String? get status => fields[kGithubGoldStatusStatusField]!.stringValue!;
+  String get status => fields[kGithubGoldStatusStatusField]!.stringValue!;
 
-  String? get description =>
+  String get description =>
       fields[kGithubGoldStatusDescriptionField]!.stringValue!;
 
-  int? get updates =>
+  int get updates =>
       int.parse(fields[kGithubGoldStatusUpdatesField]!.integerValue!);
 
   String setStatus(String status) {
@@ -114,9 +114,9 @@ class GithubGoldStatus extends AppDocument<GithubGoldStatus> {
   /// A serializable form of [slug].
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
-  String? get repository =>
+  String get repository =>
       fields[kGithubGoldStatusRepositoryField]!.stringValue!;
 
   /// [RepositorySlug] of where this commit exists.
-  RepositorySlug get slug => RepositorySlug.full(repository!);
+  RepositorySlug get slug => RepositorySlug.full(repository);
 }

--- a/app_dart/lib/src/model/firestore/github_gold_status.dart
+++ b/app_dart/lib/src/model/firestore/github_gold_status.dart
@@ -25,7 +25,7 @@ const String kGithubGoldStatusRepositoryField = 'repository';
 ///    document: <this.slug.owner>_<this.slug.name>_<this.prNumber>
 /// ```
 /*final - TODO(matanlurey): Can't add because of MockFirestoreService. */
-class GithubGoldStatus extends Document with AppDocument<GithubGoldStatus> {
+class GithubGoldStatus extends AppDocument<GithubGoldStatus> {
   static AppDocumentId<GithubGoldStatus> documentIdFor({
     required String owner,
     required String repo,
@@ -77,39 +77,37 @@ class GithubGoldStatus extends Document with AppDocument<GithubGoldStatus> {
   static const String statusRunning = 'pending';
 
   int? get prNumber =>
-      int.parse(fields![kGithubGoldStatusPrNumberField]!.integerValue!);
+      int.parse(fields[kGithubGoldStatusPrNumberField]!.integerValue!);
 
-  String? get head => fields![kGithubGoldStatusHeadField]!.stringValue!;
+  String? get head => fields[kGithubGoldStatusHeadField]!.stringValue!;
 
-  String? get status => fields![kGithubGoldStatusStatusField]!.stringValue!;
+  String? get status => fields[kGithubGoldStatusStatusField]!.stringValue!;
 
   String? get description =>
-      fields![kGithubGoldStatusDescriptionField]!.stringValue!;
+      fields[kGithubGoldStatusDescriptionField]!.stringValue!;
 
   int? get updates =>
-      int.parse(fields![kGithubGoldStatusUpdatesField]!.integerValue!);
+      int.parse(fields[kGithubGoldStatusUpdatesField]!.integerValue!);
 
   String setStatus(String status) {
-    fields![kGithubGoldStatusStatusField] = Value(stringValue: status);
+    fields[kGithubGoldStatusStatusField] = Value(stringValue: status);
     return status;
   }
 
   String setHead(String head) {
-    fields![kGithubGoldStatusHeadField] = Value(stringValue: head);
+    fields[kGithubGoldStatusHeadField] = Value(stringValue: head);
     return head;
   }
 
   int setUpdates(int updates) {
-    fields![kGithubGoldStatusUpdatesField] = Value(
+    fields[kGithubGoldStatusUpdatesField] = Value(
       integerValue: updates.toString(),
     );
     return updates;
   }
 
   String setDescription(String description) {
-    fields![kGithubGoldStatusDescriptionField] = Value(
-      stringValue: description,
-    );
+    fields[kGithubGoldStatusDescriptionField] = Value(stringValue: description);
     return description;
   }
 
@@ -117,7 +115,7 @@ class GithubGoldStatus extends Document with AppDocument<GithubGoldStatus> {
   ///
   /// This will be of the form `<org>/<repo>`. e.g. `flutter/flutter`.
   String? get repository =>
-      fields![kGithubGoldStatusRepositoryField]!.stringValue!;
+      fields[kGithubGoldStatusRepositoryField]!.stringValue!;
 
   /// [RepositorySlug] of where this commit exists.
   RepositorySlug get slug => RepositorySlug.full(repository!);

--- a/app_dart/lib/src/model/firestore/pr_check_runs.dart
+++ b/app_dart/lib/src/model/firestore/pr_check_runs.dart
@@ -34,7 +34,7 @@ import 'base.dart';
 ///       sha: string
 ///       [*fields]: "test_name": "check_run id"
 /// ```
-final class PrCheckRuns extends Document with AppDocument<PrCheckRuns> {
+final class PrCheckRuns extends AppDocument<PrCheckRuns> {
   static const kCollectionId = 'prCheckRuns';
   static const kPullRequestField = 'pull_request';
   static const kSlugField = 'slug';
@@ -59,7 +59,7 @@ final class PrCheckRuns extends Document with AppDocument<PrCheckRuns> {
   /// The json string of the pullrequest belonging to this document.
   PullRequest get pullRequest {
     final jsonData =
-        jsonDecode(fields![kPullRequestField]!.stringValue!)
+        jsonDecode(fields[kPullRequestField]!.stringValue!)
             as Map<String, Object?>;
     final result = PullRequest.fromJson(jsonData);
 
@@ -73,10 +73,10 @@ final class PrCheckRuns extends Document with AppDocument<PrCheckRuns> {
   }
 
   /// The head sha at the time this document was created for testing.
-  String get sha => fields![kShaField]!.stringValue!;
+  String get sha => fields[kShaField]!.stringValue!;
 
   RepositorySlug get slug => RepositorySlug.fromJson(
-    json.decode(fields![kSlugField]!.stringValue!) as Map<String, Object?>,
+    json.decode(fields[kSlugField]!.stringValue!) as Map<String, Object?>,
   );
 
   /// Initializes a new document for the list of check_runs in Firestore so we can find it later.

--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -101,7 +101,7 @@ final class TaskId extends AppDocumentId<Task> {
 ///    document: <this.commitSha>_<this.taskName>_<this.attempt>
 ///
 /// See also: [TaskId].
-final class Task extends Document with AppDocument<Task> {
+final class Task extends AppDocument<Task> {
   static const fieldBringup = 'bringup';
   static const fieldBuildNumber = 'buildNumber';
   static const fieldCommitSha = 'commitSha';
@@ -275,7 +275,7 @@ final class Task extends Document with AppDocument<Task> {
   /// This is _not_ when the task first started running, as tasks start out in
   /// the 'New' state until they've been picked up by an [Agent].
   int get createTimestamp =>
-      int.parse(fields![fieldCreateTimestamp]!.integerValue!);
+      int.parse(fields[fieldCreateTimestamp]!.integerValue!);
 
   /// The timestamp (in milliseconds since the Epoch) that this task started
   /// running.
@@ -283,20 +283,20 @@ final class Task extends Document with AppDocument<Task> {
   /// Tasks may be run more than once. If this task has been run more than
   /// once, this timestamp represents when the task was most recently started.
   int get startTimestamp =>
-      int.parse(fields![fieldStartTimestamp]!.integerValue!);
+      int.parse(fields[fieldStartTimestamp]!.integerValue!);
 
   /// The timestamp (in milliseconds since the Epoch) that this task last
   /// finished running.
-  int get endTimestamp => int.parse(fields![fieldEndTimestamp]!.integerValue!);
+  int get endTimestamp => int.parse(fields[fieldEndTimestamp]!.integerValue!);
 
   /// The name of the task.
   ///
   /// This is a human-readable name, typically a test name (e.g.
   /// "hello_world__memory").
-  String get taskName => fields![fieldName]!.stringValue!;
+  String get taskName => fields[fieldName]!.stringValue!;
 
   /// The sha of the task commit.
-  String get commitSha => fields![fieldCommitSha]!.stringValue!;
+  String get commitSha => fields[fieldCommitSha]!.stringValue!;
 
   /// The number of attempts that have been made to run this task successfully.
   ///
@@ -304,8 +304,8 @@ final class Task extends Document with AppDocument<Task> {
   /// attempts.
   int get currentAttempt {
     // TODO(matanlurey): Simplify this when existing documents are backfilled.
-    if (fields!.containsKey(fieldAttempt)) {
-      return int.parse(fields![fieldAttempt]!.integerValue!);
+    if (fields.containsKey(fieldAttempt)) {
+      return int.parse(fields[fieldAttempt]!.integerValue!);
     }
 
     // Read the attempts from the document name.
@@ -326,7 +326,7 @@ final class Task extends Document with AppDocument<Task> {
   ///  * <https://github.com/flutter/flutter/blob/master/.ci.yaml>
   ///
   /// A flaky (`bringup: true`) task will not block the tree.
-  bool get bringup => fields![fieldBringup]!.booleanValue!;
+  bool get bringup => fields[fieldBringup]!.booleanValue!;
 
   /// Whether the test execution of this task shows flake.
   ///
@@ -334,19 +334,19 @@ final class Task extends Document with AppDocument<Task> {
   ///
   /// See also:
   ///  * <https://github.com/flutter/flutter/blob/master/dev/devicelab/lib/framework/runner.dart>
-  bool get testFlaky => fields![fieldTestFlaky]!.booleanValue!;
+  bool get testFlaky => fields[fieldTestFlaky]!.booleanValue!;
 
   /// The build number of luci build: https://chromium.googlesource.com/infra/luci/luci-go/+/master/buildbucket/proto/build.proto#146
   int? get buildNumber =>
-      fields!.containsKey(fieldBuildNumber)
-          ? int.parse(fields![fieldBuildNumber]!.integerValue!)
+      fields.containsKey(fieldBuildNumber)
+          ? int.parse(fields[fieldBuildNumber]!.integerValue!)
           : null;
 
   /// The status of the task.
   ///
   /// Legal values and their meanings are defined in [legalStatusValues].
   String get status {
-    final taskStatus = fields![fieldStatus]!.stringValue!;
+    final taskStatus = fields[fieldStatus]!.stringValue!;
     if (!legalStatusValues.contains(taskStatus)) {
       throw ArgumentError('Invalid state: "$taskStatus"');
     }
@@ -357,30 +357,30 @@ final class Task extends Document with AppDocument<Task> {
     if (!legalStatusValues.contains(value)) {
       throw ArgumentError('Invalid state: "$value"');
     }
-    fields![fieldStatus] = Value(stringValue: value);
+    fields[fieldStatus] = Value(stringValue: value);
     return value;
   }
 
   void setEndTimestamp(int endTimestamp) {
-    fields![fieldEndTimestamp] = Value(integerValue: endTimestamp.toString());
+    fields[fieldEndTimestamp] = Value(integerValue: endTimestamp.toString());
   }
 
   void setTestFlaky(bool testFlaky) {
-    fields![fieldTestFlaky] = Value(booleanValue: testFlaky);
+    fields[fieldTestFlaky] = Value(booleanValue: testFlaky);
   }
 
   void updateFromBuild(bbv2.Build build) {
-    fields![fieldBuildNumber] = Value(integerValue: build.number.toString());
+    fields[fieldBuildNumber] = Value(integerValue: build.number.toString());
 
-    fields![fieldCreateTimestamp] = Value(
+    fields[fieldCreateTimestamp] = Value(
       integerValue:
           build.createTime.toDateTime().millisecondsSinceEpoch.toString(),
     );
-    fields![fieldStartTimestamp] = Value(
+    fields[fieldStartTimestamp] = Value(
       integerValue:
           build.startTime.toDateTime().millisecondsSinceEpoch.toString(),
     );
-    fields![fieldEndTimestamp] = Value(
+    fields[fieldEndTimestamp] = Value(
       integerValue:
           build.endTime.toDateTime().millisecondsSinceEpoch.toString(),
     );

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -106,7 +106,7 @@ final class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
               DateTime.now().millisecondsSinceEpoch;
 
           githubBuildStatus.setStatus(status);
-          githubBuildStatus.setUpdates((githubBuildStatus.updates ?? 0) + 1);
+          githubBuildStatus.setUpdates(githubBuildStatus.updates + 1);
           githubBuildStatus.setUpdateTimeMillis(
             currentTimeMillisecondsSinceEpoch,
           );

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -250,7 +250,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
 
             githubGoldStatus.setStatus(statusRequest.state!);
             githubGoldStatus.setHead(pr.head!.sha!);
-            githubGoldStatus.setUpdates((githubGoldStatus.updates ?? 0) + 1);
+            githubGoldStatus.setUpdates(githubGoldStatus.updates + 1);
             githubGoldStatus.setDescription(statusRequest.description!);
             githubGoldStatuses.add(githubGoldStatus);
           } catch (e) {

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -167,9 +167,11 @@ void main() {
     final batchWriteRequest = captured[0] as BatchWriteRequest;
     expect(batchWriteRequest.writes!.length, 1);
     final updatedDocument = batchWriteRequest.writes![0].update!;
+
+    final updatedTask = firestore.Task.fromDocument(updatedDocument);
     expect(updatedDocument.name, firestoreTask!.name);
-    expect(firestoreTask!.status, Task.statusSucceeded);
-    expect(firestoreTask!.buildNumber, 63405);
+    expect(updatedTask.status, Task.statusSucceeded);
+    expect(updatedTask.buildNumber, 63405);
   });
 
   test('skips task processing when build is with scheduled status', () async {


### PR DESCRIPTION
This mostly removes a several dozen `fields!` across the codebase.

Also update unnecessary `\w+\?\s+get` getters.