### PR TITLE
Reduce dependency on type signatures of `ds.Commit` or `ds.Task`

### DIFF
--- a/app_dart/lib/src/model/appengine/task.dart
+++ b/app_dart/lib/src/model/appengine/task.dart
@@ -10,6 +10,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../../request_handling/exceptions.dart';
 import '../../service/datastore.dart';
+import '../../service/luci_build_service/opaque_commit.dart';
 import '../ci_yaml/target.dart';
 import 'commit.dart';
 import 'key_converter.dart';
@@ -476,5 +477,5 @@ class FullTask {
   final Task task;
 
   ///  The [Commit] object references by this [task]'s [Task.commitKey].
-  final Commit commit;
+  final OpaqueCommit commit;
 }

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -74,8 +74,10 @@ class BatchBackfiller extends RequestHandler {
     for (var taskColumn in taskMap.values) {
       final task = taskColumn.first;
 
-      final ciYaml = await ciYamlFetcher.getCiYamlByDatastoreCommit(
-        task.commit,
+      final ciYaml = await ciYamlFetcher.getCiYaml(
+        commitBranch: task.commit.branch,
+        commitSha: task.commit.sha,
+        slug: task.commit.slug,
       );
       final ciYamlTargets = [
         ...ciYaml.backfillTargets(),

--- a/app_dart/lib/src/service/datastore.dart
+++ b/app_dart/lib/src/service/datastore.dart
@@ -18,6 +18,7 @@ import '../model/appengine/commit.dart';
 import '../model/appengine/task.dart';
 import '../request_handling/exceptions.dart';
 import 'config.dart';
+import 'luci_build_service/opaque_commit.dart';
 
 /// Per the docs in [DatastoreDB.withTransaction], only 5 entity groups can
 /// be touched in any given transaction, or the backing datastore will throw
@@ -149,7 +150,9 @@ class DatastoreService {
       if (taskName != null) {
         query.filter('name =', taskName);
       }
-      yield* query.run().map<FullTask>((Task task) => FullTask(task, commit));
+      yield* query.run().map<FullTask>(
+        (Task task) => FullTask(task, OpaqueCommit.fromDatastore(commit)),
+      );
     }
   }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -132,10 +132,9 @@ class Scheduler {
 
   /// Ensure [commits] exist in Cocoon.
   ///
-  /// If [Commit] does not exist in Datastore:
-  ///   * Write it to datastore
-  ///   * Schedule tasks listed in its scheduler config
-  /// Otherwise, ignore it.
+  /// If the commit already exists, it is ignored.
+  ///
+  /// Otherwise it is stored in Firestore, and scheduled, if appropriate.
   Future<void> addCommits(List<ds.Commit> commits) async {
     final newCommits = await _getMissingCommits(commits);
     log.debug('Found ${newCommits.length} new commits on GitHub');

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -17,14 +17,14 @@ import 'package:retry/retry.dart';
 import 'package:truncate/truncate.dart';
 
 import '../foundation/utils.dart';
-import '../model/appengine/commit.dart';
-import '../model/appengine/task.dart';
+import '../model/appengine/commit.dart' as ds;
+import '../model/appengine/task.dart' as ds;
 import '../model/ci_yaml/ci_yaml.dart';
 import '../model/ci_yaml/target.dart';
 import '../model/firestore/ci_staging.dart';
-import '../model/firestore/commit.dart' as firestore_commmit;
+import '../model/firestore/commit.dart' as fs;
 import '../model/firestore/pr_check_runs.dart';
-import '../model/firestore/task.dart' as firestore;
+import '../model/firestore/task.dart' as fs;
 import '../model/github/checks.dart' as cocoon_checks;
 import '../model/proto/internal/scheduler.pb.dart' as pb;
 import 'cache_service.dart';
@@ -36,6 +36,7 @@ import 'get_files_changed.dart';
 import 'github_checks_service.dart';
 import 'luci_build_service.dart';
 import 'luci_build_service/engine_artifacts.dart';
+import 'luci_build_service/opaque_commit.dart';
 import 'luci_build_service/pending_task.dart';
 import 'scheduler/ci_yaml_fetcher.dart';
 import 'scheduler/policy.dart';
@@ -135,7 +136,7 @@ class Scheduler {
   ///   * Write it to datastore
   ///   * Schedule tasks listed in its scheduler config
   /// Otherwise, ignore it.
-  Future<void> addCommits(List<Commit> commits) async {
+  Future<void> addCommits(List<ds.Commit> commits) async {
     final newCommits = await _getMissingCommits(commits);
     log.debug('Found ${newCommits.length} new commits on GitHub');
     for (var commit in newCommits) {
@@ -172,8 +173,8 @@ class Scheduler {
     }
 
     final id = '$fullRepo/$branch/$sha';
-    final key = datastore.db.emptyKey.append<String>(Commit, id: id);
-    final mergedCommit = Commit(
+    final key = datastore.db.emptyKey.append<String>(ds.Commit, id: id);
+    final mergedCommit = ds.Commit(
       author: pr.user!.login!,
       authorAvatarUrl: pr.user!.avatarUrl!,
       branch: branch,
@@ -195,7 +196,7 @@ class Scheduler {
   }
 
   /// Processes postsubmit tasks.
-  Future<void> _addCommit(Commit commit, {bool skipAllTasks = false}) async {
+  Future<void> _addCommit(ds.Commit commit, {bool skipAllTasks = false}) async {
     if (!config.supportedRepos.contains(commit.slug)) {
       log.debug('Skipping ${commit.id} as repo is not supported');
       return;
@@ -216,12 +217,12 @@ class Scheduler {
       // Note on post submit targets: CiYaml filters out release_true for release branches and fusion trees
     }
 
-    final tasks = <Task>[...targetsToTasks(commit, targets)];
+    final tasks = [...ds.targetsToTasks(commit, targets)];
     final firestoreService = await config.createFirestoreService();
     final toBeScheduled = <PendingTask>[];
     for (var target in targets) {
       final task = tasks.singleWhere(
-        (Task task) => task.name == target.value.name,
+        (ds.Task task) => task.name == target.value.name,
       );
       var policy = target.schedulerPolicy;
 
@@ -231,7 +232,7 @@ class Scheduler {
       //
       // See https://github.com/flutter/flutter/issues/163896.
       if (skipAllTasks) {
-        task.status = Task.statusSkipped;
+        task.status = ds.Task.statusSkipped;
         continue;
       }
 
@@ -248,7 +249,7 @@ class Scheduler {
       );
       if (priority != null) {
         // Mark task as in progress to ensure it isn't scheduled over
-        task.status = Task.statusInProgress;
+        task.status = ds.Task.statusInProgress;
         toBeScheduled.add(
           PendingTask(target: target, task: task, priority: priority),
         );
@@ -262,7 +263,7 @@ class Scheduler {
       );
       final datastore = datastoreProvider(config.db);
       await datastore.withTransaction<void>((Transaction transaction) async {
-        transaction.queueMutations(inserts: <Commit>[commit]);
+        transaction.queueMutations(inserts: <ds.Commit>[commit]);
         transaction.queueMutations(inserts: tasks);
         await transaction.commit();
         log.debug(
@@ -276,7 +277,7 @@ class Scheduler {
     log.info(
       'Firestore initial targets created for $commit: ${targets.map((t) => '"${t.value.name}"').join(', ')}',
     );
-    final commitDocument = firestore_commmit.Commit(
+    final commitDocument = fs.Commit(
       author: commit.author!,
       avatar: commit.authorAvatarUrl!,
       branch: commit.branch!,
@@ -286,7 +287,7 @@ class Scheduler {
       sha: commit.sha!,
     );
     final writes = documentsToWrites([
-      ...[...tasks.map(firestore.Task.fromDatastore)],
+      ...[...tasks.map(fs.Task.fromDatastore)],
       commitDocument,
     ], exists: false);
     // TODO(keyonghan): remove try catch logic after validated to work.
@@ -299,7 +300,10 @@ class Scheduler {
     log.info(
       'Immediately scheduled tasks for $commit: ${toBeScheduled.map((t) => '"${t.task.name}"').join(', ')}',
     );
-    await _batchScheduleBuilds(commit, toBeScheduled);
+    await _batchScheduleBuilds(
+      OpaqueCommit.fromDatastore(commit),
+      toBeScheduled,
+    );
     await _uploadToBigQuery(commit);
   }
 
@@ -307,7 +311,7 @@ class Scheduler {
   ///
   /// Each batch request contains [Config.batchSize] builds to be scheduled.
   Future<void> _batchScheduleBuilds(
-    Commit commit,
+    OpaqueCommit commit,
     List<PendingTask> toBeScheduled,
   ) async {
     final batchLog = StringBuffer(
@@ -334,10 +338,10 @@ class Scheduler {
   }
 
   /// Return subset of [commits] not stored in Datastore.
-  Future<List<Commit>> _getMissingCommits(List<Commit> commits) async {
-    final newCommits = <Commit>[];
+  Future<List<ds.Commit>> _getMissingCommits(List<ds.Commit> commits) async {
+    final newCommits = <ds.Commit>[];
     // Ensure commits are sorted from newest to oldest (descending order)
-    commits.sort((Commit a, Commit b) => b.timestamp!.compareTo(a.timestamp!));
+    commits.sort((a, b) => b.timestamp!.compareTo(a.timestamp!));
     for (var commit in commits) {
       // Cocoon may randomly drop commits, so check the entire list.
       if (!await _commitExistsInFirestore(sha: commit.sha!)) {
@@ -355,7 +359,7 @@ class Scheduler {
   /// scheduled. Since webhooks or cron jobs can schedule commits, we must
   /// verify a commit has not already been scheduled.
   Future<bool> _commitExistsInFirestore({required String sha}) async {
-    final commit = await firestore_commmit.Commit.tryFromFirestoreBySha(
+    final commit = await fs.Commit.tryFromFirestoreBySha(
       await config.createFirestoreService(),
       sha: sha,
     );
@@ -716,7 +720,7 @@ class Scheduler {
 
       // Create the minimal Commit needed to pass the next stage.
       // Note: headRef encodes refs/heads/... and what we want is the branch
-      final commit = Commit(
+      final commit = ds.Commit(
         branch: mergeGroup.headRef.substring('refs/heads/'.length),
         repository: slug.fullName,
         sha: headSha,
@@ -1485,15 +1489,15 @@ $stacktrace
 
             // Only merged commits are added to the datastore. If a matching commit is found, this must be a postsubmit checkrun.
             final datastore = datastoreProvider(config.db);
-            final commitKey = Commit.createKey(
+            final commitKey = ds.Commit.createKey(
               db: datastore.db,
               slug: slug,
               gitBranch: gitBranch,
               sha: sha,
             );
-            Commit? commit;
+            ds.Commit? commit;
             try {
-              commit = await Commit.fromDatastore(
+              commit = await ds.Commit.fromDatastore(
                 datastore: datastore,
                 key: commitKey,
               );
@@ -1568,7 +1572,7 @@ $stacktrace
             } else {
               log.debug('Rescheduling postsubmit build.');
               final checkName = checkRunEvent.checkRun!.name!;
-              final task = await Task.fromDatastore(
+              final task = await ds.Task.fromDatastore(
                 datastore: datastore,
                 commitKey: commitKey,
                 name: checkName,
@@ -1595,7 +1599,7 @@ $stacktrace
               await luciBuildService
                   .reschedulePostsubmitBuildUsingCheckRunEvent(
                     checkRunEvent,
-                    commit: commit,
+                    commit: OpaqueCommit.fromDatastore(commit),
                     task: task,
                     target: target,
                     taskDocument: taskDocument,
@@ -1628,7 +1632,7 @@ $stacktrace
   }
 
   /// Push [Commit] to BigQuery as part of the infra metrics dashboards.
-  Future<void> _uploadToBigQuery(Commit commit) async {
+  Future<void> _uploadToBigQuery(ds.Commit commit) async {
     const projectId = 'flutter-dashboard';
     const dataset = 'cocoon';
     const table = 'Checklist';

--- a/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
+++ b/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/src/model/appengine/commit.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/ci_yaml/target.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
+import 'package:cocoon_service/src/service/luci_build_service/opaque_commit.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -330,17 +331,26 @@ void main() {
         final backfill = <Tuple<Target, FullTask, int>>[
           Tuple(
             generateTarget(1),
-            FullTask(generateTask(1), generateCommit(1)),
+            FullTask(
+              generateTask(1),
+              OpaqueCommit.fromDatastore(generateCommit(1)),
+            ),
             LuciBuildService.kRerunPriority,
           ),
           Tuple(
             generateTarget(2),
-            FullTask(generateTask(2), generateCommit(2)),
+            FullTask(
+              generateTask(2),
+              OpaqueCommit.fromDatastore(generateCommit(2)),
+            ),
             LuciBuildService.kBackfillPriority,
           ),
           Tuple(
             generateTarget(3),
-            FullTask(generateTask(3), generateCommit(3)),
+            FullTask(
+              generateTask(3),
+              OpaqueCommit.fromDatastore(generateCommit(3)),
+            ),
             LuciBuildService.kRerunPriority,
           ),
         ];

--- a/app_dart/test/service/luci_build_service_test.dart
+++ b/app_dart/test/service/luci_build_service_test.dart
@@ -1091,7 +1091,7 @@ void main() {
         priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
-        commit: commit,
+        commit: OpaqueCommit.fromDatastore(commit),
         toBeScheduled: <PendingTask>[toBeScheduled],
       );
       // Only one batch request should be published
@@ -1186,7 +1186,7 @@ void main() {
           priority: LuciBuildService.kDefaultPriority,
         );
         await service.schedulePostsubmitBuilds(
-          commit: commit,
+          commit: OpaqueCommit.fromDatastore(commit),
           toBeScheduled: <PendingTask>[toBeScheduled],
         );
         // Only one batch request should be published
@@ -1275,7 +1275,7 @@ void main() {
           priority: LuciBuildService.kDefaultPriority,
         );
         await service.schedulePostsubmitBuilds(
-          commit: commit,
+          commit: OpaqueCommit.fromDatastore(commit),
           toBeScheduled: <PendingTask>[toBeScheduled],
         );
         // Only one batch request should be published
@@ -1325,7 +1325,7 @@ void main() {
           priority: LuciBuildService.kDefaultPriority,
         );
         final results = await service.schedulePostsubmitBuilds(
-          commit: commit,
+          commit: OpaqueCommit.fromDatastore(commit),
           toBeScheduled: <PendingTask>[toBeScheduled],
         );
         expect(results, <PendingTask>[toBeScheduled]);
@@ -1359,7 +1359,7 @@ void main() {
       expect(
         () async => service.reschedulePostsubmitBuildUsingCheckRunEvent(
           checkRunEvent,
-          commit: generateCommit(0),
+          commit: OpaqueCommit.fromDatastore(generateCommit(0)),
           task: generateTask(0),
           target: generateTarget(0),
           taskDocument: generateFirestoreTask(0),
@@ -1417,7 +1417,7 @@ void main() {
       expect(task.attempts, 1);
       await service.reschedulePostsubmitBuildUsingCheckRunEvent(
         checkRunEvent,
-        commit: generateCommit(0),
+        commit: OpaqueCommit.fromDatastore(generateCommit(0)),
         task: task,
         target: generateTarget(0),
         taskDocument: taskDocument,
@@ -1460,7 +1460,7 @@ void main() {
           priority: LuciBuildService.kDefaultPriority,
         );
         await service.schedulePostsubmitBuilds(
-          commit: commit,
+          commit: OpaqueCommit.fromDatastore(commit),
           toBeScheduled: <PendingTask>[toBeScheduled],
         );
         // Only one batch request should be published
@@ -1530,7 +1530,7 @@ void main() {
         priority: LuciBuildService.kDefaultPriority,
       );
       await service.schedulePostsubmitBuilds(
-        commit: commit,
+        commit: OpaqueCommit.fromDatastore(commit),
         toBeScheduled: <PendingTask>[toBeScheduled1, toBeScheduled2],
       );
       expect(pubsub.messages.length, 1);

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -38,12 +38,12 @@ import 'package:cocoon_service/src/service/luci_build_service/cipd_version.dart'
 import 'package:cocoon_service/src/service/luci_build_service/engine_artifacts.dart'
     as _i41;
 import 'package:cocoon_service/src/service/luci_build_service/opaque_commit.dart'
-    as _i46;
+    as _i44;
 import 'package:cocoon_service/src/service/luci_build_service/pending_task.dart'
-    as _i45;
+    as _i46;
 import 'package:cocoon_service/src/service/luci_build_service/user_data.dart'
     as _i42;
-import 'package:fixnum/fixnum.dart' as _i44;
+import 'package:fixnum/fixnum.dart' as _i45;
 import 'package:gcloud/db.dart' as _i9;
 import 'package:github/github.dart' as _i11;
 import 'package:github/hooks.dart' as _i30;
@@ -4856,7 +4856,7 @@ class MockLuciBuildService extends _i1.Mock implements _i13.LuciBuildService {
   @override
   _i16.Future<void> reschedulePostsubmitBuildUsingCheckRunEvent(
     _i43.CheckRunEvent? checkRunEvent, {
-    required _i33.Commit? commit,
+    required _i44.OpaqueCommit? commit,
     required _i34.Task? task,
     required _i40.Target? target,
     required _i38.Task? taskDocument,
@@ -4883,7 +4883,7 @@ class MockLuciBuildService extends _i1.Mock implements _i13.LuciBuildService {
 
   @override
   _i16.Future<_i6.Build> getBuildById(
-    _i44.Int64? id, {
+    _i45.Int64? id, {
     _i6.BuildMask? buildMask,
   }) =>
       (super.noSuchMethod(
@@ -4912,20 +4912,20 @@ class MockLuciBuildService extends _i1.Mock implements _i13.LuciBuildService {
           as _i16.Future<Set<String>>);
 
   @override
-  _i16.Future<List<_i45.PendingTask>> schedulePostsubmitBuilds({
-    required _i33.Commit? commit,
-    required List<_i45.PendingTask>? toBeScheduled,
+  _i16.Future<List<_i46.PendingTask>> schedulePostsubmitBuilds({
+    required _i44.OpaqueCommit? commit,
+    required List<_i46.PendingTask>? toBeScheduled,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#schedulePostsubmitBuilds, [], {
               #commit: commit,
               #toBeScheduled: toBeScheduled,
             }),
-            returnValue: _i16.Future<List<_i45.PendingTask>>.value(
-              <_i45.PendingTask>[],
+            returnValue: _i16.Future<List<_i46.PendingTask>>.value(
+              <_i46.PendingTask>[],
             ),
           )
-          as _i16.Future<List<_i45.PendingTask>>);
+          as _i16.Future<List<_i46.PendingTask>>);
 
   @override
   _i16.Future<void> scheduleMergeGroupBuilds({
@@ -4944,7 +4944,7 @@ class MockLuciBuildService extends _i1.Mock implements _i13.LuciBuildService {
 
   @override
   _i16.Future<_i11.CheckRun> createPostsubmitCheckRun(
-    _i46.OpaqueCommit? commit,
+    _i44.OpaqueCommit? commit,
     _i40.Target? target,
   ) =>
       (super.noSuchMethod(
@@ -4960,7 +4960,7 @@ class MockLuciBuildService extends _i1.Mock implements _i13.LuciBuildService {
 
   @override
   _i16.Future<bool> checkRerunBuilder({
-    required _i46.OpaqueCommit? commit,
+    required _i44.OpaqueCommit? commit,
     required _i40.Target? target,
     required _i34.Task? task,
     required _i7.DatastoreService? datastore,


### PR DESCRIPTION
... or, make it explicit (`ds.*`) where the change would be too disruptive in a single PR. 