### PR TITLE
Refactor `GerritService`, use retries for `GET`s, fix FIXME

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -47,19 +47,23 @@ Future<void> main() async {
       accessTokenService: AccessTokenService.defaultProvider(config),
     );
 
+    // Gerrit service class to communicate with GoB.
+    final gerritService = GerritService(
+      config: config,
+      authClient: await const GoogleAuthProvider().createClient(scopes: []),
+    );
+
     /// LUCI service class to communicate with buildBucket service.
     final luciBuildService = LuciBuildService(
       config: config,
       cache: cache,
       buildBucketClient: buildBucketClient,
       pubsub: const PubSub(),
+      gerritService: gerritService,
     );
 
     /// Github checks api service used to provide luci test execution status on the Github UI.
     final githubChecksService = GithubChecksService(config);
-
-    // Gerrit service class to communicate with GoB.
-    final gerritService = GerritService(config: config);
 
     final ciYamlFetcher = CiYamlFetcher(cache: cache, config: config);
 

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -41,11 +41,10 @@ class LuciBuildService {
     required this.cache,
     required this.buildBucketClient,
     GithubChecksUtil? githubChecksUtil,
-    GerritService? gerritService,
+    required this.gerritService,
     required this.pubsub,
     @visibleForTesting this.findPullRequestFor = PrCheckRuns.findPullRequestFor,
-  }) : githubChecksUtil = githubChecksUtil ?? const GithubChecksUtil(),
-       gerritService = gerritService ?? GerritService(config: config);
+  }) : githubChecksUtil = githubChecksUtil ?? const GithubChecksUtil();
 
   BuildBucketClient buildBucketClient;
   final CacheService cache;

--- a/app_dart/test/service/gerrit_service_test.dart
+++ b/app_dart/test/service/gerrit_service_test.dart
@@ -31,7 +31,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
         retryDelay: const Duration(milliseconds: 1),
       );
 
@@ -51,7 +51,7 @@ void main() {
       });
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final branches = await gerritService.branches(
         'myhost',
@@ -71,7 +71,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final branches = await gerritService.branches(
         'myhost',
@@ -89,7 +89,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final commits = await gerritService.commits(Config.recipesSlug, 'main');
       expect(commits.length, 1);
@@ -116,7 +116,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final commit = await gerritService.getCommit(
         RepositorySlug('flutter', 'flutter'),
@@ -138,7 +138,7 @@ void main() {
       });
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final commit = await gerritService.getCommit(
         RepositorySlug('flutter', 'mirrors/flutter'),
@@ -156,7 +156,7 @@ void main() {
       });
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
+        authClient: mockHttpClient,
       );
       final commit = await gerritService.findMirroredCommit(
         RepositorySlug('flutter', 'packages'),
@@ -173,10 +173,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
-        authClientProvider:
-            ({Client? baseClient, required List<String> scopes}) async =>
-                FakeAuthClient(baseClient!),
+        authClient: FakeAuthClient(mockHttpClient),
         retryDelay: Duration.zero,
       );
 
@@ -193,10 +190,7 @@ void main() {
       );
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
-        authClientProvider:
-            ({Client? baseClient, required List<String> scopes}) async =>
-                FakeAuthClient(baseClient!),
+        authClient: FakeAuthClient(mockHttpClient),
         retryDelay: Duration.zero,
       );
       expect(
@@ -221,10 +215,7 @@ void main() {
       });
       gerritService = GerritService(
         config: FakeConfig(),
-        httpClient: mockHttpClient,
-        authClientProvider:
-            ({Client? baseClient, required List<String> scopes}) async =>
-                FakeAuthClient(baseClient!),
+        authClient: FakeAuthClient(mockHttpClient),
         retryDelay: Duration.zero,
       );
       await gerritService.createBranch(

--- a/app_dart/test/service/gerrit_service_test.dart
+++ b/app_dart/test/service/gerrit_service_test.dart
@@ -32,18 +32,15 @@ void main() {
       gerritService = GerritService(
         config: FakeConfig(),
         httpClient: mockHttpClient,
+        retryDelay: const Duration(milliseconds: 1),
       );
-      try {
-        await gerritService.branches(
-          'myhost',
-          'a/b/c',
-          filterRegex: 'flutter-*',
-        );
-      } catch (e) {
-        // FIXME: Write/restore test.
-        // expect(e, isA<RetryException>());
-      }
+
+      await expectLater(
+        gerritService.branches('myhost', 'a/b/c', filterRegex: 'flutter-*'),
+        throwsA(isA<InternalServerError>()),
+      );
     });
+
     test('Returns a list of branches', () async {
       Request? requestAux;
       const body =

--- a/app_dart/test/service/luci_build_service/cancel_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/cancel_builds_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 import '../../src/datastore/fake_config.dart';
 import '../../src/request_handling/fake_pubsub.dart';
 import '../../src/service/fake_firestore_service.dart';
+import '../../src/service/fake_gerrit_service.dart';
 import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.mocks.dart';
 
@@ -42,6 +43,7 @@ void main() {
     luci = LuciBuildService(
       cache: CacheService(inMemory: true),
       config: FakeConfig(firestoreService: firestoreService),
+      gerritService: FakeGerritService(),
       buildBucketClient: mockBuildBucketClient,
       githubChecksUtil: mockGithubChecksUtil,
       pubsub: pubSub,

--- a/app_dart/test/service/luci_build_service/check_rerun_builder_test.dart
+++ b/app_dart/test/service/luci_build_service/check_rerun_builder_test.dart
@@ -14,6 +14,7 @@ import '../../src/datastore/fake_config.dart';
 import '../../src/datastore/fake_datastore.dart';
 import '../../src/request_handling/fake_pubsub.dart';
 import '../../src/service/fake_firestore_service.dart';
+import '../../src/service/fake_gerrit_service.dart';
 import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.mocks.dart';
 
@@ -48,6 +49,7 @@ void main() {
         dbValue: datastoreDB,
         maxLuciTaskRetriesValue: 2,
       ),
+      gerritService: FakeGerritService(),
       buildBucketClient: mockBuildBucketClient,
       githubChecksUtil: mockGithubChecksUtil,
       pubsub: pubSub,

--- a/app_dart/test/service/luci_build_service/find_or_get_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/find_or_get_builds_test.dart
@@ -15,6 +15,7 @@ import 'package:test/test.dart';
 
 import '../../src/datastore/fake_config.dart';
 import '../../src/request_handling/fake_pubsub.dart';
+import '../../src/service/fake_gerrit_service.dart';
 import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.mocks.dart';
 
@@ -43,6 +44,7 @@ void main() {
     luci = LuciBuildService(
       config: FakeConfig(),
       cache: cacheService,
+      gerritService: FakeGerritService(),
       buildBucketClient: mockBuildBucketClient,
       pubsub: FakePubSub(),
     );

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -24,6 +24,7 @@ import '../../src/datastore/fake_config.dart';
 import '../../src/datastore/fake_datastore.dart';
 import '../../src/request_handling/fake_pubsub.dart';
 import '../../src/service/fake_firestore_service.dart';
+import '../../src/service/fake_gerrit_service.dart';
 import '../../src/utilities/entity_generators.dart';
 import '../../src/utilities/mocks.mocks.dart';
 import '../../src/utilities/webhook_generators.dart';
@@ -59,6 +60,7 @@ void main() {
         firestoreService: firestoreService,
         dbValue: datastoreDB,
       ),
+      gerritService: FakeGerritService(),
       buildBucketClient: mockBuildBucketClient,
       githubChecksUtil: mockGithubChecksUtil,
       pubsub: pubSub,

--- a/app_dart/tool/local_server.dart
+++ b/app_dart/tool/local_server.dart
@@ -25,19 +25,23 @@ Future<void> main() async {
     accessTokenService: AccessTokenService.defaultProvider(config),
   );
 
+  // Gerrit service class to communicate with GoB.
+  final gerritService = GerritService(
+    config: config,
+    authClient: authProvider.httpClientProvider(),
+  );
+
   /// LUCI service class to communicate with buildBucket service.
   final luciBuildService = LuciBuildService(
     config: config,
     cache: cache,
     buildBucketClient: buildBucketClient,
+    gerritService: gerritService,
     pubsub: const PubSub(),
   );
 
   /// Github checks api service used to provide luci test execution status on the Github UI.
   final githubChecksService = GithubChecksService(config);
-
-  // Gerrit service class to communicate with GoB.
-  final gerritService = GerritService(config: config);
 
   final ciYamlFetcher = CiYamlFetcher(cache: cache, config: config);
 

--- a/dev/cocoon_code_health/lib/src/checks/do_not_submit_fixme.dart
+++ b/dev/cocoon_code_health/lib/src/checks/do_not_submit_fixme.dart
@@ -1,0 +1,33 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_common/cocoon_common.dart';
+import 'package:file/file.dart';
+import 'package:glob/glob.dart';
+
+import '../checks.dart';
+
+/// Enforces that `FIXME` is not present in the codebase.
+final class DoNotSubmitFixme extends Check {
+  const DoNotSubmitFixme();
+
+  @override
+  Glob get shouldCheck => Glob('**/*');
+
+  @override
+  Future<CheckResult> check(LogSink logger, File file) async {
+    final badLines = [
+      for (final (line, contents) in file.readAsLinesSync().indexed)
+        if (contents.contains('FIXME')) '${line + 1}: $contents',
+    ];
+    if (badLines.isNotEmpty) {
+      logger.error(
+        'FIXME present on the following lines:\n'
+        '${badLines.join('\n')}',
+      );
+      return CheckResult.failed;
+    }
+    return CheckResult.passed;
+  }
+}


### PR DESCRIPTION
This PR removes a FIXME, lints for FIXMEs in the future, and fixes the test.

The original test did nothing, because if you write:
```dart
try {
  doSomethingThatNeverThrows();
} catch (e) {
  expect(e, 'You can literally write anything here');
}
```

The test will always pass. It turns out `GerritService` never retried (or threw) on `.get()` requests.

Fixing this and using a retry-client will also reduce the amount of pub-sub messages we use just to check Gerrit when waiting a few seconds in thread would have been sufficient. In addition did some TLC to `GerritService` and `FakeGerritService` across the repo.