### PR TITLE
Remove `\t` from query - update FakeFirstoreService

### DIFF
--- a/app_dart/lib/src/request_handlers/update_discord_status.dart
+++ b/app_dart/lib/src/request_handlers/update_discord_status.dart
@@ -54,7 +54,7 @@ final class UpdateDiscordStatus extends GetBuildStatus {
       'last_build_status',
       <String, Object>{},
       limit: 1,
-      orderMap: {'createTimestamp	': kQueryOrderDescending},
+      orderMap: {'createTimestamp': kQueryOrderDescending},
     );
 
     if (lastDocs.isEmpty ||

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -18,6 +18,8 @@ import '../utilities/mocks.dart';
 
 export '../model/firestore_matcher.dart';
 
+final queryKeyValidator = RegExp(r'(^[a-zA-Z_][a-zA-Z_0-9]*)$');
+
 abstract base class _FakeInMemoryFirestoreService
     with FirestoreQueries
     implements FirestoreService {
@@ -337,6 +339,14 @@ abstract base class _FakeInMemoryFirestoreService
     if (orderMap != null) {
       if (orderMap.values.any((v) => v != kQueryOrderDescending)) {
         throw UnimplementedError('orderMap: ${[...orderMap.values]}');
+      }
+
+      for (var key in orderMap.keys) {
+        if (!queryKeyValidator.hasMatch(key)) {
+          throw ArgumentError.value(
+            'order map key($key) does not match firestore regex',
+          );
+        }
       }
 
       // Hard-coded to assume all sorts are DESCENDING.


### PR DESCRIPTION
The regex for firestore is:

> Unquoted property paths must match regex ([a-zA-Z_][a-zA-Z_0-9]*), and quoted property paths must match regex (`(?:[^`\\]|(?:\\.))+`)

We appear to only have unquoted property paths.