### PR TITLE
Store `statusCode` and `reasonPhrase` in `CacheRequestHandler`.

### DIFF
--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -86,7 +86,9 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
     final body = await delegate.get();
     final response = this.response!;
     final builder = BytesBuilder();
-    await body.serialize().forEach(builder.add);
+    await body.serialize().forEach((d) {
+      if (d != null) builder.add(d);
+    });
     return _CachedHttpResponse._(
       response.statusCode,
       response.reasonPhrase,

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -85,13 +85,12 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   ) async {
     final body = await delegate.get();
     final response = this.response!;
+    final builder = BytesBuilder();
+    await body.serialize().forEach(builder.add);
     return _CachedHttpResponse._(
       response.statusCode,
       response.reasonPhrase,
-      (await body.serialize().fold(
-        BytesBuilder(copy: true),
-        (prev, element) => prev..add(element!),
-      )).takeBytes(),
+      builder.toBytes(),
     );
   }
 }

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -57,6 +57,7 @@ class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
       responseSubcacheName,
       responseKey,
       createFn: () async {
+        // TODO(matanlurey): Evaluate if 5XX errors should not be cached.
         final response = await _createCachedResponse(_delegate);
         return response.toBytes();
       },

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   process_runner: 4.2.0
   protobuf: 3.1.0
   retry: ^3.1.2
-  standard_message_codec: ^0.0.1+4
   truncate: 3.0.1
   yaml: ^3.1.3
 

--- a/app_dart/pubspec.yaml
+++ b/app_dart/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   process_runner: 4.2.0
   protobuf: 3.1.0
   retry: ^3.1.2
+  standard_message_codec: ^0.0.1+4
   truncate: 3.0.1
   yaml: ^3.1.3
 

--- a/app_dart/test/src/request_handling/fake_request_handler.dart
+++ b/app_dart/test/src/request_handling/fake_request_handler.dart
@@ -7,20 +7,39 @@ import 'package:cocoon_service/src/request_handling/request_handler.dart';
 
 // ignore: must_be_immutable
 class FakeRequestHandler extends RequestHandler<Body> {
-  FakeRequestHandler({required this.body, required super.config});
+  FakeRequestHandler({
+    required this.body,
+    required super.config,
+    this.statusCode,
+    this.reasonPhrase,
+  });
 
   final Body body;
 
   int callCount = 0;
+  int? statusCode;
+  String? reasonPhrase;
 
   @override
   Future<Body> get() async {
     callCount++;
+    _updateResponseMetadata();
     return body;
   }
 
   @override
   Future<Body> post() async {
+    callCount++;
+    _updateResponseMetadata();
     return body;
+  }
+
+  void _updateResponseMetadata() {
+    if (statusCode case final statusCode?) {
+      response!.statusCode = statusCode;
+    }
+    if (reasonPhrase case final reasonPhrase?) {
+      response!.reasonPhrase = reasonPhrase;
+    }
   }
 }


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/166930.