### PR TITLE
Start a `/v2/...` dashboard for an improved Cocoon UI

### DIFF
--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -14,6 +14,7 @@ import 'build_dashboard_page.dart';
 import 'firebase_options.dart';
 import 'service/cocoon.dart';
 import 'service/google_authentication.dart';
+import 'src/pages/v2_landing_page.dart';
 import 'state/build.dart';
 import 'widgets/now.dart';
 import 'widgets/state_provider.dart';
@@ -47,14 +48,18 @@ void main([List<String> args = const <String>[]]) async {
   }
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  FlutterError.onError = (errorDetails) {
-    FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
-  };
-  // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
-  PlatformDispatcher.instance.onError = (error, stack) {
-    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
-    return true;
-  };
+
+  if (kReleaseMode) {
+    FlutterError.onError = (errorDetails) {
+      FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
+    };
+    // Pass all uncaught asynchronous errors that aren't handled by the Flutter framework to Crashlytics
+    PlatformDispatcher.instance.onError = (error, stack) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+      return true;
+    };
+  }
+
   final authService = GoogleSignInService();
   final cocoonService = CocoonService(
     useProductionService: useProductionService,
@@ -79,7 +84,7 @@ class MyApp extends StatelessWidget {
     return TaskBox(
       child: MaterialApp(
         title: 'Flutter Build Dashboard — Cocoon',
-        shortcuts: <ShortcutActivator, Intent>{
+        shortcuts: {
           ...WidgetsApp.defaultShortcuts,
           const SingleActivator(LogicalKeyboardKey.select):
               const ActivateIntent(),
@@ -91,26 +96,68 @@ class MyApp extends StatelessWidget {
           ),
         ),
         darkTheme: ThemeData.dark(),
+
+        // The default page is the build dashboard.
         initialRoute: BuildDashboardPage.routeName,
-        routes: <String, WidgetBuilder>{
-          BuildDashboardPage.routeName:
-              (BuildContext context) => const BuildDashboardPage(),
+        routes: {
+          BuildDashboardPage.routeName: (_) => const BuildDashboardPage(),
         },
+
+        // dashboard.com/x/flutter/flutter/presubmit
+        // jonahwilliams@ [1234] > .../1234
+        // matanlurey@    [4568] > .../4567
+        //
+        // dashboard.com/x/flutter/flutter/presubmit/1234
         onGenerateRoute: (RouteSettings settings) {
           final uriData = Uri.parse(settings.name!);
-          if (uriData.path == BuildDashboardPage.routeName) {
-            return MaterialPageRoute<void>(
-              settings: RouteSettings(name: uriData.toString()),
-              builder: (BuildContext context) {
-                return BuildDashboardPage(
-                  queryParameters: uriData.queryParameters,
+          if (uriData.pathSegments.isEmpty) {
+            return null;
+          }
+
+          switch (uriData.pathSegments.first) {
+            case BuildDashboardPage.routeName:
+              return MaterialPageRoute<void>(
+                settings: settings,
+                builder: (BuildContext context) {
+                  return BuildDashboardPage(
+                    queryParameters: uriData.queryParameters,
+                  );
+                },
+              );
+            case 'v2':
+              if (_findV2Route(uriData) case final builder?) {
+                return MaterialPageRoute<void>(
+                  builder: builder,
+                  settings: settings,
                 );
-              },
-            );
+              }
           }
           return null;
         },
       ),
     );
+  }
+
+  WidgetBuilder? _findV2Route(Uri route) {
+    if (route.pathSegments.isEmpty || route.pathSegments.first != 'v2') {
+      throw ArgumentError.value(route, 'route', 'not a v2 route');
+    }
+
+    final [_, ...v2PathSegments] = route.pathSegments;
+    if (v2PathSegments.isEmpty) {
+      return (_) => const V2LandingPage();
+    }
+
+    final [repoOwner, ...] = v2PathSegments;
+    if (v2PathSegments.length == 1) {
+      return (_) => V2LandingPage(repoOwner);
+    }
+
+    final [_, repoName, ...] = v2PathSegments;
+    if (v2PathSegments.length == 2) {
+      return (_) => V2LandingPage(repoOwner, repoName);
+    }
+
+    return null;
   }
 }

--- a/dashboard/lib/main.dart
+++ b/dashboard/lib/main.dart
@@ -144,20 +144,12 @@ class MyApp extends StatelessWidget {
     }
 
     final [_, ...v2PathSegments] = route.pathSegments;
-    if (v2PathSegments.isEmpty) {
+    if (v2PathSegments case [final repoOwner, final repoName, ...]) {
+      return (_) => V2LandingPage(repoOwner, repoName);
+    } else if (v2PathSegments case [final repoOwner, ...]) {
+      return (_) => V2LandingPage(repoOwner);
+    } else {
       return (_) => const V2LandingPage();
     }
-
-    final [repoOwner, ...] = v2PathSegments;
-    if (v2PathSegments.length == 1) {
-      return (_) => V2LandingPage(repoOwner);
-    }
-
-    final [_, repoName, ...] = v2PathSegments;
-    if (v2PathSegments.length == 2) {
-      return (_) => V2LandingPage(repoOwner, repoName);
-    }
-
-    return null;
   }
 }

--- a/dashboard/lib/src/pages/v2_landing_page.dart
+++ b/dashboard/lib/src/pages/v2_landing_page.dart
@@ -1,0 +1,35 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+final class V2LandingPage extends StatefulWidget {
+  const V2LandingPage([this.repoOwner, this.repoName]);
+
+  final String? repoOwner;
+  final String? repoName;
+
+  @override
+  State<StatefulWidget> createState() => _V2LandingState();
+}
+
+final class _V2LandingState extends State<V2LandingPage> {
+  String? repoOwner;
+  String? repoName;
+
+  @override
+  void initState() {
+    repoOwner = widget.repoOwner;
+    repoName = widget.repoName;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(child: Text('$repoOwner/$repoName')),
+    );
+  }
+}


### PR DESCRIPTION
Imagine the following:

```sh
open https://flutter-dashboard.appspot.com/flutter/flutter/1234/presubmit
```

Ok this doesn't do that yet, but it does create a placeholder widget for it at `v2/<owner>/<repo>`.

Also disables Firebase Crashlytics in debug mode, it doesn't work and spams the console.