### PR TITLE
Tweak `UpdateDiscordStatus` a bit

### DIFF
--- a/app_dart/lib/src/model/firestore/build_status_snapshot.dart
+++ b/app_dart/lib/src/model/firestore/build_status_snapshot.dart
@@ -1,0 +1,121 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:googleapis/firestore/v1.dart' as g;
+import 'package:meta/meta.dart';
+
+import '../../service/firestore.dart';
+import 'base.dart';
+
+/// A tree-status update.
+final class BuildStatusSnapshot extends AppDocument<BuildStatusSnapshot> {
+  static Future<BuildStatusSnapshot?> getLatest(
+    FirestoreService firestore,
+  ) async {
+    final docs = await firestore.query(
+      metadata.collectionId,
+      {},
+      limit: 1,
+      orderMap: {_fieldCreateTimestamp: kQueryOrderDescending},
+    );
+    return docs.isEmpty ? null : BuildStatusSnapshot.fromDocument(docs.first);
+  }
+
+  @override
+  AppDocumentMetadata<BuildStatusSnapshot> get runtimeMetadata => metadata;
+
+  /// Description of the document in Firestore.
+  static final metadata = AppDocumentMetadata<BuildStatusSnapshot>(
+    collectionId: 'build_status_snapshot',
+    fromDocument: BuildStatusSnapshot.fromDocument,
+  );
+
+  factory BuildStatusSnapshot({
+    required DateTime createdOn,
+    required BuildStatus status,
+    required List<String> failingTasks,
+  }) {
+    final sortedTasks = failingTasks.sorted();
+    return BuildStatusSnapshot.fromDocument(
+      g.Document(
+        fields: {
+          _fieldCreateTimestamp: g.Value(
+            timestampValue: createdOn.toUtc().toIso8601String(),
+          ),
+          _fieldStatus: g.Value(stringValue: status.name),
+          _fieldFailingTasks: g.Value(
+            arrayValue: g.ArrayValue(
+              values: [...sortedTasks.map((t) => g.Value(stringValue: t))],
+            ),
+          ),
+        },
+      ),
+    );
+  }
+
+  /// Create [BuildStatusSnapshot] from a GithubBuildStatus Document.
+  BuildStatusSnapshot.fromDocument(super.document);
+
+  static const _fieldCreateTimestamp = 'createTimestamp';
+  static const _fieldStatus = 'status';
+  static const _fieldFailingTasks = 'failing_tasks';
+
+  DateTime get createdOn {
+    return DateTime.parse(fields[_fieldCreateTimestamp]!.timestampValue!);
+  }
+
+  BuildStatus get status {
+    return BuildStatus.values.byName(fields[_fieldStatus]!.stringValue!);
+  }
+
+  Set<String> get failingTasks {
+    return {
+      ...fields[_fieldFailingTasks]!.arrayValue!.values!.map(
+        (t) => t.stringValue!,
+      ),
+    };
+  }
+
+  /// Returns if the [status] and/or [failingTasks] is different than [other].
+  @useResult
+  SnapshotDiff diffContents(BuildStatusSnapshot other) {
+    final BuildStatus? newStatus;
+    if (status != other.status) {
+      newStatus = status;
+    } else {
+      newStatus = null;
+    }
+
+    final nowPassing = other.failingTasks.difference(failingTasks);
+    final nowFailing = failingTasks.difference(other.failingTasks);
+    return SnapshotDiff._(
+      newStatus: newStatus,
+      nowPassing: nowPassing,
+      nowFailing: nowFailing,
+    );
+  }
+}
+
+@immutable
+final class SnapshotDiff {
+  const SnapshotDiff._({
+    required this.newStatus,
+    required this.nowPassing,
+    required this.nowFailing,
+  });
+
+  /// If non-null,
+  final BuildStatus? newStatus;
+  final Set<String> nowPassing;
+  final Set<String> nowFailing;
+
+  /// Whether a meaningful difference was recorded.
+  bool get isDifferent {
+    return newStatus != null || nowPassing.isNotEmpty || nowFailing.isNotEmpty;
+  }
+}
+
+/// Whether the [BuildStatusSnapshot] was a success or failure.
+enum BuildStatus { success, failure }

--- a/app_dart/lib/src/request_handlers/update_discord_status.dart
+++ b/app_dart/lib/src/request_handlers/update_discord_status.dart
@@ -67,23 +67,14 @@ final class UpdateDiscordStatus extends GetBuildStatus {
     );
 
     // Check against the previous, if any.
-    final BuildStatusSnapshot previous;
-    final bool isSyntheticPrevious;
-    {
-      final inStorage = await BuildStatusSnapshot.getLatest(firestore);
-      if (inStorage == null) {
-        previous = _getDefaultAssumedPassing();
-        isSyntheticPrevious = true;
-      } else {
-        previous = inStorage;
-        isSyntheticPrevious = false;
-      }
-    }
+    final previous =
+        await BuildStatusSnapshot.getLatest(firestore) ??
+        _getDefaultAssumedPassing();
 
     final diff = latest.diffContents(previous);
 
-    // Record the new status, even if this is the initial message.
-    if (isSyntheticPrevious || diff.isDifferent) {
+    // Record the new status.
+    if (diff.isDifferent) {
       log.debug('[update_discord_status] status changed: $latest');
       await firestore.createDocument(
         latest,

--- a/app_dart/lib/src/service/discord_service.dart
+++ b/app_dart/lib/src/service/discord_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:cocoon_server/logging.dart';
 import 'package:http/http.dart' show Client;
 import 'package:meta/meta.dart';
+import 'package:truncate/truncate.dart';
 
 import 'config.dart' show Config;
 
@@ -14,23 +15,22 @@ enum DiscordStatus { ok, failed }
 
 interface class DiscordService {
   DiscordService({
-    required this.config, //
+    required Config config, //
     @visibleForTesting Client? client,
-  }) : _client = client ?? Client();
+  }) : _config = config,
+       _client = client ?? Client();
 
   /// The global configuration of this AppEngine server.
-  final Config config;
+  final Config _config;
 
   /// A way to POST to discord.
   final Client _client;
 
   /// Post a message to the #tree-status-🚦 channel
   Future<DiscordStatus> postTreeStatusMessage(String message) async {
-    final discordMessage =
-        message.length < 2000 ? message : message.substring(0, 2000);
-
+    final discordMessage = truncate(message, 2000);
     final discordResponse = await _client.post(
-      Uri.parse(await config.discordTreeStatusWebhookUrl),
+      Uri.parse(await _config.discordTreeStatusWebhookUrl),
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',

--- a/app_dart/test/request_handlers/update_discord_status_test.dart
+++ b/app_dart/test/request_handlers/update_discord_status_test.dart
@@ -5,17 +5,20 @@
 import 'dart:convert';
 
 import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/build_status_snapshot.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart';
 import 'package:cocoon_service/src/request_handlers/update_discord_status.dart';
-import 'package:cocoon_service/src/service/build_status_provider.dart';
+import 'package:cocoon_service/src/service/build_status_provider.dart'
+    hide BuildStatus;
 import 'package:cocoon_service/src/service/discord_service.dart';
-import 'package:googleapis/firestore/v1.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
+import '../src/model/firestore_matcher.dart';
 import '../src/request_handling/request_handler_tester.dart';
-import '../src/service/fake_firestore_service.dart' show FakeFirestoreService;
+import '../src/service/fake_firestore_service.dart'
+    show FakeFirestoreService, existsInStorage;
 import '../src/utilities/entity_generators.dart';
 import '../src/utilities/mocks.mocks.dart';
 
@@ -59,7 +62,7 @@ void main() {
     );
   });
 
-  test('posts when status is missing in firestore', () async {
+  test('creates an initial doc when status is missing in firestore', () async {
     firestore.putDocument(generateFirestoreCommit(1));
     firestore.putDocument(
       generateFirestoreTask(1, status: Task.statusSucceeded, commitSha: '1'),
@@ -67,29 +70,17 @@ void main() {
 
     await decodeHandlerBody<Map<String, Object?>>();
 
-    // Verify we wrote the status
-    final lastBuildStatuses = [
-      for (var doc in firestore.documents)
-        if (doc.name!.startsWith(
-          'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/',
-        ))
-          doc,
-    ];
-    expect(lastBuildStatuses, hasLength(1));
-    final doc = lastBuildStatuses.first;
     expect(
-      doc.fields!['status']!.stringValue,
-      'flutter/flutter is :green_circle:!',
-    );
-    expect(
-      doc.fields!['createTimestamp']!.timestampValue,
-      alwaysTime.toUtc().toIso8601String(),
+      firestore,
+      existsInStorage(BuildStatusSnapshot.metadata, [
+        isBuildStatusSnapshot.hasStatus(BuildStatus.success),
+      ]),
     );
 
     // Verify we actually posted it
-    verify(
-      discord.postTreeStatusMessage('flutter/flutter is :green_circle:!'),
-    ).called(1);
+    final [message] =
+        verify(discord.postTreeStatusMessage(captureAny)).captured;
+    expect(message, contains('flutter/flutter is now :green_circle:!'));
   });
 
   test('does not post on unchanged value', () async {
@@ -97,85 +88,174 @@ void main() {
     firestore.putDocument(
       generateFirestoreTask(1, status: Task.statusSucceeded, commitSha: '1'),
     );
-    firestore.putDocument(
-      Document(
-        name:
-            'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/fu',
-        fields: {
-          'status': Value(stringValue: 'flutter/flutter is :green_circle:!'),
-          'createTimestamp': Value(
-            timestampValue:
-                alwaysTime
-                    .subtract(const Duration(seconds: 1))
-                    .toUtc()
-                    .toIso8601String(),
-          ),
-        },
+
+    await firestore.createDocument(
+      BuildStatusSnapshot(
+        createdOn: alwaysTime.toUtc(),
+        status: BuildStatus.success,
+        failingTasks: [],
       ),
+      collectionId: BuildStatusSnapshot.metadata.collectionId,
     );
 
     await decodeHandlerBody<Map<String, Object?>>();
 
-    // Verify we never wrote another
-    final lastBuildStatuses = [
-      for (var doc in firestore.documents)
-        if (doc.name!.startsWith(
-          'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/',
-        ))
-          doc,
-    ];
-    expect(lastBuildStatuses, hasLength(1));
+    // Verify we never wrote a document
+    expect(
+      firestore,
+      existsInStorage(BuildStatusSnapshot.metadata, hasLength(1)),
+    );
 
     // Verify we never posted it
     verifyNever(discord.postTreeStatusMessage(any));
   });
 
-  test('posts on changed value', () async {
+  test('posts on success -> failed', () async {
     firestore.putDocument(generateFirestoreCommit(1));
     firestore.putDocument(
-      generateFirestoreTask(1, status: Task.statusSucceeded, commitSha: '1'),
-    );
-    firestore.putDocument(
-      Document(
-        name:
-            'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/fu',
-        fields: {
-          'status': Value(stringValue: 'flutter/flutter is :red_circle:!'),
-          'createTimestamp': Value(
-            timestampValue:
-                alwaysTime
-                    .subtract(const Duration(seconds: 1))
-                    .toUtc()
-                    .toIso8601String(),
-          ),
-        },
+      generateFirestoreTask(
+        1,
+        status: Task.statusFailed,
+        commitSha: '1',
+        name: 'Linux foo',
       ),
+    );
+    await firestore.createDocument(
+      BuildStatusSnapshot(
+        createdOn: alwaysTime.toUtc(),
+        status: BuildStatus.success,
+        failingTasks: [],
+      ),
+      collectionId: BuildStatusSnapshot.metadata.collectionId,
     );
 
     await decodeHandlerBody<Map<String, Object?>>();
 
     // Verify we wrote the status
-    final lastBuildStatuses = [
-      for (var doc in firestore.documents)
-        if (doc.name!.startsWith(
-          'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/',
-        ))
-          doc,
-    ];
-    expect(lastBuildStatuses, hasLength(2));
-
-    final doc = lastBuildStatuses.firstWhere(
-      (doc) => !doc.name!.endsWith('/fu'),
-    );
     expect(
-      doc.fields!['status']!.stringValue,
-      'flutter/flutter is :green_circle:!',
+      firestore,
+      existsInStorage(BuildStatusSnapshot.metadata, [
+        isBuildStatusSnapshot.hasStatus(BuildStatus.success),
+        isBuildStatusSnapshot.hasStatus(BuildStatus.failure),
+      ]),
     );
 
     // Verify we actually posted it
-    verify(
-      discord.postTreeStatusMessage('flutter/flutter is :green_circle:!'),
-    ).called(1);
+    final [String message] =
+        verify(discord.postTreeStatusMessage(captureAny)).captured;
+    expect(
+      message,
+      stringContainsInOrder([
+        'flutter/flutter is now :red_circle:',
+        'Now failing',
+        'Linux foo',
+      ]),
+    );
+  });
+
+  test('posts on failed -> success', () async {
+    firestore.putDocument(generateFirestoreCommit(1));
+    firestore.putDocument(
+      generateFirestoreTask(
+        1,
+        status: Task.statusSucceeded,
+        commitSha: '1',
+        name: 'Linux foo',
+      ),
+    );
+    await firestore.createDocument(
+      BuildStatusSnapshot(
+        createdOn: alwaysTime.toUtc(),
+        status: BuildStatus.failure,
+        failingTasks: ['Linux foo'],
+      ),
+      collectionId: BuildStatusSnapshot.metadata.collectionId,
+    );
+
+    await decodeHandlerBody<Map<String, Object?>>();
+
+    // Verify we wrote the status
+    expect(
+      firestore,
+      existsInStorage(BuildStatusSnapshot.metadata, [
+        isBuildStatusSnapshot.hasStatus(BuildStatus.failure),
+        isBuildStatusSnapshot.hasStatus(BuildStatus.success),
+      ]),
+    );
+
+    // Verify we actually posted it
+    final [String message] =
+        verify(discord.postTreeStatusMessage(captureAny)).captured;
+    expect(
+      message,
+      stringContainsInOrder([
+        'flutter/flutter is now :green_circle:',
+        'Now passing',
+        'Linux foo',
+      ]),
+    );
+  });
+
+  test('posts on failed -> failed (tasks changed)', () async {
+    firestore.putDocument(generateFirestoreCommit(1));
+    firestore.putDocument(
+      generateFirestoreTask(
+        1,
+        status: Task.statusFailed,
+        commitSha: '1',
+        name: 'Linux foo',
+      ),
+    );
+    firestore.putDocument(
+      generateFirestoreTask(
+        1,
+        status: Task.statusFailed,
+        commitSha: '1',
+        name: 'Mac bar',
+      ),
+    );
+    firestore.putDocument(
+      generateFirestoreTask(
+        1,
+        status: Task.statusSucceeded,
+        commitSha: '1',
+        name: 'Windows baz',
+      ),
+    );
+
+    await firestore.createDocument(
+      BuildStatusSnapshot(
+        createdOn: alwaysTime.toUtc(),
+        status: BuildStatus.failure,
+        failingTasks: ['Linux foo', 'Windows baz'],
+      ),
+      collectionId: BuildStatusSnapshot.metadata.collectionId,
+    );
+
+    await decodeHandlerBody<Map<String, Object?>>();
+
+    // Verify we wrote the status
+    expect(
+      firestore,
+      existsInStorage(BuildStatusSnapshot.metadata, [
+        isBuildStatusSnapshot.hasStatus(BuildStatus.failure),
+        isBuildStatusSnapshot.hasStatus(BuildStatus.failure),
+      ]),
+    );
+
+    // Verify we actually posted it
+    final [String message] =
+        verify(discord.postTreeStatusMessage(captureAny)).captured;
+    expect(
+      message,
+      stringContainsInOrder([
+        'flutter/flutter is still :red_circle:',
+        'Now failing',
+        'Mac bar',
+        'Now passing',
+        'Windows baz',
+      ]),
+    );
   });
 
   test('limits size of the message sent to discord', () async {
@@ -189,48 +269,18 @@ void main() {
       ),
     );
 
-    firestore.putDocument(
-      Document(
-        name:
-            'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/fu',
-        fields: {
-          'status': Value(stringValue: 'flutter/flutter is :red_circle:!'),
-          'createTimestamp': Value(
-            timestampValue:
-                alwaysTime
-                    .subtract(const Duration(seconds: 1))
-                    .toUtc()
-                    .toIso8601String(),
-          ),
-        },
-      ),
-    );
-
     await decodeHandlerBody<Map<String, Object?>>();
 
-    final lastStatus = firestore.documents.firstWhere(
-      (doc) =>
-          doc.name!.startsWith(
-            'projects/flutter-dashboard/databases/cocoon/documents/last_build_status/',
-          ) &&
-          !doc.name!.endsWith('/fu'),
-    );
-
-    expect(
-      lastStatus.fields!['status']!.stringValue,
-      'flutter/flutter is :red_circle:! Failing tasks: ${'a' * 2000}',
-    );
-
     // Verify we actually posted it
-    final captured = verify(discord.postTreeStatusMessage(captureAny)).captured;
-    expect(captured, hasLength(1));
+    final [String message] =
+        verify(discord.postTreeStatusMessage(captureAny)).captured;
+
     expect(
-      captured.first,
-      startsWith('flutter/flutter is :red_circle:! Failing tasks: aaaaaaaaa'),
-    );
-    expect(
-      captured.first,
-      endsWith('aaaaa... things appear to be very broken right now. :cry:'),
+      message,
+      stringContainsInOrder([
+        'flutter/flutter is now :red_circle:!',
+        ':cry: 1 tasks are failing',
+      ]),
     );
   });
 }

--- a/app_dart/test/request_handlers/update_discord_status_test.dart
+++ b/app_dart/test/request_handlers/update_discord_status_test.dart
@@ -62,10 +62,10 @@ void main() {
     );
   });
 
-  test('creates an initial doc when status is missing in firestore', () async {
+  test('creates an initial doc when the first status is a failure', () async {
     firestore.putDocument(generateFirestoreCommit(1));
     firestore.putDocument(
-      generateFirestoreTask(1, status: Task.statusSucceeded, commitSha: '1'),
+      generateFirestoreTask(1, status: Task.statusFailed, commitSha: '1'),
     );
 
     await decodeHandlerBody<Map<String, Object?>>();
@@ -73,14 +73,14 @@ void main() {
     expect(
       firestore,
       existsInStorage(BuildStatusSnapshot.metadata, [
-        isBuildStatusSnapshot.hasStatus(BuildStatus.success),
+        isBuildStatusSnapshot.hasStatus(BuildStatus.failure),
       ]),
     );
 
     // Verify we actually posted it
     final [message] =
         verify(discord.postTreeStatusMessage(captureAny)).captured;
-    expect(message, contains('flutter/flutter is now :green_circle:!'));
+    expect(message, contains('flutter/flutter is now :red_circle:!'));
   });
 
   test('does not post on unchanged value', () async {

--- a/app_dart/test/src/model/_build_status_snapshot.dart
+++ b/app_dart/test/src/model/_build_status_snapshot.dart
@@ -1,0 +1,37 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of 'firestore_matcher.dart';
+
+final class BuildStatusSnapshotMatcher
+    extends ModelMatcher<BuildStatusSnapshot> {
+  const BuildStatusSnapshotMatcher._(super._delegate) : super._();
+
+  @override
+  AppDocumentMetadata<BuildStatusSnapshot> get metadata {
+    return BuildStatusSnapshot.metadata;
+  }
+
+  BuildStatusSnapshotMatcher hasStatus(Object? matcherOr) {
+    return BuildStatusSnapshotMatcher._(
+      _delegate.having((status) => status.status, 'status', matcherOr),
+    );
+  }
+
+  BuildStatusSnapshotMatcher hasCreatedOn(Object? matcherOr) {
+    return BuildStatusSnapshotMatcher._(
+      _delegate.having((status) => status.createdOn, 'createdOn', matcherOr),
+    );
+  }
+
+  BuildStatusSnapshotMatcher hasFailingTasks(Object? matcherOr) {
+    return BuildStatusSnapshotMatcher._(
+      _delegate.having(
+        (status) => status.failingTasks,
+        'failingTasks',
+        matcherOr,
+      ),
+    );
+  }
+}

--- a/app_dart/test/src/model/firestore_matcher.dart
+++ b/app_dart/test/src/model/firestore_matcher.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cocoon_service/src/model/firestore/base.dart';
+import 'package:cocoon_service/src/model/firestore/build_status_snapshot.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart';
 import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
@@ -13,6 +14,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+part '_build_status_snapshot.dart';
 part '_commit.dart';
 part '_github_build_status.dart';
 part '_github_gold_status.dart';
@@ -31,8 +33,11 @@ const isGithubBuildStatus = GithubBuildStatusMatcher._(TypeMatcher());
 /// Matches a Firestore model, or raw document, of type [GithubGoldStatus].
 const isGithubGoldStatus = GithubGoldStatusMatcher._(TypeMatcher());
 
-/// Matches a Firestore model, or raw document, of type [PrCheckRun].
+/// Matches a Firestore model, or raw document, of type [PrCheckRuns].
 const isPrCheckRun = PrCheckRunsMatcher._(TypeMatcher());
+
+/// Matches a Firestore model, or raw document, of type [BuildStatusSnapshot].
+const isBuildStatusSnapshot = BuildStatusSnapshotMatcher._(TypeMatcher());
 
 /// Returns whether the document is a path to the collection [metadata].
 bool isDocumentA(g.Document document, AppDocumentMetadata<void> metadata) {

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -1580,14 +1580,6 @@ class MockDiscordService extends _i1.Mock implements _i36.DiscordService {
   }
 
   @override
-  _i2.Config get config =>
-      (super.noSuchMethod(
-            Invocation.getter(#config),
-            returnValue: _FakeConfig_0(this, Invocation.getter(#config)),
-          )
-          as _i2.Config);
-
-  @override
   _i15.Future<_i36.DiscordStatus> postTreeStatusMessage(String? message) =>
       (super.noSuchMethod(
             Invocation.method(#postTreeStatusMessage, [message]),


### PR DESCRIPTION
**Give ourselves a model** (I know, I know, but like, I'd prefer to know what's in the database - at some point someone will want to change something or something will break and purely for consistency it's nice to have all of the documents in a single place) and **make the Discord message include more details** (and diff between that and the previous status).

In addition:
1. Stores the failing tasks instead of the raw Discord message, in Firestore.
1. Reset the collection name so that the schemas are not incompatible (can delete the old one after).

Links would be nice, but I'd prefer to just building out a `/v2/flutter/flutter` page that is nice to look at instead.