### PR TITLE
Remove `DatastoreServceProvider` where not needed in services.

### DIFF
--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_common/is_dart_internal.dart';
 import 'package:cocoon_server/logging.dart';
-import 'package:gcloud/db.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:meta/meta.dart';
 
@@ -28,13 +27,7 @@ final class DartInternalSubscription extends SubscriptionHandler {
     required super.cache,
     required super.config,
     super.authProvider,
-    @visibleForTesting
-    DatastoreService Function(DatastoreDB) datastoreProvider =
-        DatastoreService.defaultProvider,
-  }) : _datastoreProvider = datastoreProvider,
-       super(subscriptionName: 'dart-internal-build-results-sub');
-
-  final DatastoreServiceProvider _datastoreProvider;
+  }) : super(subscriptionName: 'dart-internal-build-results-sub');
 
   @override
   Future<Body> post() async {
@@ -92,7 +85,7 @@ final class DartInternalSubscription extends SubscriptionHandler {
 
   Future<void> _legacyUpdateDatastoretask(bbv2.Build build) async {
     log.info('Checking for existing task in Datastore');
-    final datastore = _datastoreProvider(config.db);
+    final datastore = DatastoreService.defaultProvider(config.db);
     final existingTask = await datastore.getTaskFromBuildbucketBuild(build);
 
     final ds.Task taskToInsert;

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -40,19 +40,14 @@ final class PostsubmitLuciSubscription extends SubscriptionHandler {
     required super.cache,
     required super.config,
     super.authProvider,
-    @visibleForTesting
-    DatastoreService Function(DatastoreDB) datastoreProvider =
-        DatastoreService.defaultProvider,
     required Scheduler scheduler,
     required GithubChecksService githubChecksService,
     required CiYamlFetcher ciYamlFetcher,
   }) : _ciYamlFetcher = ciYamlFetcher,
        _githubChecksService = githubChecksService,
        _scheduler = scheduler,
-       _datastoreProvider = datastoreProvider,
        super(subscriptionName: 'build-bucket-postsubmit-sub');
 
-  final DatastoreServiceProvider _datastoreProvider;
   final Scheduler _scheduler;
   final GithubChecksService _githubChecksService;
   final CiYamlFetcher _ciYamlFetcher;
@@ -64,7 +59,7 @@ final class PostsubmitLuciSubscription extends SubscriptionHandler {
       return Body.empty;
     }
 
-    final datastore = _datastoreProvider(config.db);
+    final datastore = DatastoreService.defaultProvider(config.db);
     final firestoreService = await config.createFirestoreService();
 
     final pubSubCallBack = bbv2.PubSubCallBack();

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -30,15 +30,10 @@ final class VacuumStaleTasks extends RequestHandler<Body> {
     required LuciBuildService luciBuildService,
     Duration timeoutLimit = const Duration(hours: 3),
     @visibleForTesting DateTime Function() now = DateTime.now,
-    @visibleForTesting
-    DatastoreService Function(DatastoreDB) datastoreProvider =
-        DatastoreService.defaultProvider,
-  }) : _datastoreProvider = datastoreProvider,
-       _luciBuildService = luciBuildService,
+  }) : _luciBuildService = luciBuildService,
        _timeoutLimit = timeoutLimit,
        _now = now;
 
-  final DatastoreServiceProvider _datastoreProvider;
   final DateTime Function() _now;
   final Duration _timeoutLimit;
   final LuciBuildService _luciBuildService;
@@ -137,7 +132,7 @@ final class VacuumStaleTasks extends RequestHandler<Body> {
   }
 
   Future<void> _legacyUpdateDatastore(List<_UpdateTaskIntent> toUpdate) async {
-    final datastore = _datastoreProvider(config.db);
+    final datastore = DatastoreService.defaultProvider(config.db);
     final tasks = <ds.Task>[];
     for (final intent in toUpdate) {
       final commitKey = _toCommitKey(datastore.db, intent.commit);

--- a/app_dart/lib/src/service/commit_service.dart
+++ b/app_dart/lib/src/service/commit_service.dart
@@ -23,15 +23,10 @@ interface class CommitService {
   CommitService({
     required Config config,
     @visibleForTesting DateTime Function() now = DateTime.now,
-    @visibleForTesting
-    DatastoreService Function(ds.DatastoreDB) datastoreProvider =
-        DatastoreService.defaultProvider,
-  }) : _datastoreProvider = datastoreProvider,
-       _config = config,
+  }) : _config = config,
        _now = now;
 
   final Config _config;
-  final DatastoreServiceProvider _datastoreProvider;
   final DateTime Function() _now;
 
   /// Add a commit based on a [CreateEvent] to the Datastore.
@@ -71,7 +66,7 @@ interface class CommitService {
   }
 
   Future<void> _insertDatastore(_Commit commit) async {
-    final datastore = _datastoreProvider(_config.db);
+    final datastore = DatastoreService.defaultProvider(_config.db);
     final commitKey = datastore.db.emptyKey.append<String>(
       ds.Commit,
       id: '${commit.repository.fullName}/${commit.branch}/${commit.sha}',

--- a/app_dart/test/request_handlers/dart_internal_subscription_test.dart
+++ b/app_dart/test/request_handlers/dart_internal_subscription_test.dart
@@ -10,8 +10,6 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart' as ds;
 import 'package:cocoon_service/src/model/firestore/task.dart' as fs;
 import 'package:cocoon_service/src/model/luci/pubsub_message.dart';
-import 'package:cocoon_service/src/service/datastore.dart';
-import 'package:gcloud/db.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -85,7 +83,6 @@ void main() {
       cache: CacheService(inMemory: true),
       config: config,
       authProvider: FakeAuthenticationProvider(),
-      datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
     );
 
     request = FakeHttpRequest();

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -8,7 +8,6 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/commit.dart' as fs;
 import 'package:cocoon_service/src/model/firestore/task.dart' as firestore;
-import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:cocoon_service/src/service/luci_build_service/user_data.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:googleapis/firestore/v1.dart';
@@ -111,7 +110,6 @@ void main() {
       config: config,
       authProvider: FakeAuthenticationProvider(),
       githubChecksService: mockGithubChecksService,
-      datastoreProvider: (_) => DatastoreService(config.db, 5),
       scheduler: scheduler,
       ciYamlFetcher: ciYamlFetcher,
     );

--- a/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
+++ b/app_dart/test/request_handlers/scheduler/vacuum_stale_tasks_test.dart
@@ -9,7 +9,6 @@ import 'package:cocoon_service/src/model/appengine/task.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as fs;
 import 'package:cocoon_service/src/service/datastore.dart';
 import 'package:fixnum/fixnum.dart';
-import 'package:gcloud/db.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -46,7 +45,6 @@ void main() {
       tester = RequestHandlerTester();
       handler = VacuumStaleTasks(
         config: config,
-        datastoreProvider: (DatastoreDB db) => DatastoreService(config.db, 5),
         luciBuildService: luciBuildService,
       );
     });


### PR DESCRIPTION
All of these classes already can just self-wrap `config.db` if needed.

This reduces the amount of work required to rip out Datastore entirely when the time (soon) comes.