### PR TITLE
Add `still failing: ...` to the Discord tree status update

### DIFF
--- a/app_dart/lib/src/model/firestore/build_status_snapshot.dart
+++ b/app_dart/lib/src/model/firestore/build_status_snapshot.dart
@@ -93,6 +93,7 @@ final class BuildStatusSnapshot extends AppDocument<BuildStatusSnapshot> {
     return SnapshotDiff._(
       newStatus: newStatus,
       nowPassing: nowPassing,
+      stillFailing: failingTasks.intersection(other.failingTasks),
       nowFailing: nowFailing,
     );
   }
@@ -103,12 +104,14 @@ final class SnapshotDiff {
   const SnapshotDiff._({
     required this.newStatus,
     required this.nowPassing,
+    required this.stillFailing,
     required this.nowFailing,
   });
 
   /// If non-null,
   final BuildStatus? newStatus;
   final Set<String> nowPassing;
+  final Set<String> stillFailing;
   final Set<String> nowFailing;
 
   /// Whether a meaningful difference was recorded.

--- a/app_dart/lib/src/request_handlers/update_discord_status.dart
+++ b/app_dart/lib/src/request_handlers/update_discord_status.dart
@@ -104,6 +104,13 @@ final class UpdateDiscordStatus extends GetBuildStatus {
       details.writeln('```');
     }
 
+    if (diff.stillFailing.isNotEmpty) {
+      details.writeln('Still failing:');
+      details.writeln('```');
+      details.writeln(diff.stillFailing.join(', '));
+      details.writeln('```');
+    }
+
     if (diff.nowPassing.isNotEmpty) {
       details.writeln('Now passing:');
       details.writeln('```');

--- a/app_dart/test/request_handlers/update_discord_status_test.dart
+++ b/app_dart/test/request_handlers/update_discord_status_test.dart
@@ -252,6 +252,8 @@ void main() {
         'flutter/flutter is still :red_circle:',
         'Now failing',
         'Mac bar',
+        'Still failing',
+        'Linux foo',
         'Now passing',
         'Windows baz',
       ]),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9472b274-2253-441e-b8de-b2f6c8f12b64)

That middle update would be better if it repeated what was still failing.