### PR TITLE
Properly record a new task for a new `dart_internal` build ID.

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -373,9 +373,18 @@ final class Task extends AppDocument<Task> {
     _setStatusFromLuciStatus(build);
   }
 
-  void resetAsRetry({int attempt = 1}) {
-    name =
-        '$kDatabase/documents/$kTaskCollectionId/${commitSha}_${taskName}_$attempt';
+  void resetAsRetry({int? attempt}) {
+    attempt ??= currentAttempt + 1;
+    name = p.posix.join(
+      kDatabase,
+      'documents',
+      kTaskCollectionId,
+      Task.documentIdFor(
+        commitSha: commitSha,
+        currentAttempt: attempt,
+        taskName: taskName,
+      ).documentId,
+    );
     fields = <String, Value>{
       fieldCreateTimestamp: DateTime.now().millisecondsSinceEpoch.toValue(),
       fieldEndTimestamp: 0.toValue(),
@@ -387,6 +396,10 @@ final class Task extends AppDocument<Task> {
       fieldCommitSha: commitSha.toValue(),
       fieldAttempt: attempt.toValue(),
     };
+  }
+
+  void setBuildNumber(int buildNumber) {
+    fields[fieldBuildNumber] = buildNumber.toValue();
   }
 
   String _setStatusFromLuciStatus(bbv2.Build build) {

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -53,6 +53,10 @@ final class DartInternalSubscription extends SubscriptionHandler {
       );
       if (existing != null) {
         fsTask = existing;
+        if (build.number != fsTask.buildNumber) {
+          fsTask.resetAsRetry();
+          fsTask.setBuildNumber(build.number);
+        }
         fsTask.updateFromBuild(build);
       } else {
         fsTask = fs.Task(

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -1108,8 +1108,7 @@ class LuciBuildService {
     fs.Task task,
   ) async {
     // Update task status in Firestore.
-    final newAttempt = task.currentAttempt + 1;
-    task.resetAsRetry(attempt: newAttempt);
+    task.resetAsRetry();
     task.setStatus(fs.Task.statusInProgress);
 
     final firestore = await _config.createFirestoreService();
@@ -1132,11 +1131,11 @@ class LuciBuildService {
       name: task.taskName,
     );
     dsExistingTask
-      ..attempts = newAttempt
+      ..attempts = task.currentAttempt
       ..status = Task.statusInProgress;
     await datastore.insert([dsExistingTask]);
 
-    return newAttempt;
+    return task.currentAttempt;
   }
 
   /// Check if a builder should be rerun.

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -117,7 +117,7 @@ void main() {
         status: Task.statusFailed,
         testFlaky: true,
       );
-      task.resetAsRetry(attempt: 2);
+      task.resetAsRetry();
 
       expect(int.parse(task.name!.split('_').last), 2);
       expect(task.status, Task.statusNew);


### PR DESCRIPTION
I think this has been a bug for a while, but could have also been caused by the Firestore migration.

After this PR, `dart_internal` should show re-runs and previous builds like expected.

Closes https://github.com/flutter/flutter/issues/166935.

/cc @reidbaker 