### PR TITLE
Makes 'unexpected engineArtifacts' an error.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -306,10 +306,8 @@ class LuciBuildService {
         }
       } else if (engineArtifacts is! UnnecessaryEngineArtifacts) {
         // This is an error case, as we're setting artifacts for a PR that will never use them.
-        log.warn(
+        throw StateError(
           'Unexpected engineArtifacts were specified for PR#${pullRequest.number} (${pullRequest.head!.sha})',
-          null,
-          StackTrace.current,
         );
       }
 

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -278,8 +278,8 @@ void main() {
     await luci.scheduleTryBuilds(
       pullRequest: pullRequest,
       targets: [buildTarget],
-      engineArtifacts: EngineArtifacts.usingExistingEngine(
-        commitSha: pullRequest.base!.sha!,
+      engineArtifacts: const EngineArtifacts.noFrameworkTests(
+        reason: 'Not a flutter/flutter PR',
       ),
     );
 


### PR DESCRIPTION
This is effectively an unreachable error case, and does not appear in our logs.

Closes https://github.com/flutter/flutter/issues/166795.