### PR TITLE
Remove pinned `package:analyzer`.

### DIFF
--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -41,8 +41,8 @@ dev_dependencies:
   cocoon_server_test:
     path: ../packages/cocoon_server_test
   dart_flutter_team_lints: 3.5.1
-  json_serializable: 6.9.4
-  mockito: 5.4.5
+  json_serializable: ^6.9.4
+  mockito: ^5.4.5
   test: 1.25.15
 
 builders:

--- a/auto_submit/pubspec.yaml
+++ b/auto_submit/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   yaml: 3.1.2
 
 dev_dependencies:
-  build_runner: 2.4.13
+  build_runner: ^2.4.15
   cocoon_common_test:
     path: ../packages/cocoon_common_test
   cocoon_server_test:

--- a/cipd_packages/device_doctor/pubspec.yaml
+++ b/cipd_packages/device_doctor/pubspec.yaml
@@ -6,7 +6,6 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: 6.11.0
   args: 2.7.0
   file: any
   logging: 1.2.0

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -35,7 +35,6 @@ dev_dependencies:
   dart_flutter_team_lints: 3.5.1
   flutter_test:
     sdk: flutter
-  json_serializable: ^6.9.0
   mockito: 5.4.4 # Remember to run ./regen_mocks.sh!
   path: any # Match Flutter SDK
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167322.

There is no (good) reason to pin this package, it's an indirect dependency used by Mockito only.