### PR TITLE
Split up AuthenticationProvider

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_server/google_auth_provider.dart';
 import 'package:cocoon_server/secret_manager.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/server.dart';
+import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
@@ -40,7 +41,7 @@ Future<void> main() async {
         projectId: Config.flutterGcpProjectId,
       ),
     );
-    final authProvider = AuthenticationProvider(config: config);
+    final authProvider = DashboardAuthentication(config: config);
     final AuthenticationProvider swarmingAuthProvider =
         SwarmingAuthenticationProvider(config: config);
 

--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -55,7 +55,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
       _paramTaskName: String taskName,
     } = requestData!;
 
-    final token = await tokenInfo(request!);
+    final email = authContext?.email ?? 'EMAIL-MISSING';
     final slug = RepositorySlug('flutter', repo);
 
     // Ensure the commit exists in Firestore.
@@ -83,7 +83,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
         commit: commit,
         slug: slug,
         branch: branch,
-        email: token.email!,
+        email: email,
         statusesToRerun: statusesToRerun,
       );
       return Body.forJson(ranTasks);
@@ -111,7 +111,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
       task: task,
       slug: slug,
       branch: branch,
-      email: token.email!,
+      email: email,
     );
     if (!didRerun) {
       throw InternalServerError('Failed to rerun task "$taskName"');

--- a/app_dart/lib/src/request_handling/api_request_handler.dart
+++ b/app_dart/lib/src/request_handling/api_request_handler.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 
-import '../model/google/token_info.dart';
 import 'authentication.dart';
 import 'body.dart';
 import 'exceptions.dart';
@@ -50,11 +49,11 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
     }
   }
 
-  /// Gets [TokenInfo] using X-Flutter-IdToken header from an authenticated request.
-  @protected
-  Future<TokenInfo> tokenInfo(HttpRequest request) async {
-    return authenticationProvider.tokenInfo(request);
-  }
+  // /// Gets [TokenInfo] using X-Flutter-IdToken header from an authenticated request.
+  // @protected
+  // Future<TokenInfo> tokenInfo(HttpRequest request) async {
+  //   return authenticationProvider.tokenInfo(request);
+  // }
 
   /// Throws a [BadRequestException] if any of [requiredQueryParameters] are missing from [requestData].
   @protected

--- a/app_dart/lib/src/request_handling/authentication.dart
+++ b/app_dart/lib/src/request_handling/authentication.dart
@@ -3,72 +3,15 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_server/logging.dart';
 import 'package:meta/meta.dart';
 
-import '../../cocoon_service.dart';
-import '../foundation/providers.dart';
-import '../foundation/typedefs.dart';
-import '../model/firestore/account.dart';
-import '../model/google/token_info.dart';
 import 'exceptions.dart';
 
-/// Class capable of authenticating [HttpRequest]s.
-///
-/// There are two types of authentication this class supports:
-///
-///  1. If the request has the `'X-Appengine-Cron'` HTTP header set to "true",
-///     then the request will be authenticated as an App Engine cron job.
-///
-///     The `'X-Appengine-Cron'` HTTP header is set automatically by App Engine
-///     and will be automatically stripped from the request by the App Engine
-///     runtime if the request originated from anything other than a cron job.
-///     Thus, the header is safe to trust as an authentication indicator.
-///
-///  2. If the request has the `'X-Flutter-IdToken'` HTTP header
-///     set to a valid encrypted JWT token, then the request will be authenticated
-///     as a user account.
-///
-///     @google.com accounts can call APIs using curl and gcloud.
-///     E.g. curl '<api_url>' -H "X-Flutter-IdToken: $(gcloud auth print-identity-token)"
-///
-///     User accounts are only authorized if the user is either a "@google.com"
-///     account or is an [AllowedAccount] in Cocoon's Datastore.
-///
-/// If none of the above authentication methods yield an authenticated
-/// request, then the request is unauthenticated, and any call to
-/// [authenticate] will throw an [Unauthenticated] exception.
-///
-/// See also:
-///
-///  * <https://cloud.google.com/appengine/docs/standard/python/reference/request-response-headers>
 @immutable
-class AuthenticationProvider {
-  const AuthenticationProvider({
-    required this.config,
-    this.clientContextProvider = Providers.serviceScopeContext,
-    this.httpClientProvider = Providers.freshHttpClient,
-  });
-
-  /// The Cocoon config, guaranteed to be non-null.
-  final Config config;
-
-  /// Provides the App Engine client context as part of the
-  /// [AuthenticatedContext].
-  ///
-  /// This is guaranteed to be non-null.
-  final ClientContextProvider clientContextProvider;
-
-  /// Provides the HTTP client that will be used (if necessary) to verify OAuth
-  /// ID tokens (JWT tokens).
-  ///
-  /// This is guaranteed to be non-null.
-  final HttpClientProvider httpClientProvider;
-
+abstract interface class AuthenticationProvider {
   /// Authenticates the specified [request] and returns the associated
   /// [AuthenticatedContext].
   ///
@@ -77,97 +20,46 @@ class AuthenticationProvider {
   ///
   /// This will throw an [Unauthenticated] exception if the request is
   /// unauthenticated.
-  Future<AuthenticatedContext> authenticate(HttpRequest request) async {
-    final isCron = request.headers.value('X-Appengine-Cron') == 'true';
-    final idTokenFromHeader = request.headers.value('X-Flutter-IdToken');
-    final clientContext = clientContextProvider();
-    if (isCron) {
-      // Authenticate cron requests
-      return AuthenticatedContext(clientContext: clientContext);
-    } else if (idTokenFromHeader != null) {
-      TokenInfo token;
-      try {
-        token = await tokenInfo(request);
-      } on Unauthenticated {
-        token = await tokenInfo(request, tokenType: 'access_token');
-      }
-      return authenticateToken(token, clientContext: clientContext);
-    }
-
-    throw const Unauthenticated('User is not signed in');
-  }
+  Future<AuthenticatedContext> authenticate(HttpRequest request);
 
   /// Gets oauth token information. This method requires the token to be stored in
   /// X-Flutter-IdToken header.
-  Future<TokenInfo> tokenInfo(
-    HttpRequest request, {
-    String tokenType = 'id_token',
-  }) async {
-    final idTokenFromHeader = request.headers.value('X-Flutter-IdToken');
-    final client = httpClientProvider();
-    try {
-      final verifyTokenResponse = await client.get(
-        Uri.https('oauth2.googleapis.com', '/tokeninfo', <String, String?>{
-          tokenType: idTokenFromHeader,
-        }),
-      );
+  // Future<TokenInfo> tokenInfo(
+  //   HttpRequest request, {
+  //   String tokenType = 'id_token',
+  // }) async {
+  //   final idTokenFromHeader = request.headers.value('X-Flutter-IdToken');
+  //   final client = httpClientProvider();
+  //   try {
+  //     final verifyTokenResponse = await client.get(
+  //       Uri.https('oauth2.googleapis.com', '/tokeninfo', <String, String?>{
+  //         tokenType: idTokenFromHeader,
+  //       }),
+  //     );
 
-      if (verifyTokenResponse.statusCode != HttpStatus.ok) {
-        /// Google Auth API returns a message in the response body explaining why
-        /// the request failed. Such as "Invalid Token".
-        log.debug(
-          'Token verification failed: ${verifyTokenResponse.statusCode}; '
-          '${verifyTokenResponse.body}',
-        );
-        throw const Unauthenticated('Invalid ID token');
-      }
+  //     if (verifyTokenResponse.statusCode != HttpStatus.ok) {
+  //       /// Google Auth API returns a message in the response body explaining why
+  //       /// the request failed. Such as "Invalid Token".
+  //       log.debug(
+  //         'Token verification failed: ${verifyTokenResponse.statusCode}; '
+  //         '${verifyTokenResponse.body}',
+  //       );
+  //       throw const Unauthenticated('Invalid ID token');
+  //     }
 
-      try {
-        return TokenInfo.fromJson(
-          json.decode(verifyTokenResponse.body) as Map<String, dynamic>,
-        );
-      } on FormatException {
-        throw InternalServerError(
-          'Invalid JSON: "${verifyTokenResponse.body}"',
-        );
-      }
-    } finally {
-      client.close();
-    }
-  }
-
-  Future<AuthenticatedContext> authenticateToken(
-    TokenInfo token, {
-    required ClientContext clientContext,
-  }) async {
-    // Authenticate as a signed-in Google account via OAuth id token.
-    final clientId = await config.oauthClientId;
-    if (token.audience != clientId && !token.email!.endsWith('@google.com')) {
-      log.warn(
-        'Possible forged token: "${token.audience}" (expected "$clientId")',
-      );
-      throw const Unauthenticated('Invalid ID token');
-    }
-
-    if (token.hostedDomain != 'google.com') {
-      final isAllowed = await _isAllowed(token.email);
-      if (!isAllowed) {
-        throw Unauthenticated(
-          '${token.email} is not authorized to access the dashboard',
-        );
-      }
-    }
-    return AuthenticatedContext(clientContext: clientContext);
-  }
-
-  Future<bool> _isAllowed(String? email) async {
-    if (email == null) {
-      return false;
-    }
-    final firestore = await config.createFirestoreService();
-    final account = await Account.getByEmail(firestore, email: email);
-    return account != null;
-  }
+  //     try {
+  //       return TokenInfo.fromJson(
+  //         json.decode(verifyTokenResponse.body) as Map<String, dynamic>,
+  //       );
+  //     } on FormatException {
+  //       throw InternalServerError(
+  //         'Invalid JSON: "${verifyTokenResponse.body}"',
+  //       );
+  //     }
+  //   } finally {
+  //     client.close();
+  //   }
+  // }
 }
 
 /// Class that represents an authenticated request having been made, and any
@@ -179,10 +71,16 @@ class AuthenticationProvider {
 @immutable
 class AuthenticatedContext {
   /// Creates a new [AuthenticatedContext].
-  const AuthenticatedContext({required this.clientContext});
+  const AuthenticatedContext({
+    required this.clientContext,
+    required this.email,
+  });
 
   /// The App Engine [ClientContext] of the current request.
   ///
   /// This is guaranteed to be non-null.
   final ClientContext clientContext;
+
+  /// The email address associated with this authenticated context.
+  final String email; // maybe TokenInfo
 }

--- a/app_dart/lib/src/request_handling/dashboard_authentication.dart
+++ b/app_dart/lib/src/request_handling/dashboard_authentication.dart
@@ -1,0 +1,178 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:cocoon_server/logging.dart';
+import 'package:meta/meta.dart';
+
+import '../../cocoon_service.dart';
+import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
+import '../model/firestore/account.dart';
+import '../model/google/token_info.dart';
+import 'exceptions.dart';
+
+/// Class capable of authenticating [HttpRequest]s.
+///
+/// There are two types of authentication this class supports:
+///
+///  1. If the request has the `'X-Appengine-Cron'` HTTP header set to "true",
+///     then the request will be authenticated as an App Engine cron job.
+///
+///     The `'X-Appengine-Cron'` HTTP header is set automatically by App Engine
+///     and will be automatically stripped from the request by the App Engine
+///     runtime if the request originated from anything other than a cron job.
+///     Thus, the header is safe to trust as an authentication indicator.
+///
+///  2. If the request has the `'X-Flutter-IdToken'` HTTP header
+///     set to a valid encrypted JWT token, then the request will be authenticated
+///     as a user account.
+///
+///     @google.com accounts can call APIs using curl and gcloud.
+///     E.g. curl '<api_url>' -H "X-Flutter-IdToken: $(gcloud auth print-identity-token)"
+///
+///     User accounts are only authorized if the user is either a "@google.com"
+///     account or is an [AllowedAccount] in Cocoon's Datastore.
+///
+/// If none of the above authentication methods yield an authenticated
+/// request, then the request is unauthenticated, and any call to
+/// [authenticate] will throw an [Unauthenticated] exception.
+///
+/// See also:
+///
+///  * <https://cloud.google.com/appengine/docs/standard/python/reference/request-response-headers>
+@immutable
+class DashboardAuthentication implements AuthenticationProvider {
+  const DashboardAuthentication({
+    required this.config,
+    this.clientContextProvider = Providers.serviceScopeContext,
+    this.httpClientProvider = Providers.freshHttpClient,
+  });
+
+  /// The Cocoon config, guaranteed to be non-null.
+  final Config config;
+
+  /// Provides the App Engine client context as part of the
+  /// [AuthenticatedContext].
+  ///
+  /// This is guaranteed to be non-null.
+  final ClientContextProvider clientContextProvider;
+
+  /// Provides the HTTP client that will be used (if necessary) to verify OAuth
+  /// ID tokens (JWT tokens).
+  ///
+  /// This is guaranteed to be non-null.
+  final HttpClientProvider httpClientProvider;
+
+  /// Authenticates the specified [request] and returns the associated
+  /// [AuthenticatedContext].
+  ///
+  /// See the class documentation on [AuthenticationProvider] for a discussion
+  /// of the different types of authentication that are accepted.
+  ///
+  /// This will throw an [Unauthenticated] exception if the request is
+  /// unauthenticated.
+  @override
+  Future<AuthenticatedContext> authenticate(HttpRequest request) async {
+    final isCron = request.headers.value('X-Appengine-Cron') == 'true';
+    final idTokenFromHeader = request.headers.value('X-Flutter-IdToken');
+    final clientContext = clientContextProvider();
+    if (isCron) {
+      // Authenticate cron requests
+      return AuthenticatedContext(
+        clientContext: clientContext,
+        email: 'CRON_JOB',
+      );
+    } else if (idTokenFromHeader != null) {
+      TokenInfo token;
+      try {
+        token = await tokenInfo(request);
+      } on Unauthenticated {
+        token = await tokenInfo(request, tokenType: 'access_token');
+      }
+      return authenticateToken(token, clientContext: clientContext);
+    }
+
+    throw const Unauthenticated('User is not signed in');
+  }
+
+  /// Gets oauth token information. This method requires the token to be stored in
+  /// X-Flutter-IdToken header.
+  Future<TokenInfo> tokenInfo(
+    HttpRequest request, {
+    String tokenType = 'id_token',
+  }) async {
+    final idTokenFromHeader = request.headers.value('X-Flutter-IdToken');
+    final client = httpClientProvider();
+    try {
+      final verifyTokenResponse = await client.get(
+        Uri.https('oauth2.googleapis.com', '/tokeninfo', <String, String?>{
+          tokenType: idTokenFromHeader,
+        }),
+      );
+
+      if (verifyTokenResponse.statusCode != HttpStatus.ok) {
+        /// Google Auth API returns a message in the response body explaining why
+        /// the request failed. Such as "Invalid Token".
+        log.debug(
+          'Token verification failed: ${verifyTokenResponse.statusCode}; '
+          '${verifyTokenResponse.body}',
+        );
+        throw const Unauthenticated('Invalid ID token');
+      }
+
+      try {
+        return TokenInfo.fromJson(
+          json.decode(verifyTokenResponse.body) as Map<String, dynamic>,
+        );
+      } on FormatException {
+        throw InternalServerError(
+          'Invalid JSON: "${verifyTokenResponse.body}"',
+        );
+      }
+    } finally {
+      client.close();
+    }
+  }
+
+  Future<AuthenticatedContext> authenticateToken(
+    TokenInfo token, {
+    required ClientContext clientContext,
+  }) async {
+    // Authenticate as a signed-in Google account via OAuth id token.
+    final clientId = await config.oauthClientId;
+    if (token.audience != clientId && !token.email!.endsWith('@google.com')) {
+      log.warn(
+        'Possible forged token: "${token.audience}" (expected "$clientId")',
+      );
+      throw const Unauthenticated('Invalid ID token');
+    }
+
+    if (token.hostedDomain != 'google.com') {
+      final isAllowed = await _isAllowed(token.email);
+      if (!isAllowed) {
+        throw Unauthenticated(
+          '${token.email} is not authorized to access the dashboard',
+        );
+      }
+    }
+    return AuthenticatedContext(
+      clientContext: clientContext,
+      email: token.email ?? 'EMAIL MISSING',
+    );
+  }
+
+  Future<bool> _isAllowed(String? email) async {
+    if (email == null) {
+      return false;
+    }
+    final firestore = await config.createFirestoreService();
+    final account = await Account.getByEmail(firestore, email: email);
+    return account != null;
+  }
+}

--- a/app_dart/lib/src/request_handling/pubsub_authentication.dart
+++ b/app_dart/lib/src/request_handling/pubsub_authentication.dart
@@ -12,6 +12,7 @@ import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';
 import '../foundation/providers.dart';
+import '../foundation/typedefs.dart';
 import 'exceptions.dart';
 
 /// Class capable of authenticating [HttpRequest]s for PubSub messages.
@@ -25,12 +26,27 @@ import 'exceptions.dart';
 ///
 /// If there is no token, or it cannot be authenticated, [Unauthenticated] is thrown.
 @immutable
-class PubsubAuthenticationProvider extends AuthenticationProvider {
+class PubsubAuthenticationProvider implements AuthenticationProvider {
   const PubsubAuthenticationProvider({
-    required super.config,
-    super.clientContextProvider = Providers.serviceScopeContext,
-    super.httpClientProvider = Providers.freshHttpClient,
+    required this.config,
+    this.clientContextProvider = Providers.serviceScopeContext,
+    this.httpClientProvider = Providers.freshHttpClient,
   });
+
+  /// The Cocoon config, guaranteed to be non-null.
+  final Config config;
+
+  /// Provides the App Engine client context as part of the
+  /// [AuthenticatedContext].
+  ///
+  /// This is guaranteed to be non-null.
+  final ClientContextProvider clientContextProvider;
+
+  /// Provides the HTTP client that will be used (if necessary) to verify OAuth
+  /// ID tokens (JWT tokens).
+  ///
+  /// This is guaranteed to be non-null.
+  final HttpClientProvider httpClientProvider;
 
   static const String kBearerTokenPrefix = 'Bearer ';
 
@@ -72,7 +88,10 @@ class PubsubAuthenticationProvider extends AuthenticationProvider {
     }
 
     if (Config.allowedPubsubServiceAccounts.contains(info.email)) {
-      return AuthenticatedContext(clientContext: clientContext);
+      return AuthenticatedContext(
+        clientContext: clientContext,
+        email: info.email!,
+      );
     }
     throw Unauthenticated(
       '${info.email} is not in allowedPubsubServiceAccounts',

--- a/app_dart/test/request_handlers/check_flaky_builders_test.dart
+++ b/app_dart/test/request_handlers/check_flaky_builders_test.dart
@@ -22,7 +22,7 @@ import 'package:yaml/yaml.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/utilities/mocks.dart';
 import 'check_flaky_builders_test_data.dart';
@@ -42,7 +42,7 @@ void main() {
     FakeHttpRequest request;
     late FakeConfig config;
     FakeClientContext clientContext;
-    FakeAuthenticationProvider auth;
+    FakeDashboardAuthentication auth;
     late MockBigqueryService mockBigqueryService;
     MockGitHub mockGitHubClient;
     late MockRepositoriesService mockRepositoriesService;
@@ -59,7 +59,7 @@ void main() {
       );
 
       clientContext = FakeClientContext();
-      auth = FakeAuthenticationProvider(clientContext: clientContext);
+      auth = FakeDashboardAuthentication(clientContext: clientContext);
       mockBigqueryService = MockBigqueryService();
       mockGitHubClient = MockGitHub();
       mockRepositoriesService = MockRepositoriesService();

--- a/app_dart/test/request_handlers/create_branch_test.dart
+++ b/app_dart/test/request_handlers/create_branch_test.dart
@@ -10,7 +10,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/request_handler_tester.dart';
 import '../src/utilities/mocks.dart';
@@ -31,7 +31,7 @@ void main() {
       final RequestHandler handler = CreateBranch(
         branchService: branchService,
         config: FakeConfig(),
-        authenticationProvider: FakeAuthenticationProvider(),
+        authenticationProvider: FakeDashboardAuthentication(),
       );
       await tester.get(handler);
       verify(

--- a/app_dart/test/request_handlers/dart_internal_subscription_test.dart
+++ b/app_dart/test/request_handlers/dart_internal_subscription_test.dart
@@ -14,7 +14,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/subscription_tester.dart';
 import '../src/service/fake_firestore_service.dart';
@@ -82,7 +82,7 @@ void main() {
     handler = DartInternalSubscription(
       cache: CacheService(inMemory: true),
       config: config,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
     );
 
     request = FakeHttpRequest();

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -21,7 +21,7 @@ import 'package:yaml/yaml.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/utilities/mocks.dart';
 import 'file_flaky_issue_and_pr_test_data.dart';
@@ -41,7 +41,7 @@ void main() {
     late FakeHttpRequest request;
     late FakeConfig config;
     late FakeClientContext clientContext;
-    late FakeAuthenticationProvider auth;
+    late FakeDashboardAuthentication auth;
     late MockBigqueryService mockBigqueryService;
     late MockGitHub mockGitHubClient;
     late MockRepositoriesService mockRepositoriesService;
@@ -58,7 +58,7 @@ void main() {
       );
 
       clientContext = FakeClientContext();
-      auth = FakeAuthenticationProvider(clientContext: clientContext);
+      auth = FakeDashboardAuthentication(clientContext: clientContext);
       mockBigqueryService = MockBigqueryService();
       mockGitHubClient = MockGitHub();
       mockRepositoriesService = MockRepositoriesService();

--- a/app_dart/test/request_handlers/flush_cache_test.dart
+++ b/app_dart/test/request_handlers/flush_cache_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 
 void main() {
@@ -31,7 +31,7 @@ void main() {
       config = FakeConfig();
       handler = FlushCache(
         config: config,
-        authenticationProvider: FakeAuthenticationProvider(),
+        authenticationProvider: FakeDashboardAuthentication(),
         cache: cache,
       );
     });

--- a/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/postsubmit_luci_subscription_test.dart
@@ -13,7 +13,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/subscription_tester.dart';
 import '../src/service/fake_ci_yaml_fetcher.dart';
@@ -72,7 +72,7 @@ void main() {
     handler = PostsubmitLuciSubscription(
       cache: CacheService(inMemory: true),
       config: config,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
       githubChecksService: mockGithubChecksService,
       ciYamlFetcher: ciYamlFetcher,
       luciBuildService: luciBuildService,

--- a/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
+++ b/app_dart/test/request_handlers/presubmit_luci_subscription_test.dart
@@ -13,7 +13,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/request_handling/subscription_tester.dart';
 import '../src/service/fake_ci_yaml_fetcher.dart';
@@ -54,7 +54,7 @@ void main() {
       config: config,
       luciBuildService: FakeLuciBuildService(config: config),
       githubChecksService: mockGithubChecksService,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
       scheduler: scheduler,
       ciYamlFetcher: ciYamlFetcher,
     );
@@ -242,7 +242,7 @@ void main() {
       config: config,
       luciBuildService: mockLuciBuildService,
       githubChecksService: mockGithubChecksService,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
       scheduler: scheduler,
       ciYamlFetcher: ciYamlFetcher,
     );
@@ -421,7 +421,7 @@ void main() {
       config: config,
       luciBuildService: mockLuciBuildService,
       githubChecksService: mockGithubChecksService,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
       scheduler: scheduler,
       ciYamlFetcher: ciYamlFetcher,
     );

--- a/app_dart/test/request_handlers/push_build_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_build_status_to_github_test.dart
@@ -18,7 +18,7 @@ import '../src/bigquery/fake_tabledata_resource.dart';
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/service/fake_build_status_provider.dart';
 import '../src/service/fake_firestore_service.dart';
 import '../src/service/fake_github_service.dart';
@@ -69,7 +69,7 @@ void main() {
     tester = ApiRequestHandlerTester(context: authContext);
     handler = PushBuildStatusToGithub(
       config: config,
-      authenticationProvider: FakeAuthenticationProvider(
+      authenticationProvider: FakeDashboardAuthentication(
         clientContext: clientContext,
       ),
       buildStatusService: buildStatusService,

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -25,7 +25,7 @@ import 'package:test/test.dart';
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/service/fake_firestore_service.dart';
 import '../src/service/fake_graphql_client.dart';
 import '../src/utilities/entity_generators.dart';
@@ -38,7 +38,7 @@ void main() {
 
   late FakeConfig config;
   late FakeClientContext clientContext;
-  late FakeAuthenticationProvider auth;
+  late FakeDashboardAuthentication auth;
   late FakeFirestoreService firestore;
   late FakeDatastoreDB db;
   late ApiRequestHandlerTester tester;
@@ -51,7 +51,7 @@ void main() {
   setUp(() {
     clientContext = FakeClientContext();
     firestore = FakeFirestoreService();
-    auth = FakeAuthenticationProvider(clientContext: clientContext);
+    auth = FakeDashboardAuthentication(clientContext: clientContext);
     db = FakeDatastoreDB();
     config = FakeConfig(dbValue: db, firestoreService: firestore);
     tester = ApiRequestHandlerTester(

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -16,7 +16,7 @@ import 'package:test/test.dart';
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/service/fake_ci_yaml_fetcher.dart';
 import '../src/service/fake_firestore_service.dart';
 import '../src/service/fake_scheduler.dart';
@@ -58,7 +58,7 @@ void main() {
     ciYamlFetcher = FakeCiYamlFetcher(ciYaml: multiTargetFusionConfig);
     handler = RerunProdTask(
       config: config,
-      authenticationProvider: FakeAuthenticationProvider(
+      authenticationProvider: FakeDashboardAuthentication(
         clientContext: clientContext,
       ),
       luciBuildService: mockLuciBuildService,

--- a/app_dart/test/request_handlers/reset_try_task_test.dart
+++ b/app_dart/test/request_handlers/reset_try_task_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/service/fake_github_service.dart';
 import '../src/service/fake_scheduler.dart';
@@ -49,7 +49,7 @@ void main() {
       );
       handler = ResetTryTask(
         config: config,
-        authenticationProvider: FakeAuthenticationProvider(
+        authenticationProvider: FakeDashboardAuthentication(
           clientContext: clientContext,
         ),
         scheduler: fakeScheduler,

--- a/app_dart/test/request_handlers/scheduler/scheduler_request_subscription_test.dart
+++ b/app_dart/test/request_handlers/scheduler/scheduler_request_subscription_test.dart
@@ -16,7 +16,7 @@ import 'package:retry/retry.dart';
 import 'package:test/test.dart';
 
 import '../../src/datastore/fake_config.dart';
-import '../../src/request_handling/fake_authentication.dart';
+import '../../src/request_handling/fake_dashboard_authentication.dart';
 import '../../src/request_handling/fake_http.dart';
 import '../../src/request_handling/subscription_tester.dart';
 import '../../src/service/fake_github_service.dart';
@@ -36,7 +36,7 @@ void main() {
     handler = SchedulerRequestSubscription(
       cache: CacheService(inMemory: true),
       config: FakeConfig()..githubService = githubService,
-      authProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
       buildBucketClient: buildBucketClient,
       retryOptions: const RetryOptions(maxAttempts: 3, maxDelay: Duration.zero),
     );

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/utilities/mocks.dart';
 import 'update_existing_flaky_issues_test_data.dart';
@@ -43,7 +43,7 @@ void main() {
       );
 
       final clientContext = FakeClientContext();
-      final auth = FakeAuthenticationProvider(clientContext: clientContext);
+      final auth = FakeDashboardAuthentication(clientContext: clientContext);
       mockBigqueryService = MockBigqueryService();
       mockGitHubClient = MockGitHub();
       mockIssuesService = MockIssuesService();

--- a/app_dart/test/request_handlers/vacuum_github_commits_test.dart
+++ b/app_dart/test/request_handlers/vacuum_github_commits_test.dart
@@ -20,7 +20,7 @@ import 'package:test/test.dart';
 import '../src/datastore/fake_config.dart';
 import '../src/datastore/fake_datastore.dart';
 import '../src/request_handling/api_request_handler_tester.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/service/fake_firestore_service.dart';
 import '../src/service/fake_github_service.dart';
 import '../src/service/fake_scheduler.dart';
@@ -98,7 +98,7 @@ void main() {
       supportedReposValue: {Config.flutterSlug},
     );
 
-    final auth = FakeAuthenticationProvider();
+    final auth = FakeDashboardAuthentication();
     final scheduler = FakeScheduler(config: config);
     tester = ApiRequestHandlerTester();
     handler = VacuumGithubCommits(

--- a/app_dart/test/request_handling/api_request_handler_test.dart
+++ b/app_dart/test/request_handling/api_request_handler_test.dart
@@ -15,7 +15,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 
 void main() {
   useTestLoggerPerTest();
@@ -131,7 +131,7 @@ class Unauth extends ApiRequestHandler<Body> {
   Unauth()
     : super(
         config: FakeConfig(),
-        authenticationProvider: FakeAuthenticationProvider(
+        authenticationProvider: FakeDashboardAuthentication(
           authenticated: false,
         ),
       );
@@ -144,7 +144,7 @@ class ReadParams extends ApiRequestHandler<Body> {
   ReadParams()
     : super(
         config: FakeConfig(),
-        authenticationProvider: FakeAuthenticationProvider(),
+        authenticationProvider: FakeDashboardAuthentication(),
       );
 
   @override
@@ -159,7 +159,7 @@ class NeedsParams extends ApiRequestHandler<Body> {
   NeedsParams()
     : super(
         config: FakeConfig(),
-        authenticationProvider: FakeAuthenticationProvider(),
+        authenticationProvider: FakeDashboardAuthentication(),
       );
 
   @override
@@ -173,7 +173,7 @@ class AccessAuth extends ApiRequestHandler<Body> {
   AccessAuth()
     : super(
         config: FakeConfig(),
-        authenticationProvider: FakeAuthenticationProvider(),
+        authenticationProvider: FakeDashboardAuthentication(),
       );
 
   @override

--- a/app_dart/test/request_handling/dashboard_authentication_test.dart
+++ b/app_dart/test/request_handling/dashboard_authentication_test.dart
@@ -9,26 +9,26 @@ import 'package:cocoon_server/logging.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/model/firestore/account.dart';
 import 'package:cocoon_service/src/model/google/token_info.dart';
-import 'package:cocoon_service/src/request_handling/authentication.dart';
+import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 import '../src/service/fake_firestore_service.dart';
 
 void main() {
   useTestLoggerPerTest();
 
-  group('AuthenticationProvider', () {
+  group('DashboardAuthentication', () {
     late FakeConfig config;
     late FakeFirestoreService firestoreService;
     late FakeClientContext clientContext;
     late FakeHttpRequest request;
-    late AuthenticationProvider auth;
+    late DashboardAuthentication auth;
     late TokenInfo token;
 
     setUp(() {
@@ -37,7 +37,7 @@ void main() {
       token = TokenInfo(email: 'abc123@gmail.com', issued: DateTime.now());
       clientContext = FakeClientContext();
       request = FakeHttpRequest();
-      auth = AuthenticationProvider(
+      auth = DashboardAuthentication(
         config: config,
         clientContextProvider: () => clientContext,
         httpClientProvider: () => throw AssertionError(),
@@ -58,7 +58,7 @@ void main() {
       late MockClient httpClient;
 
       setUp(() {
-        auth = AuthenticationProvider(
+        auth = DashboardAuthentication(
           config: config,
           clientContextProvider: () => clientContext,
           httpClientProvider: () => httpClient,
@@ -72,7 +72,7 @@ void main() {
             HttpStatus.ok,
           ),
         );
-        auth = AuthenticationProvider(
+        auth = DashboardAuthentication(
           config: config,
           clientContextProvider: () => clientContext,
           httpClientProvider: () => httpClient,
@@ -80,6 +80,7 @@ void main() {
         config.oauthClientIdValue = 'client-id';
         request.headers.add('X-Flutter-IdToken', 'authenticated');
         final result = await auth.authenticate(request);
+        expect(result.email, 'EMAIL MISSING');
         expect(result.clientContext, same(clientContext));
         expect(result, isNotNull);
       });
@@ -174,6 +175,7 @@ void main() {
           token,
           clientContext: clientContext,
         );
+        expect(result.email, 'test@gmail.com');
         expect(result.clientContext, same(clientContext));
       });
     });

--- a/app_dart/test/request_handling/pubsub_authentication_test.dart
+++ b/app_dart/test/request_handling/pubsub_authentication_test.dart
@@ -13,7 +13,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 
 void main() {

--- a/app_dart/test/request_handling/subscription_handler_test.dart
+++ b/app_dart/test/request_handling/subscription_handler_test.dart
@@ -16,7 +16,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 
 void main() {
   useTestLoggerPerTest();
@@ -146,7 +146,7 @@ class UnauthTest extends SubscriptionHandler {
     : super(
         cache: CacheService(inMemory: true),
         config: FakeConfig(),
-        authProvider: FakeAuthenticationProvider(authenticated: false),
+        authProvider: FakeDashboardAuthentication(authenticated: false),
         subscriptionName: 'unauth',
       );
 
@@ -160,7 +160,7 @@ class AuthTest extends SubscriptionHandler {
     : super(
         cache: CacheService(inMemory: true),
         config: FakeConfig(),
-        authProvider: FakeAuthenticationProvider(),
+        authProvider: FakeDashboardAuthentication(),
         subscriptionName: 'auth',
       );
 
@@ -174,7 +174,7 @@ class ErrorTest extends SubscriptionHandler {
     : super(
         cache: cache ?? CacheService(inMemory: true),
         config: FakeConfig(),
-        authProvider: FakeAuthenticationProvider(),
+        authProvider: FakeDashboardAuthentication(),
         subscriptionName: 'error',
       );
 
@@ -188,7 +188,7 @@ class ErrorCodeTest extends SubscriptionHandler {
     : super(
         cache: cache ?? CacheService(inMemory: true),
         config: FakeConfig(),
-        authProvider: FakeAuthenticationProvider(),
+        authProvider: FakeDashboardAuthentication(),
         subscriptionName: 'error',
       );
 
@@ -205,7 +205,7 @@ class ReadMessageTest extends SubscriptionHandler {
     : super(
         cache: cache ?? CacheService(inMemory: true),
         config: FakeConfig(),
-        authProvider: FakeAuthenticationProvider(),
+        authProvider: FakeDashboardAuthentication(),
         subscriptionName: 'read',
       );
 

--- a/app_dart/test/request_handling/swarming_authentication_test.dart
+++ b/app_dart/test/request_handling/swarming_authentication_test.dart
@@ -13,7 +13,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import '../src/datastore/fake_config.dart';
-import '../src/request_handling/fake_authentication.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
 import '../src/request_handling/fake_http.dart';
 
 void main() {

--- a/app_dart/test/server_test.dart
+++ b/app_dart/test/server_test.dart
@@ -8,7 +8,7 @@ import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:test/test.dart';
 
 import 'src/datastore/fake_config.dart';
-import 'src/request_handling/fake_authentication.dart';
+import 'src/request_handling/fake_dashboard_authentication.dart';
 import 'src/service/fake_build_bucket_client.dart';
 import 'src/service/fake_build_status_provider.dart';
 import 'src/service/fake_ci_yaml_fetcher.dart';
@@ -21,8 +21,8 @@ void main() {
     createServer(
       config: FakeConfig(webhookKeyValue: 'fake-secret'),
       cache: CacheService(inMemory: true),
-      authProvider: FakeAuthenticationProvider(),
-      swarmingAuthProvider: FakeAuthenticationProvider(),
+      authProvider: FakeDashboardAuthentication(),
+      swarmingAuthProvider: FakeDashboardAuthentication(),
       branchService: BranchService(
         config: FakeConfig(),
         gerritService: FakeGerritService(),

--- a/app_dart/test/src/datastore/fake_config.dart
+++ b/app_dart/test/src/datastore/fake_config.dart
@@ -13,7 +13,7 @@ import 'package:cocoon_service/src/service/luci_build_service/cipd_version.dart'
 import 'package:github/github.dart' as gh;
 import 'package:graphql/client.dart';
 
-import '../request_handling/fake_authentication.dart';
+import '../request_handling/fake_dashboard_authentication.dart';
 import '../service/fake_github_service.dart';
 import 'fake_datastore.dart';
 

--- a/app_dart/test/src/request_handling/api_request_handler_tester.dart
+++ b/app_dart/test/src/request_handling/api_request_handler_tester.dart
@@ -9,7 +9,7 @@ import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/request_handling/request_handler.dart';
 import 'package:meta/meta.dart';
 
-import 'fake_authentication.dart';
+import 'fake_dashboard_authentication.dart';
 import 'request_handler_tester.dart';
 
 class ApiRequestHandlerTester extends RequestHandlerTester {

--- a/app_dart/test/src/request_handling/fake_dashboard_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_dashboard_authentication.dart
@@ -9,12 +9,13 @@ import 'package:cocoon_service/src/foundation/typedefs.dart';
 import 'package:cocoon_service/src/model/appengine/key_helper.dart';
 import 'package:cocoon_service/src/model/google/token_info.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';
+import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
 import 'package:cocoon_service/src/service/config.dart';
 
 // ignore: must_be_immutable
-class FakeAuthenticationProvider implements AuthenticationProvider {
-  FakeAuthenticationProvider({
+class FakeDashboardAuthentication implements DashboardAuthentication {
+  FakeDashboardAuthentication({
     FakeClientContext? clientContext,
     this.authenticated = true,
   }) : clientContext = clientContext ?? FakeClientContext();
@@ -72,6 +73,9 @@ class FakeAuthenticatedContext implements AuthenticatedContext {
 
   @override
   FakeClientContext clientContext;
+
+  @override
+  String email = 'fake@example.com';
 }
 
 class FakeClientContext implements ClientContext {

--- a/app_dart/test/src/request_handling/subscription_tester.dart
+++ b/app_dart/test/src/request_handling/subscription_tester.dart
@@ -11,7 +11,7 @@ import 'package:cocoon_service/src/request_handling/request_handler.dart';
 import 'package:cocoon_service/src/request_handling/subscription_handler.dart';
 import 'package:meta/meta.dart';
 
-import 'fake_authentication.dart';
+import 'fake_dashboard_authentication.dart';
 import 'request_handler_tester.dart';
 
 class SubscriptionTester extends RequestHandlerTester {

--- a/app_dart/tool/local_server.dart
+++ b/app_dart/tool/local_server.dart
@@ -8,6 +8,7 @@ import 'package:appengine/appengine.dart';
 import 'package:cocoon_server_test/fake_secret_manager.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/server.dart';
+import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:cocoon_service/src/service/get_files_changed.dart';
@@ -19,7 +20,7 @@ import '../test/src/service/fake_content_aware_hash_service.dart';
 Future<void> main() async {
   final cache = CacheService(inMemory: false);
   final config = Config(dbService, cache, FakeSecretManager());
-  final authProvider = AuthenticationProvider(config: config);
+  final authProvider = DashboardAuthentication(config: config);
   final AuthenticationProvider swarmingAuthProvider =
       SwarmingAuthenticationProvider(config: config);
 


### PR DESCRIPTION
Towards flutter/flutter/#167006

AuthenticationProvider is too large an API surface and needs to be refactored. This will faclitate adding a new Firebase auth provider.

- Move bulk to DashboardAutehnticationProvider
- Simplify the API in AuthenticationProvider
- Update AuthenticatedContext to offert the one piece of information everyone wants: email (removes the need to call `tokenInfo` API endpoints multiple times.
