### PR TITLE
Hook in FirebaseJwt to dashboard authentication

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -13,6 +13,7 @@ import 'package:cocoon_service/src/request_handling/dashboard_authentication.dar
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
 import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
+import 'package:cocoon_service/src/service/firebase_jwt_validator.dart';
 import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
 import 'package:gcloud/db.dart';
@@ -41,7 +42,10 @@ Future<void> main() async {
         projectId: Config.flutterGcpProjectId,
       ),
     );
-    final authProvider = DashboardAuthentication(config: config);
+    final authProvider = DashboardAuthentication(
+      config: config,
+      firebaseJwtValidator: FirebaseJwtValidator(cache: cache),
+    );
     final AuthenticationProvider swarmingAuthProvider =
         SwarmingAuthenticationProvider(config: config);
 

--- a/app_dart/test/src/request_handling/fake_dashboard_authentication.dart
+++ b/app_dart/test/src/request_handling/fake_dashboard_authentication.dart
@@ -5,13 +5,10 @@
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:cocoon_service/src/foundation/typedefs.dart';
 import 'package:cocoon_service/src/model/appengine/key_helper.dart';
-import 'package:cocoon_service/src/model/google/token_info.dart';
 import 'package:cocoon_service/src/request_handling/authentication.dart';
 import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
-import 'package:cocoon_service/src/service/config.dart';
 
 // ignore: must_be_immutable
 class FakeDashboardAuthentication implements DashboardAuthentication {
@@ -30,39 +27,6 @@ class FakeDashboardAuthentication implements DashboardAuthentication {
     } else {
       throw const Unauthenticated('Not authenticated');
     }
-  }
-
-  @override
-  Future<AuthenticatedContext> authenticateToken(
-    TokenInfo token, {
-    ClientContext? clientContext,
-    Logging? log,
-  }) async {
-    if (authenticated) {
-      return FakeAuthenticatedContext(
-        clientContext: clientContext as FakeClientContext?,
-      );
-    } else {
-      throw const Unauthenticated('Not authenticated');
-    }
-  }
-
-  @override
-  ClientContextProvider get clientContextProvider => throw UnimplementedError();
-
-  @override
-  Config get config => throw UnimplementedError();
-
-  @override
-  HttpClientProvider get httpClientProvider => throw UnimplementedError();
-
-  @override
-  Future<TokenInfo> tokenInfo(
-    HttpRequest request, {
-    Logging? log,
-    String tokenType = 'id_token',
-  }) async {
-    return TokenInfo(email: 'abc@gmail.com', issued: DateTime.now());
   }
 }
 

--- a/app_dart/tool/local_server.dart
+++ b/app_dart/tool/local_server.dart
@@ -8,9 +8,11 @@ import 'package:appengine/appengine.dart';
 import 'package:cocoon_server_test/fake_secret_manager.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/server.dart';
+import 'package:cocoon_service/src/foundation/providers.dart';
 import 'package:cocoon_service/src/request_handling/dashboard_authentication.dart';
 import 'package:cocoon_service/src/service/build_status_provider.dart';
 import 'package:cocoon_service/src/service/commit_service.dart';
+import 'package:cocoon_service/src/service/firebase_jwt_validator.dart';
 import 'package:cocoon_service/src/service/get_files_changed.dart';
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
 import 'package:gcloud/db.dart';
@@ -20,7 +22,10 @@ import '../test/src/service/fake_content_aware_hash_service.dart';
 Future<void> main() async {
   final cache = CacheService(inMemory: false);
   final config = Config(dbService, cache, FakeSecretManager());
-  final authProvider = DashboardAuthentication(config: config);
+  final authProvider = DashboardAuthentication(
+    config: config,
+    firebaseJwtValidator: FirebaseJwtValidator(cache: cache),
+  );
   final AuthenticationProvider swarmingAuthProvider =
       SwarmingAuthenticationProvider(config: config);
 
@@ -31,7 +36,7 @@ Future<void> main() async {
   // Gerrit service class to communicate with GoB.
   final gerritService = GerritService(
     config: config,
-    authClient: authProvider.httpClientProvider(),
+    authClient: Providers.freshHttpClient(),
   );
 
   /// LUCI service class to communicate with buildBucket service.


### PR DESCRIPTION
Towards flutter/flutter#167006

1. Break up DashboardAuthentcationProvider in to specific providers.
2. Extend that list to [cron, googlesignin, firebase]