### PR TITLE
Disable passing `FPEV=...` for release candidates for now.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -57,6 +57,10 @@ class LuciBuildService {
   final GerritService _gerritService;
   final PubSub _pubsub;
 
+  // TODO(matanlurey): Re-enable to true/remove.
+  // See https://github.com/flutter/flutter/issues/167383.
+  static final _useFlutterPrebuiltEngineForReleaseCandidateBuilds = false;
+
   static const int kBackfillPriority = 35;
   static const int kDefaultPriority = 30;
   static const int kRerunPriority = 29;
@@ -852,7 +856,8 @@ class LuciBuildService {
     final isFusion = commit.slug == Config.flutterSlug;
     if (isFusion) {
       processedProperties['is_fusion'] = 'true';
-      if (isReleaseCandidateBranch(branchName: commit.branch)) {
+      if (_useFlutterPrebuiltEngineForReleaseCandidateBuilds &&
+          isReleaseCandidateBranch(branchName: commit.branch)) {
         processedProperties.addAll({
           // Always provide an engine version, just like we do in presubmit.
           // See https://github.com/flutter/flutter/issues/167010.

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -428,8 +428,11 @@ void main() {
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
+      // TODO(matanlurey): Re-enable in https://github.com/flutter/flutter/issues/167383.
+      /*
       'flutter_prebuilt_engine_version': bbv2.Value(stringValue: commit.sha),
       'flutter_realm': bbv2.Value(stringValue: ''),
+      */
     });
 
     expect(scheduleBuild.dimensions, [


### PR DESCRIPTION
At the moment, the ability to re-run prod tasks does not work (work gated on finishing the Firestore migration), and as such, we need the ability for `engine.version` files to work in post-submit so that there is a reliable way to test, otherwise it is not reasonably feasible (without hacking on the backend).

See https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=flutter-3.32-candidate.0.

![image](https://github.com/user-attachments/assets/704c205a-50d6-4951-8d0b-151eb2037afd)

Filed https://github.com/flutter/flutter/issues/167383 to track re-enabling this.

/cc @reidbaker