### PR TITLE
Fix `policy.triggerPriority`

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -231,7 +231,7 @@ class Scheduler {
         policy = const GuaranteedPolicy();
       }
       final priority = await policy.triggerPriority(
-        taskName: task.name!,
+        taskName: task.taskName,
         commitSha: commit.sha,
         recentTasks: await firestoreService.queryRecentTasks(name: task.name!),
       );

--- a/app_dart/lib/src/service/scheduler/policy.dart
+++ b/app_dart/lib/src/service/scheduler/policy.dart
@@ -75,7 +75,7 @@ final class BatchPolicy implements SchedulerPolicy {
       (Task t) => t.taskName == taskName && t.commitSha == commitSha,
     );
     if (recentTasks.length < kBatchSize) {
-      log.warn(
+      log.debug(
         '$taskName has less than $kBatchSize, skip scheduling to wait for '
         'ci.yaml roll.',
       );


### PR DESCRIPTION
Oops!

This is a mistype that queries by the full document name instead of the name of the task!