### PR TITLE
Treat `rerun-prod-task?task=all` as marking all statuses as new.

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -63,6 +63,7 @@ mixin FirestoreQueries {
     int? limit,
     Map<String, String>? orderMap,
     String compositeFilterOp = kCompositeFilterOpAnd,
+    Transaction? transaction,
   });
 
   /// Queries for recent commits.
@@ -100,6 +101,7 @@ mixin FirestoreQueries {
     String? name,
     String? status,
     String? commitSha,
+    Transaction? transaction,
   }) async {
     final filterMap = {
       if (name != null) '${Task.fieldName} =': name,
@@ -123,6 +125,7 @@ mixin FirestoreQueries {
       kTaskCollectionId,
       filterMap,
       orderMap: orderMap,
+      transaction: transaction,
     );
     return [...documents.map(Task.fromDocument)];
   }
@@ -149,12 +152,14 @@ mixin FirestoreQueries {
     required String commitSha,
     String? status,
     String? name,
+    Transaction? transaction,
   }) async {
     return await _queryTasks(
       limit: null,
       commitSha: commitSha,
       status: status,
       name: name,
+      transaction: transaction,
     );
   }
 
@@ -441,6 +446,7 @@ class FirestoreService with FirestoreQueries {
     int? limit,
     Map<String, String>? orderMap,
     String compositeFilterOp = kCompositeFilterOpAnd,
+    Transaction? transaction,
   }) async {
     final from = <CollectionSelector>[
       CollectionSelector(collectionId: collectionId),
@@ -454,6 +460,7 @@ class FirestoreService with FirestoreQueries {
         orderBy: orders,
         limit: limit,
       ),
+      transaction: transaction?.identifier,
     );
     final runQueryResponseElements = await _api.projects.databases.documents
         .runQuery(runQueryRequest, kDocumentParent);

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -163,7 +163,8 @@ class Scheduler {
     // TODO(matanlurey): Expand to every release candidate branch instead of a test branch.
     // See https://github.com/flutter/flutter/issues/163896.
     var markAllTasksSkipped = false;
-    if (branch == 'flutter-0.42-candidate.0') {
+    if (branch == 'flutter-0.42-candidate.0' ||
+        branch == 'flutter-3.32-candidate.0') {
       markAllTasksSkipped = true;
       log.info(
         '[release-candidate-postsubmit-skip] For merged PR ${pr.number}, SHA=$sha, skipping all post-submit tasks',

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -159,7 +159,7 @@ void main() {
     );
   });
 
-  test('Rerun all failed tasks when task name is all', () async {
+  test('Mark all failed tasks for rerun task name is all', () async {
     final fsCommit = generateFirestoreCommit(1);
     final fsTaskA = generateFirestoreTask(
       2,
@@ -186,14 +186,39 @@ void main() {
 
     await tester.post(handler);
 
-    verify(
+    verifyNever(
       mockLuciBuildService.checkRerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
         task: anyNamed('task'),
       ),
-    ).called(2);
+    );
+
+    expect(
+      firestoreService,
+      existsInStorage(
+        fs.Task.metadata,
+        unorderedEquals([
+          isTask
+              .hasTaskName('Linux A')
+              .hasStatus(fs.Task.statusFailed)
+              .hasCurrentAttempt(1),
+          isTask
+              .hasTaskName('Linux A')
+              .hasStatus(fs.Task.statusNew)
+              .hasCurrentAttempt(2),
+          isTask
+              .hasTaskName('Mac A')
+              .hasStatus(fs.Task.statusFailed)
+              .hasCurrentAttempt(1),
+          isTask
+              .hasTaskName('Mac A')
+              .hasStatus(fs.Task.statusNew)
+              .hasCurrentAttempt(2),
+        ]),
+      ),
+    );
   });
 
   test('Rerun all runs nothing when everything is passed', () async {
@@ -277,14 +302,89 @@ void main() {
     };
     await tester.post(handler);
 
-    verify(
+    verifyNever(
       mockLuciBuildService.checkRerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
         task: anyNamed('task'),
       ),
-    ).called(1);
+    );
+
+    expect(
+      firestoreService,
+      existsInStorage(
+        fs.Task.metadata,
+        unorderedEquals([
+          isTask
+              .hasTaskName('Windows A')
+              .hasStatus(fs.Task.statusSkipped)
+              .hasCurrentAttempt(1),
+          isTask
+              .hasTaskName('Windows A')
+              .hasStatus(fs.Task.statusNew)
+              .hasCurrentAttempt(2),
+        ]),
+      ),
+    );
+  });
+
+  test('Rerun all cancels in-progress tasks', () async {
+    final fsCommit = generateFirestoreCommit(1);
+    firestoreService.putDocument(fsCommit);
+    firestoreService.putDocument(
+      generateFirestoreTask(
+        2,
+        name: 'Windows A',
+        commitSha: fsCommit.sha,
+        status: fs.Task.statusInProgress,
+      ),
+    );
+
+    tester.requestData = {
+      'branch': fsCommit.branch,
+      'repo': fsCommit.slug.name,
+      'commit': fsCommit.sha,
+      'task': 'all',
+      'include': Task.statusInProgress,
+    };
+    await tester.post(handler);
+
+    verifyNever(
+      mockLuciBuildService.checkRerunBuilder(
+        commit: anyNamed('commit'),
+        target: anyNamed('target'),
+        tags: anyNamed('tags'),
+        task: anyNamed('task'),
+      ),
+    );
+
+    expect(
+      firestoreService,
+      existsInStorage(
+        fs.Task.metadata,
+        unorderedEquals([
+          isTask
+              .hasTaskName('Windows A')
+              .hasStatus(fs.Task.statusCancelled)
+              .hasCurrentAttempt(1),
+          isTask
+              .hasTaskName('Windows A')
+              .hasStatus(fs.Task.statusNew)
+              .hasCurrentAttempt(2),
+        ]),
+      ),
+    );
+
+    verify(
+      mockLuciBuildService.cancelBuildsBySha(
+        sha: argThat(equals(fsCommit.sha), named: 'sha'),
+        reason: argThat(
+          contains('cancelled build to schedule a fresh '),
+          named: 'reason',
+        ),
+      ),
+    );
   });
 
   test('Rerun all can verifies included statuses are valid', () async {

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -412,6 +412,8 @@ abstract base class _FakeInMemoryFirestoreService
     int? limit,
     Map<String, String>? orderMap,
     String compositeFilterOp = kCompositeFilterOpAnd,
+    // TODO(matanlurey): Consider implementing read transactions.
+    Transaction? transaction,
   }) async {
     var results = documents.where((document) {
       final collection = p.basename(p.dirname(document.name!));


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/165816.

Since we have several hundred tasks, scheduling them all in an RPC is not viable. This PR repurposes `rerun-prod-task?task=all` (the RPC powering the button labeled below) to mark all tasks as `New`, so that the _backfiller_ picks them up. We can change priorities (i.e. have the backfiller fill release candidates with priority) in a future PR if desired.

Also changes the branch to run the query/updates in a transaction.

![Screenshot 2025-04-21 at 10 52 52 AM](https://github.com/user-attachments/assets/e2b9e3fa-7491-47c4-aaba-c142ef25a0d3)


- Towards https://github.com/flutter/flutter/issues/163896.
- Unblocks https://github.com/flutter/flutter/issues/165078.
- Unblocks https://github.com/flutter/flutter/issues/167383.
