### PR TITLE
Add a `log.debug` before calling `fetchStreamed`.

### DIFF
--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
 import 'package:http/http.dart';
 
@@ -42,18 +43,21 @@ class GithubService {
 
     var commits = <Map<String, dynamic>>[];
 
-    /// [lastCommitTimestamp+1] excludes last commit itself.
-    /// Github api url: https://developer.github.com/v3/repos/commits/#list-commits
-    await for (Response response in paginationHelper.fetchStreamed(
+    // [lastCommitTimestamp+1] excludes last commit itself.
+    // Github api url: https://developer.github.com/v3/repos/commits/#list-commits
+    final path = '/repos/${slug.fullName}/commits';
+    final params = {
+      'sha': branch,
+      'since':
+          DateTime.fromMillisecondsSinceEpoch(
+            (lastCommitTimestampMills ?? 0) + 1,
+          ).toUtc().toIso8601String(),
+    };
+    log.debug('Calling ${Uri(path: path, queryParameters: params)}');
+    await for (final response in paginationHelper.fetchStreamed(
       'GET',
-      '/repos/${slug.fullName}/commits',
-      params: <String, dynamic>{
-        'sha': branch,
-        'since':
-            DateTime.fromMillisecondsSinceEpoch(
-              (lastCommitTimestampMills ?? 0) + 1,
-            ).toUtc().toIso8601String(),
-      },
+      path,
+      params: params,
       pages: pages,
       headers: headers,
     )) {


### PR DESCRIPTION
Hope to get more context on why errors such as [this](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2025-04-21T22:04:20.652Z;duration=PT6H;query=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22default%22%0AprotoPayload.resource!%3D%22readiness_check%22%0Aseverity%3E%3DWARNING%0Atimestamp%3D%222025-04-21T22:04:20.652Z%22%0AinsertId%3D%2229c4hxf48wnsf%22?project=flutter-dashboard) occur in production.