### PR TITLE
Fix `rerun-all` logic with cases involving `flutter_release_builder`.

### DIFF
--- a/app_dart/lib/src/service/firestore/commit_and_tasks.dart
+++ b/app_dart/lib/src/service/firestore/commit_and_tasks.dart
@@ -30,9 +30,10 @@ final class CommitAndTasks {
   CommitAndTasks withMostRecentTaskOnly() {
     final mostRecent = <String, Task>{};
     for (final task in tasks) {
-      mostRecent.update(task.taskName, (current) {
-        return current.currentAttempt > task.createTimestamp ? current : task;
-      }, ifAbsent: () => task);
+      final previous = mostRecent[task.taskName];
+      if (previous == null || previous.currentAttempt < task.currentAttempt) {
+        mostRecent[task.taskName] = task;
+      }
     }
     return CommitAndTasks(commit, mostRecent.values);
   }

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -313,18 +313,69 @@ void main() {
 
     expect(
       firestore,
+      existsInStorage(fs.Task.metadata, [
+        isTask
+            .hasTaskName('Windows A')
+            .hasStatus(fs.Task.statusNew)
+            .hasCurrentAttempt(1),
+      ]),
+    );
+  });
+
+  test('Rerun all cancels in-progress tasks', () async {
+    final fsCommit = generateFirestoreCommit(1);
+    firestore.putDocument(fsCommit);
+    firestore.putDocument(
+      generateFirestoreTask(
+        2,
+        name: 'Windows A',
+        commitSha: fsCommit.sha,
+        status: fs.Task.statusInProgress,
+      ),
+    );
+
+    tester.requestData = {
+      'branch': fsCommit.branch,
+      'repo': fsCommit.slug.name,
+      'commit': fsCommit.sha,
+      'task': 'all',
+      'include': Task.statusInProgress,
+    };
+    await tester.post(handler);
+
+    verifyNever(
+      mockLuciBuildService.checkRerunBuilder(
+        commit: anyNamed('commit'),
+        target: anyNamed('target'),
+        tags: anyNamed('tags'),
+        task: anyNamed('task'),
+      ),
+    );
+
+    expect(
+      firestore,
       existsInStorage(
         fs.Task.metadata,
         unorderedEquals([
           isTask
               .hasTaskName('Windows A')
-              .hasStatus(fs.Task.statusSkipped)
+              .hasStatus(fs.Task.statusCancelled)
               .hasCurrentAttempt(1),
           isTask
               .hasTaskName('Windows A')
               .hasStatus(fs.Task.statusNew)
               .hasCurrentAttempt(2),
         ]),
+      ),
+    );
+
+    verify(
+      mockLuciBuildService.cancelBuildsBySha(
+        sha: argThat(equals(fsCommit.sha), named: 'sha'),
+        reason: argThat(
+          contains('cancelled build to schedule a fresh '),
+          named: 'reason',
+        ),
       ),
     );
   });
@@ -408,6 +459,129 @@ void main() {
           contains('Invalid "include" statuses: Malformed.'),
         ),
       ),
+    );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/167600.
+  test('Rerun all only considers the latest task for each target', () async {
+    final date = DateTime(2025, 1, 1);
+    final commit = generateFirestoreCommit(1);
+
+    firestore.putDocuments([
+      commit,
+      generateFirestoreTask(
+        1,
+        name: 'Linux flutter_release_builder',
+        attempts: 1,
+        status: fs.Task.statusFailed,
+        commitSha: '1',
+        created: date,
+      ),
+      generateFirestoreTask(
+        2,
+        name: 'Linux flutter_release_builder',
+        attempts: 2,
+        status: fs.Task.statusSucceeded,
+        commitSha: '1',
+        created: date.add(const Duration(hours: 1)),
+      ),
+      generateFirestoreTask(
+        3,
+        name: 'Linux depends_on_release_builder_passing_first',
+        attempts: 1,
+        status: fs.Task.statusSkipped,
+        commitSha: '1',
+        created: date,
+      ),
+    ]);
+
+    tester.requestData = {
+      'branch': commit.branch,
+      'repo': commit.slug.name,
+      'commit': commit.sha,
+      'task': 'all',
+      'include': 'Skipped',
+    };
+
+    await tester.post(handler);
+
+    expect(
+      firestore,
+      existsInStorage(fs.Task.metadata, [
+        isTask
+            .hasTaskName('Linux flutter_release_builder')
+            .hasCurrentAttempt(1)
+            .hasStatus(fs.Task.statusFailed),
+        isTask
+            .hasTaskName('Linux flutter_release_builder')
+            .hasCurrentAttempt(2)
+            .hasStatus(fs.Task.statusSucceeded),
+        isTask
+            .hasTaskName('Linux depends_on_release_builder_passing_first')
+            .hasCurrentAttempt(1)
+            .hasStatus(fs.Task.statusNew),
+      ]),
+    );
+  });
+
+  test('Rerun specific refuses flutter_release_builder', () async {
+    final commit = generateFirestoreCommit(1);
+
+    firestore.putDocuments([
+      commit,
+      generateFirestoreTask(
+        1,
+        name: 'Linux flutter_release_builder',
+        attempts: 1,
+        status: fs.Task.statusFailed,
+        commitSha: '1',
+      ),
+    ]);
+
+    tester.requestData = {
+      'branch': commit.branch,
+      'repo': commit.slug.name,
+      'commit': commit.sha,
+      'task': 'Linux flutter_release_builder',
+    };
+
+    await expectLater(
+      tester.post(handler),
+      throwsA(isA<BadRequestException>()),
+    );
+  });
+
+  test('Rerun all ignores flutter_release_builder', () async {
+    final commit = generateFirestoreCommit(1);
+
+    firestore.putDocuments([
+      commit,
+      generateFirestoreTask(
+        1,
+        name: 'Linux flutter_release_builder',
+        attempts: 1,
+        status: fs.Task.statusFailed,
+        commitSha: '1',
+      ),
+    ]);
+
+    tester.requestData = {
+      'branch': commit.branch,
+      'repo': commit.slug.name,
+      'commit': commit.sha,
+      'task': 'all',
+    };
+
+    await tester.post(handler);
+
+    expect(
+      firestore,
+      existsInStorage(fs.Task.metadata, [
+        isTask
+            .hasTaskName('Linux flutter_release_builder')
+            .hasCurrentAttempt(1)
+            .hasStatus(fs.Task.statusFailed),
+      ]),
     );
   });
 

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -4,8 +4,12 @@
 
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/service/firestore.dart';
+import 'package:cocoon_service/src/service/firestore/commit_and_tasks.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:test/test.dart';
+
+import '../src/service/fake_firestore_service.dart';
+import '../src/utilities/entity_generators.dart';
 
 void main() {
   useTestLoggerPerTest();
@@ -19,5 +23,19 @@ void main() {
     expect(writes.length, documents.length);
     expect(writes[0].update, documents[0]);
     expect(writes[0].currentDocument!.exists, false);
+  });
+
+  group('CommitAndTasks', () {
+    test('withMostRecentTaskOnly returns the largest currentAttempt', () {
+      final commit = CommitAndTasks(generateFirestoreCommit(1), [
+        generateFirestoreTask(1, name: 'Linux A', attempts: 2),
+        generateFirestoreTask(1, name: 'Linux A', attempts: 1),
+        generateFirestoreTask(1, name: 'Linux A', attempts: 3),
+      ]);
+      final recent = commit.withMostRecentTaskOnly();
+      expect(recent.tasks, [
+        isTask.hasTaskName('Linux A').hasCurrentAttempt(3),
+      ]);
+    });
   });
 }

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -351,7 +351,18 @@ abstract base class _FakeInMemoryFirestoreService
       _documents
         ..clear()
         ..addAll(beforeTransaction);
-      throw DetailedApiRequestError(500, 'The transaction was aborted');
+      if (_failOnTransactionCommit) {
+        throw DetailedApiRequestError(
+          500,
+          'The transaction was aborted: failOnTransactionCommit() was used to '
+          'simulate a backend failure.',
+        );
+      }
+      throw DetailedApiRequestError(
+        500,
+        'The transaction was aborted:\n'
+        '${result.where((r) => r.code != 0).map((r) => r.message).join('\n')}',
+      );
     }
 
     final updated = _now().toUtc().toIso8601String();


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167600.

Prior to this PR, there were multiple bugs:

- Most "recent" task was computed incorrectly (regression test added)
- It wasn't clear how we handled `flutter_release_builder` (made explicit ignore/error cases now)