### PR TITLE
Backfill release candidates commits (otherwise are ignored)

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -127,12 +127,14 @@ Server createServer({
       ciYamlFetcher: ciYamlFetcher,
       luciBuildService: luciBuildService,
       firestore: firestore,
+      branchService: branchService,
     ),
     '/api/v2/scheduler/batch-backfiller': BatchBackfiller(
       config: config,
       ciYamlFetcher: ciYamlFetcher,
       luciBuildService: luciBuildService,
       firestore: firestore,
+      branchService: branchService,
     ),
     '/api/v2/scheduler/batch-request-subscription':
         SchedulerRequestSubscription(

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -61,7 +61,7 @@ final class BatchBackfiller extends RequestHandler {
     // 2025-04-23 is every 5 minutes, so this is `3 * 5 * 12` or 180 calls to
     // GitHub per hour.
     //
-    // We could either:
+    // We could possibly do one of the following to mitigate:
     // - Use `githubFileContent`, which doesn't use the GitHub API (uses CDN);
     // - Cache the result and read this less often (it does change, but rarely);
     // - Have some sort of job that periodically updates a Firestore document:

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:cocoon_common/is_release_branch.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
 import 'package:meta/meta.dart';
@@ -31,34 +32,81 @@ final class BatchBackfiller extends RequestHandler {
     required CiYamlFetcher ciYamlFetcher,
     required LuciBuildService luciBuildService,
     required FirestoreService firestore,
+    required BranchService branchService,
     BackfillStrategy backfillerStrategy = const DefaultBackfillStrategy(),
   }) : _ciYamlFetcher = ciYamlFetcher,
        _luciBuildService = luciBuildService,
        _backfillerStrategy = backfillerStrategy,
-       _firestore = firestore;
+       _firestore = firestore,
+       _branchService = branchService;
 
   final LuciBuildService _luciBuildService;
   final CiYamlFetcher _ciYamlFetcher;
   final BackfillStrategy _backfillerStrategy;
   final FirestoreService _firestore;
+  final BranchService _branchService;
 
   @override
   Future<Body> get() async {
-    await Future.forEach(config.supportedRepos, _backfillRepository);
+    await Future.forEach(config.supportedRepos, _backfillDefaultBranch);
+    await _backfillReleaseBranch(Config.flutterSlug);
     return Body.empty;
   }
 
-  Future<void> _backfillRepository(RepositorySlug slug) async {
-    log.debug('Running backfiller for "$slug"');
+  Future<void> _backfillReleaseBranch(RepositorySlug slug) async {
+    log.debug('Running release branch backfiller for "$slug"');
+
+    // TODO(matanlurey): This is a tad inefficient, as it means we will make
+    // X calls to GitHub every invocation of the Batch Backfiller, which as of
+    // 2025-04-23 is every 5 minutes, so this is `3 * 5 * 12` or 180 calls to
+    // GitHub per hour.
+    //
+    // We could either:
+    // - Use `githubFileContent`, which doesn't use the GitHub API (uses CDN);
+    // - Cache the result and read this less often (it does change, but rarely);
+    // - Have some sort of job that periodically updates a Firestore document:
+    //   collectionId="release_branches"
+    //   [
+    //     {"channel": "...", "reference: "..."},
+    //     {"channel": "...", "reference: "..."},
+    //     {"channel": "...", "reference: "..."},
+    //   ]
+    final branches = await _branchService.getReleaseBranches(slug: slug);
+    for (final branch in branches) {
+      if (!isReleaseCandidateBranch(branchName: branch.reference)) {
+        continue;
+      }
+      final fsGrid = await _firestore.queryRecentCommitsAndTasks(
+        slug,
+        commitLimit: config.backfillerCommitLimit,
+        branch: branch.reference,
+      );
+      await _doBackfillFrom(slug, fsGrid);
+    }
+  }
+
+  Future<void> _backfillDefaultBranch(RepositorySlug slug) async {
+    log.debug('Running default branch backfiller for "$slug"');
+    final fsGrid = await _firestore.queryRecentCommitsAndTasks(
+      slug,
+      commitLimit: config.backfillerCommitLimit,
+      branch: Config.defaultBranch(slug),
+    );
+    return await _doBackfillFrom(slug, fsGrid);
+  }
+
+  Future<void> _doBackfillFrom(
+    RepositorySlug slug,
+    List<CommitAndTasks> fsGrid,
+  ) async {
+    if (fsGrid.isEmpty) {
+      log.warn('No commits to backfill');
+      return;
+    }
 
     // Fetch and build a "grid" of List<(OpaqueCommit, List<OpaqueTask>>).
     final BackfillGrid grid;
     {
-      // TODO(matanlurey): Switch this to use Firestore.
-      final fsGrid = await _firestore.queryRecentCommitsAndTasks(
-        slug,
-        commitLimit: config.backfillerCommitLimit,
-      );
       log.debug(
         'Fetched ${fsGrid.length} commits and '
         '${fsGrid.map((i) => i.tasks).expand((i) => i).length} tasks',

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -172,8 +172,13 @@ mixin FirestoreQueries {
     RepositorySlug slug, {
     required int commitLimit,
     String? status,
+    String? branch,
   }) async {
-    final commits = await queryRecentCommits(slug: slug, limit: commitLimit);
+    final commits = await queryRecentCommits(
+      slug: slug,
+      limit: commitLimit,
+      branch: branch,
+    );
     return [
       for (final commit in commits)
         CommitAndTasks(


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167675.

I think using `githubFileContent` (the same technique used by `CiYamlFetcher`) is the best way to reduce the GitHub API cost of this added operation, but I could be talked into either just letting it stand, or going for another option (caching, batch updates, etc).