### PR TITLE
Remove legacy key `firestore_task_document_name` from UserData.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service/user_data.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.dart
@@ -142,23 +142,10 @@ final class PostsubmitUserData extends BuildBucketUserData {
   final int? checkRunId;
 
   /// The firestore task document name storing results of this build.
-  @JsonKey(
-    name: 'task_id',
-    fromJson: TaskId.parse,
-    toJson: _documentToString,
-
-    // TODO(matanlurey): Remove after a week in production.
-    // See https://github.com/flutter/flutter/issues/167464.
-    readValue: _readTaskIdDuringMigration,
-  )
+  @JsonKey(name: 'task_id', fromJson: TaskId.parse, toJson: _documentToString)
   final TaskId taskId;
   static String _documentToString(TaskId firestoreTask) {
     return firestoreTask.documentId;
-  }
-
-  static Object? _readTaskIdDuringMigration(Map map, String _) {
-    // Check task_id, and fallback to firestore_task_document_name.
-    return map['task_id'] ?? map['firestore_task_document_name'];
   }
 
   @override

--- a/app_dart/test/service/luci_build_service/user_data_test.dart
+++ b/app_dart/test/service/luci_build_service/user_data_test.dart
@@ -104,23 +104,6 @@ void main() {
       );
     });
 
-    test('should decode from JSON (legacy key)', () {
-      expect(
-        PostsubmitUserData.fromJson(const {
-          'check_run_id': 1234,
-          'firestore_task_document_name': 'abc123_task-name_1',
-        }),
-        PostsubmitUserData(
-          checkRunId: 1234,
-          taskId: firestore.TaskId(
-            commitSha: 'abc123',
-            currentAttempt: 1,
-            taskName: 'task-name',
-          ),
-        ),
-      );
-    });
-
     test('should gracefully fail decoding if the format is invalid', () {
       expect(
         () => PostsubmitUserData.fromJson(const {'check_run_id': 1234}),


### PR DESCRIPTION
It's been 3 days since we replaced it with `task_id`.

Closes https://github.com/flutter/flutter/issues/167464.