### PR TITLE
Make `dev/customer_testing/tests.version` test exempt

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -653,6 +653,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('packages/flutter_tools/gradle/src/test/') ||
         filename.startsWith('dev/bots/analyze.dart') ||
         filename.startsWith('dev/bots/test.dart') ||
+        filename.startsWith('dev/customer_testing/tests.version') ||
         filename.startsWith('dev/devicelab/bin/tasks') ||
         filename.startsWith('dev/devicelab/lib/tasks') ||
         filename.startsWith('dev/benchmarks') ||

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -653,7 +653,6 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.startsWith('packages/flutter_tools/gradle/src/test/') ||
         filename.startsWith('dev/bots/analyze.dart') ||
         filename.startsWith('dev/bots/test.dart') ||
-        filename.startsWith('dev/customer_testing/tests.version') ||
         filename.startsWith('dev/devicelab/bin/tasks') ||
         filename.startsWith('dev/devicelab/lib/tasks') ||
         filename.startsWith('dev/benchmarks') ||
@@ -677,6 +676,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
         filename.contains('.github/') ||
         filename.endsWith('.md') ||
         // Exempt paths.
+        filename.startsWith('dev/customer_testing/tests.version') ||
         filename.startsWith('dev/devicelab/lib/versions/gallery.dart') ||
         filename.startsWith('dev/integration_tests/') ||
         filename.startsWith('docs/') ||

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -162,12 +162,12 @@ void main() {
       gerritService: gerritService,
       scheduler: scheduler,
       commitService: commitService,
-      pullRequestLabelProcessorProvider: ({
-        required Config config,
-        required GithubService githubService,
-        required PullRequest pullRequest,
-      }) =>
-          mockPullRequestLabelProcessor,
+      pullRequestLabelProcessorProvider:
+          ({
+            required Config config,
+            required GithubService githubService,
+            required PullRequest pullRequest,
+          }) => mockPullRequestLabelProcessor,
       now: () => fakeNow,
     );
   });
@@ -674,9 +674,10 @@ void main() {
 
       await tester.post(webhook);
 
-      final reviews = verify(
-        pullRequestsService.createReview(Config.flutterSlug, captureAny),
-      ).captured;
+      final reviews =
+          verify(
+            pullRequestsService.createReview(Config.flutterSlug, captureAny),
+          ).captured;
       expect(reviews.length, 1);
       final review = reviews.single as CreatePullRequestReview;
       expect(review.event, 'APPROVE');
@@ -1291,8 +1292,7 @@ void main() {
       );
     });
 
-    test('Framework no comment if only dev bots or devicelab changed',
-        () async {
+    test('Framework no comment if only dev bots or devicelab changed', () async {
       const issueNumber = 123;
       tester.message = generateGithubWebhookMessage(
         action: 'opened',
@@ -1419,37 +1419,39 @@ void main() {
       );
     });
 
-    test('Framework no test comment if customer testing version changed',
-        () async {
-      const issueNumber = 123;
-      tester.message = generateGithubWebhookMessage(
-        action: 'opened',
-        number: issueNumber,
-      );
+    test(
+      'Framework no test comment if customer testing version changed',
+      () async {
+        const issueNumber = 123;
+        tester.message = generateGithubWebhookMessage(
+          action: 'opened',
+          number: issueNumber,
+        );
 
-      when(
-        pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
-      ).thenAnswer(
-        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-          // Change to random other file.
-          PullRequestFile()
-            ..filename =
-                'packages/flutter_tools/gradle/src/main/kotlin/Deeplink.kt',
-          // Change to the customer version file.
-          PullRequestFile()..filename = 'dev/customer_testing/tests.version',
-        ]),
-      );
+        when(
+          pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
+        ).thenAnswer(
+          (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+            // Change to random other file.
+            PullRequestFile()
+              ..filename =
+                  'packages/flutter_tools/gradle/src/main/kotlin/Deeplink.kt',
+            // Change to the customer version file.
+            PullRequestFile()..filename = 'dev/customer_testing/tests.version',
+          ]),
+        );
 
-      await tester.post(webhook);
+        await tester.post(webhook);
 
-      verifyNever(
-        issuesService.createComment(
-          Config.flutterSlug,
-          issueNumber,
-          argThat(contains(config.missingTestsPullRequestMessageValue)),
-        ),
-      );
-    });
+        verifyNever(
+          issuesService.createComment(
+            Config.flutterSlug,
+            issueNumber,
+            argThat(contains(config.missingTestsPullRequestMessageValue)),
+          ),
+        );
+      },
+    );
 
     test('Framework no comment if only AUTHORS changed', () async {
       const issueNumber = 123;
@@ -1989,9 +1991,11 @@ void foo() {
         ],
       ];
 
-      for (var issueNumber = 0;
-          issueNumber < pullRequestFileList.length;
-          issueNumber++) {
+      for (
+        var issueNumber = 0;
+        issueNumber < pullRequestFileList.length;
+        issueNumber++
+      ) {
         tester.message = generateGithubWebhookMessage(
           action: 'opened',
           number: issueNumber,
@@ -2730,21 +2734,21 @@ void foo() {
 
         fakeBuildBucketClient.batchResponse =
             (_, _) => Future<bbv2.BatchResponse>.value(
-                  bbv2.BatchResponse(
-                    responses: <bbv2.BatchResponse_Response>[
-                      bbv2.BatchResponse_Response(
-                        searchBuilds: bbv2.SearchBuildsResponse(
-                          builds: <bbv2.Build>[],
-                        ),
-                      ),
-                      bbv2.BatchResponse_Response(
-                        searchBuilds: bbv2.SearchBuildsResponse(
-                          builds: <bbv2.Build>[],
-                        ),
-                      ),
-                    ],
+              bbv2.BatchResponse(
+                responses: <bbv2.BatchResponse_Response>[
+                  bbv2.BatchResponse_Response(
+                    searchBuilds: bbv2.SearchBuildsResponse(
+                      builds: <bbv2.Build>[],
+                    ),
                   ),
-                );
+                  bbv2.BatchResponse_Response(
+                    searchBuilds: bbv2.SearchBuildsResponse(
+                      builds: <bbv2.Build>[],
+                    ),
+                  ),
+                ],
+              ),
+            );
 
         tester.message = generateGithubWebhookMessage(
           action: action,
@@ -2806,33 +2810,33 @@ void foo() {
         () async {
           fakeBuildBucketClient.batchResponse =
               (_, _) => Future<bbv2.BatchResponse>.value(
-                    bbv2.BatchResponse(
-                      responses: <bbv2.BatchResponse_Response>[
-                        bbv2.BatchResponse_Response(
-                          searchBuilds: bbv2.SearchBuildsResponse(
-                            builds: <bbv2.Build>[
-                              bbv2.Build(
-                                number: 999,
-                                builder: bbv2.BuilderID(builder: 'Linux'),
-                                status: bbv2.Status.ENDED_MASK,
-                              ),
-                            ],
+                bbv2.BatchResponse(
+                  responses: <bbv2.BatchResponse_Response>[
+                    bbv2.BatchResponse_Response(
+                      searchBuilds: bbv2.SearchBuildsResponse(
+                        builds: <bbv2.Build>[
+                          bbv2.Build(
+                            number: 999,
+                            builder: bbv2.BuilderID(builder: 'Linux'),
+                            status: bbv2.Status.ENDED_MASK,
                           ),
-                        ),
-                        bbv2.BatchResponse_Response(
-                          searchBuilds: bbv2.SearchBuildsResponse(
-                            builds: <bbv2.Build>[
-                              bbv2.Build(
-                                number: 998,
-                                builder: bbv2.BuilderID(builder: 'Linux'),
-                                status: bbv2.Status.ENDED_MASK,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
-                  );
+                    bbv2.BatchResponse_Response(
+                      searchBuilds: bbv2.SearchBuildsResponse(
+                        builds: <bbv2.Build>[
+                          bbv2.Build(
+                            number: 998,
+                            builder: bbv2.BuilderID(builder: 'Linux'),
+                            status: bbv2.Status.ENDED_MASK,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
 
           tester.message = generateGithubWebhookMessage(
             action: 'synchronize',
@@ -3188,8 +3192,7 @@ void foo() {
       ];
     });
 
-    test('checks_requested success for non-fusion repository (simulated)',
-        () async {
+    test('checks_requested success for non-fusion repository (simulated)', () async {
       tester.message = generateMergeGroupMessage(
         repository: 'flutter/packages',
         action: 'checks_requested',
@@ -3337,12 +3340,14 @@ void foo() {
 
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
-            final requestSha = request.searchBuilds.predicate.tags
-                .singleWhere((tag) => tag.key == 'buildset')
-                .value;
-            final userAgent = request.searchBuilds.predicate.tags
-                .singleWhere((tag) => tag.key == 'user_agent')
-                .value;
+            final requestSha =
+                request.searchBuilds.predicate.tags
+                    .singleWhere((tag) => tag.key == 'buildset')
+                    .value;
+            final userAgent =
+                request.searchBuilds.predicate.tags
+                    .singleWhere((tag) => tag.key == 'user_agent')
+                    .value;
             luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
@@ -3461,12 +3466,14 @@ void foo() {
 
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
-            final requestSha = request.searchBuilds.predicate.tags
-                .singleWhere((tag) => tag.key == 'buildset')
-                .value;
-            final userAgent = request.searchBuilds.predicate.tags
-                .singleWhere((tag) => tag.key == 'user_agent')
-                .value;
+            final requestSha =
+                request.searchBuilds.predicate.tags
+                    .singleWhere((tag) => tag.key == 'buildset')
+                    .value;
+            final userAgent =
+                request.searchBuilds.predicate.tags
+                    .singleWhere((tag) => tag.key == 'user_agent')
+                    .value;
             luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
@@ -3525,8 +3532,7 @@ void foo() {
       );
     });
 
-    test('does not cancel builds if destroyed because merged successfully',
-        () async {
+    test('does not cancel builds if destroyed because merged successfully', () async {
       tester.message = generateMergeGroupMessage(
         repository: 'flutter/flutter',
         action: 'destroyed',

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -162,12 +162,12 @@ void main() {
       gerritService: gerritService,
       scheduler: scheduler,
       commitService: commitService,
-      pullRequestLabelProcessorProvider:
-          ({
-            required Config config,
-            required GithubService githubService,
-            required PullRequest pullRequest,
-          }) => mockPullRequestLabelProcessor,
+      pullRequestLabelProcessorProvider: ({
+        required Config config,
+        required GithubService githubService,
+        required PullRequest pullRequest,
+      }) =>
+          mockPullRequestLabelProcessor,
       now: () => fakeNow,
     );
   });
@@ -674,10 +674,9 @@ void main() {
 
       await tester.post(webhook);
 
-      final reviews =
-          verify(
-            pullRequestsService.createReview(Config.flutterSlug, captureAny),
-          ).captured;
+      final reviews = verify(
+        pullRequestsService.createReview(Config.flutterSlug, captureAny),
+      ).captured;
       expect(reviews.length, 1);
       final review = reviews.single as CreatePullRequestReview;
       expect(review.event, 'APPROVE');
@@ -1292,7 +1291,8 @@ void main() {
       );
     });
 
-    test('Framework no comment if only dev bots or devicelab changed', () async {
+    test('Framework no comment if only dev bots or devicelab changed',
+        () async {
       const issueNumber = 123;
       tester.message = generateGithubWebhookMessage(
         action: 'opened',
@@ -1419,7 +1419,8 @@ void main() {
       );
     });
 
-    test('Framework no test comment if customer testing version changed', () async {
+    test('Framework no test comment if customer testing version changed',
+        () async {
       const issueNumber = 123;
       tester.message = generateGithubWebhookMessage(
         action: 'opened',
@@ -1429,15 +1430,13 @@ void main() {
       when(
         pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
       ).thenAnswer(
-            (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+        (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
           // Change to random other file.
           PullRequestFile()
             ..filename =
                 'packages/flutter_tools/gradle/src/main/kotlin/Deeplink.kt',
           // Change to the customer version file.
-          PullRequestFile()
-            ..filename =
-                'dev/customer_testing/tests.version',
+          PullRequestFile()..filename = 'dev/customer_testing/tests.version',
         ]),
       );
 
@@ -1990,11 +1989,9 @@ void foo() {
         ],
       ];
 
-      for (
-        var issueNumber = 0;
-        issueNumber < pullRequestFileList.length;
-        issueNumber++
-      ) {
+      for (var issueNumber = 0;
+          issueNumber < pullRequestFileList.length;
+          issueNumber++) {
         tester.message = generateGithubWebhookMessage(
           action: 'opened',
           number: issueNumber,
@@ -2733,21 +2730,21 @@ void foo() {
 
         fakeBuildBucketClient.batchResponse =
             (_, _) => Future<bbv2.BatchResponse>.value(
-              bbv2.BatchResponse(
-                responses: <bbv2.BatchResponse_Response>[
-                  bbv2.BatchResponse_Response(
-                    searchBuilds: bbv2.SearchBuildsResponse(
-                      builds: <bbv2.Build>[],
-                    ),
+                  bbv2.BatchResponse(
+                    responses: <bbv2.BatchResponse_Response>[
+                      bbv2.BatchResponse_Response(
+                        searchBuilds: bbv2.SearchBuildsResponse(
+                          builds: <bbv2.Build>[],
+                        ),
+                      ),
+                      bbv2.BatchResponse_Response(
+                        searchBuilds: bbv2.SearchBuildsResponse(
+                          builds: <bbv2.Build>[],
+                        ),
+                      ),
+                    ],
                   ),
-                  bbv2.BatchResponse_Response(
-                    searchBuilds: bbv2.SearchBuildsResponse(
-                      builds: <bbv2.Build>[],
-                    ),
-                  ),
-                ],
-              ),
-            );
+                );
 
         tester.message = generateGithubWebhookMessage(
           action: action,
@@ -2809,33 +2806,33 @@ void foo() {
         () async {
           fakeBuildBucketClient.batchResponse =
               (_, _) => Future<bbv2.BatchResponse>.value(
-                bbv2.BatchResponse(
-                  responses: <bbv2.BatchResponse_Response>[
-                    bbv2.BatchResponse_Response(
-                      searchBuilds: bbv2.SearchBuildsResponse(
-                        builds: <bbv2.Build>[
-                          bbv2.Build(
-                            number: 999,
-                            builder: bbv2.BuilderID(builder: 'Linux'),
-                            status: bbv2.Status.ENDED_MASK,
+                    bbv2.BatchResponse(
+                      responses: <bbv2.BatchResponse_Response>[
+                        bbv2.BatchResponse_Response(
+                          searchBuilds: bbv2.SearchBuildsResponse(
+                            builds: <bbv2.Build>[
+                              bbv2.Build(
+                                number: 999,
+                                builder: bbv2.BuilderID(builder: 'Linux'),
+                                status: bbv2.Status.ENDED_MASK,
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
-                    ),
-                    bbv2.BatchResponse_Response(
-                      searchBuilds: bbv2.SearchBuildsResponse(
-                        builds: <bbv2.Build>[
-                          bbv2.Build(
-                            number: 998,
-                            builder: bbv2.BuilderID(builder: 'Linux'),
-                            status: bbv2.Status.ENDED_MASK,
+                        ),
+                        bbv2.BatchResponse_Response(
+                          searchBuilds: bbv2.SearchBuildsResponse(
+                            builds: <bbv2.Build>[
+                              bbv2.Build(
+                                number: 998,
+                                builder: bbv2.BuilderID(builder: 'Linux'),
+                                status: bbv2.Status.ENDED_MASK,
+                              ),
+                            ],
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              );
+                  );
 
           tester.message = generateGithubWebhookMessage(
             action: 'synchronize',
@@ -3191,7 +3188,8 @@ void foo() {
       ];
     });
 
-    test('checks_requested success for non-fusion repository (simulated)', () async {
+    test('checks_requested success for non-fusion repository (simulated)',
+        () async {
       tester.message = generateMergeGroupMessage(
         repository: 'flutter/packages',
         action: 'checks_requested',
@@ -3339,14 +3337,12 @@ void foo() {
 
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
-            final requestSha =
-                request.searchBuilds.predicate.tags
-                    .singleWhere((tag) => tag.key == 'buildset')
-                    .value;
-            final userAgent =
-                request.searchBuilds.predicate.tags
-                    .singleWhere((tag) => tag.key == 'user_agent')
-                    .value;
+            final requestSha = request.searchBuilds.predicate.tags
+                .singleWhere((tag) => tag.key == 'buildset')
+                .value;
+            final userAgent = request.searchBuilds.predicate.tags
+                .singleWhere((tag) => tag.key == 'user_agent')
+                .value;
             luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
@@ -3465,14 +3461,12 @@ void foo() {
 
         for (final request in batchRequest.requests) {
           if (request.hasSearchBuilds()) {
-            final requestSha =
-                request.searchBuilds.predicate.tags
-                    .singleWhere((tag) => tag.key == 'buildset')
-                    .value;
-            final userAgent =
-                request.searchBuilds.predicate.tags
-                    .singleWhere((tag) => tag.key == 'user_agent')
-                    .value;
+            final requestSha = request.searchBuilds.predicate.tags
+                .singleWhere((tag) => tag.key == 'buildset')
+                .value;
+            final userAgent = request.searchBuilds.predicate.tags
+                .singleWhere((tag) => tag.key == 'user_agent')
+                .value;
             luciLog.add('search builds for $requestSha by $userAgent');
             batchResponseResponses.add(
               bbv2.BatchResponse_Response(
@@ -3531,7 +3525,8 @@ void foo() {
       );
     });
 
-    test('does not cancel builds if destroyed because merged successfully', () async {
+    test('does not cancel builds if destroyed because merged successfully',
+        () async {
       tester.message = generateMergeGroupMessage(
         repository: 'flutter/flutter',
         action: 'destroyed',

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1432,10 +1432,6 @@ void main() {
           pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
         ).thenAnswer(
           (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
-            // Change to random other file.
-            PullRequestFile()
-              ..filename =
-                  'packages/flutter_tools/gradle/src/main/kotlin/Deeplink.kt',
             // Change to the customer version file.
             PullRequestFile()..filename = 'dev/customer_testing/tests.version',
           ]),

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1419,6 +1419,39 @@ void main() {
       );
     });
 
+    test('Framework no test comment if customer testing version changed', () async {
+      const issueNumber = 123;
+      tester.message = generateGithubWebhookMessage(
+        action: 'opened',
+        number: issueNumber,
+      );
+
+      when(
+        pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
+      ).thenAnswer(
+            (_) => Stream<PullRequestFile>.fromIterable(<PullRequestFile>[
+          // Change to random other file.
+          PullRequestFile()
+            ..filename =
+                'packages/flutter_tools/gradle/src/main/kotlin/Deeplink.kt',
+          // Change to the customer version file.
+          PullRequestFile()
+            ..filename =
+                'dev/customer_testing/tests.version',
+        ]),
+      );
+
+      await tester.post(webhook);
+
+      verifyNever(
+        issuesService.createComment(
+          Config.flutterSlug,
+          issueNumber,
+          argThat(contains(config.missingTestsPullRequestMessageValue)),
+        ),
+      );
+    });
+
     test('Framework no comment if only AUTHORS changed', () async {
       const issueNumber = 123;
       tester.message = generateGithubWebhookMessage(


### PR DESCRIPTION
Makes the file test exempt. We could alternately count it as a test, but I think it is rare (and not a great practice) for someone to test the changes in their PR exclusively by modifying an element of the customer tests.

Motivated by https://github.com/flutter/flutter/pull/167754

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
