### PR TITLE
Fix `get-green-commits`, use `bringup` instead of `flaky`.

### DIFF
--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -61,7 +61,8 @@ final class GetGreenCommits extends RequestHandler<Body> {
       slug: slug,
     );
     return Body.forJson([
-      ...allCommits.where(_isGreenCommit).map((s) => s.commit.sha),
+      for(final commit in allCommits.where(_isGreenCommit))
+        commit.commit.sha
     ]);
   }
 

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -61,8 +61,7 @@ final class GetGreenCommits extends RequestHandler<Body> {
       slug: slug,
     );
     return Body.forJson([
-      for(final commit in allCommits.where(_isGreenCommit))
-        commit.commit.sha
+      for (final commit in allCommits.where(_isGreenCommit)) commit.commit.sha,
     ]);
   }
 

--- a/app_dart/test/request_handlers/get_green_commits_test.dart
+++ b/app_dart/test/request_handlers/get_green_commits_test.dart
@@ -49,7 +49,7 @@ void main() {
   final task3FailedFlaky = generateFirestoreTask(
     3,
     status: Task.statusFailed,
-    testFlaky: true,
+    bringup: true,
   ); // should succeed if included because `bringup: true`
   final task4SucceedFlaky = generateFirestoreTask(
     4,


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167750.

There is always at least one failing task, which is bringup, so as a result we never returned any green commits.