### PR TITLE
Consider release candidate branches for vacuum-stale-tasks.

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -151,6 +151,7 @@ Server createServer({
       config: config,
       luciBuildService: luciBuildService,
       firestore: firestore,
+      branchService: branchService,
     ),
     '/api/update_existing_flaky_issues': UpdateExistingFlakyIssue(
       config: config,


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167774.

Arguably we should have _always_ have done this, but it's even more important now.