### PR TITLE
Move `backfill: "false"` out of properties, make it a boolean.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -171,7 +171,6 @@ targets:
 
   - name: Linux ci_yaml roller
     recipe: infra/ci_yaml
-    properties:
-      backfill: "false"
+    backfill: false
     runIf:
       - .ci.yaml


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/167755.

Cocoon supports both formats at the moment, so this a NOP.