### PR TITLE
Specifically mark 3.29 a legacy branch, opt-in other RC branches.

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -135,11 +135,10 @@ class Scheduler {
     final branch = pr.base!.ref;
     final sha = pr.mergeCommitSha!;
 
-    // TODO(matanlurey): Expand to every release candidate branch instead of a test branch.
-    // See https://github.com/flutter/flutter/issues/163896.
+    // TODO(matanlurey): Remove carvout for legacy branch after 3.29 is archived.
+    // https://github.com/flutter/flutter/issues/167821
     var markAllTasksSkipped = false;
-    if (branch == 'flutter-0.42-candidate.0' ||
-        branch == 'flutter-3.32-candidate.0') {
+    if (branch != 'flutter-3.29-candidate.0') {
       markAllTasksSkipped = true;
       log.info(
         '[release-candidate-postsubmit-skip] For merged PR ${pr.number}, SHA=$sha, skipping all post-submit tasks',

--- a/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
+++ b/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
@@ -37,7 +37,7 @@ final class FilesChangedOptimizer {
   // ```
   final CiYamlFetcher _ciYamlFetcher;
 
-  // See https://github.com/flutter/flutter/issues/162403.
+  // TODO(matanlurey): https://github.com/flutter/flutter/issues/167821.
   static const _doNotSkipFrameworkTestsForBranch = {'flutter-3.29-candidate.0'};
 
   final Config _config;

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -468,11 +468,11 @@ void main() {
         expect(firestore, existsInStorage(fs.Task.metadata, hasLength(3)));
       });
 
-      test('run all tasks if regular release candidate branch', () async {
+      test('run all tasks if legacy release candidate branch', () async {
         ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionCiYaml);
 
         final mergedPr = generatePullRequest(
-          branch: 'flutter-1.23-candidate.0',
+          branch: 'flutter-3.29-candidate.0',
         );
         await scheduler.addPullRequest(mergedPr);
 
@@ -485,25 +485,22 @@ void main() {
         );
       });
 
-      test(
-        'skips all tasks if experimental release candidate branch',
-        () async {
-          ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionCiYaml);
+      test('skips all tasks if release candidate branch', () async {
+        ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionCiYaml);
 
-          final mergedPr = generatePullRequest(
-            branch: 'flutter-0.42-candidate.0',
-          );
-          await scheduler.addPullRequest(mergedPr);
+        final mergedPr = generatePullRequest(
+          branch: 'flutter-0.42-candidate.0',
+        );
+        await scheduler.addPullRequest(mergedPr);
 
-          expect(
-            firestore,
-            existsInStorage(
-              fs.Task.metadata,
-              everyElement(isTask.hasStatus(Task.statusSkipped)),
-            ),
-          );
-        },
-      );
+        expect(
+          firestore,
+          existsInStorage(
+            fs.Task.metadata,
+            everyElement(isTask.hasStatus(Task.statusSkipped)),
+          ),
+        );
+      });
 
       test('schedules tasks against merged PRs', () async {
         final mergedPr = generatePullRequest(repo: 'packages', branch: 'main');


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/167821.

Closes https://github.com/flutter/flutter/issues/165078.
Closes https://github.com/flutter/flutter/issues/163896.

This marks the end of the "make release branches have delayed post-submits" arc of work.

/cc @reidbaker 