### PR TITLE
Enable use of `PBEV` on release candidate postsubmits.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -57,10 +57,6 @@ class LuciBuildService {
   final PubSub _pubsub;
   final FirestoreService _firestore;
 
-  // TODO(matanlurey): Re-enable to true/remove.
-  // See https://github.com/flutter/flutter/issues/167383.
-  static final _useFlutterPrebuiltEngineForReleaseCandidateBuilds = false;
-
   static const int kBackfillPriority = 35;
   static const int kDefaultPriority = 30;
   static const int kRerunPriority = 29;
@@ -852,8 +848,10 @@ class LuciBuildService {
     final isFusion = commit.slug == Config.flutterSlug;
     if (isFusion) {
       processedProperties['is_fusion'] = 'true';
-      if (_useFlutterPrebuiltEngineForReleaseCandidateBuilds &&
-          isReleaseCandidateBranch(branchName: commit.branch)) {
+      if (isReleaseCandidateBranch(branchName: commit.branch) &&
+          // TODO(matanlurey): Remove carvout for legacy branch after 3.29 is archived.
+          // https://github.com/flutter/flutter/issues/167821
+          commit.branch != 'flutter.3.29-candidate.0') {
         processedProperties.addAll({
           // Always provide an engine version, just like we do in presubmit.
           // See https://github.com/flutter/flutter/issues/167010.

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -522,11 +522,8 @@ void main() {
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
-      // TODO(matanlurey): Re-enable in https://github.com/flutter/flutter/issues/167383.
-      /*
       'flutter_prebuilt_engine_version': bbv2.Value(stringValue: commit.sha),
       'flutter_realm': bbv2.Value(stringValue: ''),
-      */
     });
 
     expect(scheduleBuild.dimensions, [


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/167383.

Still has a carveout for 3.29 (https://github.com/flutter/flutter/issues/167821).