### PR TITLE
Process (write) content hash to firestore only

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -84,7 +84,10 @@ Future<void> main() async {
       getFilesChanged: GithubApiGetFilesChanged(config),
       luciBuildService: luciBuildService,
       ciYamlFetcher: ciYamlFetcher,
-      contentAwareHash: ContentAwareHashService(config: config),
+      contentAwareHash: ContentAwareHashService(
+        config: config,
+        firestore: firestore,
+      ),
       firestore: firestore,
       bigQuery: bigQuery,
     );

--- a/app_dart/lib/src/service/content_aware_hash_service.dart
+++ b/app_dart/lib/src/service/content_aware_hash_service.dart
@@ -6,8 +6,13 @@ import 'dart:convert';
 
 import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
+import 'package:googleapis/firestore/v1.dart';
+import 'package:meta/meta.dart';
+import 'package:retry/retry.dart';
 
 import '../../cocoon_service.dart';
+import '../model/firestore/content_aware_hash_builds.dart'
+    show BuildStatus, ContentAwareHashBuilds;
 import '../model/github/annotations.dart';
 import '../model/github/workflow_job.dart';
 
@@ -15,12 +20,22 @@ enum ContentHashWorkflowStatus { ok, error }
 
 /// Requests GitHub to run the content-aware-hash workflow for a requests REF
 interface class ContentAwareHashService {
-  ContentAwareHashService({required Config config}) : _config = config;
+  ContentAwareHashService({
+    required Config config,
+    required FirestoreService firestore,
+    @visibleForTesting DateTime Function() now = DateTime.now,
+  }) : _config = config,
+       _firestore = firestore,
+       _now = now;
 
   /// The global configuration of this AppEngine server.
   final Config _config;
 
-  /// Trigger
+  final FirestoreService _firestore;
+
+  final DateTime Function() _now;
+
+  /// Trigger github workflow to generate a content aware hash for the [gitRef].
   Future<ContentHashWorkflowStatus> triggerWorkflow(String gitRef) async {
     // Use this specific token to trigger the workflow.
     final gh = _config.createGitHubClientWithToken(
@@ -49,7 +64,7 @@ interface class ContentAwareHashService {
 
   static final _validSha = RegExp(r'^[0-9a-f]{40}$');
 
-  /// Locates the contnet aware hash for [workflow] or null.
+  /// Locates the content aware hash for [workflow] or null.
   ///
   /// This should only be used for workflow events in the merge group.
   Future<String?> hashFromWorkflowJobEvent(WorkflowJobEvent workflow) async {
@@ -112,4 +127,102 @@ interface class ContentAwareHashService {
     // Fail
     return null;
   }
+
+  /// Finds the hash status for [job] and updates any tracking docs.
+  Future<MergeQueueHashStatus> processWorkflowJob(WorkflowJobEvent job) async {
+    final hash = await hashFromWorkflowJobEvent(job);
+    if (hash == null) return MergeQueueHashStatus.unknown;
+
+    final headSha = job.workflowJob!.headSha!;
+
+    final r = const RetryOptions(
+      maxAttempts: 5, // number of entries in the merge group?
+    );
+
+    // Important to do this bit in a transaction.
+    final result = await r.retry(() async {
+      final transaction = await _firestore.beginTransaction();
+
+      try {
+        return _updateFirestore(transaction, hash, headSha);
+      } catch (e, s) {
+        log.warn(
+          'CAHS(headSha: $headSha, hash: $hash): failure to read/modify to firestore',
+          e,
+          s,
+        );
+        await _firestore.rollback(transaction);
+        rethrow;
+      }
+    });
+
+    return result;
+  }
+
+  Future<MergeQueueHashStatus> _updateFirestore(
+    Transaction transaction,
+    String hash,
+    String headSha,
+  ) async {
+    // First, see if there's a document that already exits. This can be an old
+    // content hash that already has artifacts, or one that is currently being
+    // built.
+    final doc = await ContentAwareHashBuilds.getByContentHash(
+      _firestore,
+      contentHash: hash,
+    );
+
+    // There isn't a doc - so we're the first request. Start one.
+    if (doc == null) {
+      await _firestore.commit(transaction, [
+        Write(
+          currentDocument: Precondition(exists: false),
+          update: ContentAwareHashBuilds(
+            buildStatus: BuildStatus.inProgress,
+            createdOn: _now(),
+            contentHash: hash,
+            commitSha: headSha,
+            waitingShas: [],
+          ),
+        ),
+      ]);
+
+      log.info(
+        'CAHS(headSha: $headSha, hash: $hash): first hash seen; building',
+      );
+      return MergeQueueHashStatus.build;
+    }
+
+    // A doc exists; check to see if the artifacts are ready.
+    if (doc.status == BuildStatus.success) {
+      log.info(
+        'CAHS(headSha: $headSha, hash: $hash): artifacts already built - would auto-complete merge group here',
+      );
+      return MergeQueueHashStatus.complete;
+    }
+
+    // A doc exists, but its not built yet - add ourselves to the waiting list
+    // to be notified later.
+    log.info(
+      'CAHS(headSha: $headSha, hash: $hash): still building; adding to waiting list',
+    );
+    final commitResult = await _firestore.commit(transaction, [
+      Write(
+        update: doc,
+        updateTransforms: [
+          FieldTransform(
+            fieldPath: ContentAwareHashBuilds.fieldWaitingShas,
+            appendMissingElements: ArrayValue(values: [headSha.toValue()]),
+          ),
+        ],
+      ),
+    ]);
+
+    log.debug(
+      'CAHS(headSha: $headSha, hash: $hash): results: ${commitResult.writeResults?.map((e) => e.toJson())}',
+    );
+    return MergeQueueHashStatus.wait;
+  }
 }
+
+enum MergeQueueHashStatus { wait, build, complete, unknown }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -650,12 +650,12 @@ $s
   // Work in progress - Content Aware hash retrieval.
   Future<void> processWorkflowJob(WorkflowJobEvent job) async {
     try {
-      final hash = await _contentAwareHash.hashFromWorkflowJobEvent(job);
-      log.debug(
-        'scheduler.processWorkflowJob(): Content-Aware-Hash = $hash for $job',
+      final artifactStatus = await _contentAwareHash.processWorkflowJob(job);
+      log.info(
+        'scheduler.processWorkflowJob(): artifacts status: $artifactStatus for $job',
       );
-    } catch (e) {
-      log.debug('scheduler.processWorkflowJob($job) failed (no-op)', e);
+    } catch (e, s) {
+      log.debug('scheduler.processWorkflowJob($job) failed (no-op)', e, s);
     }
   }
 

--- a/app_dart/test/model/github/workflow_job_data.dart
+++ b/app_dart/test/model/github/workflow_job_data.dart
@@ -205,7 +205,7 @@ String workflowJobTemplate({
       "conclusion" : "$workflowConclusion",
       "created_at" : "2025-04-14T19:39:01Z",
       "head_branch" : "$headBranch",
-      "head_sha" : "296df33be866d0cd8387524e288d9b280e725795",
+      "head_sha" : "$headSha",
       "html_url" : "https://github.com/flutter/flutter/actions/runs/14454255411/job/$id",
       "id" : $id,
       "labels" : [

--- a/app_dart/test/service/content_aware_hash_service_test.dart
+++ b/app_dart/test/service/content_aware_hash_service_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:cocoon_server_test/mocks.dart';
 import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/content_aware_hash_builds.dart';
 import 'package:cocoon_service/src/model/github/workflow_job.dart';
 import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
 import 'package:http/http.dart';
@@ -14,6 +15,7 @@ import 'package:test/test.dart';
 
 import '../model/github/workflow_job_data.dart';
 import '../src/fake_config.dart';
+import '../src/service/fake_firestore_service.dart';
 import '../src/service/fake_github_service.dart';
 
 void main() {
@@ -23,12 +25,14 @@ void main() {
   late MockGitHub github;
   late FakeGithubService githubService;
   late ContentAwareHashService cahs;
+  late FakeFirestoreService firestoreService;
 
   setUp(() {
     github = MockGitHub();
     githubService = FakeGithubService(client: github);
     config = FakeConfig(githubClient: github, githubService: githubService);
-    cahs = ContentAwareHashService(config: config);
+    firestoreService = FakeFirestoreService();
+    cahs = ContentAwareHashService(config: config, firestore: firestoreService);
   });
 
   group('hashFromWorkflowJobEvent', () {
@@ -43,7 +47,7 @@ void main() {
             ),
           ),
         ),
-      ).thenAnswer((_) async => Response(goodAnnotation, 200));
+      ).thenAnswer((_) async => Response(goodAnnotation(), 200));
 
       final hash = await cahs.hashFromWorkflowJobEvent(job);
       expect(hash, '65038ef4984b927fd1762ef01d35c5ecc34ff5f7');
@@ -140,31 +144,125 @@ void main() {
       });
     });
   });
+
+  group('processWorkflowJob', () {
+    test('creates tracking document and returns build status.', () async {
+      when(github.request('GET', any)).thenAnswer(
+        (_) async => Response(goodAnnotation(contentHash: '1' * 40), 200),
+      );
+
+      final job = workflowJobTemplate(headSha: 'a' * 40).toWorkflowJob();
+      final result = await cahs.processWorkflowJob(job);
+      expect(result, MergeQueueHashStatus.build);
+      expect(
+        firestoreService,
+        existsInStorage(ContentAwareHashBuilds.metadata, [
+          isContentAwareHashBuilds
+              .hasCommitSha('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+              .hasContentHash('1' * 40)
+              .hasStatus(BuildStatus.inProgress)
+              .hasWaitingShas([]),
+        ]),
+      );
+    });
+
+    test('returns `complete` if artifacts exist', () async {
+      when(github.request('GET', any)).thenAnswer(
+        (_) async => Response(goodAnnotation(contentHash: '1' * 40), 200),
+      );
+
+      firestoreService.putDocument(
+        ContentAwareHashBuilds(
+          createdOn: DateTime.now(),
+          contentHash: '1' * 40,
+          commitSha: 'a' * 40,
+          buildStatus: BuildStatus.success,
+          waitingShas: [],
+        ),
+      );
+
+      final job = workflowJobTemplate(headSha: 'b' * 40).toWorkflowJob();
+      final result = await cahs.processWorkflowJob(job);
+      expect(result, MergeQueueHashStatus.complete);
+    });
+
+    test('stacks multiple builds in one doc', () async {
+      when(github.request('GET', any)).thenAnswer(
+        (_) async => Response(goodAnnotation(contentHash: '1' * 40), 200),
+      );
+
+      var job = workflowJobTemplate(headSha: 'a' * 40).toWorkflowJob();
+      await cahs.processWorkflowJob(job);
+
+      job = workflowJobTemplate(headSha: 'b' * 40).toWorkflowJob();
+      final result = await cahs.processWorkflowJob(job);
+      expect(result, MergeQueueHashStatus.wait);
+
+      expect(
+        firestoreService,
+        existsInStorage(ContentAwareHashBuilds.metadata, [
+          isContentAwareHashBuilds
+              .hasCommitSha('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+              .hasContentHash('1' * 40)
+              .hasStatus(BuildStatus.inProgress)
+              .hasWaitingShas(['b' * 40]),
+        ]),
+      );
+    });
+
+    test('handles rollbacks', () async {
+      firestoreService.failOnTransactionCommit(clearAfter: true);
+      when(github.request('GET', any)).thenAnswer((_) async {
+        return Response(goodAnnotation(contentHash: '1' * 40), 200);
+      });
+
+      var job = workflowJobTemplate(headSha: 'a' * 40).toWorkflowJob();
+      await cahs.processWorkflowJob(job);
+
+      job = workflowJobTemplate(headSha: 'b' * 40).toWorkflowJob();
+      final result = await cahs.processWorkflowJob(job);
+      expect(result, MergeQueueHashStatus.wait);
+
+      expect(
+        firestoreService,
+        existsInStorage(ContentAwareHashBuilds.metadata, [
+          isContentAwareHashBuilds
+              .hasCommitSha('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+              .hasContentHash('1' * 40)
+              .hasStatus(BuildStatus.inProgress)
+              .hasWaitingShas(['b' * 40]),
+        ]),
+      );
+    });
+  });
 }
 
 extension on String {
-  WorkflowJobEvent toWorkflowJob() => WorkflowJobEvent.fromJson(
-    json.decode(workflowJobTemplate()) as Map<String, Object?>,
-  );
+  WorkflowJobEvent toWorkflowJob() =>
+      WorkflowJobEvent.fromJson(json.decode(this) as Map<String, Object?>);
 }
 
-const goodAnnotation = r'''[
-   {
-      "message" : "{\"not_content_hash\": \"65038ef4984b927fd1762ef01d35c5ecc34ff5f7\"}"
-   },
-   {
-      "annotation_level" : "notice",
-      "blob_href" : "https://github.com/flutter/flutter/blob/ddb811621061c5ad2767ff4ac84b2be70b8e84bf/.github",
-      "end_column" : null,
-      "end_line" : 18,
-      "message" : "{\"engine_content_hash\": \"65038ef4984b927fd1762ef01d35c5ecc34ff5f7\"}",
-      "path" : ".github",
-      "raw_details" : "",
-      "start_column" : null,
-      "start_line" : 18,
-      "title" : ""
-   }
-]''';
+String goodAnnotation({
+  String contentHash = '65038ef4984b927fd1762ef01d35c5ecc34ff5f7',
+}) => json.encode([
+  {
+    'message':
+        '{"not_content_hash": "65038ef4984b927fd1762ef01d35c5ecc34ff5f7"}',
+  },
+  {
+    'annotation_level': 'notice',
+    'blob_href':
+        'https://github.com/flutter/flutter/blob/ddb811621061c5ad2767ff4ac84b2be70b8e84bf/.github',
+    'end_column': null,
+    'end_line': 18,
+    'message': '{"engine_content_hash": "$contentHash"}',
+    'path': '.github',
+    'raw_details': '',
+    'start_column': null,
+    'start_line': 18,
+    'title': '',
+  },
+]);
 
 const nonsesnseAnnotation = r'''[
    {},

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -35,4 +35,13 @@ class FakeContentAwareHashService implements ContentAwareHashService {
     nextHashReturn = null;
     return Future.value(hash);
   }
+
+  MergeQueueHashStatus? nextStatusReturn;
+
+  @override
+  Future<MergeQueueHashStatus> processWorkflowJob(WorkflowJobEvent job) {
+    final status = nextStatusReturn ?? MergeQueueHashStatus.unknown;
+    nextStatusReturn = null;
+    return Future.value(status);
+  }
 }


### PR DESCRIPTION
Towards: flutter/flutter#167778

Currently no action is taken and every merge group entry builds engine artifacts. This will start tracking (but not updating the status of) builds that could have been hashed / skipped.

  - ContentAwareHashBuild now addressed by the hash (no query)
  - Updates fake firestore to support ArrayValue FieldTransform
 
Future improvements:
  - Update the build status once the artifacts are built.
  - Passing the hash along to the FIRST builder to start uploading to commit sha and hash.
  - Adding a flag to enable waiting for artifacts.
  - Change the flutter tooling to look for the new hash.
