### PR TITLE
Github action to run tests

### DIFF
--- a/.github/workflows/app_dart_tests.yaml
+++ b/.github/workflows/app_dart_tests.yaml
@@ -17,27 +17,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get Dart dependencies
-        run: |
-          cd app_dart
-          dart pub get
-
       - name: Run app_dart tests
         run: |
           cd app_dart
+          dart pub get
           dart test test
 
       - name: Run dart analyze
         run: |
           cd analyze
+          dart pub get
           dart --enable-asserts analyze.dart
 
       - name: Run code_health
         run: |
           cd dev/cocoon_code_health
+          dart pub get
           dart run bin/check.dart
 
       - name: Run license check
         run: |
           cd licenses
+          dart pub get
           dart run check_licenses.dart

--- a/.github/workflows/app_dart_tests.yaml
+++ b/.github/workflows/app_dart_tests.yaml
@@ -1,0 +1,28 @@
+name: Test app_dart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'app_dart/**'
+      - 'packages/**'
+      - '.github/workflows/app_dart_tests.yaml'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get Dart dependencies
+        run: |
+          cd app_dart
+          dart pub get
+
+      - name: Run Dart tests
+        run: |
+          cd app_dart
+          dart test test

--- a/.github/workflows/app_dart_tests.yaml
+++ b/.github/workflows/app_dart_tests.yaml
@@ -4,9 +4,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'app_dart/**'
-      - 'packages/**'
-      - '.github/workflows/app_dart_tests.yaml'
+      - "app_dart/**"
+      - "packages/**"
+      - ".github/workflows/app_dart_tests.yaml"
 
 jobs:
   setup:
@@ -22,7 +22,22 @@ jobs:
           cd app_dart
           dart pub get
 
-      - name: Run Dart tests
+      - name: Run app_dart tests
         run: |
           cd app_dart
           dart test test
+
+      - name: Run dart analyze
+        run: |
+          cd analyze
+          dart --enable-asserts analyze.dart
+
+      - name: Run code_health
+        run: |
+          cd dev/cocoon_code_health
+          dart run bin/check.dart
+
+      - name: Run license check
+        run: |
+          cd licenses
+          dart run check_licenses.dart

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -652,7 +652,7 @@ $s
     try {
       final artifactStatus = await _contentAwareHash.processWorkflowJob(job);
       log.info(
-        'scheduler.processWorkflowJob(): artifacts status: $artifactStatus for $job',
+        'scheduler.processWorkflowJob(): artifacts status: $artifactStatus',
       );
     } catch (e, s) {
       log.debug('scheduler.processWorkflowJob($job) failed (no-op)', e, s);


### PR DESCRIPTION
Experiment with running some cocoon tests on actions.

 - app_dart tests
 - dart format checks (could get moved to its own action*)
 - dart analyze checks (*)
 - license checks (*)

(*): it would be slower and spin up more actions. I only saw a 5 second add on for format,analyze, and license checking.

This makes no change to the luci recipes.

