### PR TITLE
Rename `checkRerunBuilder` to `rerunBuilder`.

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -119,7 +119,7 @@ final class PostsubmitLuciSubscription extends SubscriptionHandler {
     );
     if (await _shouldAutomaticallyRerun(fsTask)) {
       log.debug('Trying to auto-retry...');
-      final retried = await _luciBuildService.checkRerunBuilder(
+      final retried = await _luciBuildService.rerunBuilder(
         commit: CommitRef.fromFirestore(fsCommit),
         target: target,
         task: fsTask,

--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -251,7 +251,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
       return false;
     }
 
-    return await _luciBuildService.checkRerunBuilder(
+    return await _luciBuildService.rerunBuilder(
       commit: CommitRef.fromFirestore(commit),
       target: taskTarget,
       tags: [TriggerdByBuildTag(email: email)],

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -993,15 +993,9 @@ class LuciBuildService {
     );
   }
 
-  /// Check to auto-rerun TOT test failures.
-  ///
-  /// A builder will be retried if:
-  ///   1. It has been tried below the max retry limit
-  ///   2. It is for the tip of tree
-  ///   3. The last known status is not green
-  ///   4. [ignoreChecks] is false. This allows manual reruns to bypass the Cocoon state.
+  /// Reruns the provided [task], returning `true` if successful.
   @useResult
-  Future<bool> checkRerunBuilder({
+  Future<bool> rerunBuilder({
     required CommitRef commit,
     required Target target,
     required fs.Task task,

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -59,7 +59,7 @@ void main() {
 
     when(
       // ignore: discarded_futures
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -122,7 +122,7 @@ void main() {
 
     expect(await tester.post(handler), Body.empty);
     verify(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -190,7 +190,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -245,7 +245,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -275,7 +275,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -306,7 +306,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -351,7 +351,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -409,7 +409,7 @@ void main() {
     await tester.post(handler);
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -719,7 +719,7 @@ void main() {
     };
 
     when(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -733,7 +733,7 @@ void main() {
     );
 
     verifyNever(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),
@@ -761,7 +761,7 @@ void main() {
 
   test('Fails if task is not rerun', () async {
     when(
-      mockLuciBuildService.checkRerunBuilder(
+      mockLuciBuildService.rerunBuilder(
         commit: anyNamed('commit'),
         target: anyNamed('target'),
         tags: anyNamed('tags'),

--- a/app_dart/test/service/luci_build_service/check_rerun_builder_test.dart
+++ b/app_dart/test/service/luci_build_service/check_rerun_builder_test.dart
@@ -19,7 +19,7 @@ import '../../src/utilities/mocks.mocks.dart';
 /// Tests [LuciBuildService] public API related to rerunning TOT test failures.
 ///
 /// Specifically:
-/// - [LuciBuildService.checkRerunBuilder]
+/// - [LuciBuildService.rerunBuilder]
 void main() {
   useTestLoggerPerTest();
 
@@ -62,7 +62,7 @@ void main() {
     firestore.putDocument(fsTask);
 
     await expectLater(
-      luci.checkRerunBuilder(
+      luci.rerunBuilder(
         commit: CommitRef.fromFirestore(fsCommit),
         task: fsTask,
         target: generateTarget(1, name: 'Linux foo'),
@@ -119,7 +119,7 @@ void main() {
     firestore.putDocument(fsTask);
 
     await expectLater(
-      luci.checkRerunBuilder(
+      luci.rerunBuilder(
         commit: CommitRef.fromFirestore(fsCommit),
         task: fsTask,
         target: generateTarget(1, name: 'Linux foo'),
@@ -178,7 +178,7 @@ void main() {
     firestore.failOnWriteCollection(fs.Task.metadata.collectionId);
 
     await expectLater(
-      luci.checkRerunBuilder(
+      luci.rerunBuilder(
         commit: CommitRef.fromFirestore(fsCommit),
         task: fsTask,
         target: generateTarget(1, name: 'Linux foo'),

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4205,14 +4205,14 @@ class MockLuciBuildService extends _i1.Mock implements _i17.LuciBuildService {
           as _i13.Future<_i7.CheckRun>);
 
   @override
-  _i13.Future<bool> checkRerunBuilder({
+  _i13.Future<bool> rerunBuilder({
     required _i31.CommitRef? commit,
     required _i27.Target? target,
     required _i32.Task? task,
     Iterable<_i35.BuildTag>? tags = const [],
   }) =>
       (super.noSuchMethod(
-            Invocation.method(#checkRerunBuilder, [], {
+            Invocation.method(#rerunBuilder, [], {
               #commit: commit,
               #target: target,
               #task: task,


### PR DESCRIPTION
Since the checks are now expected to happen _before_ invoking this method (and they do).