### PR TITLE
Add a hook to complete artifacts in the CAH service

### DIFF
--- a/app_dart/lib/src/model/firestore/base.dart
+++ b/app_dart/lib/src/model/firestore/base.dart
@@ -96,8 +96,10 @@ final class AppDocumentMetadata<T extends AppDocument<T>> {
 /// Provides methods across [g.Document] sub-types in `model/firestore/*.dart`.
 @internal
 abstract class AppDocument<T extends AppDocument<T>> implements g.Document {
+  /// Makes a new app document with potentially a shallow clone of the [from]
+  /// document.
   AppDocument([g.Document? from])
-    : _fields = from?.fields ?? {},
+    : _fields = {...?from?.fields},
       name = from?.name,
       createTime = from?.createTime,
       updateTime = from?.updateTime;

--- a/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
+++ b/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
@@ -54,9 +54,9 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
       g.Document(
         name: documentPathFor(contentHash),
         fields: {
-          _fieldCreateTimestamp: createdOn.toValue(),
+          fieldCreateTimestamp: createdOn.toValue(),
           fieldContentHash: contentHash.toValue(),
-          _fieldCommitSha: commitSha.toValue(),
+          fieldCommitSha: commitSha.toValue(),
           fieldStatus: buildStatus.name.toValue(),
           fieldWaitingShas: g.Value(
             arrayValue: g.ArrayValue(
@@ -71,21 +71,21 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
   /// Create [ContentAwareHashBuilds] from a firestore Document.
   ContentAwareHashBuilds.fromDocument(super.document);
 
-  static const _fieldCreateTimestamp = 'createTimestamp';
+  static const fieldCreateTimestamp = 'createTimestamp';
   static const fieldContentHash = 'content_hash';
-  static const _fieldCommitSha = 'commit_sha';
+  static const fieldCommitSha = 'commit_sha';
   static const fieldStatus = 'status';
   static const fieldWaitingShas = 'waiting_shas';
 
   DateTime get createdOn =>
-      DateTime.parse(fields[_fieldCreateTimestamp]!.timestampValue!);
+      DateTime.parse(fields[fieldCreateTimestamp]!.timestampValue!);
 
   BuildStatus get status =>
       BuildStatus.values.byName(fields[fieldStatus]!.stringValue!);
 
   String get contentHash => fields[fieldContentHash]!.stringValue!;
 
-  String get commitSha => fields[_fieldCommitSha]!.stringValue!;
+  String get commitSha => fields[fieldCommitSha]!.stringValue!;
 
   List<String> get waitingShas {
     return [
@@ -93,6 +93,10 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
           in fields[fieldWaitingShas]?.arrayValue?.values ?? <g.Value>[])
         t.stringValue!,
     ];
+  }
+
+  set status(BuildStatus status) {
+    fields[fieldStatus] = status.name.toValue();
   }
 }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -594,7 +594,7 @@ class Scheduler {
       };
       if (availableTargets.length != mergeGroupTargets.length) {
         log.warn(
-          '$logCrumb: missing builders for targtets: '
+          '$logCrumb: missing builders for targets: '
           '${mergeGroupTargets.difference(availableTargets)}',
         );
       }
@@ -652,10 +652,15 @@ $s
     try {
       final artifactStatus = await _contentAwareHash.processWorkflowJob(job);
       log.info(
-        'scheduler.processWorkflowJob(): artifacts status: $artifactStatus',
+        'scheduler.processWorkflowJob(): artifacts status: $artifactStatus '
+        'for ${job.workflowJob?.checkRunUrl}',
       );
     } catch (e, s) {
-      log.debug('scheduler.processWorkflowJob($job) failed (no-op)', e, s);
+      log.debug(
+        'scheduler.processWorkflowJob(${job.workflowJob?.checkRunUrl}) failed (no-op)',
+        e,
+        s,
+      );
     }
   }
 
@@ -1066,6 +1071,11 @@ $s
     //   1) in a presubmit test or
     //   2) in the merge queue
     if (detectMergeGroup(checkRun)) {
+      try {
+        await _contentAwareHash.completeArtifacts(commitSha: sha);
+      } catch (e, s) {
+        log.warn('failed to simulate closing merge group', e, s);
+      }
       await _closeMergeQueue(
         mergeQueueGuard: mergeQueueGuard,
         slug: slug,

--- a/app_dart/test/service/content_aware_hash_service_test.dart
+++ b/app_dart/test/service/content_aware_hash_service_test.dart
@@ -264,7 +264,10 @@ void main() {
     });
 
     test('does what it says on the tin', () async {
-      final shas = await cahs.completeArtifacts(commitSha: 'a' * 40);
+      final shas = await cahs.completeArtifacts(
+        commitSha: 'a' * 40,
+        successful: true,
+      );
       expect(shas, ['b' * 40, 'c' * 40, 'd' * 40]);
       expect(
         firestoreService,
@@ -289,6 +292,7 @@ void main() {
       );
       final shas = await cahs.completeArtifacts(
         commitSha: 'a' * 40,
+        successful: true,
         maxAttempts: 1,
       );
       expect(shas, isEmpty);
@@ -308,6 +312,7 @@ void main() {
       firestoreService.failOnTransactionCommit(clearAfter: false);
       final shas = await cahs.completeArtifacts(
         commitSha: 'a' * 40,
+        successful: true,
         maxAttempts: 1,
       );
       expect(shas, isEmpty);

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -47,4 +47,18 @@ class FakeContentAwareHashService implements ContentAwareHashService {
     nextStatusReturn = null;
     return Future.value(status);
   }
+
+  final List<String> completedShas = [];
+  List<String>? nextCompletedShas;
+
+  @override
+  Future<List<String>> completeArtifacts({
+    required String commitSha,
+    int maxAttempts = 5,
+  }) async {
+    completedShas.add(commitSha);
+    final shas = nextCompletedShas ?? const [];
+    nextCompletedShas = null;
+    return shas;
+  }
 }

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -48,15 +48,16 @@ class FakeContentAwareHashService implements ContentAwareHashService {
     return Future.value(status);
   }
 
-  final List<String> completedShas = [];
+  final List<({String commitSha, bool successful})> completedShas = [];
   List<String>? nextCompletedShas;
 
   @override
   Future<List<String>> completeArtifacts({
     required String commitSha,
+    required bool successful,
     int maxAttempts = 5,
   }) async {
-    completedShas.add(commitSha);
+    completedShas.add((commitSha: commitSha, successful: successful));
     final shas = nextCompletedShas ?? const [];
     nextCompletedShas = null;
     return shas;

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -443,8 +443,11 @@ abstract base class _FakeInMemoryFirestoreService
     return response;
   }
 
+  final List<Transaction> rollbacks = [];
+
   @override
   Future<void> rollback(Transaction transaction) async {
+    rollbacks.add(transaction);
     _transactions.remove(transaction.identifier);
   }
 


### PR DESCRIPTION
> [!NOTE]  
> This does not currently complete any check runs, its only to record the data.

Towards flutter/flutter#167778

Add the ability to mark the content aware documents as completed from the scheduler.  This flows from:

```mermaid
sequenceDiagram
    participant S as Scheduler
    participant CAHS as ContentAwareHashService

    S->>S: processCheckRunCompletion(checkRunEvent)
    activate S

    alt Staging Conclusion is Error AND Is Merge Group
        S->>S: failGuardForMergeGroup(...)
        S->>CAHS: completeArtifacts(commitSha: sha, failed)
        activate CAHS
        CAHS-->>S: List<String> completedShas
        deactivate CAHS
        S-->>GitHub: complete_check_runs(failure)
    else Staging Conclusion is Success AND Is Merge Group
        S->>S: _closeSuccessfulEngineBuildStage(...)
        S->>CAHS: completeArtifacts(commitSha: sha, success)
        activate CAHS
        CAHS-->>S: List<String> completedShas
        deactivate CAHS
        S-->>GitHub: complete_check_runs(success)
    end
    deactivate S
```

Minor updates:
 - Performs a shallow copy for `fromDocument()` calls to `AppDocument<T>`. Without this, "commits" that fail in testing still have the document modified in memory.