### PR TITLE
Test `rerunDartInternalReleaseBuilder` workflow.

### DIFF
--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -59,10 +59,12 @@ final class DartInternalSubscription extends SubscriptionHandler {
       );
       if (existing != null) {
         fsTask = existing;
-        if (build.number != fsTask.buildNumber) {
+        // Don't increment the task attempt if it's waiting for a build numnber.
+        if (fsTask.status != fs.Task.statusInProgress ||
+            fsTask.buildNumber != build.number) {
           fsTask.resetAsRetry();
-          fsTask.setBuildNumber(build.number);
         }
+        fsTask.setBuildNumber(build.number);
         fsTask.updateFromBuild(build);
       } else {
         fsTask = fs.Task(

--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -261,8 +261,8 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
       }
 
       return await _luciBuildService.rerunDartInternalReleaseBuilder(
-        buildNumber: buildNumber,
         commit: CommitRef.fromFirestore(commit),
+        task: task,
       );
     }
 

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -721,9 +721,16 @@ void main() {
             equals(CommitRef.fromFirestore(commit)),
             named: 'commit',
           ),
-          buildNumber: argThat(equals(123), named: 'buildNumber'),
+          task: argThat(anything, named: 'task'),
         ),
-      ).thenAnswer((_) async {
+      ).thenAnswer((i) async {
+        final task = i.namedArguments[#task] as Task;
+        expect(
+          task,
+          isTask
+              .hasTaskName('Linux flutter_release_builder')
+              .hasBuildNumber(123),
+        );
         return true;
       });
 

--- a/app_dart/test/request_handlers/rerun_prod_task_test.dart
+++ b/app_dart/test/request_handlers/rerun_prod_task_test.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart' as fs;
 import 'package:cocoon_service/src/model/firestore/task.dart';
 import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:cocoon_service/src/service/luci_build_service/commit_task_ref.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -638,11 +639,70 @@ void main() {
     );
   });
 
-  test(
-    'Rerun specific refuses flutter_release_builder',
-    () async {
-      final commit = generateFirestoreCommit(1);
+  group('Reruns of "flutter_release_builder"', () {
+    final commit = generateFirestoreCommit(
+      1,
+      branch: 'flutter-0.42-candidate.0',
+    );
 
+    setUp(() {
+      tester.requestData = {
+        'branch': commit.branch,
+        'repo': commit.slug.name,
+        'commit': commit.sha,
+        'task': 'Linux flutter_release_builder',
+      };
+    });
+
+    test('refuses to rerun an in-progress task', () async {
+      firestore.putDocuments([
+        commit,
+        generateFirestoreTask(
+          1,
+          name: 'Linux flutter_release_builder',
+          attempts: 1,
+          status: fs.Task.statusInProgress,
+          commitSha: '1',
+        ),
+      ]);
+
+      await expectLater(
+        tester.post(handler),
+        throwsA(
+          isA<BadRequestException>().having(
+            (e) => e.message,
+            'message',
+            contains('Cannot rerun a release builder that is not done running'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses to rerun a task without a build number', () async {
+      firestore.putDocuments([
+        commit,
+        generateFirestoreTask(
+          1,
+          name: 'Linux flutter_release_builder',
+          attempts: 1,
+          status: fs.Task.statusSucceeded,
+          commitSha: '1',
+        ),
+      ]);
+
+      await expectLater(
+        tester.post(handler),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Completed release builder does not have a build number'),
+          ),
+        ),
+      );
+    });
+
+    test('schedules a rerun using dart-internal', () async {
       firestore.putDocuments([
         commit,
         generateFirestoreTask(
@@ -651,23 +711,25 @@ void main() {
           attempts: 1,
           status: fs.Task.statusFailed,
           commitSha: '1',
+          buildNumber: 123,
         ),
       ]);
 
-      tester.requestData = {
-        'branch': commit.branch,
-        'repo': commit.slug.name,
-        'commit': commit.sha,
-        'task': 'Linux flutter_release_builder',
-      };
+      when(
+        mockLuciBuildService.rerunDartInternalReleaseBuilder(
+          commit: argThat(
+            equals(CommitRef.fromFirestore(commit)),
+            named: 'commit',
+          ),
+          buildNumber: argThat(equals(123), named: 'buildNumber'),
+        ),
+      ).thenAnswer((_) async {
+        return true;
+      });
 
-      await expectLater(
-        tester.post(handler),
-        throwsA(isA<BadRequestException>()),
-      );
-    },
-    skip: 'https://github.com/flutter/flutter/issues/168090',
-  );
+      await tester.post(handler);
+    });
+  });
 
   test('Rerun all ignores flutter_release_builder', () async {
     final commit = generateFirestoreCommit(1);

--- a/app_dart/test/service/luci_build_service/rerun_dart_internal_test.dart
+++ b/app_dart/test/service/luci_build_service/rerun_dart_internal_test.dart
@@ -1,0 +1,300 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
+import 'package:cocoon_common_test/cocoon_common_test.dart';
+import 'package:cocoon_server/logging.dart';
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/service/luci_build_service/commit_task_ref.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../src/fake_config.dart';
+import '../../src/request_handling/fake_pubsub.dart';
+import '../../src/service/fake_firestore_service.dart';
+import '../../src/service/fake_gerrit_service.dart';
+import '../../src/utilities/mocks.mocks.dart';
+
+/// Tests [LuciBuildService] public API related to `dart-internal` builds.
+///
+/// Specifically:
+/// - [LuciBuildService.rerunDartInternalReleaseBuilder]
+void main() {
+  useTestLoggerPerTest();
+
+  // System under test:
+  late LuciBuildService luci;
+
+  // Dependencies (mocked/faked if necessary):
+  late MockBuildBucketClient mockBuildBucketClient;
+
+  setUp(() {
+    mockBuildBucketClient = MockBuildBucketClient();
+
+    luci = LuciBuildService(
+      cache: CacheService(inMemory: true),
+      config: FakeConfig(),
+      gerritService: FakeGerritService(),
+      buildBucketClient: mockBuildBucketClient,
+      githubChecksUtil: MockGithubChecksUtil(),
+      pubsub: FakePubSub(),
+      firestore: FakeFirestoreService(),
+    );
+  });
+
+  test('must find a build or fails', () async {
+    when(mockBuildBucketClient.getBuild(any)).thenAnswer((i) async {
+      final [bbv2.GetBuildRequest request] = i.positionalArguments;
+      expect(request.buildNumber, 123);
+      expect(
+        request.builder,
+        isA<bbv2.BuilderID>()
+            .having((b) => b.project, 'project', 'dart-internal')
+            .having((b) => b.bucket, 'bucket', 'flutter')
+            .having(
+              (b) => b.builder,
+              'builder',
+              'Linux flutter_release_builder',
+            ),
+      );
+      throw const BuildBucketException(404, 'Not Found');
+    });
+
+    await expectLater(
+      luci.rerunDartInternalReleaseBuilder(
+        commit: CommitRef(
+          sha: 'abcdef',
+          branch: 'flutter-0.42-candidate.0',
+          slug: Config.flutterSlug,
+        ),
+        buildNumber: 123,
+      ),
+      completion(isFalse),
+    );
+
+    expect(
+      log,
+      bufferedLoggerOf(
+        contains(
+          logThat(
+            message: contains('No build found for 123'),
+            severity: atLeastError,
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('must find associated sub-builds or fails', () async {
+    when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
+      return bbv2.Build(id: Int64(1001));
+    });
+
+    when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
+      final [bbv2.SearchBuildsRequest request] = i.positionalArguments;
+      expect(request.predicate.childOf, Int64(1001));
+      expect(
+        request.mask.inputProperties,
+        containsAll([
+          bbv2.StructMask(path: const ['build', 'name']),
+          bbv2.StructMask(path: const ['config_name']),
+        ]),
+      );
+      return bbv2.SearchBuildsResponse(builds: []);
+    });
+
+    await expectLater(
+      luci.rerunDartInternalReleaseBuilder(
+        commit: CommitRef(
+          sha: 'abcdef',
+          branch: 'flutter-0.42-candidate.0',
+          slug: Config.flutterSlug,
+        ),
+        buildNumber: 123,
+      ),
+      completion(isFalse),
+    );
+
+    expect(
+      log,
+      bufferedLoggerOf(
+        contains(
+          logThat(
+            message: contains('No builds found for'),
+            severity: atLeastError,
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('reruns failed builds by config_name', () async {
+    when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
+      return bbv2.Build(id: Int64(1001));
+    });
+
+    when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
+      return bbv2.SearchBuildsResponse(
+        builds: [
+          bbv2.Build(
+            status: bbv2.Status.SUCCESS,
+            input: bbv2.Build_Input(
+              properties: bbv2.Struct(
+                fields: {'config_name': bbv2.Value(stringValue: 'engine_1')},
+              ),
+            ),
+          ),
+          bbv2.Build(
+            status: bbv2.Status.FAILURE,
+            input: bbv2.Build_Input(
+              properties: bbv2.Struct(
+                fields: {'config_name': bbv2.Value(stringValue: 'engine_2')},
+              ),
+            ),
+          ),
+          bbv2.Build(
+            status: bbv2.Status.INFRA_FAILURE,
+            input: bbv2.Build_Input(
+              properties: bbv2.Struct(
+                fields: {'config_name': bbv2.Value(stringValue: 'engine_3')},
+              ),
+            ),
+          ),
+          bbv2.Build(
+            status: bbv2.Status.CANCELED,
+            input: bbv2.Build_Input(
+              properties: bbv2.Struct(
+                fields: {'config_name': bbv2.Value(stringValue: 'engine_4')},
+              ),
+            ),
+          ),
+        ],
+      );
+    });
+
+    when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((i) async {
+      final [bbv2.ScheduleBuildRequest request] = i.positionalArguments;
+      expect(
+        request.builder,
+        isA<bbv2.BuilderID>()
+            .having((b) => b.project, 'project', 'dart-internal')
+            .having((b) => b.bucket, 'bucket', 'flutter')
+            .having(
+              (b) => b.builder,
+              'builder',
+              'Linux flutter_release_builder',
+            ),
+      );
+      expect(
+        request.exe,
+        bbv2.Executable(cipdVersion: 'refs/heads/flutter-0.42-candidate.0'),
+      );
+      expect(
+        request.gitilesCommit,
+        bbv2.GitilesCommit(
+          project: 'mirrors/flutter',
+          host: 'flutter.googlesource.com',
+          ref: 'refs/heads/flutter-0.42-candidate.0',
+          id: 'abcdef',
+        ),
+      );
+      expect(request.hasNotify(), isFalse);
+      expect(
+        request.properties,
+        bbv2.Struct(
+          fields: {
+            'retry_override_list': bbv2.Value(
+              stringValue: 'engine_2 engine_3 engine_4',
+            ),
+          },
+        ),
+      );
+      expect(request.priority, LuciBuildService.kRerunPriority);
+      return bbv2.Build();
+    });
+
+    await expectLater(
+      luci.rerunDartInternalReleaseBuilder(
+        commit: CommitRef(
+          sha: 'abcdef',
+          branch: 'flutter-0.42-candidate.0',
+          slug: Config.flutterSlug,
+        ),
+        buildNumber: 123,
+      ),
+      completion(isTrue),
+    );
+
+    expect(log, hasNoErrorsOrHigher);
+  });
+
+  test('reruns entire build', () async {
+    when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
+      return bbv2.Build(id: Int64(1001));
+    });
+
+    when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
+      return bbv2.SearchBuildsResponse(
+        builds: [
+          bbv2.Build(
+            status: bbv2.Status.SUCCESS,
+            input: bbv2.Build_Input(
+              properties: bbv2.Struct(
+                fields: {'config_name': bbv2.Value(stringValue: 'engine_1')},
+              ),
+            ),
+          ),
+        ],
+      );
+    });
+
+    when(mockBuildBucketClient.scheduleBuild(any)).thenAnswer((i) async {
+      final [bbv2.ScheduleBuildRequest request] = i.positionalArguments;
+      expect(
+        request.builder,
+        isA<bbv2.BuilderID>()
+            .having((b) => b.project, 'project', 'dart-internal')
+            .having((b) => b.bucket, 'bucket', 'flutter')
+            .having(
+              (b) => b.builder,
+              'builder',
+              'Linux flutter_release_builder',
+            ),
+      );
+      expect(
+        request.exe,
+        bbv2.Executable(cipdVersion: 'refs/heads/flutter-0.42-candidate.0'),
+      );
+      expect(
+        request.gitilesCommit,
+        bbv2.GitilesCommit(
+          project: 'mirrors/flutter',
+          host: 'flutter.googlesource.com',
+          ref: 'refs/heads/flutter-0.42-candidate.0',
+          id: 'abcdef',
+        ),
+      );
+      expect(request.hasNotify(), isFalse);
+      expect(request.properties, bbv2.Struct(fields: {}));
+      expect(request.priority, LuciBuildService.kRerunPriority);
+      return bbv2.Build();
+    });
+
+    await expectLater(
+      luci.rerunDartInternalReleaseBuilder(
+        commit: CommitRef(
+          sha: 'abcdef',
+          branch: 'flutter-0.42-candidate.0',
+          slug: Config.flutterSlug,
+        ),
+        buildNumber: 123,
+      ),
+      completion(isTrue),
+    );
+
+    expect(log, hasNoErrorsOrHigher);
+  });
+}

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4225,12 +4225,12 @@ class MockLuciBuildService extends _i1.Mock implements _i17.LuciBuildService {
   @override
   _i13.Future<bool> rerunDartInternalReleaseBuilder({
     required _i31.CommitRef? commit,
-    required int? buildNumber,
+    required _i32.Task? task,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#rerunDartInternalReleaseBuilder, [], {
               #commit: commit,
-              #buildNumber: buildNumber,
+              #task: task,
             }),
             returnValue: _i13.Future<bool>.value(false),
           )


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/168090.

Also some improvements: 

- Mark the task as in progress 
- Don't create unnecessary tasks as a result of initially marking the task as in progress