### PR TITLE
Start a shared `TaskStatus` enum-_lite_.

### DIFF
--- a/app_dart/lib/src/model/firestore/task.dart
+++ b/app_dart/lib/src/model/firestore/task.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
+import 'package:cocoon_common/task_status.dart';
 import 'package:googleapis/firestore/v1.dart' hide Status;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -232,27 +233,25 @@ final class Task extends AppDocument<Task> {
   }
 
   /// The task was cancelled.
-  static const String statusCancelled = 'Cancelled';
+  static const statusCancelled = TaskStatus.cancelled;
 
   /// The task is yet to be run.
-  static const String statusNew = 'New';
+  static const statusNew = TaskStatus.queuedForBackfill;
 
   /// The task failed to run due to an unexpected issue.
-  static const String statusInfraFailure = 'Infra Failure';
+  static const statusInfraFailure = TaskStatus.infraFailure;
 
   /// The task is currently running.
-  static const String statusInProgress = 'In Progress';
+  static const statusInProgress = TaskStatus.inProgress;
 
   /// The task was run successfully.
-  static const String statusSucceeded = 'Succeeded';
+  static const statusSucceeded = TaskStatus.succeeded;
 
   /// The task failed to run successfully.
-  static const String statusFailed = 'Failed';
+  static const statusFailed = TaskStatus.failed;
 
-  /// The task was skipped or canceled while running.
-  ///
-  /// This status is only used by LUCI tasks.
-  static const String statusSkipped = 'Skipped';
+  /// The task was skipped instead of being executed.
+  static const statusSkipped = TaskStatus.skipped;
 
   static const Set<String> taskFailStatusSet = <String>{
     Task.statusInfraFailure,

--- a/packages/cocoon_common/lib/rpc_model.dart
+++ b/packages/cocoon_common/lib/rpc_model.dart
@@ -17,7 +17,6 @@
 ///
 /// To regenerate the JSON serialization code after making model changes:
 /// ```sh
-/// cd dashboard
 /// dart run build_runner build
 /// ```
 ///

--- a/packages/cocoon_common/lib/task_status.dart
+++ b/packages/cocoon_common/lib/task_status.dart
@@ -1,0 +1,83 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+
+/// Represents differerent states of a task, or an execution of a build target.
+///
+/// TODO(matanlurey): Finish migrating (https://github.com/flutter/flutter/issues/167284):
+/// - [ ] All usages of `Task.status` should be of type `TaskStatus`
+/// - [ ] Stop implementing `String` and handle conversion elsewherer
+/// - [ ] Replace extension type with an `enum`
+extension type const TaskStatus._(String _schemaValue) implements String {
+  /// Returns the status represented by the provided [value].
+  ///
+  /// [value] must be a valid [TaskStatus.value].
+  factory TaskStatus.from(String value) {
+    return tryFrom(value) ?? (throw ArgumentError.value(value, 'value'));
+  }
+
+  /// Returns the task represented by the provided [value].
+  ///
+  /// Returns `null` if [value] is not a valid [TaskStatus.value].
+  static TaskStatus? tryFrom(String value) {
+    return values.firstWhereOrNull((v) => v.value == value);
+  }
+
+  /// The task was cancelled.
+  static const cancelled = TaskStatus._('Cancelled');
+
+  /// The task is waiting to be queued.
+  static const queuedForBackfill = TaskStatus._('New');
+
+  /// The task is either queued or running.
+  static const inProgress = TaskStatus._('In Progress');
+
+  /// The task has failed due to an infrastructure failure.
+  static const infraFailure = TaskStatus._('Infra Failure');
+
+  /// The task has failed.
+  static const failed = TaskStatus._('Failed');
+
+  /// The task ran successfully.
+  static const succeeded = TaskStatus._('Succeeded');
+
+  /// The task was skipped instead of being executed.
+  static const skipped = TaskStatus._('Skipped');
+
+  /// Each valid possible task status.
+  ///
+  /// This list is unmodifiable.
+  static const values = [
+    cancelled,
+    queuedForBackfill,
+    inProgress,
+    infraFailure,
+    failed,
+    succeeded,
+    skipped,
+  ];
+
+  /// The canonical string value representing `this`.
+  ///
+  /// This is the inverse of [TaskStatus.from] or [TaskStatus.tryFrom].
+  String get value => _schemaValue;
+
+  /// Whether the status represents a completed task reaching a terminal state.
+  bool get isComplete => _complete.contains(this);
+  static const _complete = {..._failed, succeeded, skipped};
+
+  /// Whether the status represents a failure state.
+  bool get isFailure => _failed.contains(this);
+  static const _failed = {cancelled, infraFailure, failed};
+
+  /// Whether the status represents a success state.
+  bool get isSuccess => this == succeeded;
+
+  /// Whether the status represents a skipped state.
+  bool get isSkipped => this == skipped;
+
+  /// Whether the status represents a running state.
+  bool get isRunning => this == inProgress;
+}

--- a/packages/cocoon_common/test/task_status_test.dart
+++ b/packages/cocoon_common/test/task_status_test.dart
@@ -1,0 +1,153 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_common/task_status.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TaskStatus.from', () {
+    for (final value in TaskStatus.values) {
+      test('$value', () {
+        expect(TaskStatus.from(value.value), same(value));
+      });
+    }
+
+    test('fails with an invalid status', () {
+      expect(() => TaskStatus.from('INVALID'), throwsArgumentError);
+    });
+  });
+
+  group('TaskStatus.tryFrom', () {
+    for (final value in TaskStatus.values) {
+      test('$value', () {
+        expect(TaskStatus.tryFrom(value.value), same(value));
+      });
+    }
+
+    test('returns null with an invalid status', () {
+      expect(TaskStatus.tryFrom('INVALID'), isNull);
+    });
+  });
+
+  group('.value', () {
+    for (final MapEntry(key: value, value: expectation)
+        in {
+          TaskStatus.cancelled: 'Cancelled',
+          TaskStatus.queuedForBackfill: 'New',
+          TaskStatus.infraFailure: 'Infra Failure',
+          TaskStatus.failed: 'Failed',
+          TaskStatus.succeeded: 'Succeeded',
+          TaskStatus.skipped: 'Skipped',
+        }.entries) {
+      test('$value == $expectation', () {
+        expect(value.value, expectation);
+      });
+    }
+  });
+
+  group('isSuccess', () {
+    test('true for succeeded', () {
+      expect(TaskStatus.succeeded.isSuccess, isTrue);
+    });
+
+    test('false for everything else', () {
+      expect(
+        TaskStatus.values
+            .where((v) => v != TaskStatus.succeeded)
+            .map((t) => t.isSuccess),
+        everyElement(isFalse),
+      );
+    });
+  });
+
+  group('isComplete', () {
+    group('true for failed tasks', () {
+      for (final status in TaskStatus.values.where((v) => v.isFailure)) {
+        test('$status', () {
+          expect(status.isComplete, isTrue);
+        });
+      }
+    });
+
+    group('true for successful tasks', () {
+      for (final status in TaskStatus.values.where((v) => v.isSuccess)) {
+        test('$status', () {
+          expect(status.isComplete, isTrue);
+        });
+      }
+    });
+
+    group('true for skipped tasks', () {
+      for (final status in TaskStatus.values.where((v) => v.isSkipped)) {
+        test('$status', () {
+          expect(status.isComplete, isTrue);
+        });
+      }
+    });
+
+    group('false otherwise', () {
+      for (final status in TaskStatus.values.where(
+        (v) => !v.isFailure && !v.isSuccess && !v.isSkipped,
+      )) {
+        test('$status', () {
+          expect(status.isComplete, isFalse);
+        });
+      }
+    });
+  });
+
+  group('isFailure', () {
+    const failures = [
+      TaskStatus.failed,
+      TaskStatus.infraFailure,
+      TaskStatus.cancelled,
+    ];
+
+    for (final failure in failures) {
+      test('true for $failure', () {
+        expect(failure.isFailure, isTrue);
+      });
+    }
+
+    group('false otherwise', () {
+      for (final status in TaskStatus.values.where(
+        (v) => !failures.contains(v),
+      )) {
+        test('$status', () {
+          expect(status.isFailure, isFalse);
+        });
+      }
+    });
+  });
+
+  test('isSuccess', () {
+    expect(TaskStatus.succeeded.isSuccess, isTrue);
+    expect(
+      TaskStatus.values.where((v) => v != TaskStatus.succeeded),
+      everyElement(
+        isA<TaskStatus>().having((t) => t.isSuccess, 'isSuccess', isFalse),
+      ),
+    );
+  });
+
+  test('isSkipped', () {
+    expect(TaskStatus.skipped.isSkipped, isTrue);
+    expect(
+      TaskStatus.values.where((v) => v != TaskStatus.skipped),
+      everyElement(
+        isA<TaskStatus>().having((t) => t.isSkipped, 'isSkipped', isFalse),
+      ),
+    );
+  });
+
+  test('isRunning', () {
+    expect(TaskStatus.inProgress.isRunning, isTrue);
+    expect(
+      TaskStatus.values.where((v) => v != TaskStatus.inProgress),
+      everyElement(
+        isA<TaskStatus>().having((t) => t.isRunning, 'isRunning', isFalse),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/167284.

This change is non-breaking, because `extension type implements String` _is_ a `String`, and will be represented using the same exact (backing) implementation. The next step(s) would be to remove all manual string references (i.e. to `'New'`), and start using the getters on `TaskStatus` instead of things like `failedStatusSet.contains(...)` across the codebase.