### PR TITLE
Stop using Zones for `Request`/`requestData`, which was barely used.

### DIFF
--- a/app_dart/lib/src/request_handlers/check_flaky_builders.dart
+++ b/app_dart/lib/src/request_handlers/check_flaky_builders.dart
@@ -14,6 +14,7 @@ import '../../protos.dart' as pb;
 import '../foundation/utils.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import '../service/big_query.dart';
 import '../service/config.dart';
 import '../service/github_service.dart';
@@ -56,7 +57,7 @@ class CheckFlakyBuilders extends ApiRequestHandler<Body> {
   };
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     final slug = Config.flutterSlug;
     final gitHub = config.createGithubServiceWithToken(
       await config.githubOAuthToken,

--- a/app_dart/lib/src/request_handlers/create_branch.dart
+++ b/app_dart/lib/src/request_handlers/create_branch.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import '../service/branch_service.dart';
 
 /// Creates the flutter/recipes branch to match a flutter/flutter branch.
@@ -27,10 +28,13 @@ class CreateBranch extends ApiRequestHandler<Body> {
   static const String engineShaParam = 'engine';
 
   @override
-  Future<Body> get() async {
-    checkRequiredQueryParameters(<String>[branchParam, engineShaParam]);
-    final branch = request!.uri.queryParameters[branchParam]!;
-    final engineSha = request!.uri.queryParameters[engineShaParam]!;
+  Future<Body> get(Request request) async {
+    checkRequiredQueryParameters(request, <String>[
+      branchParam,
+      engineShaParam,
+    ]);
+    final branch = request.uri.queryParameters[branchParam]!;
+    final engineSha = request.uri.queryParameters[engineShaParam]!;
 
     await branchService.branchFlutterRecipes(branch, engineSha);
 

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -33,7 +33,7 @@ final class DartInternalSubscription extends SubscriptionHandler {
   final FirestoreService _firestore;
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     final bbv2.Build build;
     try {
       final decoded = json.decode(message.data!);

--- a/app_dart/lib/src/request_handlers/flush_cache.dart
+++ b/app_dart/lib/src/request_handlers/flush_cache.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
 import '../request_handling/exceptions.dart';
+import '../request_handling/request_handler.dart';
 import '../service/cache_service.dart';
 import '../service/config.dart';
 
@@ -32,9 +33,9 @@ class FlushCache extends ApiRequestHandler<Body> {
   static const String cacheKeyParam = 'key';
 
   @override
-  Future<Body> get() async {
-    checkRequiredQueryParameters(<String>[cacheKeyParam]);
-    final cacheKey = request!.uri.queryParameters[cacheKeyParam]!;
+  Future<Body> get(Request request) async {
+    checkRequiredQueryParameters(request, <String>[cacheKeyParam]);
+    final cacheKey = request.uri.queryParameters[cacheKeyParam]!;
 
     // To validate cache flushes, validate that the key exists.
     await cache.getOrCreate(

--- a/app_dart/lib/src/request_handlers/get_build_status.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status.dart
@@ -23,15 +23,15 @@ base class GetBuildStatus extends RequestHandler<Body> {
   static const _kBranchParam = 'branch';
 
   @override
-  Future<Body> get() async {
-    final response = await createResponse();
+  Future<Body> get(Request request) async {
+    final response = await createResponse(request);
     return Body.forJson(response);
   }
 
   @protected
-  Future<rpc_model.BuildStatusResponse> createResponse() async {
-    final repoName = request!.uri.queryParameters[_kRepoParam] ?? 'flutter';
-    final repoBranch = request!.uri.queryParameters[_kBranchParam];
+  Future<rpc_model.BuildStatusResponse> createResponse(Request request) async {
+    final repoName = request.uri.queryParameters[_kRepoParam] ?? 'flutter';
+    final repoBranch = request.uri.queryParameters[_kBranchParam];
 
     final slug = RepositorySlug('flutter', repoName);
     final status = await _buildStatusService.calculateCumulativeStatus(

--- a/app_dart/lib/src/request_handlers/get_build_status_badge.dart
+++ b/app_dart/lib/src/request_handlers/get_build_status_badge.dart
@@ -9,6 +9,7 @@ import 'package:cocoon_common/rpc_model.dart' as rpc_model;
 import 'package:meta/meta.dart';
 
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import 'get_build_status.dart';
 
 /// [GetBuildStatusBadge] returns an SVG representing the current tree status for the given repo.
@@ -45,11 +46,10 @@ final class GetBuildStatusBadge extends GetBuildStatus {
   static const green = '#3BB143';
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     // Set HTTP content-type so SVG is viewable.
-    final response = request!.response;
-    response.headers.contentType = ContentType.parse('image/svg+xml');
-    final buildStatusResponse = await super.createResponse();
+    response!.headers.contentType = ContentType.parse('image/svg+xml');
+    final buildStatusResponse = await super.createResponse(request);
     return Body.forString(generateSVG(buildStatusResponse));
   }
 

--- a/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
+++ b/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
@@ -37,8 +37,8 @@ final class GetEngineArtifactsReady extends RequestHandler<Body> {
   static const _paramSha = 'sha';
 
   @override
-  Future<Body> get() async {
-    final commitSha = request!.uri.queryParameters[_paramSha];
+  Future<Body> get(Request request) async {
+    final commitSha = request.uri.queryParameters[_paramSha];
     if (commitSha == null) {
       throw const BadRequestException('Missing query parameter: "$_paramSha"');
     }

--- a/app_dart/lib/src/request_handlers/get_green_commits.dart
+++ b/app_dart/lib/src/request_handlers/get_green_commits.dart
@@ -46,13 +46,12 @@ final class GetGreenCommits extends RequestHandler<Body> {
   static const kRepoParam = 'repo';
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     final repoName =
-        request!.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
+        request.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
     final slug = RepositorySlug('flutter', repoName);
     final branch =
-        request!.uri.queryParameters[kBranchParam] ??
-        Config.defaultBranch(slug);
+        request.uri.queryParameters[kBranchParam] ?? Config.defaultBranch(slug);
     final commitNumber = config.commitNumber;
 
     final allCommits = await _buildStatusService.retrieveCommitStatusFirestore(

--- a/app_dart/lib/src/request_handlers/get_release_branches.dart
+++ b/app_dart/lib/src/request_handlers/get_release_branches.dart
@@ -38,7 +38,7 @@ final class GetReleaseBranches extends RequestHandler<Body> {
   final BranchService _branchService;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     return Body.forJson(
       await _branchService.getReleaseBranches(slug: Config.flutterSlug),
     );

--- a/app_dart/lib/src/request_handlers/get_repos.dart
+++ b/app_dart/lib/src/request_handlers/get_repos.dart
@@ -17,7 +17,7 @@ final class GetRepos extends RequestHandler<Body> {
   const GetRepos({required super.config});
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     return Body.forJson([
       ...config.supportedRepos.map((RepositorySlug slug) => slug.name),
     ]);

--- a/app_dart/lib/src/request_handlers/get_status.dart
+++ b/app_dart/lib/src/request_handlers/get_status.dart
@@ -32,15 +32,14 @@ final class GetStatus extends RequestHandler<Body> {
   static const String kRepoParam = 'repo';
 
   @override
-  Future<Body> get() async {
-    final lastCommitSha = request!.uri.queryParameters[kLastCommitShaParam];
+  Future<Body> get(Request request) async {
+    final lastCommitSha = request.uri.queryParameters[kLastCommitShaParam];
 
     final repoName =
-        request!.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
+        request.uri.queryParameters[kRepoParam] ?? Config.flutterSlug.name;
     final slug = RepositorySlug('flutter', repoName);
     final branch =
-        request!.uri.queryParameters[kBranchParam] ??
-        Config.defaultBranch(slug);
+        request.uri.queryParameters[kBranchParam] ?? Config.defaultBranch(slug);
     final commitNumber = config.commitNumber;
     final lastCommitTimestamp =
         lastCommitSha != null

--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -91,7 +91,7 @@ class GithubWebhookSubscription extends SubscriptionHandler {
   final PullRequestLabelProcessorProvider pullRequestLabelProcessorProvider;
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     if (message.data == null || message.data!.isEmpty) {
       log.warn('GitHub webhook message was empty. No-oping');
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
+++ b/app_dart/lib/src/request_handlers/github_rate_limit_status.dart
@@ -33,7 +33,7 @@ class GithubRateLimitStatus extends RequestHandler<Body> {
   final BigQueryService _bigQuery;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     final githubService = await config.createDefaultGitHubService();
     final quotaUsage = (await githubService.getRateLimit()).toJson();
     quotaUsage['timestamp'] = DateTime.now().toIso8601String();

--- a/app_dart/lib/src/request_handlers/github_webhook.dart
+++ b/app_dart/lib/src/request_handlers/github_webhook.dart
@@ -39,14 +39,14 @@ class GithubWebhook extends RequestHandler<Body> {
   final Future<String> secret;
 
   @override
-  Future<Body> post() async {
-    final event = request!.headers.value('X-GitHub-Event');
+  Future<Body> post(Request request) async {
+    final event = request.header('X-GitHub-Event');
 
-    if (event == null || request!.headers.value('X-Hub-Signature') == null) {
+    if (event == null || request.header('X-Hub-Signature') == null) {
       throw const BadRequestException('Missing required headers.');
     }
-    final requestBytes = await request!.expand((i) => i).toList();
-    final hmacSignature = request!.headers.value('X-Hub-Signature');
+    final requestBytes = await request.readBodyAsBytes();
+    final hmacSignature = request.header('X-Hub-Signature');
     await _validateRequest(hmacSignature, requestBytes);
 
     final requestString = utf8.decode(requestBytes);

--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -14,6 +14,7 @@ import '../../ci_yaml.dart';
 import '../model/firestore/commit.dart' as fs;
 import '../model/firestore/task.dart' as fs;
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import '../request_handling/subscription_handler.dart';
 import '../service/firestore.dart';
 import '../service/github_checks_service.dart';
@@ -50,7 +51,7 @@ final class PostsubmitLuciSubscription extends SubscriptionHandler {
   final FirestoreService _firestore;
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     if (message.data == null) {
       log.info('no data in message');
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/presubmit_luci_subscription.dart
@@ -14,6 +14,7 @@ import '../model/ci_yaml/ci_yaml.dart';
 import '../model/ci_yaml/target.dart';
 import '../request_handling/authentication.dart';
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import '../request_handling/subscription_handler.dart';
 import '../service/config.dart';
 import '../service/github_checks_service.dart';
@@ -54,7 +55,7 @@ class PresubmitLuciSubscription extends SubscriptionHandler {
   final CiYamlFetcher ciYamlFetcher;
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     if (message.data == null) {
       log.info('no data in message');
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_build_status_to_github.dart
@@ -35,7 +35,7 @@ final class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
   static const _fullNameRepoParam = 'repo';
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     if (authContext!.clientContext.isDevelopmentEnvironment) {
       // Don't push GitHub status from the local dev server.
       log.debug('GitHub statuses are not pushed from local dev environments');
@@ -43,7 +43,7 @@ final class PushBuildStatusToGithub extends ApiRequestHandler<Body> {
     }
 
     final repository =
-        request!.uri.queryParameters[_fullNameRepoParam] ?? 'flutter/flutter';
+        request.uri.queryParameters[_fullNameRepoParam] ?? 'flutter/flutter';
     final slug = RepositorySlug.full(repository);
     final status = await _buildStatusService.calculateCumulativeStatus(slug);
     await _insertBigQuery(

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -10,7 +10,7 @@ import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart';
 import 'package:gql/language.dart' as lang;
-import 'package:graphql/client.dart';
+import 'package:graphql/client.dart' hide Request;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
@@ -36,7 +36,7 @@ class PushGoldStatusToGithub extends ApiRequestHandler<Body> {
   final Duration _ingestionDelay;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     if (authContext!.clientContext.isDevelopmentEnvironment) {
       // Don't push gold status from the local dev server.
       return Body.empty;

--- a/app_dart/lib/src/request_handlers/readiness_check.dart
+++ b/app_dart/lib/src/request_handlers/readiness_check.dart
@@ -12,7 +12,7 @@ class ReadinessCheck extends RequestHandler<Body> {
   const ReadinessCheck({required super.config});
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     return Body.empty;
   }
 }

--- a/app_dart/lib/src/request_handlers/reset_try_task.dart
+++ b/app_dart/lib/src/request_handlers/reset_try_task.dart
@@ -29,12 +29,15 @@ class ResetTryTask extends ApiRequestHandler<Body> {
   static const String kBuilderParam = 'builders';
 
   @override
-  Future<Body> get() async {
-    checkRequiredQueryParameters(<String>[kRepoParam, kPullRequestNumberParam]);
-    final owner = request!.uri.queryParameters[kOwnerParam] ?? 'flutter';
-    final repo = request!.uri.queryParameters[kRepoParam]!;
-    final pr = request!.uri.queryParameters[kPullRequestNumberParam]!;
-    final builders = request!.uri.queryParameters[kBuilderParam] ?? '';
+  Future<Body> get(Request request) async {
+    checkRequiredQueryParameters(request, <String>[
+      kRepoParam,
+      kPullRequestNumberParam,
+    ]);
+    final owner = request.uri.queryParameters[kOwnerParam] ?? 'flutter';
+    final repo = request.uri.queryParameters[kRepoParam]!;
+    final pr = request.uri.queryParameters[kPullRequestNumberParam]!;
+    final builders = request.uri.queryParameters[kBuilderParam] ?? '';
     final builderList = getBuilderList(builders);
 
     final prNumber = int.tryParse(pr);

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -46,7 +46,7 @@ final class BatchBackfiller extends RequestHandler {
   final BranchService _branchService;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     await _backfillReleaseBranch(Config.flutterSlug);
     await Future.forEach(config.supportedRepos, _backfillDefaultBranch);
     return Body.empty;

--- a/app_dart/lib/src/request_handlers/scheduler/scheduler_request_subscription.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/scheduler_request_subscription.dart
@@ -41,7 +41,7 @@ class SchedulerRequestSubscription extends SubscriptionHandler {
   final RetryOptions retryOptions;
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     if (message.data == null) {
       log.info('no data in message');
       throw const BadRequestException('no data in message');

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -43,7 +43,7 @@ final class VacuumStaleTasks extends RequestHandler<Body> {
   final BranchService _branchService;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     // Default branches.
     await Future.forEach(config.supportedRepos, _vaccumRepository);
 

--- a/app_dart/lib/src/request_handlers/trigger_workflow.dart
+++ b/app_dart/lib/src/request_handlers/trigger_workflow.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 
 @immutable
 class TriggerWorkflow extends ApiRequestHandler<Body> {
@@ -22,11 +23,11 @@ class TriggerWorkflow extends ApiRequestHandler<Body> {
   static const String workflowParam = 'workflow';
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(Request request) async {
     // auth already happened; grab the query parameters.
-    checkRequiredQueryParameters([refParam, workflowParam]);
-    final ref = request!.uri.queryParameters[refParam]!;
-    final workflow = request!.uri.queryParameters[workflowParam]!;
+    checkRequiredQueryParameters(request, [refParam, workflowParam]);
+    final ref = request.uri.queryParameters[refParam]!;
+    final workflow = request.uri.queryParameters[workflowParam]!;
     await triggerWorkflow(ref, workflow);
     return Body.empty;
   }

--- a/app_dart/lib/src/request_handlers/update_discord_status.dart
+++ b/app_dart/lib/src/request_handlers/update_discord_status.dart
@@ -32,13 +32,13 @@ final class UpdateDiscordStatus extends GetBuildStatus {
   static const _kRepoParam = 'repo';
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     // For now, limit these to flutter/flutter only
-    if (request!.uri.queryParameters[_kRepoParam] != 'flutter') {
+    if (request.uri.queryParameters[_kRepoParam] != 'flutter') {
       throw const BadRequestException('Only ?repo=flutter is supported');
     }
 
-    final response = await super.createResponse();
+    final response = await super.createResponse(request);
 
     await recordStatus(response);
 

--- a/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
+++ b/app_dart/lib/src/request_handlers/vacuum_github_commits.dart
@@ -11,6 +11,7 @@ import 'package:meta/meta.dart';
 import '../model/firestore/commit.dart' as fs;
 import '../request_handling/api_request_handler.dart';
 import '../request_handling/body.dart';
+import '../request_handling/request_handler.dart';
 import '../service/config.dart';
 import '../service/github_service.dart';
 import '../service/scheduler.dart';
@@ -28,10 +29,10 @@ final class VacuumGithubCommits extends ApiRequestHandler<Body> {
   static const String branchParam = 'branch';
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(Request request) async {
     for (var slug in config.supportedRepos) {
       final branch =
-          request!.uri.queryParameters[branchParam] ??
+          request.uri.queryParameters[branchParam] ??
           Config.defaultBranch(slug);
       await _vacuumRepository(slug, branch: branch);
     }

--- a/app_dart/lib/src/request_handling/api_request_handler.dart
+++ b/app_dart/lib/src/request_handling/api_request_handler.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -30,7 +29,6 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
   const ApiRequestHandler({
     required super.config,
     required this.authenticationProvider,
-    this.requestBodyValue,
   });
 
   /// Service responsible for authenticating this [HttpRequest].
@@ -39,9 +37,12 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
   /// Throws a [BadRequestException] if any of [requiredParameters] is missing
   /// from [requestData].
   @protected
-  void checkRequiredParameters(List<String> requiredParameters) {
+  void checkRequiredParameters(
+    Map<String, Object?> requestData,
+    List<String> requiredParameters,
+  ) {
     final Iterable<String> missingParams =
-        requiredParameters..removeWhere(requestData!.containsKey);
+        requiredParameters..removeWhere(requestData.containsKey);
     if (missingParams.isNotEmpty) {
       throw BadRequestException(
         'Missing required parameter: ${missingParams.join(', ')}',
@@ -49,18 +50,15 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
     }
   }
 
-  // /// Gets [TokenInfo] using X-Flutter-IdToken header from an authenticated request.
-  // @protected
-  // Future<TokenInfo> tokenInfo(HttpRequest request) async {
-  //   return authenticationProvider.tokenInfo(request);
-  // }
-
   /// Throws a [BadRequestException] if any of [requiredQueryParameters] are missing from [requestData].
   @protected
-  void checkRequiredQueryParameters(List<String> requiredQueryParameters) {
+  void checkRequiredQueryParameters(
+    Request request,
+    List<String> requiredQueryParameters,
+  ) {
     final Iterable<String> missingParams =
         requiredQueryParameters
-          ..removeWhere(request!.uri.queryParameters.containsKey);
+          ..removeWhere(request.uri.queryParameters.containsKey);
     if (missingParams.isNotEmpty) {
       throw BadRequestException(
         'Missing required parameter: ${missingParams.join(', ')}',
@@ -75,35 +73,6 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
   @protected
   AuthenticatedContext? get authContext =>
       getValue<AuthenticatedContext>(ApiKey.authContext);
-
-  /// The raw byte contents of the HTTP request body.
-  ///
-  /// If the request did not specify any content in the body, this will be an
-  /// empty list. It will never be null.
-  ///
-  /// See also:
-  ///
-  ///  * [requestData], which contains the JSON-decoded [Map] of the request
-  ///    body content (if applicable).
-  @protected
-  Uint8List? get requestBody =>
-      requestBodyValue ?? getValue<Uint8List>(ApiKey.requestBody);
-
-  /// Used for injecting [requestBody] in tests.
-  final Uint8List? requestBodyValue;
-
-  /// The JSON data specified in the HTTP request body.
-  ///
-  /// This is guaranteed to be non-null. If the request body was empty, or if
-  /// it contained non-JSON or binary (non-UTF-8) data, this will be an empty
-  /// map.
-  ///
-  /// See also:
-  ///
-  ///  * [requestBody], which specifies the raw bytes of the HTTP request body.
-  @protected
-  Map<String, dynamic>? get requestData =>
-      getValue<Map<String, dynamic>>(ApiKey.requestData);
 
   @override
   Future<void> service(
@@ -123,47 +92,9 @@ abstract class ApiRequestHandler<T extends Body> extends RequestHandler<T> {
       return;
     }
 
-    List<int> body;
-    try {
-      body = await request.expand<int>((List<int> chunk) => chunk).toList();
-    } catch (error) {
-      final response = request.response;
-      response
-        ..statusCode = HttpStatus.internalServerError
-        ..write('$error');
-      await response.flush();
-      await response.close();
-      return;
-    }
-
-    Map<String, dynamic>? requestData = const <String, dynamic>{};
-    if (body.isNotEmpty) {
-      try {
-        requestData = json.decode(utf8.decode(body)) as Map<String, dynamic>?;
-      } on FormatException {
-        // The HTTP request body is not valid UTF-8 encoded JSON. This is
-        // allowed; just let [requestData] be null.
-      } catch (error) {
-        final response = request.response;
-        response
-          ..statusCode = HttpStatus.internalServerError
-          ..write('$error');
-        await response.flush();
-        await response.close();
-        return;
-      }
-    }
-
-    await runZoned<Future<void>>(
-      () async {
-        await super.service(request);
-      },
-      zoneValues: <ApiKey<dynamic>, Object?>{
-        ApiKey.authContext: context,
-        ApiKey.requestBody: Uint8List.fromList(body),
-        ApiKey.requestData: requestData,
-      },
-    );
+    await runZoned<Future<void>>(() async {
+      await super.service(request);
+    }, zoneValues: <ApiKey<dynamic>, Object?>{ApiKey.authContext: context});
   }
 }
 

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -46,10 +46,10 @@ final class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
   /// response from the cache before getting it to set the cached response
   /// to the latest information.
   @override
-  Future<T> get() async {
-    final responseKey = '${request!.uri.path}:${request!.uri.query}';
+  Future<T> get(Request request) async {
+    final responseKey = '${request.uri.path}:${request.uri.query}';
 
-    if (request!.uri.queryParameters[flushCacheQueryParam] == 'true') {
+    if (request.uri.queryParameters[flushCacheQueryParam] == 'true') {
       await _cache.purge(responseSubcacheName, responseKey);
     }
 
@@ -58,7 +58,7 @@ final class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
       responseKey,
       createFn: () async {
         // TODO(matanlurey): Evaluate if 5XX errors should not be cached.
-        final response = await _createCachedResponse(_delegate);
+        final response = await _createCachedResponse(request, _delegate);
         return response.toBytes();
       },
       ttl: _ttl,
@@ -78,9 +78,10 @@ final class CacheRequestHandler<T extends Body> extends RequestHandler<T> {
 
   /// Invokes [delegate.get], and returns the result as a [_CachedHttpResponse].
   Future<_CachedHttpResponse> _createCachedResponse(
+    Request request,
     RequestHandler<T> delegate,
   ) async {
-    final body = await delegate.get();
+    final body = await delegate.get(request);
     final response = this.response!;
     final builder = BytesBuilder();
     await body.serialize().forEach((d) {

--- a/app_dart/lib/src/request_handling/static_file_handler.dart
+++ b/app_dart/lib/src/request_handling/static_file_handler.dart
@@ -33,8 +33,8 @@ class StaticFileHandler extends RequestHandler<Body> {
 
   /// Services an HTTP GET Request for static files.
   @override
-  Future<Body> get() async {
-    final response = request!.response;
+  Future<Body> get(Request request) async {
+    final response = this.response!;
 
     /// The map of mimeTypes not found in [mime] package.
     final mimeTypeMap = <String, String>{

--- a/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
+++ b/app_dart/test/request_handlers/file_flaky_issue_and_pr_test.dart
@@ -1063,7 +1063,10 @@ void main() {
         totalNumber: 6,
       );
       final targets = unCheckedSchedulerConfig.targets;
-      expect(handler.shouldSkip(builderStatistic, ciYaml, targets), true);
+      expect(
+        handler.shouldSkip(builderStatistic, ciYaml, targets, threshold: 0.02),
+        true,
+      );
     });
 
     test('skips if the flakiness_threshold is not met', () {
@@ -1087,7 +1090,7 @@ void main() {
       );
       final targets = unCheckedSchedulerConfig.targets;
       expect(
-        handler.shouldSkip(builderStatistic, ciYaml, targets),
+        handler.shouldSkip(builderStatistic, ciYaml, targets, threshold: 0.02),
         true,
         reason: 'test specific flakiness_threshold overrides global threshold',
       );
@@ -1114,7 +1117,7 @@ void main() {
       );
       final targets = unCheckedSchedulerConfig.targets;
       expect(
-        handler.shouldSkip(builderStatistic, ciYaml, targets),
+        handler.shouldSkip(builderStatistic, ciYaml, targets, threshold: 0.02),
         false,
         reason: 'falkiness greater than test specified should trigger',
       );

--- a/app_dart/test/request_handlers/get_build_status_test.dart
+++ b/app_dart/test/request_handlers/get_build_status_test.dart
@@ -96,7 +96,7 @@ void main() {
     firestore.putDocument(taskPass);
     firestore.putDocument(taskFail);
 
-    tester.request!.uri = tester.request!.uri.replace(
+    tester.request.uri = tester.request.uri.replace(
       queryParameters: {'branch': 'flutter-0.42-candidate.0'},
     );
     final response = await decodeHandlerBody<Map<String, Object?>>();

--- a/app_dart/test/request_handlers/get_engine_artifacts_ready_test.dart
+++ b/app_dart/test/request_handlers/get_engine_artifacts_ready_test.dart
@@ -57,7 +57,7 @@ void main() {
   });
 
   test('returns a 404, "sha" is missing from database', () async {
-    tester.request!.uri = tester.request!.uri.replace(
+    tester.request.uri = tester.request.uri.replace(
       queryParameters: {'sha': 'abc123'},
     );
 
@@ -67,7 +67,7 @@ void main() {
   });
 
   test('returns "complete"', () async {
-    tester.request!.uri = tester.request!.uri.replace(
+    tester.request.uri = tester.request.uri.replace(
       queryParameters: {'sha': 'abc123'},
     );
 
@@ -90,7 +90,7 @@ void main() {
   });
 
   test('returns "pending"', () async {
-    tester.request!.uri = tester.request!.uri.replace(
+    tester.request.uri = tester.request.uri.replace(
       queryParameters: {'sha': 'abc123'},
     );
 
@@ -113,7 +113,7 @@ void main() {
   });
 
   test('returns "failed"', () async {
-    tester.request!.uri = tester.request!.uri.replace(
+    tester.request.uri = tester.request.uri.replace(
       queryParameters: {'sha': 'abc123'},
     );
 

--- a/app_dart/test/request_handlers/update_discord_status_test.dart
+++ b/app_dart/test/request_handlers/update_discord_status_test.dart
@@ -31,7 +31,7 @@ void main() {
   late MockDiscordService discord;
 
   Future<T> decodeHandlerBody<T>() async {
-    tester.request!.uri = tester.request!.uri.replace(query: 'repo=flutter');
+    tester.request.uri = tester.request.uri.replace(query: 'repo=flutter');
     final body = await tester.get(handler);
     return await utf8.decoder
             .bind(body.serialize() as Stream<List<int>>)

--- a/app_dart/test/request_handling/request_handler_test.dart
+++ b/app_dart/test/request_handling/request_handler_test.dart
@@ -168,43 +168,43 @@ class EmptyBodyHandler extends RequestHandler<Body> {
   EmptyBodyHandler() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async => Body.empty;
+  Future<Body> get(_) async => Body.empty;
 }
 
 class StringBodyHandler extends RequestHandler<Body> {
   StringBodyHandler() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async => Body.forString('Hello world');
+  Future<Body> get(_) async => Body.forString('Hello world');
 }
 
 class JsonBodyHandler extends RequestHandler<TestBody> {
   JsonBodyHandler() : super(config: FakeConfig());
 
   @override
-  Future<TestBody> get() async => const TestBody();
+  Future<TestBody> get(_) async => const TestBody();
 }
 
 class ThrowsHttpException extends RequestHandler<Body> {
   ThrowsHttpException() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async => throw const BadRequestException();
+  Future<Body> get(_) async => throw const BadRequestException();
 }
 
 class ThrowsStateError extends RequestHandler<Body> {
   ThrowsStateError() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async => throw StateError('error message');
+  Future<Body> get(_) async => throw StateError('error message');
 }
 
 class AccessesRequestAndResponseDirectly extends RequestHandler<Body> {
   AccessesRequestAndResponseDirectly() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async {
-    response!.headers.add('X-Test-Path', request!.uri.path);
+  Future<Body> get(Request request) async {
+    response!.headers.add('X-Test-Path', request.uri.path);
     return Body.empty;
   }
 }
@@ -213,13 +213,13 @@ class ImplementsBothGetAndPost extends RequestHandler<Body> {
   ImplementsBothGetAndPost() : super(config: FakeConfig());
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(_) async {
     response!.headers.add('X-Test-Get', 'true');
     return Body.empty;
   }
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(_) async {
     response!.headers.add('X-Test-Post', 'true');
     return Body.empty;
   }
@@ -229,5 +229,5 @@ class ImplementsOnlyPost extends RequestHandler<Body> {
   ImplementsOnlyPost() : super(config: FakeConfig());
 
   @override
-  Future<Body> post() async => Body.empty;
+  Future<Body> post(_) async => Body.empty;
 }

--- a/app_dart/test/request_handling/subscription_handler_test.dart
+++ b/app_dart/test/request_handling/subscription_handler_test.dart
@@ -151,7 +151,7 @@ class UnauthTest extends SubscriptionHandler {
       );
 
   @override
-  Future<Body> get() async => throw StateError('Unreachable');
+  Future<Body> get(_) async => throw StateError('Unreachable');
 }
 
 /// Test stub of [SubscriptionHandler] to validate authenticated requests.
@@ -165,7 +165,7 @@ class AuthTest extends SubscriptionHandler {
       );
 
   @override
-  Future<Body> get() async => Body.empty;
+  Future<Body> get(_) async => Body.empty;
 }
 
 /// Test stub of [SubscriptionHandler] to validate push messages can be read.
@@ -179,7 +179,7 @@ class ErrorTest extends SubscriptionHandler {
       );
 
   @override
-  Future<Body> get() async => throw const InternalServerError('Test error!');
+  Future<Body> get(_) async => throw const InternalServerError('Test error!');
 }
 
 /// Test stub of [SubscriptionHandler] to validate push messages can be read.
@@ -193,7 +193,7 @@ class ErrorCodeTest extends SubscriptionHandler {
       );
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(_) async {
     response!.statusCode = HttpStatus.serviceUnavailable;
     return Body.empty;
   }
@@ -210,5 +210,5 @@ class ReadMessageTest extends SubscriptionHandler {
       );
 
   @override
-  Future<Body> get() async => Body.forString(message.data!);
+  Future<Body> get(_) async => Body.forString(message.data!);
 }

--- a/app_dart/test/src/request_handling/api_request_handler_tester.dart
+++ b/app_dart/test/src/request_handling/api_request_handler_tester.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:cocoon_service/src/request_handling/api_request_handler.dart';
 import 'package:cocoon_service/src/request_handling/body.dart';
@@ -14,14 +15,14 @@ import 'request_handler_tester.dart';
 
 class ApiRequestHandlerTester extends RequestHandlerTester {
   ApiRequestHandlerTester({
-    super.request,
+    super.request, //
     FakeAuthenticatedContext? context,
-    Map<String, dynamic>? requestData,
-  }) : context = context ?? FakeAuthenticatedContext(),
-       requestData = requestData ?? <String, dynamic>{};
+  }) : context = context ?? FakeAuthenticatedContext();
 
   FakeAuthenticatedContext context;
-  Map<String, dynamic> requestData;
+  set requestData(Map<String, Object?> requestData) {
+    request.body = jsonEncode(requestData);
+  }
 
   @override
   @protected
@@ -31,10 +32,7 @@ class ApiRequestHandlerTester extends RequestHandlerTester {
         () {
           return callback();
         },
-        zoneValues: <RequestKey<dynamic>, Object>{
-          ApiKey.authContext: context,
-          ApiKey.requestData: requestData,
-        },
+        zoneValues: <RequestKey<dynamic>, Object>{ApiKey.authContext: context},
       );
     });
   }

--- a/app_dart/test/src/request_handling/fake_request_handler.dart
+++ b/app_dart/test/src/request_handling/fake_request_handler.dart
@@ -21,14 +21,14 @@ class FakeRequestHandler extends RequestHandler<Body> {
   String? reasonPhrase;
 
   @override
-  Future<Body> get() async {
+  Future<Body> get(_) async {
     callCount++;
     _updateResponseMetadata();
     return body;
   }
 
   @override
-  Future<Body> post() async {
+  Future<Body> post(_) async {
     callCount++;
     _updateResponseMetadata();
     return body;

--- a/app_dart/test/src/request_handling/request_handler_tester.dart
+++ b/app_dart/test/src/request_handling/request_handler_tester.dart
@@ -6,33 +6,32 @@ import 'dart:async';
 
 import 'package:cocoon_service/src/request_handling/body.dart';
 import 'package:cocoon_service/src/request_handling/request_handler.dart';
-import 'package:http/testing.dart' as http;
 import 'package:meta/meta.dart';
 
 import 'fake_http.dart';
 
 class RequestHandlerTester {
-  RequestHandlerTester({FakeHttpRequest? request, this.httpClient}) {
-    this.request = request ?? FakeHttpRequest();
-  }
+  RequestHandlerTester({FakeHttpRequest? request})
+    : request = request ?? FakeHttpRequest();
 
-  FakeHttpRequest? request;
-  http.MockClient? httpClient;
+  FakeHttpRequest request;
 
   /// This tester's [FakeHttpResponse], derived from [request].
-  FakeHttpResponse get response => request!.response;
+  FakeHttpResponse get response => request.response;
 
   /// Executes [RequestHandler.get] on the specified [handler].
   Future<T> get<T extends Body>(RequestHandler<T> handler) {
     return run<T>(() {
-      return handler.get(); // ignore: invalid_use_of_protected_member
+      // ignore: invalid_use_of_protected_member
+      return handler.get(Request.fromHttpRequest(request));
     });
   }
 
   /// Executes [RequestHandler.post] on the specified [handler].
   Future<T> post<T extends Body>(RequestHandler<T> handler) {
     return run<T>(() {
-      return handler.post(); // ignore: invalid_use_of_protected_member
+      // ignore: invalid_use_of_protected_member
+      return handler.post(Request.fromHttpRequest(request));
     });
   }
 
@@ -42,10 +41,7 @@ class RequestHandlerTester {
       () {
         return callback();
       },
-      zoneValues: <RequestKey<dynamic>, Object?>{
-        RequestKey.request: request,
-        RequestKey.response: response,
-      },
+      zoneValues: <RequestKey<dynamic>, Object?>{RequestKey.response: response},
     );
   }
 }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/168333.

Removes an over-engineered use of zones, and pre-reading data just to stick the data and request on `RequestHandler.this.` - there was exactly _one_ class that ever used the Zone-based features of `RequestHandler` (`file_flaky_issue_and_pr.dart`), and it was trivially changed to a named argument instead of reading directly from `this.request`.