### PR TITLE
More adoption of `TaskStatus`

### DIFF
--- a/app_dart/lib/src/model/bbv2_extension.dart
+++ b/app_dart/lib/src/model/bbv2_extension.dart
@@ -1,0 +1,22 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
+import 'package:cocoon_common/task_status.dart';
+
+extension StatusExtension on bbv2.Status {
+  /// Converts from a [bbv2.Status] to a [TaskStatus].
+  ///
+  /// An unrecognized status is disallowed.
+  TaskStatus toTaskStatus() {
+    return switch (this) {
+      bbv2.Status.SCHEDULED || bbv2.Status.STARTED => TaskStatus.inProgress,
+      bbv2.Status.SUCCESS => TaskStatus.succeeded,
+      bbv2.Status.CANCELED => TaskStatus.cancelled,
+      bbv2.Status.INFRA_FAILURE => TaskStatus.infraFailure,
+      bbv2.Status.FAILURE => TaskStatus.failed,
+      _ => throw StateError('Unexpected status: $this'),
+    };
+  }
+}

--- a/app_dart/lib/src/model/commit_ref.dart
+++ b/app_dart/lib/src/model/commit_ref.dart
@@ -8,11 +8,7 @@ import 'package:meta/meta.dart';
 /// Represents components of a GitHub commit without specifying the backend.
 @immutable
 final class CommitRef {
-  const CommitRef({
-    required this.sha,
-    required this.branch,
-    required this.slug,
-  });
+  CommitRef({required this.sha, required this.branch, required this.slug});
 
   /// The commit SHA.
   final String sha;

--- a/app_dart/lib/src/model/task_ref.dart
+++ b/app_dart/lib/src/model/task_ref.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_common/task_status.dart';
 import 'package:meta/meta.dart';
 
 /// Represents components of a backend task without specifying the backend.
@@ -21,7 +22,7 @@ final class TaskRef {
   final int currentAttempt;
 
   /// Status of the task.
-  final String status;
+  final TaskStatus status;
 
   /// Commit the task belongs to.
   final String commitSha;

--- a/app_dart/lib/src/model/task_ref.dart
+++ b/app_dart/lib/src/model/task_ref.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 /// Represents components of a backend task without specifying the backend.
 @immutable
 final class TaskRef {
-  const TaskRef({
+  TaskRef({
     required this.name,
     required this.currentAttempt,
     required this.status,

--- a/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
+++ b/app_dart/lib/src/request_handlers/dart_internal_subscription.dart
@@ -11,6 +11,7 @@ import 'package:googleapis/firestore/v1.dart';
 import 'package:meta/meta.dart';
 
 import '../../cocoon_service.dart';
+import '../model/bbv2_extension.dart';
 import '../model/firestore/task.dart' as fs;
 import '../request_handling/exceptions.dart';
 import '../request_handling/subscription_handler.dart';
@@ -75,7 +76,7 @@ final class DartInternalSubscription extends SubscriptionHandler {
           startTimestamp: build.startTime.toDateTime().millisecondsSinceEpoch,
           endTimestamp: build.endTime.toDateTime().millisecondsSinceEpoch,
           commitSha: build.input.gitilesCommit.id,
-          status: fs.Task.convertBuildbucketStatusToString(build.status),
+          status: build.status.toTaskStatus(),
 
           // These are all assumed values.
           bringup: false,

--- a/app_dart/test/model/bbv2_extension_test.dart
+++ b/app_dart/test/model/bbv2_extension_test.dart
@@ -1,0 +1,32 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
+import 'package:cocoon_common/task_status.dart';
+import 'package:cocoon_service/src/model/bbv2_extension.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const expectedMapping = {
+    bbv2.Status.CANCELED: TaskStatus.cancelled,
+    bbv2.Status.FAILURE: TaskStatus.failed,
+    bbv2.Status.INFRA_FAILURE: TaskStatus.infraFailure,
+    bbv2.Status.SCHEDULED: TaskStatus.inProgress,
+    bbv2.Status.STARTED: TaskStatus.inProgress,
+    bbv2.Status.SUCCESS: TaskStatus.succeeded,
+  };
+
+  for (final MapEntry(key: bbv2, value: expected) in expectedMapping.entries) {
+    test('$bbv2 -> $expected', () {
+      expect(bbv2.toTaskStatus(), expected);
+    });
+  }
+
+  test('refuses to convert unknown status', () {
+    expect(
+      () => bbv2.Status.STATUS_UNSPECIFIED.toTaskStatus(),
+      throwsStateError,
+    );
+  });
+}

--- a/app_dart/test/model/firestore/task_test.dart
+++ b/app_dart/test/model/firestore/task_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart';
-import 'package:googleapis/firestore/v1.dart';
 import 'package:test/test.dart';
 
 import '../../src/service/fake_firestore_service.dart';
@@ -17,15 +16,6 @@ void main() {
   useTestLoggerPerTest();
 
   group('Task', () {
-    test('disallows illegal status', () {
-      final task = Task.fromDocument(
-        Document()
-          ..name = 'name'
-          ..fields = {},
-      );
-      expect(() => task.setStatus('unknown'), throwsArgumentError);
-    });
-
     group('updateFromBuild', () {
       test('update succeeds from buildbucket v2', () async {
         final pubSubCallBack = bbv2.BuildsV2PubSub().createEmptyInstance();

--- a/app_dart/test/model/ref_test.dart
+++ b/app_dart/test/model/ref_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_common/task_status.dart';
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/commit_ref.dart';
+import 'package:cocoon_service/src/model/task_ref.dart';
+import 'package:github/github.dart';
+import 'package:test/test.dart';
+
+import '../src/model/ref_matcher.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  group('TaskRef', () {
+    final ref = TaskRef(
+      name: 'name',
+      currentAttempt: 1,
+      status: TaskStatus.succeeded,
+      commitSha: 'abc123',
+    );
+
+    test('stores arguments', () {
+      expect(
+        ref,
+        isTaskRef
+            .hasName('name')
+            .hasCurrentAttempt(1)
+            .hasStatus(TaskStatus.succeeded)
+            .hasCommitSha('abc123'),
+      );
+    });
+
+    test('implements == and hashCode', () {
+      expect(ref, equals(ref));
+      expect(ref.hashCode, ref.hashCode);
+    });
+
+    test('implements toString', () {
+      expect(
+        ref.toString(),
+        stringContainsInOrder(['name', 'abc123', 'Succeeded', '1']),
+      );
+    });
+  });
+
+  group('CommitRef', () {
+    final ref = CommitRef(
+      branch: 'branch',
+      sha: 'sha',
+      slug: RepositorySlug('owner', 'name'),
+    );
+
+    test('stores arguments', () {
+      expect(
+        ref,
+        isCommitRef
+            .hasBranch('branch')
+            .hasSha('sha')
+            .hasSlug(RepositorySlug('owner', 'name')),
+      );
+    });
+
+    test('implements == and hashCode', () {
+      expect(ref, equals(ref));
+      expect(ref.hashCode, ref.hashCode);
+    });
+
+    test('implements toString', () {
+      expect(
+        ref.toString(),
+        stringContainsInOrder(['sha', 'owner/name/branch']),
+      );
+    });
+  });
+}

--- a/app_dart/test/src/delegate_matcher.dart
+++ b/app_dart/test/src/delegate_matcher.dart
@@ -1,0 +1,44 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
+abstract base class DelegateMatcher<T> extends Matcher {
+  const DelegateMatcher(this._delegate);
+  final TypeMatcher<T> _delegate;
+
+  @protected
+  TypeMatcher<T> having(
+    Object? Function(T) feature,
+    String description,
+    Object? matcher,
+  ) {
+    return _delegate.having(feature, description, matcher);
+  }
+
+  @override
+  bool matches(Object? item, _) {
+    if (item is! T) {
+      return false;
+    }
+
+    return _delegate.matches(item, {});
+  }
+
+  @override
+  Description describe(Description description) {
+    return _delegate.describe(description);
+  }
+
+  @override
+  Description describeMismatch(
+    Object? item,
+    Description mismatchDescription,
+    _,
+    _,
+  ) {
+    return _delegate.describeMismatch(item, mismatchDescription, {}, false);
+  }
+}

--- a/app_dart/test/src/model/ref_matcher.dart
+++ b/app_dart/test/src/model/ref_matcher.dart
@@ -1,0 +1,50 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_service/src/model/commit_ref.dart';
+import 'package:cocoon_service/src/model/task_ref.dart';
+import 'package:test/test.dart';
+
+import '../delegate_matcher.dart';
+
+const isCommitRef = CommitRefMatcher._(TypeMatcher());
+const isTaskRef = TaskRefMatcher._(TypeMatcher());
+
+final class CommitRefMatcher extends DelegateMatcher<CommitRef> {
+  const CommitRefMatcher._(super._delegate);
+
+  CommitRefMatcher hasSha(Object? matcherOr) {
+    return CommitRefMatcher._(having((e) => e.sha, 'sha', matcherOr));
+  }
+
+  CommitRefMatcher hasBranch(Object? matcherOr) {
+    return CommitRefMatcher._(having((e) => e.branch, 'branch', matcherOr));
+  }
+
+  CommitRefMatcher hasSlug(Object? matcherOr) {
+    return CommitRefMatcher._(having((e) => e.slug, 'slug', matcherOr));
+  }
+}
+
+final class TaskRefMatcher extends DelegateMatcher<TaskRef> {
+  const TaskRefMatcher._(super._delegate);
+
+  TaskRefMatcher hasName(Object? matcherOr) {
+    return TaskRefMatcher._(having((e) => e.name, 'name', matcherOr));
+  }
+
+  TaskRefMatcher hasCurrentAttempt(Object? matcherOr) {
+    return TaskRefMatcher._(
+      having((e) => e.currentAttempt, 'currentAttempt', matcherOr),
+    );
+  }
+
+  TaskRefMatcher hasStatus(Object? matcherOr) {
+    return TaskRefMatcher._(having((e) => e.status, 'status', matcherOr));
+  }
+
+  TaskRefMatcher hasCommitSha(Object? matcherOr) {
+    return TaskRefMatcher._(having((e) => e.commitSha, 'commitSha', matcherOr));
+  }
+}


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/167284.

Removes (and tests) a subset of the original functionality, which is now migrated over.