### PR TITLE
Adopt `CommitRef` even more, reducing dependencies on Firestore model.

### DIFF
--- a/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
+++ b/app_dart/lib/src/request_handlers/postsubmit_luci_subscription.dart
@@ -94,12 +94,13 @@ final class PostsubmitLuciSubscription extends SubscriptionHandler {
       );
     }
 
+    // TODO(matanlurey): Store the CommitRef in UserData and avoid this call!
     final fsCommit = await fs.Commit.fromFirestoreBySha(
       _firestore,
       sha: fsTask.commitSha,
     );
 
-    final ciYaml = await _ciYamlFetcher.getCiYamlByFirestoreCommit(fsCommit);
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(fsCommit.toRef());
     final postsubmitTargets = [
       ...ciYaml.postsubmitTargets(),
       if (ciYaml.isFusion)

--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -4,12 +4,12 @@
 
 import 'package:cocoon_common/is_dart_internal.dart';
 import 'package:cocoon_server/logging.dart';
-import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:meta/meta.dart';
 
 import '../model/ci_yaml/ci_yaml.dart';
 import '../model/ci_yaml/target.dart';
+import '../model/commit_ref.dart';
 import '../model/firestore/commit.dart' as fs;
 import '../model/firestore/task.dart' as fs;
 import '../request_handling/api_request_handler.dart';
@@ -66,7 +66,6 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
     } = requestData.cast<String, String>();
 
     final email = authContext?.email ?? 'EMAIL-MISSING';
-    final slug = RepositorySlug('flutter', repo);
 
     // Ensure the commit exists in Firestore.
     final commit = await fs.Commit.tryFromFirestoreBySha(
@@ -89,9 +88,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
         );
       }
       final ranTasks = await _markAllTestsForRerun(
-        commit: commit,
-        slug: slug,
-        branch: branch,
+        commit: commit.toRef(),
         email: email,
         statusesToRerun: statusesToRerun,
       );
@@ -116,10 +113,8 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
     }
 
     final didRerun = await _rerunSpecificTask(
-      commit: commit,
+      commit: commit.toRef(),
       task: task,
-      slug: slug,
-      branch: branch,
       email: email,
     );
     if (!didRerun) {
@@ -130,8 +125,8 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
   }
 
   @useResult
-  Future<Map<String, Target>> _getPostsubmitTargets(fs.Commit commit) async {
-    final ciYaml = await _ciYamlFetcher.getCiYamlByFirestoreCommit(commit);
+  Future<Map<String, Target>> _getPostsubmitTargets(CommitRef commit) async {
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(commit);
     final targets = [
       ...ciYaml.postsubmitTargets(),
       if (ciYaml.isFusion)
@@ -159,9 +154,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
 
   @useResult
   Future<List<String>> _markAllTestsForRerun({
-    required fs.Commit commit,
-    required RepositorySlug slug,
-    required String branch,
+    required CommitRef commit,
     required String email,
     required Set<String> statusesToRerun,
   }) async {
@@ -233,10 +226,8 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
   }
 
   Future<bool> _rerunSpecificTask({
-    required fs.Commit commit,
+    required CommitRef commit,
     required fs.Task task,
-    required RepositorySlug slug,
-    required String branch,
     required String email,
   }) async {
     if (!_isTaskOwnedByCocoon(task)) {
@@ -262,7 +253,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
       }
 
       return await _luciBuildService.rerunDartInternalReleaseBuilder(
-        commit: commit.toRef(),
+        commit: commit,
         task: task,
       );
     }
@@ -274,7 +265,7 @@ final class RerunProdTask extends ApiRequestHandler<Body> {
     }
 
     return await _luciBuildService.rerunBuilder(
-      commit: commit.toRef(),
+      commit: commit,
       target: taskTarget,
       tags: [TriggerdByBuildTag(email: email)],
       task: task,

--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -11,6 +11,7 @@ import 'package:meta/meta.dart';
 
 import '../../../cocoon_service.dart';
 import '../../model/ci_yaml/ci_yaml.dart';
+import '../../model/commit_ref.dart';
 import '../../model/firestore/task.dart' as fs;
 import '../../request_handling/exceptions.dart';
 import '../../service/firestore/commit_and_tasks.dart';
@@ -96,10 +97,12 @@ final class BatchBackfiller extends RequestHandler {
       );
 
       // Download the ToT .ci.yaml targets.
-      final ciYaml = await _ciYamlFetcher.getCiYaml(
-        slug: slug,
-        commitSha: fsGrid.first.commit.sha,
-        commitBranch: Config.defaultBranch(slug),
+      final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
+        CommitRef(
+          slug: slug,
+          sha: fsGrid.first.commit.sha,
+          branch: Config.defaultBranch(slug),
+        ),
       );
 
       final totTargets = [
@@ -111,7 +114,7 @@ final class BatchBackfiller extends RequestHandler {
 
       grid = BackfillGrid.from([
         for (final CommitAndTasks(:commit, :tasks) in fsGrid)
-          (commit.toRef(), [...tasks.map((t) => t.toRef())]),
+          (commit, [...tasks.map((t) => t.toRef())]),
       ], tipOfTreeTargets: totTargets);
     }
     log.debug('Built a grid of ${grid.eligibleTasks.length} target columns');

--- a/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/vacuum_stale_tasks.dart
@@ -12,7 +12,7 @@ import 'package:googleapis/firestore/v1.dart';
 import 'package:meta/meta.dart';
 
 import '../../../cocoon_service.dart';
-import '../../model/firestore/commit.dart' as fs;
+import '../../model/commit_ref.dart';
 import '../../model/firestore/task.dart' as fs;
 import '../../service/firestore/commit_and_tasks.dart';
 
@@ -94,7 +94,7 @@ final class VacuumStaleTasks extends RequestHandler<Body> {
   }
 
   Future<_UpdateTaskIntent?> _considerTaskReset(
-    fs.Commit commit,
+    CommitRef commit,
     fs.Task task,
   ) async {
     // Check the timeout limit.
@@ -145,7 +145,7 @@ final class VacuumStaleTasks extends RequestHandler<Body> {
 
 sealed class _UpdateTaskIntent {
   _UpdateTaskIntent(this.commit, this.task);
-  final fs.Commit commit;
+  final CommitRef commit;
   final fs.Task task;
 
   @mustBeOverridden

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -182,7 +182,7 @@ mixin FirestoreQueries {
     return [
       for (final commit in commits)
         CommitAndTasks(
-          commit,
+          commit.toRef(),
           await queryAllTasksForCommit(commitSha: commit.sha, status: status),
         ).withMostRecentTaskOnly(),
     ];

--- a/app_dart/lib/src/service/firestore/commit_and_tasks.dart
+++ b/app_dart/lib/src/service/firestore/commit_and_tasks.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import '../../model/commit_ref.dart';
 import '../../model/firestore/commit.dart';
 import '../../model/firestore/task.dart';
 
@@ -14,7 +15,7 @@ final class CommitAndTasks {
     : tasks = List.unmodifiable(tasks);
 
   /// Commit from Firestore.
-  final Commit commit;
+  final CommitRef commit;
 
   /// Tasks where [Task.commitSha] is the same as [Commit.sha].
   ///

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -164,7 +164,7 @@ class Scheduler {
       return;
     }
 
-    final ciYaml = await _ciYamlFetcher.getCiYamlByFirestoreCommit(commit);
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(commit.toRef());
     final targets = ciYaml.getInitialTargets(ciYaml.postsubmitTargets());
     final isFusion = commit.slug == Config.flutterSlug;
     if (isFusion) {
@@ -699,11 +699,8 @@ $s
     );
 
     final branch = baseRef.substring('refs/heads/'.length);
-    final ciYaml = await _ciYamlFetcher.getCiYaml(
-      slug: slug,
-      commitBranch: branch,
-      commitSha: headSha,
-      validate: branch == Config.defaultBranch(slug),
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
+      CommitRef(sha: headSha, branch: branch, slug: slug),
     );
     log.info(
       'ci.yaml loaded successfully; collecting merge group targets for $headSha',
@@ -830,11 +827,8 @@ $s
 
     final branch = pullRequest.base!.ref!;
     final slug = pullRequest.base!.repo!.slug();
-    final ciYaml = await _ciYamlFetcher.getCiYaml(
-      commitBranch: branch,
-      commitSha: pullRequest.head!.sha!,
-      slug: slug,
-      validate: branch == Config.defaultBranch(slug),
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
+      CommitRef(slug: slug, branch: branch, sha: pullRequest.head!.sha!),
     );
 
     log.info('ci.yaml loaded successfully.');
@@ -1506,8 +1500,8 @@ $stacktrace
                 fsTask = fsTasks.first;
               }
               log.debug('Latest firestore task is $fsTask');
-              final ciYaml = await _ciYamlFetcher.getCiYamlByFirestoreCommit(
-                fsCommit,
+              final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
+                fsCommit.toRef(),
               );
               final target = ciYaml.postsubmitTargets().singleWhere(
                 (target) => target.name == fsTask.taskName,

--- a/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
+++ b/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
@@ -6,6 +6,7 @@ import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
 import 'package:path/path.dart' as p;
 
+import '../../model/commit_ref.dart';
 import '../config.dart';
 import '../get_files_changed.dart';
 import 'ci_yaml_fetcher.dart';
@@ -53,10 +54,9 @@ final class FilesChangedOptimizer {
       return FilesChangedOptimization.none;
     }
 
-    final ciYaml = await _ciYamlFetcher.getCiYaml(
-      slug: slug,
-      commitSha: commitSha,
-      commitBranch: commitBranch,
+    final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
+      CommitRef(slug: slug, sha: commitSha, branch: commitBranch),
+      validate: false,
     );
 
     final refusePrefix = 'Not optimizing: ${slug.fullName}/pulls/${pr.number}';

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -27,7 +27,7 @@ void main() {
 
   group('CommitAndTasks', () {
     test('withMostRecentTaskOnly returns the largest currentAttempt', () {
-      final commit = CommitAndTasks(generateFirestoreCommit(1), [
+      final commit = CommitAndTasks(generateFirestoreCommit(1).toRef(), [
         generateFirestoreTask(1, name: 'Linux A', attempts: 2),
         generateFirestoreTask(1, name: 'Linux A', attempts: 1),
         generateFirestoreTask(1, name: 'Linux A', attempts: 3),

--- a/app_dart/test/service/scheduler/ci_yaml_fetcher_test.dart
+++ b/app_dart/test/service/scheduler/ci_yaml_fetcher_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/ci_yaml.dart';
 import 'package:cocoon_service/cocoon_service.dart';
+import 'package:cocoon_service/src/model/commit_ref.dart';
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
 import 'package:github/github.dart';
 import 'package:http/http.dart' as http;
@@ -96,10 +97,8 @@ void main() {
 
     mockFillFirestore(slug: Config.packagesSlug, branch: 'main');
 
-    final ciYaml = await ciYamlFetcher.getCiYaml(
-      slug: Config.packagesSlug,
-      commitSha: currentSha,
-      commitBranch: 'main',
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
+      CommitRef(slug: Config.packagesSlug, sha: currentSha, branch: 'main'),
       validate: true,
     );
 
@@ -134,17 +133,15 @@ void main() {
 
     mockFillFirestore(slug: Config.packagesSlug, branch: 'main');
 
-    final ciYaml = await ciYamlFetcher.getCiYaml(
-      slug: Config.packagesSlug,
-      commitSha: currentSha,
-      commitBranch: 'main',
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
+      CommitRef(slug: Config.packagesSlug, sha: currentSha, branch: 'main'),
       validate: true,
     );
 
     expect(ciYaml.targets().map((t) => t.name), unorderedEquals(['Linux A']));
   });
 
-  test('fetches the root .ci.yaml for a firestore commit', () async {
+  test('fetches the root .ci.yaml for a commit ref', () async {
     httpClient = MockClient((request) async {
       if (request.url.host != 'raw.githubusercontent.com') {
         fail('Unexpected host: ${request.url}');
@@ -164,13 +161,13 @@ void main() {
 
     mockFillFirestore(slug: Config.packagesSlug, branch: 'main');
 
-    final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
       generateFirestoreCommit(
         1,
         sha: currentSha,
         repo: 'packages',
         branch: 'main',
-      ),
+      ).toRef(),
       validate: true,
     );
 
@@ -204,10 +201,8 @@ void main() {
     mockFillFirestore(slug: Config.packagesSlug, branch: 'main');
 
     await expectLater(
-      ciYamlFetcher.getCiYaml(
-        slug: Config.packagesSlug,
-        commitSha: currentSha,
-        commitBranch: 'main',
+      ciYamlFetcher.getCiYamlByCommit(
+        CommitRef(slug: Config.packagesSlug, sha: currentSha, branch: 'main'),
         validate: true,
       ),
       throwsA(
@@ -246,13 +241,13 @@ void main() {
 
     mockFillFirestore(slug: Config.packagesSlug, branch: 'main');
 
-    final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
       generateFirestoreCommit(
         1,
         sha: currentSha,
         repo: 'packages',
         branch: 'main',
-      ),
+      ).toRef(),
       validate: true,
     );
 
@@ -285,12 +280,12 @@ void main() {
       branch: Config.defaultBranch(Config.flutterSlug),
     );
 
-    final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
       generateFirestoreCommit(
         1,
         sha: currentSha,
         branch: 'flutter-0.42-candidate.0',
-      ),
+      ).toRef(),
       validate: true,
     );
 
@@ -321,8 +316,8 @@ void main() {
 
     mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
-    final ciYaml = await ciYamlFetcher.getCiYamlByFirestoreCommit(
-      generateFirestoreCommit(1, sha: currentSha),
+    final ciYaml = await ciYamlFetcher.getCiYamlByCommit(
+      generateFirestoreCommit(1, sha: currentSha).toRef(),
       validate: true,
     );
 
@@ -347,10 +342,8 @@ void main() {
     mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     await expectLater(
-      ciYamlFetcher.getCiYaml(
-        slug: Config.flutterSlug,
-        commitSha: currentSha,
-        commitBranch: 'master',
+      ciYamlFetcher.getCiYamlByCommit(
+        CommitRef(slug: Config.flutterSlug, sha: currentSha, branch: 'master'),
         validate: true,
       ),
       throwsA(
@@ -379,10 +372,8 @@ targets:
     mockFillFirestore(slug: Config.flutterSlug, branch: 'master');
 
     await expectLater(
-      ciYamlFetcher.getCiYaml(
-        slug: Config.flutterSlug,
-        commitSha: currentSha,
-        commitBranch: 'master',
+      ciYamlFetcher.getCiYamlByCommit(
+        CommitRef(slug: Config.flutterSlug, sha: currentSha, branch: 'master'),
         validate: true,
       ),
       throwsA(

--- a/app_dart/test/src/service/fake_ci_yaml_fetcher.dart
+++ b/app_dart/test/src/service/fake_ci_yaml_fetcher.dart
@@ -4,16 +4,16 @@
 
 import 'package:cocoon_service/protos.dart' as pb;
 import 'package:cocoon_service/src/model/ci_yaml/ci_yaml.dart';
+import 'package:cocoon_service/src/model/commit_ref.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/scheduler/ci_yaml_fetcher.dart';
 import 'package:github/src/common/model/repos.dart';
 import 'package:yaml/yaml.dart';
 
-final class FakeCiYamlFetcher extends CiYamlFetcher {
-  FakeCiYamlFetcher({this.ciYaml, this.failCiYamlValidation = false})
-    : super.forTesting();
+final class FakeCiYamlFetcher implements CiYamlFetcher {
+  FakeCiYamlFetcher({this.ciYaml, this.failCiYamlValidation = false});
 
-  /// The value that should be returned as a canned response for [getCiYaml].
+  /// The value that should be returned as a canned response for [getCiYamlByCommit].
   ///
   /// If omitted (`null`) defaults to a configuration with a single target.
   CiYamlSet? ciYaml;
@@ -34,25 +34,26 @@ final class FakeCiYamlFetcher extends CiYamlFetcher {
     );
   }
 
-  /// If `true`, [getCiYaml] will throw a [FormatException].
+  /// If `true`, [getCiYamlByCommit] will throw a [FormatException].
   ///
   /// This simulates failing validation.
   bool failCiYamlValidation;
 
   @override
-  Future<CiYamlSet> getCiYaml({
-    required RepositorySlug slug,
-    required String commitSha,
-    required String commitBranch,
-    bool validate = false,
+  Future<CiYamlSet> getCiYamlByCommit(
+    CommitRef commit, {
+    bool? validate,
   }) async {
+    validate ??= commit.branch == Config.defaultBranch(commit.slug);
     if (validate && failCiYamlValidation) {
       throw const FormatException('Failed validation!');
     }
-    final ci = ciYaml ?? _createDefault(slug: slug, commitBranch: commitBranch);
+    final ci =
+        ciYaml ??
+        _createDefault(slug: commit.slug, commitBranch: commit.branch);
     return CiYamlSet(
-      slug: slug,
-      branch: commitBranch,
+      slug: commit.slug,
+      branch: commit.branch,
       yamls: ci.configs.map((k, v) => MapEntry(k, v.config)),
     );
   }


### PR DESCRIPTION
... also cleans up `CiYamlFetcher`-messiness due to supporting Firestore+Datastore.