### PR TITLE
Make `Stream<Uint8List?>` always non-nullable

### DIFF
--- a/app_dart/lib/src/request_handling/body.dart
+++ b/app_dart/lib/src/request_handling/body.dart
@@ -17,7 +17,7 @@ abstract class Body {
   factory Body.forString(String content) => _StringBody(content);
 
   /// Creates a [Body] that passes through the already-serialized [stream].
-  factory Body.forStream(Stream<Uint8List?> stream) => _StreamBody(stream);
+  factory Body.forStream(Stream<Uint8List> stream) => _StreamBody(stream);
 
   /// Creates a [Body] that serializes the specified JSON [value].
   ///
@@ -30,7 +30,7 @@ abstract class Body {
   static const Body empty = _EmptyBody();
 
   /// Serializes this response body to bytes.
-  Stream<Uint8List?> serialize();
+  Stream<Uint8List> serialize();
 }
 
 abstract class JsonBody extends Body {
@@ -45,7 +45,7 @@ abstract class JsonBody extends Body {
   }
 
   /// Serializes this response body to a JSON-primitive map.
-  Map<String, dynamic> toJson();
+  Map<String, Object?> toJson();
 }
 
 class _EmptyBody extends Body {
@@ -76,8 +76,8 @@ class _StringBody extends Body {
 class _StreamBody extends Body {
   const _StreamBody(this.stream);
 
-  final Stream<Uint8List?> stream;
+  final Stream<Uint8List> stream;
 
   @override
-  Stream<Uint8List?> serialize() => stream;
+  Stream<Uint8List> serialize() => stream;
 }

--- a/app_dart/lib/src/request_handling/cache_request_handler.dart
+++ b/app_dart/lib/src/request_handling/cache_request_handler.dart
@@ -73,7 +73,7 @@ final class CacheRequestHandler extends RequestHandler {
       ..statusCode = cachedResponse.statusCode
       ..reasonPhrase = cachedResponse.reason;
 
-    return Body.forStream(Stream<Uint8List?>.value(cachedResponse.body));
+    return Body.forStream(Stream<Uint8List>.value(cachedResponse.body));
   }
 
   /// Invokes [delegate.get], and returns the result as a [_CachedHttpResponse].
@@ -84,9 +84,7 @@ final class CacheRequestHandler extends RequestHandler {
     final body = await delegate.get(request);
     final response = this.response!;
     final builder = BytesBuilder();
-    await body.serialize().forEach((d) {
-      if (d != null) builder.add(d);
-    });
+    await body.serialize().forEach(builder.add);
     return _CachedHttpResponse._(
       response.statusCode,
       response.reasonPhrase,

--- a/app_dart/test/request_handlers/scheduler/scheduler_request_subscription_test.dart
+++ b/app_dart/test/request_handlers/scheduler/scheduler_request_subscription_test.dart
@@ -166,7 +166,7 @@ void main() {
       final body = await tester.post(handler);
 
       final bodyString =
-          await utf8.decoder.bind(body.serialize().asyncMap((b) => b!)).join();
+          await utf8.decoder.bind(body.serialize().asyncMap((b) => b)).join();
       expect(bodyString, 'Failed to schedule builds: (builder: Linux A\n).');
       expect(verify(buildBucketClient.batch(any)).callCount, 3);
       expect(githubService.checkRunUpdates, hasLength(1));

--- a/app_dart/test/request_handling/cache_request_handler_test.dart
+++ b/app_dart/test/request_handling/cache_request_handler_test.dart
@@ -56,7 +56,7 @@ void main() {
     );
 
     final body = await tester.get(cacheRequestHandler);
-    final response = (await body.serialize().first)!;
+    final response = await body.serialize().first;
     final strResponse = utf8.decode(response);
     expect(strResponse, expectedResponse);
   });
@@ -87,7 +87,7 @@ void main() {
     );
 
     final body = await tester.get(cacheRequestHandler);
-    final response = (await body.serialize().first)!;
+    final response = await body.serialize().first;
     final strResponse = utf8.decode(response);
     expect(strResponse, expectedResponse);
     expect(tester.response.statusCode, 200);
@@ -166,7 +166,7 @@ void main() {
     expect(fallbackHandler.callCount, 0);
 
     final body = await tester.get(cacheRequestHandler);
-    final response = (await body.serialize().first)!;
+    final response = await body.serialize().first;
     final strResponse = utf8.decode(response);
 
     // the mock should update the cache to have null -> empty string


### PR DESCRIPTION
... it turns out it always could have been, but like uh, ok.