### PR TITLE
Experimental backfill for `ios-experimental` branch.

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/backfill_grid.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/backfill_grid.dart
@@ -200,6 +200,17 @@ final class BackfillTask {
   /// The LUCI scheduling priority of backfilling this task.
   final int priority;
 
+  /// Creates a copy of `this` with the provided properties replaced.
+  @useResult
+  BackfillTask copyWith({int? priority}) {
+    return BackfillTask._from(
+      task,
+      target: target,
+      commit: commit,
+      priority: priority ?? this.priority,
+    );
+  }
+
   @override
   String toString() {
     return 'BackfillTask ${const JsonEncoder.withIndent('  ').convert({

--- a/app_dart/test/request_handlers/scheduler/backfill_grid_test.dart
+++ b/app_dart/test/request_handlers/scheduler/backfill_grid_test.dart
@@ -162,4 +162,26 @@ void main() {
       ]),
     );
   });
+
+  test('can override BackfillTask priority after creation', () {
+    final commit = generateFirestoreCommit(1).toRef();
+    final task = generateFirestoreTask(2, commitSha: commit.sha).toRef();
+    final target = generateTarget(1, name: task.name);
+
+    final grid = BackfillGrid.from(
+      [
+        (commit, [task]),
+      ],
+      tipOfTreeTargets: [target],
+    );
+
+    expect(
+      grid.createBackfillTask(task, priority: 1001).copyWith(priority: 1002),
+      isBackfillTask
+          .hasTask(task)
+          .hasTarget(target)
+          .hasCommit(commit)
+          .hasPriority(1002),
+    );
+  });
 }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/168738.

This enables backfill support for `ios-experimental`. More work is required to make this work e2e.

/cc @vashworth