### PR TITLE
Use the word `bringup` not `flaky` to describe `bringup: true`.

### DIFF
--- a/dashboard/lib/widgets/task_overlay.dart
+++ b/dashboard/lib/widgets/task_overlay.dart
@@ -278,7 +278,7 @@ class TaskOverlayContents extends StatelessWidget {
     final summaryText = [
       'Attempts: ${task.attempts}',
       _describeTaskRunning(task, now: now!),
-      if (task.isBringup) 'Flaky: ${task.isBringup}',
+      if (task.isBringup) 'Bringup',
     ].join('\n');
 
     return Card(

--- a/dashboard/test/widgets/task_overlay_test.dart
+++ b/dashboard/test/widgets/task_overlay_test.dart
@@ -110,7 +110,7 @@ void main() {
         'Attempts: 3\n'
         'Queued for 2 minutes\n'
         'Ran for 48 minutes\n'
-        'Flaky: true';
+        'Bringup';
 
     await tester.pumpWidget(
       Now.fixed(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fd5d6e28-2e35-4f33-ad01-423b3fd2d8d2)
