### PR TITLE
Do not show a loading indicator when we are not loading.

### DIFF
--- a/dashboard/lib/widgets/task_grid.dart
+++ b/dashboard/lib/widgets/task_grid.dart
@@ -59,9 +59,12 @@ class TaskGridContainer extends StatelessWidget {
       builder: (BuildContext context, Widget? child) {
         final commitStatuses = buildState.statuses;
 
-        // Assume if there is no data that it is loading.
         if (commitStatuses.isEmpty) {
-          return const Center(child: CircularProgressIndicator());
+          if (buildState.moreStatusesExist) {
+            return const Center(child: CircularProgressIndicator());
+          } else {
+            return const Center(child: Text('No commits found.'));
+          }
         }
 
         return TaskGrid(


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/168851.