### PR TITLE
Handle flag`waitOnContentHash`

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -323,9 +323,7 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
         log.info(
           '$slug/$headSha was found on GoB mirror. Scheduling merge group tasks',
         );
-        await scheduler.triggerMergeGroupTargets(
-          mergeGroupEvent: mergeGroupEvent,
-        );
+        await scheduler.handleMergeGroupEvent(mergeGroupEvent: mergeGroupEvent);
 
       // A merge group was deleted. This can happen when a PR is pulled from the
       // merge queue. All CI jobs pertaining to this merge group should be

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -3245,7 +3245,7 @@ void foo() {
             ),
             logThat(
               message: equals(
-                'triggerMergeGroupTargets(flutter/packages, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): scheduling merge group checks',
+                'triggerTargetsForMergeGroup(flutter/packages, c9affbbb12aa40cb3afbe94b9ea6b119a256bebf, simulated): scheduling merge group checks',
               ),
             ),
             logThat(

--- a/app_dart/test/service/scheduler/ci_yaml_strings.dart
+++ b/app_dart/test/service/scheduler/ci_yaml_strings.dart
@@ -1,0 +1,112 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String otherBranchCiYaml = r'''
+enabled_branches:
+  - ios-experimental
+targets:
+  - name: Linux A
+''';
+
+const String singleCiYaml = r'''
+enabled_branches:
+  - master
+  - main
+  - flutter-\d+\.\d+-candidate\.\d+
+targets:
+  - name: Linux A
+    properties:
+      custom: abc
+  - name: Linux B
+    enabled_branches:
+      - stable
+    scheduler: luci
+  - name: Linux runIf
+    runIf:
+      - .ci.yaml
+      - DEPS
+      - dev/**
+      - engine/**
+  - name: Google Internal Roll
+    postsubmit: true
+    presubmit: false
+    scheduler: google_internal
+''';
+
+const String singleCiYamlWithLinuxAnalyze = r'''
+enabled_branches:
+  - master
+  - main
+  - flutter-\d+\.\d+-candidate\.\d+
+targets:
+  - name: Linux A
+    properties:
+      custom: abc
+  - name: Linux B
+    enabled_branches:
+      - stable
+    scheduler: luci
+  - name: Linux runIf
+    runIf:
+      - .ci.yaml
+      - DEPS
+      - dev/**
+      - engine/**
+  - name: Linux analyze
+''';
+
+const String fusionCiYaml = r'''
+enabled_branches:
+  - master
+  - main
+  - codefu
+  - flutter-\d+\.\d+-candidate\.\d+
+targets:
+  - name: Linux Z
+    properties:
+      custom: abc
+  - name: Linux Y
+    enabled_branches:
+      - stable
+    scheduler: luci
+  - name: Linux engine_presubmit
+  - name: Linux engine_build
+    scheduler: luci
+    properties:
+      release_build: "true"
+  - name: Linux runIf engine
+    runIf:
+      - DEPS
+      - engine/src/flutter/.ci.yaml
+      - engine/src/flutter/dev/**
+''';
+
+const String fusionDualCiYaml = r'''
+enabled_branches:
+  - master
+  - main
+  - codefu
+  - flutter-\d+\.\d+-candidate\.\d+
+targets:
+  - name: Linux Z
+    properties:
+      custom: abc
+  - name: Linux Y
+    enabled_branches:
+      - stable
+    scheduler: luci
+  - name: Linux engine_build
+    scheduler: luci
+    properties:
+      release_build: "true"
+  - name: Mac engine_build
+    scheduler: luci
+    properties:
+      release_build: "true"
+  - name: Linux runIf engine
+    runIf:
+      - DEPS
+      - engine/src/flutter/.ci.yaml
+      - engine/src/flutter/dev/**
+''';

--- a/app_dart/test/service/scheduler/create_check_run.dart
+++ b/app_dart/test/service/scheduler/create_check_run.dart
@@ -1,0 +1,84 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'package:github/github.dart';
+
+CheckRun createCheckRun({
+  int id = 1,
+  String sha = '1234',
+  String? name = 'Linux unit_test',
+  String conclusion = 'success',
+  String owner = 'flutter',
+  String repo = 'flutter',
+  String headBranch = 'master',
+  CheckRunStatus status = CheckRunStatus.completed,
+  int checkSuiteId = 668083231,
+}) {
+  final checkRunJson = checkRunFor(
+    id: id,
+    sha: sha,
+    name: name,
+    conclusion: conclusion,
+    owner: owner,
+    repo: repo,
+    headBranch: headBranch,
+    status: status,
+    checkSuiteId: checkSuiteId,
+  );
+  return CheckRun.fromJson(jsonDecode(checkRunJson) as Map<String, dynamic>);
+}
+
+String checkRunFor({
+  int id = 1,
+  String sha = '1234',
+  String? name = 'Linux unit_test',
+  String conclusion = 'success',
+  String owner = 'flutter',
+  String repo = 'flutter',
+  String headBranch = 'master',
+  CheckRunStatus status = CheckRunStatus.completed,
+  int checkSuiteId = 668083231,
+}) {
+  final externalId = id * 2;
+  return '''{
+  "id": $id,
+  "external_id": "{$externalId}",
+  "head_sha": "$sha",
+  "name": "$name",
+  "conclusion": "$conclusion",
+  "started_at": "2020-05-10T02:49:31Z",
+  "completed_at": "2020-05-10T03:11:08Z",
+  "status": "$status",
+  "check_suite": {
+    "id": $checkSuiteId,
+    "pull_requests": [],
+    "conclusion": "$conclusion",
+    "head_branch": "$headBranch"
+  }
+}''';
+}
+
+String checkRunEventFor({
+  String action = 'completed',
+  String sha = '1234',
+  String test = 'Linux unit_test',
+  String conclusion = 'success',
+  String owner = 'flutter',
+  String repo = 'flutter',
+  String headBranch = 'master',
+}) => '''{
+  "action": "$action",
+  "check_run": ${checkRunFor(name: test, sha: sha, conclusion: conclusion, owner: owner, repo: repo, headBranch: headBranch)},
+  "repository": {
+    "name": "$repo",
+    "full_name": "$owner/$repo",
+    "owner": {
+      "avatar_url": "",
+      "html_url": "",
+      "login": "$owner",
+      "id": 54371434
+    }
+  }
+}''';

--- a/app_dart/test/service/scheduler/hash_workflow_test.dart
+++ b/app_dart/test/service/scheduler/hash_workflow_test.dart
@@ -1,0 +1,199 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_server_test/mocks.dart';
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/cocoon_service.dart' hide Response;
+import 'package:cocoon_service/src/model/firestore/content_aware_hash_builds.dart';
+import 'package:cocoon_service/src/model/github/workflow_job.dart';
+import 'package:cocoon_service/src/service/big_query.dart';
+import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
+import 'package:github/github.dart';
+import 'package:http/http.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../model/github/workflow_job_data.dart';
+import '../../src/fake_config.dart';
+import '../../src/service/fake_ci_yaml_fetcher.dart';
+import '../../src/service/fake_firestore_service.dart';
+import '../../src/service/fake_get_files_changed.dart';
+import '../../src/service/fake_github_service.dart';
+import '../../src/utilities/mocks.mocks.dart';
+import '../content_aware_hash_service_test.dart' show goodAnnotation;
+import 'ci_yaml_strings.dart';
+import 'create_check_run.dart';
+
+void main() async {
+  useTestLoggerPerTest();
+
+  late CacheService cache;
+  late FakeConfig config;
+  late FakeCiYamlFetcher ciYamlFetcher;
+  late FakeFirestoreService firestore;
+  late MockGithubChecksUtil mockGithubChecksUtil;
+  late Scheduler scheduler;
+  late FakeGetFilesChanged getFilesChanged;
+  late BigQueryService bigQuery;
+  late ContentAwareHashService cahs;
+
+  setUp(() {
+    ciYamlFetcher = FakeCiYamlFetcher();
+
+    ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionDualCiYaml);
+    final luci = MockLuciBuildService();
+    when(
+      luci.getAvailableBuilderSet(
+        project: anyNamed('project'),
+        bucket: anyNamed('bucket'),
+      ),
+    ).thenAnswer((inv) async {
+      return {'Mac engine_build'};
+    });
+    when(
+      luci.scheduleTryBuilds(
+        targets: anyNamed('targets'),
+        pullRequest: anyNamed('pullRequest'),
+        engineArtifacts: anyNamed('engineArtifacts'),
+      ),
+    ).thenAnswer((inv) async {
+      return [];
+    });
+    mockGithubChecksUtil = MockGithubChecksUtil();
+    final checkRuns = <CheckRun>[];
+    when(
+      mockGithubChecksUtil.createCheckRun(
+        any,
+        any,
+        any,
+        any,
+        output: anyNamed('output'),
+      ),
+    ).thenAnswer((inv) async {
+      final slug = inv.positionalArguments[1] as RepositorySlug;
+      final sha = inv.positionalArguments[2] as String;
+      final name = inv.positionalArguments[3] as String?;
+      checkRuns.add(
+        createCheckRun(
+          id: 1,
+          owner: slug.owner,
+          repo: slug.name,
+          sha: sha,
+          name: name,
+        ),
+      );
+      return checkRuns.last;
+    });
+    getFilesChanged = FakeGetFilesChanged.inconclusive();
+    getFilesChanged.cannedFiles = ['abc/def'];
+    cache = CacheService(inMemory: true);
+
+    final github = MockGitHub();
+    when(
+      github.request(
+        'GET',
+        argThat(
+          equals(
+            'https://api.github.com/repos/flutter/flutter/check-runs/40533761873/annotations',
+          ),
+        ),
+      ),
+    ).thenAnswer((_) async => Response(goodAnnotation(), 200));
+
+    final githubService = FakeGithubService(client: github);
+    config = FakeConfig(githubService: githubService, githubClient: github);
+    firestore = FakeFirestoreService();
+    bigQuery = BigQueryService.forTesting(
+      MockTabledataResource(),
+      MockJobsResource(),
+    );
+
+    cahs = ContentAwareHashService(config: config, firestore: firestore);
+    scheduler = Scheduler(
+      cache: cache,
+      config: config,
+      githubChecksService: GithubChecksService(
+        config,
+        githubChecksUtil: mockGithubChecksUtil,
+      ),
+      getFilesChanged: getFilesChanged,
+      ciYamlFetcher: ciYamlFetcher,
+      luciBuildService: luci,
+      contentAwareHash: cahs,
+      firestore: firestore,
+      bigQuery: bigQuery,
+    );
+  });
+
+  test('only processes workflow events !waitOnContentHash', () async {
+    final job = workflowJobTemplate().toWorkflowJob();
+    // fakeContentAwareHash.nextStatusReturn = MergeQueueHashStatus.build;
+
+    await scheduler.processWorkflowJob(job);
+
+    // expect(fakeContentAwareHash.processWorkflowJobs, [job]);
+    expect(firestore.documents, isNotEmpty);
+    expect(
+      firestore,
+      existsInStorage(ContentAwareHashBuilds.metadata, [
+        isContentAwareHashBuilds
+            .hasCommitSha('27bfdee25949bc48044c4e16678f3449dd213b6e')
+            .hasContentHash('65038ef4984b927fd1762ef01d35c5ecc34ff5f7')
+            .hasStatus(BuildStatus.inProgress)
+            .hasWaitingShas([]),
+      ]),
+    );
+    verifyNever(
+      mockGithubChecksUtil.createCheckRun(
+        any,
+        any,
+        any,
+        any,
+        output: anyNamed('output'),
+        conclusion: anyNamed('conclusion'),
+      ),
+    );
+  });
+
+  test('triggers tests on waitOnContentHash', () async {
+    config.dynamicConfig = DynamicConfig.fromJson({
+      'contentAwareHashing': {'waitOnContentHash': true},
+    });
+
+    final job = workflowJobTemplate().toWorkflowJob();
+    // fakeContentAwareHash.nextStatusReturn = MergeQueueHashStatus.build;
+
+    await scheduler.processWorkflowJob(job);
+
+    // expect(fakeContentAwareHash.processWorkflowJobs, [job]);
+    expect(firestore.documents, isNotEmpty);
+    expect(
+      firestore,
+      existsInStorage(ContentAwareHashBuilds.metadata, [
+        isContentAwareHashBuilds
+            .hasCommitSha('27bfdee25949bc48044c4e16678f3449dd213b6e')
+            .hasContentHash('65038ef4984b927fd1762ef01d35c5ecc34ff5f7')
+            .hasStatus(BuildStatus.inProgress)
+            .hasWaitingShas([]),
+      ]),
+    );
+    verify(
+      mockGithubChecksUtil.createCheckRun(
+        any,
+        RepositorySlug.full('flutter/flutter'),
+        '27bfdee25949bc48044c4e16678f3449dd213b6e',
+        'Merge Queue Guard',
+        output: anyNamed('output'),
+        conclusion: anyNamed('conclusion'),
+      ),
+    ).called(1);
+  });
+}
+
+extension on String {
+  WorkflowJobEvent toWorkflowJob() =>
+      WorkflowJobEvent.fromJson(json.decode(this) as Map<String, Object?>);
+}

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:cocoon_service/src/model/github/workflow_job.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
@@ -25,25 +27,31 @@ class FakeContentAwareHashService implements ContentAwareHashService {
     return status;
   }
 
-  final calledForJob = <WorkflowJobEvent>[];
+  final hashFromWorkflowJobs = <WorkflowJobEvent>[];
   String? nextHashReturn;
 
   @override
   Future<String?> hashFromWorkflowJobEvent(WorkflowJobEvent workflow) {
     // make a copy
-    calledForJob.add(WorkflowJobEvent.fromJson(workflow.toJson()));
+    hashFromWorkflowJobs.add(
+      WorkflowJobEvent.fromJson(
+        json.decode(json.encode(workflow.toJson())) as Map<String, Object?>,
+      ),
+    );
     final hash = nextHashReturn;
     nextHashReturn = null;
     return Future.value(hash);
   }
 
+  final processWorkflowJobs = <WorkflowJobEvent>[];
   MergeQueueHashStatus? nextStatusReturn;
 
   @override
   Future<MergeQueueHashStatus> processWorkflowJob(
-    WorkflowJobEvent job, {
+    WorkflowJobEvent workflow, {
     RetryOptions? retry,
   }) {
+    processWorkflowJobs.add(workflow);
     final status = nextStatusReturn ?? MergeQueueHashStatus.ignoreJob;
     nextStatusReturn = null;
     return Future.value(status);


### PR DESCRIPTION
This ONLY waits on the content hash before triggering all builds.

- renames `triggerMergeGroupTargets` -> `handleMergeGroupEvent`. We want to be able to trigger targets in the merge group later from synthetic data. See `triggerTargetsForMergeGroup`.
- Moves some test strings out to ci_yaml_test_strings
- Moves some test check run methods to new file.
- Tests really need to be broken out; follow up PR