### PR TITLE
Add a log statement when a `dart-internal` re-run occurs but won't succeed.

### DIFF
--- a/app_dart/lib/src/request_handlers/rerun_prod_task.dart
+++ b/app_dart/lib/src/request_handlers/rerun_prod_task.dart
@@ -252,6 +252,10 @@ final class RerunProdTask extends ApiRequestHandler {
       // waiting for the task to be complete, we'd need a different strategy
       // (i.e. multiple tasks per release builder, versus one).
       if (!task.status.isComplete) {
+        log.info(
+          'Refused to re-run "${task.taskName}" (status: ${task.status}) - '
+          'attempt ${task.currentAttempt} already in progress',
+        );
         throw const BadRequestException(
           'Cannot rerun a release builder that is not done running',
         );


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/168905.

Haven't had the chance to dig further yet, but should help for next time.