### PR TITLE
Remove legacy branch logic for `3.29`.

### DIFF
--- a/app_dart/integration_test/data/cocoon_config.json
+++ b/app_dart/integration_test/data/cocoon_config.json
@@ -160,9 +160,7 @@
     },
     {
       "name": "Linux ci_yaml roller",
-      "properties": {
-        "backfill": "false"
-      },
+      "backfill": false,
       "runIf": [
         ".ci.yaml"
       ],

--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -131,20 +131,9 @@ final class Target {
 
   /// Whether the target should be considered for backfill.
   bool get backfill {
-    if (schedulerPolicy is! BatchPolicy) {
-      return false;
-    }
-    // TODO(matanlurey): Stop reading this property:
-    // https://github.com/flutter/flutter/issues/167755
-    //
-    // For practical sake, since it's used to guard Linux Docs Publish, we'll
-    // want to wait until 100+ commits have landed before changing this,
-    // otherwise we run the risk of backfilling (and overriding) the published
-    // Flutter API docs.
-    if (_value.properties['backfill'] == 'false') {
-      return false;
-    }
-    return _value.backfill;
+    return _value.hasBackfill()
+        ? _value.backfill
+        : schedulerPolicy is BatchPolicy;
   }
 
   /// The target's enabled branches.

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -861,10 +861,7 @@ class LuciBuildService {
     final isFusion = commit.slug == Config.flutterSlug;
     if (isFusion) {
       processedProperties['is_fusion'] = 'true';
-      if (isReleaseCandidateBranch(branchName: commit.branch) &&
-          // TODO(matanlurey): Remove carvout for legacy branch after 3.29 is archived.
-          // https://github.com/flutter/flutter/issues/167821
-          commit.branch != 'flutter.3.29-candidate.0') {
+      if (isReleaseCandidateBranch(branchName: commit.branch)) {
         processedProperties.addAll({
           // Always provide an engine version, just like we do in presubmit.
           // See https://github.com/flutter/flutter/issues/167010.

--- a/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
+++ b/app_dart/lib/src/service/scheduler/files_changed_optimization.dart
@@ -38,9 +38,6 @@ final class FilesChangedOptimizer {
   // ```
   final CiYamlFetcher _ciYamlFetcher;
 
-  // TODO(matanlurey): https://github.com/flutter/flutter/issues/167821.
-  static const _doNotSkipFrameworkTestsForBranch = {'flutter-3.29-candidate.0'};
-
   final Config _config;
 
   /// Returns an optimization type possible given the pull request.
@@ -48,11 +45,6 @@ final class FilesChangedOptimizer {
     final slug = pr.base!.repo!.slug();
     final commitSha = pr.head!.sha!;
     final commitBranch = pr.base!.ref!;
-
-    if (_doNotSkipFrameworkTestsForBranch.contains(commitBranch)) {
-      log.info('$commitBranch does not support the framework-only optimizer');
-      return FilesChangedOptimization.none;
-    }
 
     final ciYaml = await _ciYamlFetcher.getCiYamlByCommit(
       CommitRef(slug: slug, sha: commitSha, branch: commitBranch),

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -292,13 +292,6 @@ void main() {
       expect(generateTarget(1, backfill: false), isTarget.hasBackfill(false));
     });
 
-    test('can be explicitly set to false (legacy via properties)', () {
-      expect(
-        generateTarget(1, properties: {'backfill': 'false'}),
-        isTarget.hasBackfill(false),
-      );
-    });
-
     test('is false if the scheduling system is not Cocoon', () {
       expect(
         generateTarget(1, schedulerSystem: SchedulerSystem.release),

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -441,23 +441,6 @@ void main() {
         );
       });
 
-      test('run all tasks if legacy release candidate branch', () async {
-        ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionCiYaml);
-
-        final mergedPr = generatePullRequest(
-          branch: 'flutter-3.29-candidate.0',
-        );
-        await scheduler.addPullRequest(mergedPr);
-
-        expect(
-          firestore,
-          existsInStorage(
-            fs.Task.metadata,
-            everyElement(isTask.hasStatus(TaskStatus.inProgress)),
-          ),
-        );
-      });
-
       test('skips all tasks if release candidate branch', () async {
         ciYamlFetcher.setCiYamlFrom(singleCiYaml, engine: fusionCiYaml);
 
@@ -3446,28 +3429,6 @@ targets:
           fakeLuciBuildService.scheduledTryBuilds.map((t) => t.name),
           ['Linux analyze'],
           reason: 'Only scheduled a special-cased build',
-        );
-      });
-
-      // Regression test for https://github.com/flutter/flutter/issues/162403.
-      test('engine builds still run for flutter-3.29-candidate.0', () async {
-        getFilesChanged.cannedFiles = ['packages/flutter/lib/material.dart'];
-        final pullRequest = generatePullRequest(
-          branch: 'flutter-3.29-candidate.0',
-        );
-
-        await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
-        expect(
-          fakeLuciBuildService.engineArtifacts,
-          EngineArtifacts.usingExistingEngine(
-            commitSha: pullRequest.head!.sha!,
-          ),
-          reason: 'Release candidates use an "existing" dart-internal build',
-        );
-        expect(
-          fakeLuciBuildService.scheduledTryBuilds.map((t) => t.name),
-          ['Linux engine_build'],
-          reason: 'Should run the engine_build',
         );
       });
     });


### PR DESCRIPTION
We will not make any future 3.29 updates.

Closes https://github.com/flutter/flutter/issues/167821.
Closes https://github.com/flutter/flutter/issues/167755.