### PR TITLE
chore: turn on `waitOnContentHash` flag

### DIFF
--- a/app_dart/config.yaml
+++ b/app_dart/config.yaml
@@ -4,3 +4,8 @@
 # app_dart/lib/src/service/config.dart
 
 backfillerCommitLimit: 50
+
+contentAwareHashing:
+  # This will cause PRs that enter the merge queue to wait on CAH hashing
+  # to happen before scheduling builds.
+  waitOnContentHash: true


### PR DESCRIPTION
Round 2: roll-forward after a new build that supports this.