### PR TITLE
fix: `waitOnContentHash` should also trigger on completed hash

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -672,10 +672,14 @@ $s
       // TODO: MergeQueueHashStatus
       //   - .build: trigger targets!
       //   - .wait: something is building.
+      //   - .completed: hash already built, complete!
       //   - .*: do nothing
-      // FOR NOW: trigger builds for build/wait
+      // FOR NOW: trigger builds for build/wait/completed because they are also
+      //          building for SHA.
       switch (artifactStatus) {
-        case MergeQueueHashStatus.build || MergeQueueHashStatus.wait
+        case MergeQueueHashStatus.build ||
+                MergeQueueHashStatus.wait ||
+                MergeQueueHashStatus.complete
             when _config.flags.contentAwareHashing.waitOnContentHash:
           // Note from codefu: We do not have the merge queue lock yet.
           // It was short-circuited if the waitOnContentHash is set. The


### PR DESCRIPTION
Prior to flipping completely over; we need to trigger tests for all shas, even if the content hash was generated.