### PR TITLE
Add and use a `TimeRange` class to represent before/after timestamp.

### DIFF
--- a/app_dart/lib/src/service/build_status_service.dart
+++ b/app_dart/lib/src/service/build_status_service.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:cocoon_common/core_extensions.dart';
 import 'package:cocoon_common/task_status.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:github/github.dart';
@@ -88,14 +89,14 @@ interface class BuildStatusService {
   /// The returned stream will be ordered by most recent commit first, then
   /// the next newest, and so on.
   Future<List<CommitTasksStatus>> retrieveCommitStatusFirestore({
-    required int limit,
-    int? timestamp,
-    String? branch,
     required RepositorySlug slug,
+    required int limit,
+    TimeRange? created,
+    String? branch,
   }) async {
     final commits = await _firestore.queryRecentCommits(
       limit: limit,
-      timestamp: timestamp,
+      created: created,
       branch: branch,
       slug: slug,
     );

--- a/app_dart/test/request_handlers/get_status_test.dart
+++ b/app_dart/test/request_handlers/get_status_test.dart
@@ -61,7 +61,7 @@ void main() {
     expect(result, containsPair('Commits', isEmpty));
   });
 
-  test('reports statuses without input commit key', () async {
+  test('reports statuses without input commit SHA', () async {
     buildStatusService = FakeBuildStatusService(
       commitTasksStatuses: [
         CommitTasksStatus(generateFirestoreCommit(1, sha: commit1.sha), []),
@@ -79,11 +79,20 @@ void main() {
     expect(result, containsPair('Commits', hasLength(2)));
   });
 
-  test('reports statuses with input commit key', () async {
+  test('reports statuses with input commit SHA', () async {
     buildStatusService = FakeBuildStatusService(
       commitTasksStatuses: [
-        CommitTasksStatus(generateFirestoreCommit(1, sha: commit1.sha), []),
-        CommitTasksStatus(generateFirestoreCommit(2, sha: commit2.sha), []),
+        // Newer
+        CommitTasksStatus(
+          generateFirestoreCommit(2, sha: commit2.sha, createTimestamp: 2),
+          [],
+        ),
+
+        // Older
+        CommitTasksStatus(
+          generateFirestoreCommit(1, sha: commit1.sha, createTimestamp: 1),
+          [],
+        ),
       ],
     );
     handler = GetStatus(

--- a/app_dart/test/src/service/fake_build_status_service.dart
+++ b/app_dart/test/src/service/fake_build_status_service.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cocoon_common/core_extensions.dart';
 import 'package:cocoon_service/src/service/build_status_provider/commit_tasks_status.dart';
 import 'package:cocoon_service/src/service/build_status_service.dart';
 import 'package:collection/collection.dart';
 import 'package:github/github.dart';
 
+// TODO(matanlurey): Remove this shim over Firestore and use FakeFirestore instead.
 class FakeBuildStatusService implements BuildStatusService {
   FakeBuildStatusService({this.cumulativeStatus, this.commitTasksStatuses});
 
@@ -27,19 +29,21 @@ class FakeBuildStatusService implements BuildStatusService {
   @override
   Future<List<CommitTasksStatus>> retrieveCommitStatusFirestore({
     int limit = 100,
-    int? timestamp,
+    TimeRange? created,
     String? branch,
     required RepositorySlug slug,
   }) async {
     commitTasksStatuses!.sortBy((c) => c.commit.createTimestamp);
-    return commitTasksStatuses!
-        .where(
-          (status) =>
-              ((timestamp == null)
-                  ? true
-                  : status.commit.createTimestamp < timestamp) &&
-              status.commit.branch == branch,
-        )
-        .toList();
+    return commitTasksStatuses!.where((status) {
+      if (status.commit.branch != branch) {
+        return false;
+      }
+      if (created != null) {
+        return created.contains(
+          DateTime.fromMillisecondsSinceEpoch(status.commit.createTimestamp),
+        );
+      }
+      return true;
+    }).toList();
   }
 }

--- a/packages/cocoon_common/lib/core_extensions.dart
+++ b/packages/cocoon_common/lib/core_extensions.dart
@@ -5,6 +5,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+export 'src/time_range.dart';
+
 extension BytesStreamExtension on Stream<List<int>> {
   /// Collects and returns all of the integer lists as list of bytes.
   Future<Uint8List> collectBytes({bool copy = true}) async {

--- a/packages/cocoon_common/lib/src/time_range.dart
+++ b/packages/cocoon_common/lib/src/time_range.dart
@@ -1,0 +1,161 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+/// A definition of a time range, which can be specific or indefinite.
+@immutable
+sealed class TimeRange {
+  const TimeRange();
+
+  /// Matches any time.
+  static const TimeRange indefinite = IndefiniteTimeRange();
+
+  /// Creates a range matching time between [start] and [end].
+  ///
+  /// If [exclusive] is set, the specific moments described in [start] and [end]
+  /// are excluded.
+  ///
+  /// [end] must be after [start].
+  factory TimeRange.between(
+    DateTime start, //
+    DateTime end, {
+    bool exclusive,
+  }) = SpecificTimeRange.between;
+
+  /// Creates a range matching time before [end].
+  ///
+  /// If [exclusive] is set, the specific moment described in [end] is excluded.
+  factory TimeRange.before(
+    DateTime end, { //
+    bool exclusive,
+  }) = SpecificTimeRange.before;
+
+  /// Creates a range matching time after [start].
+  ///
+  /// If [exclusive] is set, the specific moment described in [start] is
+  /// excluded.
+  factory TimeRange.after(
+    DateTime start, { //
+    bool exclusive,
+  }) = SpecificTimeRange.after;
+
+  @override
+  @nonVirtual
+  bool operator ==(Object other) {
+    return other is TimeRange && start == other.start && end == other.end;
+  }
+
+  @override
+  @nonVirtual
+  int get hashCode => Object.hash(start, end);
+
+  /// A starting point in time.
+  ///
+  /// If `null`, the time range is infinite in the past.
+  DateTime? get start;
+
+  /// An ending point in time.
+  ///
+  /// If `null`, the time range is infinite in the future.
+  DateTime? get end;
+
+  /// Returns whether [time] is within `this` range.
+  bool contains(DateTime time);
+
+  @override
+  String toString() {
+    if (start == null && end == null) {
+      return 'TimeRange.indefinite';
+    }
+    if (start == null) {
+      return 'TimeRange.before($end)';
+    }
+    if (end == null) {
+      return 'TimeRange.after($start)';
+    }
+    return 'TimeRange.between($start, $end)';
+  }
+}
+
+/// No specific start or end time.
+final class IndefiniteTimeRange extends TimeRange {
+  @literal
+  const IndefiniteTimeRange();
+
+  @override
+  Null get start => null;
+
+  @override
+  Null get end => null;
+
+  @override
+  bool contains(DateTime time) => true;
+}
+
+/// A specific time range, which includes at _least_ [start] or [end], or both.
+final class SpecificTimeRange extends TimeRange {
+  /// Creates a time range with a specific [end] time.
+  ///
+  /// If [exclusive] is set, the specific moment described in [end] is excluded.
+  SpecificTimeRange.before(
+    DateTime this.end, { //
+    this.exclusive = false,
+  }) : start = null;
+
+  /// Creates a time range with a specific [start] time.
+  ///
+  /// If [exclusive] is set, the specific moment described in [start] is
+  /// excluded.
+  SpecificTimeRange.after(
+    DateTime this.start, { //
+    this.exclusive = false,
+  }) : end = null;
+
+  /// Creates a time range with a specific [start] and [end] time.
+  ///
+  /// If [exclusive] is set, the specific moment described in [start] and [end]
+  /// are excluded.
+  ///
+  /// [start] must be before [end].
+  SpecificTimeRange.between(
+    DateTime this.start, //
+    DateTime this.end, {
+    this.exclusive = false,
+  }) {
+    if (start!.isAfter(end!)) {
+      throw ArgumentError.value(
+        start,
+        'start',
+        'Start time must be before end time.',
+      );
+    }
+  }
+
+  /// Whether [start], or [end], if specified, should exclude that instant.
+  final bool exclusive;
+
+  /// Whether [start], or [end], if specified, should include that instant.
+  bool get inclusive => !exclusive;
+
+  @override
+  final DateTime? start;
+
+  @override
+  final DateTime? end;
+
+  @override
+  bool contains(DateTime time) {
+    if (start case final start? when start.isAfter(time)) {
+      return false;
+    }
+    if (end case final end? when end.isBefore(time)) {
+      return false;
+    }
+    if (exclusive) {
+      return time != start && time != end;
+    }
+    return true;
+  }
+}

--- a/packages/cocoon_common/test/time_range_test.dart
+++ b/packages/cocoon_common/test/time_range_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_common/core_extensions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TimeRange.indefinite', () {
+    test('omits start and end', () {
+      expect(
+        TimeRange.indefinite,
+        isA<IndefiniteTimeRange>()
+            .having((r) => r.start, 'start', isNull)
+            .having((r) => r.end, 'end', isNull),
+      );
+    });
+
+    test('matches any date', () {
+      final now = DateTime.now();
+      for (var i = -365; i < 365; i++) {
+        final date = now.add(Duration(days: i));
+        expect(
+          TimeRange.indefinite.contains(date),
+          isTrue,
+          reason: 'Expected $date to be contained in indefinite range',
+        );
+      }
+    });
+  });
+
+  group('TimeRange.between', () {
+    test('matches specific date', () {
+      final start = DateTime(2020, 1, 1);
+      final end = DateTime(2020, 1, 2);
+      final range = TimeRange.between(start, end);
+
+      expect(range.start, start);
+      expect(range.end, end);
+
+      expect(range.contains(start), isTrue);
+      expect(range.contains(end), isTrue);
+    });
+
+    test('does not match specific date (exclusive)', () {
+      final start = DateTime(2020, 1, 1);
+      final end = DateTime(2020, 1, 2);
+      final range = TimeRange.between(start, end, exclusive: true);
+
+      expect(range.start, start);
+      expect(range.end, end);
+
+      expect(range.contains(start), isFalse);
+      expect(range.contains(end), isFalse);
+    });
+
+    test('does not match date outside range', () {
+      final start = DateTime(2020, 1, 1);
+      final end = DateTime(2020, 1, 2);
+      final range = TimeRange.between(start, end);
+
+      expect(range.contains(start.subtract(const Duration(days: 1))), isFalse);
+      expect(range.contains(end.add(const Duration(days: 1))), isFalse);
+    });
+  });
+
+  group('TimeRange.before', () {
+    test('matches specific date', () {
+      final end = DateTime(2020, 1, 1);
+      final range = TimeRange.before(end);
+
+      expect(range.end, end);
+      expect(range.start, isNull);
+
+      expect(range.contains(end), isTrue);
+    });
+
+    test('does not match specific date (exclusive)', () {
+      final end = DateTime(2020, 1, 1);
+      final range = TimeRange.before(end, exclusive: true);
+
+      expect(range.end, end);
+      expect(range.start, isNull);
+
+      expect(range.contains(end), isFalse);
+    });
+
+    test('does not match date after range', () {
+      final end = DateTime(2020, 1, 1);
+      final range = TimeRange.before(end);
+
+      expect(range.contains(end.add(const Duration(days: 1))), isFalse);
+    });
+  });
+
+  group('TimeRange.after', () {
+    test('matches specific date', () {
+      final start = DateTime(2020, 1, 1);
+      final range = TimeRange.after(start);
+
+      expect(range.start, start);
+      expect(range.end, isNull);
+
+      expect(range.contains(start), isTrue);
+    });
+
+    test('does not match specific date (exclusive)', () {
+      final start = DateTime(2020, 1, 1);
+      final range = TimeRange.after(start, exclusive: true);
+
+      expect(range.start, start);
+      expect(range.end, isNull);
+
+      expect(range.contains(start), isFalse);
+    });
+
+    test('does not match date before range', () {
+      final start = DateTime(2020, 1, 1);
+      final range = TimeRange.after(start);
+
+      expect(range.contains(start.subtract(const Duration(days: 1))), isFalse);
+    });
+
+    test('matches date after range', () {
+      final start = DateTime(2020, 1, 1);
+      final range = TimeRange.after(start);
+
+      expect(range.contains(start.add(const Duration(days: 1))), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
I started to work on https://github.com/flutter/flutter/issues/169234 and realized the current way timestamp filtering is done with Firebase is inflexible (and personally, confusing). This adds a small-ish `TimeRange` class in `cocoon_commons` and uses it instead of `int? timestamp` to determine which commits to find.

(Even if we want a different approach than https://github.com/flutter/flutter/issues/169234, this seems worth it?)