### PR TITLE
chore: waitOnContentHash=true part 3

### DIFF
--- a/app_dart/config.yaml
+++ b/app_dart/config.yaml
@@ -4,3 +4,8 @@
 # app_dart/lib/src/service/config.dart
 
 backfillerCommitLimit: 50
+
+contentAwareHashing:
+  # This will cause PRs that enter the merge queue to wait on CAH hashing
+  # to happen before scheduling builds.
+  waitOnContentHash: true


### PR DESCRIPTION
Previous failure was due to not handling the assets completed case. All cases should be handled (and tested) now.
