### PR TITLE
Use any branch with commits in the last week as a backfill signal.

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -131,14 +131,6 @@ Server createServer({
       ciYamlFetcher: ciYamlFetcher,
       luciBuildService: luciBuildService,
       firestore: firestore,
-      branchService: branchService,
-    ),
-    '/api/v2/scheduler/batch-backfiller': BatchBackfiller(
-      config: config,
-      ciYamlFetcher: ciYamlFetcher,
-      luciBuildService: luciBuildService,
-      firestore: firestore,
-      branchService: branchService,
     ),
     '/api/v2/scheduler/batch-request-subscription':
         SchedulerRequestSubscription(

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -68,7 +68,7 @@ mixin FirestoreQueries {
     Transaction? transaction,
   });
 
-  static Map<String, String> _filterByTimeRAnge(
+  static Map<String, Object> _filterByTimeRAnge(
     String fieldName,
     TimeRange range,
   ) {
@@ -76,31 +76,29 @@ mixin FirestoreQueries {
       IndefiniteTimeRange() => const {},
       SpecificTimeRange(:final start, :final end, :final exclusive) => {
         if (start != null)
-          '$fieldName ${exclusive ? '>' : '>='}':
-              '${start.millisecondsSinceEpoch}',
+          '$fieldName ${exclusive ? '>' : '>='}': start.millisecondsSinceEpoch,
         if (end != null)
-          '$fieldName ${exclusive ? '<' : '<='}':
-              '${end.millisecondsSinceEpoch}',
+          '$fieldName ${exclusive ? '<' : '<='}': end.millisecondsSinceEpoch,
       },
     };
   }
 
   /// Queries for recent commits.
   ///
-  /// The [limit] argument specifies the maximum number of commits to retrieve.
+  /// If [limit] is `null`, all commits are returned.
   ///
-  /// The returned commits will be ordered by most recent [Commit.timestamp].
+  /// The returned commits will be ordered by most recent
+  /// [Commit.createTimestamp].
   Future<List<Commit>> queryRecentCommits({
-    int limit = 100,
+    required int? limit,
+    required RepositorySlug slug,
     TimeRange? created,
     String? branch,
-    required RepositorySlug slug,
   }) async {
-    branch ??= Config.defaultBranch(slug);
     created ??= TimeRange.indefinite;
     final filterMap = <String, Object>{
-      '${Commit.fieldBranch} =': branch,
       '${Commit.fieldRepositoryPath} =': slug.fullName,
+      if (branch != null) '${Commit.fieldBranch} =': branch,
       ..._filterByTimeRAnge(Commit.fieldCreateTimestamp, created),
     };
     final orderMap = <String, String>{

--- a/cron.yaml
+++ b/cron.yaml
@@ -12,7 +12,7 @@ cron:
   schedule: every 1 hours
 
 - description: backfills builds
-  url: /api/v2/scheduler/batch-backfiller
+  url: /api/scheduler/batch-backfiller
   schedule: every 5 minutes
 
 - description: sends build status to GitHub to annotate flutter PRs and commits


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/169234.

This could be made a (dynamic) flag if needed in the future, but I don't see the need for now.