### PR TITLE
Fix backfill execution based on ToT target comparison.

### DIFF
--- a/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
+++ b/app_dart/lib/src/request_handlers/scheduler/batch_backfiller.dart
@@ -106,26 +106,26 @@ final class BatchBackfiller extends RequestHandler {
         '${fsGrid.map((i) => i.tasks).expand((i) => i).length} tasks',
       );
 
-      // Download the ToT .ci.yaml targets.
-      final totCiYaml = await _ciYamlFetcher.getTipOfTreeCiYaml(slug: slug);
-
-      final totTargets = [
-        ...totCiYaml.postsubmitTargets(),
-        if (totCiYaml.isFusion)
-          ...totCiYaml.postsubmitTargets(type: CiType.fusionEngine),
+      // Download the current commits targets.
+      final currentCiYaml = await _ciYamlFetcher.getCiYamlByCommit(
+        fsGrid.first.commit,
+        postsubmit: true,
+      );
+      final currentTargets = [
+        ...currentCiYaml.postsubmitTargets(),
+        if (currentCiYaml.isFusion)
+          ...currentCiYaml.postsubmitTargets(type: CiType.fusionEngine),
       ];
-      if (totTargets.isEmpty) {
-        log.warn(
-          'Did not fetch any tip-of-tree targets. Backfill will do nothing!',
-        );
+      if (currentTargets.isEmpty) {
+        log.warn('Did not fetch any targets. Backfill will do nothing!');
       } else {
-        log.debug('Fetched ${totTargets.length} tip-of-tree targets');
+        log.debug('Fetched ${currentTargets.length} targets');
       }
 
       grid = BackfillGrid.from([
         for (final CommitAndTasks(:commit, :tasks) in fsGrid)
           (commit, [...tasks.map((t) => t.toRef())]),
-      ], tipOfTreeTargets: totTargets);
+      ], postsubmitTargets: currentTargets);
     }
     log.debug('Built a grid of ${grid.eligibleTasks.length} target columns');
 

--- a/app_dart/test/request_handlers/scheduler/backfill_grid_test.dart
+++ b/app_dart/test/request_handlers/scheduler/backfill_grid_test.dart
@@ -24,7 +24,7 @@ void main() {
       [
         (commit, [task]),
       ],
-      tipOfTreeTargets: [target],
+      postsubmitTargets: [target],
     );
 
     expect(
@@ -51,7 +51,7 @@ void main() {
         (c1, [t1c1, t2c1]),
         (c2, [t1c2, t2c2]),
       ],
-      tipOfTreeTargets: [tg1, tg2],
+      postsubmitTargets: [tg1, tg2],
     );
 
     expect(
@@ -88,7 +88,7 @@ void main() {
         (c1, [t1c1, t2c1]),
         (c2, [t1c2, t2c2]),
       ],
-      tipOfTreeTargets: [tg1, tg2],
+      postsubmitTargets: [tg1, tg2],
     );
 
     expect(
@@ -119,7 +119,7 @@ void main() {
       [
         (commit, [taskExists, taskMissing]),
       ],
-      tipOfTreeTargets: [targetExists],
+      postsubmitTargets: [targetExists],
     );
 
     expect(
@@ -149,7 +149,7 @@ void main() {
       [
         (commit, [taskBatch, taskNonBatch]),
       ],
-      tipOfTreeTargets: [targetBatch, targetNonBatch],
+      postsubmitTargets: [targetBatch, targetNonBatch],
     );
 
     expect(
@@ -172,7 +172,7 @@ void main() {
       [
         (commit, [task]),
       ],
-      tipOfTreeTargets: [target],
+      postsubmitTargets: [target],
     );
 
     expect(

--- a/app_dart/test/request_handlers/scheduler/backfill_strategy_test.dart
+++ b/app_dart/test/request_handlers/scheduler/backfill_strategy_test.dart
@@ -88,7 +88,7 @@ void main() {
         //           Linux TASK_0           Linux TASK_1
         (commits[0], [taskNew       (0, 0),        taskNew (0, 1)]),
         (commits[1], [taskSucceeded (1, 0), taskInProgress (1, 1)]),
-      ], tipOfTreeTargets: [
+      ], postsubmitTargets: [
         targets[0],
         targets[1],
       ]);
@@ -112,7 +112,7 @@ void main() {
         //           Linux TASK_0            Linux TASK_1
         (commits[0], [taskNew       (0, 0),  taskNew (0, 1)]),
         (commits[1], [taskNew       (1, 0),  taskNew (1, 1)]),
-      ], tipOfTreeTargets: [
+      ], postsubmitTargets: [
         targets[0],
         targets[1],
       ]);
@@ -146,7 +146,7 @@ void main() {
         //           Linux TASK_0            Linux TASK_1
         (commits[0], [taskNew       (0, 0),  taskSucceeded (0, 1)]),
         (commits[1], [taskNew       (1, 0),  taskNew       (1, 1)]),
-      ], tipOfTreeTargets: [
+      ], postsubmitTargets: [
         targets[0],
         targets[1],
       ]);
@@ -195,7 +195,7 @@ void main() {
         (commits[1], [taskNew       (5, 0),  taskNew    (5, 1),    taskFailed (5, 2)]), // < 5
         (commits[1], [taskNew       (6, 0),  taskFailed (6, 1),    taskNew    (6, 2)]), // < 6
         (commits[1], [taskFailed    (7, 0),  taskNew    (7, 1),    taskNew    (7, 2)]), // < 7
-      ], tipOfTreeTargets: [
+      ], postsubmitTargets: [
         targets[0],
         targets[1],
         targets[2],
@@ -228,7 +228,7 @@ void main() {
         (commit, [
           generateFirestoreTask(1, commitSha: '123', name: targets[0].name).toRef()
         ])
-      ], tipOfTreeTargets: [
+      ], postsubmitTargets: [
         targets[0],
       ]);
       // dart format on

--- a/app_dart/test/src/service/fake_ci_yaml_fetcher.dart
+++ b/app_dart/test/src/service/fake_ci_yaml_fetcher.dart
@@ -17,30 +17,47 @@ final class FakeCiYamlFetcher implements CiYamlFetcher {
     this.failCiYamlValidation = false,
   });
 
-  /// The value that should be returned as a canned response for [getCiYamlByCommit].
-  ///
-  /// If omitted (`null`) defaults to a configuration with a single target.
-  CiYamlSet? ciYaml;
-
-  /// The value that should be returned as a canned response for [getTipOfTreeCiYaml].
-  ///
-  /// If omitted (`null`), defaults to the same response as [ciYaml].
-  CiYamlSet? totCiYaml;
-
-  /// Sets [ciYaml] by loading a YAML document.
-  ///
-  /// Optionally may also specify [engine] for a fusion [CiYamlSet].
-  void setCiYamlFrom(String root, {String? engine}) {
-    ciYaml = CiYamlSet(
+  static CiYamlSet _from(
+    String root, {
+    String? branch,
+    String? engine,
+    CiYamlSet? totCiYaml,
+  }) {
+    return CiYamlSet(
       slug: Config.flutterSlug,
-      branch: 'will-be-replaced',
+      branch: branch ?? Config.defaultBranch(Config.flutterSlug),
       yamls: {
         CiType.any: pb.SchedulerConfig()..mergeFromProto3Json(loadYaml(root)),
         if (engine != null)
           CiType.fusionEngine:
               pb.SchedulerConfig()..mergeFromProto3Json(loadYaml(engine)),
       },
+      totConfig: totCiYaml,
     );
+  }
+
+  /// The value that should be returned as a canned response for [getCiYamlByCommit].
+  ///
+  /// If omitted (`null`) defaults to a configuration with a single target.
+  CiYamlSet? ciYaml;
+
+  /// Sets [ciYaml] by loading a YAML document.
+  ///
+  /// Optionally may also specify [engine] for a fusion [CiYamlSet].
+  void setCiYamlFrom(String root, {String? engine}) {
+    ciYaml = _from(root, engine: engine, totCiYaml: totCiYaml);
+  }
+
+  /// The value that should be returned as a canned response for [getTipOfTreeCiYaml].
+  ///
+  /// If omitted (`null`), defaults to the same response as [ciYaml].
+  CiYamlSet? totCiYaml;
+
+  /// Sets [totCiYaml] by loading a YAML document.
+  ///
+  /// Optionally may also specify [engine] for a fusion [CiYamlSet].
+  void setTotCiYamlFrom(String root, {String? engine}) {
+    totCiYaml = _from(root, engine: engine);
   }
 
   /// If `true`, [getCiYamlByCommit] will throw a [FormatException].
@@ -65,6 +82,7 @@ final class FakeCiYamlFetcher implements CiYamlFetcher {
       slug: commit.slug,
       branch: commit.branch,
       yamls: ci.configs.map((k, v) => MapEntry(k, v.config)),
+      totConfig: totCiYaml,
     );
   }
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/169405.

- Properly downloads (and compares) both the _current_ commit `.ci.yaml` _and_ the ToT `.ci.yaml`
- A missing target is not an error, it just implicitly disables (skips) the target at the current commit
- Adds tests for both skipping tasks properly _and_ for the right `properties: ...` to be used as a system result

/cc @gmackall 