### PR TITLE
Enable `onlyUseTipOfTreeTargetsExistenceToFilterTargets`.

### DIFF
--- a/app_dart/config.yaml
+++ b/app_dart/config.yaml
@@ -6,7 +6,7 @@
 backfillerCommitLimit: 50
 
 ciYaml:
-  onlyUseTipOfTreeTargetsExistenceToFilterTargets: false
+  onlyUseTipOfTreeTargetsExistenceToFilterTargets: true
 
 contentAwareHashing:
   # This will cause PRs that enter the merge queue to wait on CAH hashing


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/169625.