### PR TITLE
Update Docker SDK images to latest `stable`.

### DIFF
--- a/Dockerfile.app_dart
+++ b/Dockerfile.app_dart
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 # Dart Docker official images can be found here: https://hub.docker.com/_/dart
-FROM dart:3.7.1
+FROM dart:stable
 
 # Packages are PATH dependencies of app_dart, and need to be copied/accessible.
 WORKDIR /packages

--- a/Dockerfile.auto_submit
+++ b/Dockerfile.auto_submit
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 # Dart Docker official images can be found here: https://hub.docker.com/_/dart
-FROM dart:3.7.1
+FROM dart:stable
 
 # Packages are PATH dependencies of app_dart, and need to be copied/accessible.
 WORKDIR /packages


### PR DESCRIPTION
... instead of manual revs.

We can always pin to an older version if that ends up being needed, but this will be in line with how most of us do development (using the latest version of `dart` that ships with the master channel of `flutter`).