### PR TITLE
Add `/api/update-tree-status`, which is currently write-only

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -9,6 +9,7 @@ import 'cocoon_service.dart';
 import 'src/request_handlers/get_engine_artifacts_ready.dart';
 import 'src/request_handlers/trigger_workflow.dart';
 import 'src/request_handlers/update_discord_status.dart';
+import 'src/request_handlers/update_tree_status.dart';
 import 'src/service/big_query.dart';
 import 'src/service/build_status_service.dart';
 import 'src/service/commit_service.dart';
@@ -126,6 +127,11 @@ Server createServer({
       authenticationProvider: authProvider,
       scheduler: scheduler,
     ),
+    '/api/update-tree-status': UpdateTreeStatus(
+      config: config,
+      authenticationProvider: authProvider,
+      firestore: firestore,
+    ),
     '/api/scheduler/batch-backfiller': BatchBackfiller(
       config: config,
       ciYamlFetcher: ciYamlFetcher,
@@ -150,7 +156,6 @@ Server createServer({
       bigQuery: bigQuery,
       ciYamlFetcher: ciYamlFetcher,
     ),
-
     '/api/vacuum-github-commits': VacuumGithubCommits(
       config: config,
       authenticationProvider: authProvider,

--- a/app_dart/lib/src/model/firestore/tree_status_change.dart
+++ b/app_dart/lib/src/model/firestore/tree_status_change.dart
@@ -1,0 +1,78 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:googleapis/firestore/v1.dart' as g;
+
+import '../../service/firestore.dart';
+import 'base.dart';
+
+/// A row for each tree status change.
+final class TreeStatusChange extends AppDocument<TreeStatusChange> {
+  /// Returns the latest [TreeStatusChange].
+  ///
+  /// If no changes exist, returns `null`.
+  static Future<TreeStatusChange?> getLatest(FirestoreService firestore) async {
+    final docs = await firestore.query(
+      metadata.collectionId,
+      {},
+      limit: 1,
+      orderMap: {_fieldCreateTimestamp: kQueryOrderDescending},
+    );
+    return docs.isEmpty ? null : TreeStatusChange.fromDocument(docs.first);
+  }
+
+  @override
+  AppDocumentMetadata<TreeStatusChange> get runtimeMetadata => metadata;
+
+  /// Description of the document in Firestore.
+  static final metadata = AppDocumentMetadata<TreeStatusChange>(
+    collectionId: 'tree_status_change',
+    fromDocument: TreeStatusChange.fromDocument,
+  );
+
+  /// Creates and inserts a [TreeStatusChange] into [firestore].
+  static Future<TreeStatusChange> create(
+    FirestoreService firestore, {
+    required DateTime createdOn,
+    required TreeStatus status,
+    required String authoredBy,
+  }) async {
+    final document = TreeStatusChange.fromDocument(
+      g.Document(
+        fields: {
+          _fieldCreateTimestamp: createdOn.toValue(),
+          _fieldStatus: status.name.toValue(),
+          _fieldAuthoredBy: authoredBy.toValue(),
+        },
+      ),
+    );
+    final result = await firestore.createDocument(
+      document,
+      collectionId: metadata.collectionId,
+    );
+    return TreeStatusChange.fromDocument(result);
+  }
+
+  /// Create [BuildStatusSnapshot] from a GithubBuildStatus Document.
+  TreeStatusChange.fromDocument(super.document);
+
+  static const _fieldCreateTimestamp = 'createTimestamp';
+  static const _fieldStatus = 'status';
+  static const _fieldAuthoredBy = 'author';
+
+  DateTime get createdOn {
+    return DateTime.parse(fields[_fieldCreateTimestamp]!.timestampValue!);
+  }
+
+  TreeStatus get status {
+    return TreeStatus.values.byName(fields[_fieldStatus]!.stringValue!);
+  }
+
+  String get authoredBy {
+    return fields[_fieldAuthoredBy]!.stringValue!;
+  }
+}
+
+/// Whether the [TreeStatusChange] was a success or failure.
+enum TreeStatus { success, failure }

--- a/app_dart/lib/src/model/firestore/tree_status_change.dart
+++ b/app_dart/lib/src/model/firestore/tree_status_change.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:github/github.dart';
 import 'package:googleapis/firestore/v1.dart' as g;
 
 import '../../service/firestore.dart';
@@ -12,10 +13,13 @@ final class TreeStatusChange extends AppDocument<TreeStatusChange> {
   /// Returns the latest [TreeStatusChange].
   ///
   /// If no changes exist, returns `null`.
-  static Future<TreeStatusChange?> getLatest(FirestoreService firestore) async {
+  static Future<TreeStatusChange?> getLatest(
+    FirestoreService firestore, {
+    required RepositorySlug repository,
+  }) async {
     final docs = await firestore.query(
       metadata.collectionId,
-      {},
+      {'$_fieldRepository =': repository.fullName},
       limit: 1,
       orderMap: {_fieldCreateTimestamp: kQueryOrderDescending},
     );
@@ -37,6 +41,7 @@ final class TreeStatusChange extends AppDocument<TreeStatusChange> {
     required DateTime createdOn,
     required TreeStatus status,
     required String authoredBy,
+    required RepositorySlug repository,
   }) async {
     final document = TreeStatusChange.fromDocument(
       g.Document(
@@ -44,6 +49,7 @@ final class TreeStatusChange extends AppDocument<TreeStatusChange> {
           _fieldCreateTimestamp: createdOn.toValue(),
           _fieldStatus: status.name.toValue(),
           _fieldAuthoredBy: authoredBy.toValue(),
+          _fieldRepository: repository.fullName.toValue(),
         },
       ),
     );
@@ -60,6 +66,7 @@ final class TreeStatusChange extends AppDocument<TreeStatusChange> {
   static const _fieldCreateTimestamp = 'createTimestamp';
   static const _fieldStatus = 'status';
   static const _fieldAuthoredBy = 'author';
+  static const _fieldRepository = 'repository';
 
   DateTime get createdOn {
     return DateTime.parse(fields[_fieldCreateTimestamp]!.timestampValue!);
@@ -71,6 +78,10 @@ final class TreeStatusChange extends AppDocument<TreeStatusChange> {
 
   String get authoredBy {
     return fields[_fieldAuthoredBy]!.stringValue!;
+  }
+
+  RepositorySlug get repository {
+    return RepositorySlug.full(fields[_fieldRepository]!.stringValue!);
   }
 }
 

--- a/app_dart/lib/src/request_handlers/update_tree_status.dart
+++ b/app_dart/lib/src/request_handlers/update_tree_status.dart
@@ -1,0 +1,49 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '../model/firestore/tree_status_change.dart';
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/exceptions.dart';
+import '../request_handling/request_handler.dart';
+import '../request_handling/response.dart';
+import '../service/firestore.dart';
+
+/// Manually updates the tree status.
+final class UpdateTreeStatus extends ApiRequestHandler {
+  const UpdateTreeStatus({
+    required FirestoreService firestore,
+    required super.config,
+    required super.authenticationProvider,
+    @visibleForTesting DateTime Function() now = DateTime.now,
+  }) : _firestore = firestore,
+       _now = now;
+
+  final FirestoreService _firestore;
+  final DateTime Function() _now;
+
+  static const _passingParam = 'passing';
+
+  @override
+  Future<Response> post(Request request) async {
+    final body = await request.readBodyAsJson();
+    checkRequiredParameters(body, [_passingParam]);
+
+    final passing = body[_passingParam];
+    if (passing is! bool) {
+      throw const BadRequestException(
+        'Parameter "$_passingParam" must be a boolean',
+      );
+    }
+
+    await TreeStatusChange.create(
+      _firestore,
+      createdOn: _now(),
+      status: passing ? TreeStatus.success : TreeStatus.failure,
+      authoredBy: authContext!.email,
+    );
+    return Response.emptyOk;
+  }
+}

--- a/app_dart/test/request_handlers/update_tree_status_test.dart
+++ b/app_dart/test/request_handlers/update_tree_status_test.dart
@@ -1,0 +1,71 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/tree_status_change.dart';
+import 'package:cocoon_service/src/request_handlers/update_tree_status.dart';
+import 'package:cocoon_service/src/request_handling/exceptions.dart';
+import 'package:test/test.dart';
+
+import '../src/fake_config.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
+import '../src/service/fake_firestore_service.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  late FakeFirestoreService firestore;
+  late ApiRequestHandlerTester tester;
+  late UpdateTreeStatus handler;
+
+  final fakeNow = DateTime.now().toUtc();
+
+  setUp(() {
+    firestore = FakeFirestoreService();
+    tester = ApiRequestHandlerTester();
+    handler = UpdateTreeStatus(
+      config: FakeConfig(),
+      authenticationProvider: FakeDashboardAuthentication(),
+      firestore: firestore,
+      now: () => fakeNow,
+    );
+  });
+
+  test('requires a "passing" status', () async {
+    await expectLater(
+      tester.post(handler),
+      throwsA(isA<BadRequestException>()),
+    );
+
+    expect(firestore, existsInStorage(TreeStatusChange.metadata, isEmpty));
+  });
+
+  test('a "passing" status must be a boolean', () async {
+    tester.request.body = jsonEncode({'passing': 'not-a-boolean'});
+    await expectLater(
+      tester.post(handler),
+      throwsA(isA<BadRequestException>()),
+    );
+
+    expect(firestore, existsInStorage(TreeStatusChange.metadata, isEmpty));
+  });
+
+  test('updates Firestore', () async {
+    tester.request.body = jsonEncode({'passing': false});
+    await tester.post(handler);
+
+    expect(
+      firestore,
+      existsInStorage(TreeStatusChange.metadata, [
+        isTreeStatusChange
+            .hasCreatedOn(fakeNow)
+            .hasStatus(TreeStatus.failure)
+            .hasAuthoredBy('fake@example.com'),
+      ]),
+    );
+  });
+}

--- a/app_dart/test/src/model/_tree_status_change.dart
+++ b/app_dart/test/src/model/_tree_status_change.dart
@@ -1,0 +1,32 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of 'firestore_matcher.dart';
+
+final class TreeStatusChangeMatcher extends ModelMatcher<TreeStatusChange> {
+  const TreeStatusChangeMatcher._(super._delegate) : super._();
+
+  @override
+  AppDocumentMetadata<TreeStatusChange> get metadata {
+    return TreeStatusChange.metadata;
+  }
+
+  TreeStatusChangeMatcher hasCreatedOn(Object? matcherOr) {
+    return TreeStatusChangeMatcher._(
+      _delegate.having((t) => t.createdOn, 'createdOn', matcherOr),
+    );
+  }
+
+  TreeStatusChangeMatcher hasStatus(Object? matcherOr) {
+    return TreeStatusChangeMatcher._(
+      _delegate.having((t) => t.status, 'status', matcherOr),
+    );
+  }
+
+  TreeStatusChangeMatcher hasAuthoredBy(Object? matcherOr) {
+    return TreeStatusChangeMatcher._(
+      _delegate.having((t) => t.authoredBy, 'authoredBy', matcherOr),
+    );
+  }
+}

--- a/app_dart/test/src/model/_tree_status_change.dart
+++ b/app_dart/test/src/model/_tree_status_change.dart
@@ -29,4 +29,10 @@ final class TreeStatusChangeMatcher extends ModelMatcher<TreeStatusChange> {
       _delegate.having((t) => t.authoredBy, 'authoredBy', matcherOr),
     );
   }
+
+  TreeStatusChangeMatcher hasRepository(Object? matcherOr) {
+    return TreeStatusChangeMatcher._(
+      _delegate.having((t) => t.repository, 'repository', matcherOr),
+    );
+  }
 }

--- a/app_dart/test/src/model/firestore_matcher.dart
+++ b/app_dart/test/src/model/firestore_matcher.dart
@@ -11,6 +11,7 @@ import 'package:cocoon_service/src/model/firestore/github_build_status.dart';
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
 import 'package:cocoon_service/src/model/firestore/pr_check_runs.dart';
 import 'package:cocoon_service/src/model/firestore/task.dart';
+import 'package:cocoon_service/src/model/firestore/tree_status_change.dart';
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -24,6 +25,7 @@ part '_github_build_status.dart';
 part '_github_gold_status.dart';
 part '_pr_check_run.dart';
 part '_task.dart';
+part '_tree_status_change.dart';
 
 /// Matches a Firestore model, or raw document, of type [Commit].
 const isCommit = CommitMatcher._(TypeMatcher());
@@ -46,8 +48,11 @@ const isPrCheckRun = PrCheckRunsMatcher._(TypeMatcher());
 /// Matches a Firestore model, or raw document, of type [BuildStatusSnapshot].
 const isBuildStatusSnapshot = BuildStatusSnapshotMatcher._(TypeMatcher());
 
-/// Matches a Firestore model, or raw document, of type [Content].
+/// Matches a Firestore model, or raw document, of type [ContentAwareHashBuilds].
 const isContentAwareHashBuilds = ContentAwareHashBuildsMatcher._(TypeMatcher());
+
+/// Matches a Firestore model, or raw document, of type [TreeStatusChange].
+const isTreeStatusChange = TreeStatusChangeMatcher._(TypeMatcher());
 
 /// Returns whether the document is a path to the collection [metadata].
 bool isDocumentA(g.Document document, AppDocumentMetadata<void> metadata) {


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/74529.

Inserts documents into the collection `tree_status_change`, with the following "schema":
```dart
static Future<TreeStatusChange> create(
  FirestoreService firestore, {
  required DateTime createdOn,
  required TreeStatus status,
  required String authoredBy,
  required RepositorySlug repository,
});
```

To determine if the current tree should be (manually) failing, we'd run:
```dart
static Future<TreeStatusChange?> getLatest(
  FirestoreService firestore, {
  required RepositorySlug repository,
}) async {
  final docs = await firestore.query(
    metadata.collectionId,
    {'$_fieldRepository =': repository.fullName},
    limit: 1,
    orderMap: {_fieldCreateTimestamp: kQueryOrderDescending},
  );
  return docs.isEmpty ? null : TreeStatusChange.fromDocument(docs.first);
}
```

... however, that is not hooked up yet (we also need to create indexes first, etc).