### PR TITLE
Move off deprecated `Matrix4.transform`.

### DIFF
--- a/dashboard/lib/widgets/lattice.dart
+++ b/dashboard/lib/widgets/lattice.dart
@@ -812,7 +812,7 @@ class _RenderLatticeBody extends RenderBox {
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final childParentData = child.parentData as _LatticeParentData;
     final offset = _coordinateToOffset(childParentData.coordinate!)!;
-    transform.translate(offset.dx, offset.dy);
+    transform.translateByDouble(offset.dx, offset.dy, 0, 0);
   }
 
   @override


### PR DESCRIPTION
... and use `translateByDouble` instead.

See https://pub.dev/documentation/vector_math/latest/vector_math/Matrix4/translate.html.