### PR TITLE
Allow manually closing the tree.

### DIFF
--- a/app_dart/config.yaml
+++ b/app_dart/config.yaml
@@ -3,6 +3,8 @@
 # The schema for this file is defined in DynamicConfig of
 # app_dart/lib/src/service/config.dart
 
+allowManualTreeClosures: true
+
 backfillerCommitLimit: 50
 
 ciYaml:

--- a/dashboard/lib/logic/links.dart
+++ b/dashboard/lib/logic/links.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../views/build_dashboard_page.dart';
+import '../views/tree_status_page.dart';
 
 /// List of links that are shown in the [DashboardNavigationDrawer].
 List<CocoonLink> createCocoonLinks(BuildContext context) {
@@ -19,6 +20,14 @@ List<CocoonLink> createCocoonLinks(BuildContext context) {
           context,
           BuildDashboardPage.routeName,
         );
+      },
+    ),
+    CocoonLink(
+      name: 'Manual Tree Status',
+      route: BuildDashboardPage.routeName,
+      icon: const Icon(Icons.admin_panel_settings),
+      action: () async {
+        await Navigator.pushReplacementNamed(context, TreeStatusPage.routeName);
       },
     ),
     CocoonLink(


### PR DESCRIPTION
The "secret" (but auth required) https://flutter-dashboard.appspot.com/#/status page allows turning a tree red manually.

I'll submit this PR when I'm back Tuesday.