### PR TITLE
Fix `get-tree-status` call as well.

### DIFF
--- a/app_dart/lib/src/request_handlers/get_tree_status_changes.dart
+++ b/app_dart/lib/src/request_handlers/get_tree_status_changes.dart
@@ -29,7 +29,10 @@ final class GetTreeStatus extends ApiRequestHandler {
 
     final changes = await TreeStatusChange.getLatest10(
       _firestore,
-      repository: RepositorySlug.full(request.uri.queryParameters[_paramRepo]!),
+      repository: RepositorySlug(
+        'flutter',
+        request.uri.queryParameters[_paramRepo]!,
+      ),
     );
 
     return Response.json([

--- a/app_dart/test/request_handlers/get_tree_status_test.dart
+++ b/app_dart/test/request_handlers/get_tree_status_test.dart
@@ -33,7 +33,7 @@ void main() {
     );
 
     tester.request.uri = tester.request.uri.replace(
-      queryParameters: {'repo': 'flutter/flutter'},
+      queryParameters: {'repo': 'flutter'},
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/170366.

... the `GET` part of https://github.com/flutter/cocoon/pull/4775.