### PR TITLE
Use pinned `engine.version` for release candidate prod tests.

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
+import 'package:cocoon_common/is_release_branch.dart';
 import 'package:cocoon_common/task_status.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:fixnum/fixnum.dart';
@@ -864,9 +865,10 @@ class LuciBuildService {
       processedProperties['is_fusion'] = 'true';
       if (commit.branch != Config.defaultBranch(Config.flutterSlug)) {
         processedProperties.addAll({
-          // Always provide an engine version, just like we do in presubmit.
-          // See https://github.com/flutter/flutter/issues/167010.
-          'flutter_prebuilt_engine_version': commit.sha,
+          // For release candidates, use the version pinned in engine.version.
+          // https://github.com/flutter/flutter/issues/170568
+          if (!isReleaseCandidateBranch(branchName: commit.branch))
+            'flutter_prebuilt_engine_version': commit.sha,
 
           // Prod build bucket, built during the merge queue.
           'flutter_realm': '',

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -447,7 +447,7 @@ void main() {
     );
   });
 
-  // Regression test for https://github.com/flutter/flutter/issues/167010.
+  // Regression test for https://github.com/flutter/flutter/issues/170568.
   test('schedules a post-submit release candidate build', () async {
     final commit = generateFirestoreCommit(
       1,
@@ -533,7 +533,7 @@ void main() {
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: commit.sha),
+      // Intentionally omitted: flutter_prebuilt_engine_version
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/170568.