### PR TITLE
Include `showBringup=true` in Dashboard links

### DIFF
--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -108,7 +108,7 @@ Flaky builds:
 ${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!, bucket: buildBucket)}
 
 Recent test runs:
-${_issueBuilderLink(statistic.name)}
+${_issueBuilderLink(statistic.name, bringup: bringup)}
 
 Please follow https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';
@@ -132,12 +132,14 @@ class IssueUpdateBuilder {
     required this.threshold,
     required this.existingIssue,
     required this.bucket,
+    required this.bringup,
   });
 
   final BuilderStatistic statistic;
   final double threshold;
   final Issue existingIssue;
   final Bucket bucket;
+  final bool bringup;
 
   bool get isBelow => statistic.flakyRate < threshold;
 
@@ -169,7 +171,7 @@ Flaky builds:
 ${_issueBuildLinks(builder: statistic.name, builds: statistic.flakyBuilds!, bucket: bucket)}
 
 Recent test runs:
-${_issueBuilderLink(statistic.name)}
+${_issueBuilderLink(statistic.name, bringup: bringup)}
 ''';
     }
     return result;
@@ -475,8 +477,11 @@ String _issueBuildLink({
   return Uri.encodeFull('$buildPrefix$builder/$build');
 }
 
-String _issueBuilderLink(String? builder) {
-  return Uri.encodeFull('$_buildDashboardPrefix?taskFilter=$builder');
+String _issueBuilderLink(String builder, {required bool bringup}) {
+  final showBringup = bringup ? '&showBringup=true' : '';
+  return Uri.encodeFull(
+    '$_buildDashboardPrefix?taskFilter=$builder$showBringup',
+  );
 }
 
 String? getTeamLabelFromTeam(Team? team) {

--- a/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
+++ b/app_dart/lib/src/request_handlers/update_existing_flaky_issues.dart
@@ -100,6 +100,7 @@ final class UpdateExistingFlakyIssue extends ApiRequestHandler {
       threshold: computedThreshold,
       existingIssue: existingIssue,
       bucket: bucket,
+      bringup: bringup,
     );
     await gitHub.createComment(
       slug,

--- a/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
+++ b/app_dart/test/request_handlers/update_existing_flaky_issues_test_data.dart
@@ -32,7 +32,7 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20r
 https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/101
 
 Recent test runs:
-https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller&showBringup=true
 ''';
 
 const String expectedStagingCiyamlTestIssueComment = '''
@@ -45,7 +45,7 @@ https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%
 https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20ci_yaml%20flutter%20roller/101
 
 Recent test runs:
-https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml%20flutter%20roller&showBringup=true
 ''';
 
 const String expectedSemanticsIntegrationTestZeroFlakeIssueComment = '''
@@ -250,7 +250,7 @@ https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20r
 https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20ci_yaml%20flutter%20roller/101
 
 Recent test runs:
-https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter%20roller
+https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux%20ci_yaml_flutter%20roller&showBringup=true
 
 Please follow https://github.com/flutter/flutter/blob/master/docs/infra/Reducing-Test-Flakiness.md#fixing-flaky-tests to fix the flakiness and enable the test back after validating the fix (internal dashboard to validate: go/flutter_test_flakiness).
 ''';


### PR DESCRIPTION
Comments on flakiness issues are leading to an empty dashboard page (e.g. https://github.com/flutter/flutter/issues/169574#issuecomment-2961845607). That's because `bringup` tasks are hidden by default.

This PRs adds the `&showBringup=true` query param for bringup tasks to make sure the Dashboard link works as expected.