### PR TITLE
Update "Settings" popup to grow in size vertically

### DIFF
--- a/dashboard/lib/views/build_dashboard_page.dart
+++ b/dashboard/lib/views/build_dashboard_page.dart
@@ -135,65 +135,59 @@ class BuildDashboardPageState extends State<BuildDashboardPage> {
         child: Material(
           color: Colors.transparent,
           child: FocusTraversalGroup(
-            child: SizedBox(
-              width: 500,
-              height: 360,
-              child: ListView(
-                children: <Widget>[
-                  if (_smallScreen)
-                    ..._buildRepositorySelectionWidgets(context, buildState),
-                  AnimatedBuilder(
-                    animation: buildState,
-                    builder: (context, child) {
-                      final isAuthenticated =
-                          buildState.authService.isAuthenticated;
-                      return TextButton(
-                        onPressed:
-                            isAuthenticated
-                                ? buildState.refreshGitHubCommits
-                                : null,
-                        child: child!,
-                      );
-                    },
-                    child: const Text('Refresh GitHub Commits'),
-                  ),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: Center(child: FilterPropertySheet(_filter)),
-                      ),
-                    ],
-                  ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      TextButton(
-                        onPressed:
-                            _filter!.isDefault ? null : () => _filter!.reset(),
-                        child: const Text('Defaults'),
-                      ),
-                      TextButton(
-                        onPressed:
-                            _filter == _settingsBasis
-                                ? null
-                                : () => _updateNavigation(context),
-                        child: const Text('Apply'),
-                      ),
-                      TextButton(
-                        child: const Text('Cancel'),
-                        onPressed: () {
-                          if (_filter != _settingsBasis) {
-                            _filter!.reset();
-                            _filter!.applyMap(_settingsBasis!.toMap());
-                          }
-                          _removeSettingsDialog();
-                        },
-                      ),
-                    ],
-                  ),
-                ],
-              ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                if (_smallScreen)
+                  ..._buildRepositorySelectionWidgets(context, buildState),
+                AnimatedBuilder(
+                  animation: buildState,
+                  builder: (context, child) {
+                    final isAuthenticated =
+                        buildState.authService.isAuthenticated;
+                    return TextButton(
+                      onPressed:
+                          isAuthenticated
+                              ? buildState.refreshGitHubCommits
+                              : null,
+                      child: child!,
+                    );
+                  },
+                  child: const Text('Refresh GitHub Commits'),
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [Center(child: FilterPropertySheet(_filter))],
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    TextButton(
+                      onPressed:
+                          _filter!.isDefault ? null : () => _filter!.reset(),
+                      child: const Text('Defaults'),
+                    ),
+                    TextButton(
+                      onPressed:
+                          _filter == _settingsBasis
+                              ? null
+                              : () => _updateNavigation(context),
+                      child: const Text('Apply'),
+                    ),
+                    TextButton(
+                      child: const Text('Cancel'),
+                      onPressed: () {
+                        if (_filter != _settingsBasis) {
+                          _filter!.reset();
+                          _filter!.applyMap(_settingsBasis!.toMap());
+                        }
+                        _removeSettingsDialog();
+                      },
+                    ),
+                  ],
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
TIL the "Settings" popup (triggered by clicking the gear button) has buttons at the bottom but they are hidden by the fixed height. Unfortunately on MacOS the scroll bars are hidden by default so I never knew they were there.
<img width="1179" alt="Screenshot 2025-06-24 at 10 49 30 AM" src="https://github.com/user-attachments/assets/51666a6e-dccd-47b4-8011-cf0fb3b20ecd" />

With this change the height can now expand enough to fix the contents.
<img width="1288" alt="Screenshot 2025-06-24 at 10 40 16 AM" src="https://github.com/user-attachments/assets/5b7cc3b4-dcd5-4f73-a6de-8ce3ee7d1ca7" />

There are some overflow issues on very small screen sizes so if there are preferable ways to achieve this please let me know. 
Ideally it should resize to fit the contents if the screen size allows, otherwise be scrollable.