### PR TITLE
feat: Plumbs content hash to post-submit LUCI builds

### DIFF
--- a/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
+++ b/app_dart/test/request_handlers/scheduler/batch_backfiller_test.dart
@@ -520,6 +520,7 @@ final class _FakeLuciBuildService extends Fake implements LuciBuildService {
   Future<List<PendingTask>> schedulePostsubmitBuilds({
     required CommitRef commit,
     required List<PendingTask> toBeScheduled,
+    String? contentHash,
   }) async {
     scheduledPostsubmitBuilds.addAll(toBeScheduled);
     return [];

--- a/app_dart/test/service/content_aware_hash_service_test.dart
+++ b/app_dart/test/service/content_aware_hash_service_test.dart
@@ -379,6 +379,27 @@ void main() {
       );
     });
   });
+
+  group('getHashByCommitSha', () {
+    test('returns the hash when the document is found', () async {
+      firestoreService.putDocument(
+        ContentAwareHashBuilds(
+          createdOn: DateTime.now(),
+          contentHash: '1' * 40,
+          commitSha: 'a' * 40,
+          buildStatus: BuildStatus.inProgress,
+          waitingShas: [],
+        ),
+      );
+      final hash = await cahs.getHashByCommitSha('a' * 40);
+      expect(hash, '1' * 40);
+    });
+
+    test('returns null when the document is not found', () async {
+      final hash = await cahs.getHashByCommitSha('a' * 40);
+      expect(hash, isNull);
+    });
+  });
 }
 
 extension on String {

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -281,6 +281,45 @@ void main() {
         );
       });
 
+      test('schedules cocoon based targets with content hash', () async {
+        final luciBuildService = MockLuciBuildService();
+        const contentHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        fakeContentAwareHash.hashByCommit['1'] = contentHash;
+        when(
+          luciBuildService.schedulePostsubmitBuilds(
+            commit: anyNamed('commit'),
+            toBeScheduled: anyNamed('toBeScheduled'),
+            contentHash: contentHash,
+          ),
+        ).thenAnswer((_) async => []);
+        scheduler = Scheduler(
+          cache: cache,
+          config: config,
+          githubChecksService: GithubChecksService(
+            config,
+            githubChecksUtil: mockGithubChecksUtil,
+          ),
+          getFilesChanged: getFilesChanged,
+          ciYamlFetcher: ciYamlFetcher,
+          luciBuildService: luciBuildService,
+          contentAwareHash: fakeContentAwareHash,
+          firestore: firestore,
+          bigQuery: bigQuery,
+        );
+
+        // This test is testing `GuaranteedPolicy` get scheduled - there's only one now.
+        await scheduler.addCommits(
+          createCommitList(<String>['1'], branch: 'main', repo: 'packages'),
+        );
+        verify(
+          luciBuildService.schedulePostsubmitBuilds(
+            commit: anyNamed('commit'),
+            toBeScheduled: anyNamed('toBeScheduled'),
+            contentHash: contentHash,
+          ),
+        ).called(1);
+      });
+
       test(
         'schedules cocoon based targets - multiple batch requests',
         () async {

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -73,4 +73,10 @@ class FakeContentAwareHashService implements ContentAwareHashService {
     nextCompletedShas = null;
     return shas;
   }
+
+  final hashByCommit = <String, String>{};
+  @override
+  Future<String?> getHashByCommitSha(String commitSha) async {
+    return hashByCommit[commitSha];
+  }
 }

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4164,11 +4164,13 @@ class MockLuciBuildService extends _i1.Mock implements _i17.LuciBuildService {
   _i13.Future<List<_i35.PendingTask>> schedulePostsubmitBuilds({
     required _i32.CommitRef? commit,
     required List<_i35.PendingTask>? toBeScheduled,
+    String? contentHash,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#schedulePostsubmitBuilds, [], {
               #commit: commit,
               #toBeScheduled: toBeScheduled,
+              #contentHash: contentHash,
             }),
             returnValue: _i13.Future<List<_i35.PendingTask>>.value(
               <_i35.PendingTask>[],


### PR DESCRIPTION
This change plumbs the content-aware hash from the scheduler to the LUCI build service for post-submit builds. This will allow LUCI/recipes to use the content hash in post-submit builds (windows arm, ddm, etc).

The following changes are included:
- The `ContentAwareHashService` is updated to include a `getHashByCommitSha` method.
- The `Scheduler` now retrieves the content hash on addCommit() and passes it to `LuciBuildService`.
- `LuciBuildService` plumbs the `contentHash` through to buildbucket properties.
- Tests have been added to verify that the content hash is correctly passed to the `LuciBuildService`.

Extension of flutter/flutter#167779