### PR TITLE
fix: signin api breakage

### DIFF
--- a/dashboard/lib/widgets/sign_in_button/sign_in_button_web.dart
+++ b/dashboard/lib/widgets/sign_in_button/sign_in_button_web.dart
@@ -36,11 +36,13 @@ class _SignInButtonState extends State<SignInButton> {
           GoogleSignInAuthenticationEventSignIn() => data.user,
           GoogleSignInAuthenticationEventSignOut() => null,
         };
+        final fireAuth = FirebaseAuth.instance;
+
         if (user == null) {
+          await fireAuth.signOut();
           print('signed out');
           return;
         }
-        final fireAuth = FirebaseAuth.instance;
         final credential = GoogleAuthProvider.credential(
           idToken: user.authentication.idToken,
         );


### PR DESCRIPTION
Removes calling the plugin directly. Uses the `authenticationEvents` stream, and the web-only exposed render button.


fixes flutter/flutter#171479
