### PR TITLE
Make java android engine tests count as tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -785,7 +785,7 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
 
   bool _isAnEngineTest(String filename) {
     final engineTestRegExp = RegExp(
-      r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py)$',
+      r'(tests?|benchmarks?|Test)\.(dart|java|mm|m|cc|sh|py)$',
     );
     return filename.contains('IosBenchmarks') ||
         filename.contains('IosUnitTests') ||

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -1971,7 +1971,7 @@ void foo() {
         <String>[
           // Java tests.
           'engine/src/flutter/shell/platform/android/io/flutter/Blah.java',
-          'engine/src/flutter/shell/platform/android/test/io/flutter/BlahTest.java',
+          'engine/src/flutter/shell/platform/android/test/io/flutter/BlahTesting.java',
         ],
         <String>[
           // Script tests.
@@ -2005,6 +2005,7 @@ void foo() {
         issueNumber < pullRequestFileList.length;
         issueNumber++
       ) {
+        clearInteractions(issuesService);
         tester.message = generateGithubWebhookMessage(
           action: 'opened',
           number: issueNumber,


### PR DESCRIPTION
Seems like they aren't working based on https://github.com/flutter/flutter/pull/170553?

but this is very odd because we have a test case saying it should work... https://github.com/flutter/cocoon/blob/27067c3bfeae55947016a69cac8a3808ceefdbb3/app_dart/test/request_handlers/github/webhook_subscription_test.dart#L1974

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
