### PR TITLE
feat(content-aware-hashing): Allow builds to take over failed hashes

### DIFF
--- a/app_dart/lib/src/model/common/firestore_extensions.dart
+++ b/app_dart/lib/src/model/common/firestore_extensions.dart
@@ -19,3 +19,20 @@ extension BooleanToValue on bool {
 extension DateTimeToValue on DateTime {
   Value toValue() => Value(timestampValue: toUtc().toIso8601String());
 }
+
+extension ArrayToValue on List {
+  Value toValue() => Value(
+    arrayValue: ArrayValue(
+      values: [
+        for (final t in this)
+          switch (t) {
+            String() => t.toValue(),
+            int() => t.toValue(),
+            bool() => t.toValue(),
+            DateTime() => t.toValue(),
+            _ => throw UnimplementedError(),
+          },
+      ],
+    ),
+  );
+}

--- a/app_dart/lib/src/model/common/firestore_extensions.dart
+++ b/app_dart/lib/src/model/common/firestore_extensions.dart
@@ -20,19 +20,19 @@ extension DateTimeToValue on DateTime {
   Value toValue() => Value(timestampValue: toUtc().toIso8601String());
 }
 
-extension ArrayToValue on List {
-  Value toValue() => Value(
-    arrayValue: ArrayValue(
-      values: [
-        for (final t in this)
-          switch (t) {
-            String() => t.toValue(),
-            int() => t.toValue(),
-            bool() => t.toValue(),
-            DateTime() => t.toValue(),
-            _ => throw UnimplementedError(),
-          },
-      ],
-    ),
+extension ListToValue on List {
+  Value toValue() => Value(arrayValue: toArrayValue());
+
+  ArrayValue toArrayValue() => ArrayValue(
+    values: [
+      for (final t in this)
+        switch (t) {
+          String() => t.toValue(),
+          int() => t.toValue(),
+          bool() => t.toValue(),
+          DateTime() => t.toValue(),
+          _ => throw UnimplementedError(),
+        },
+    ],
   );
 }

--- a/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
+++ b/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
@@ -49,6 +49,7 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
     required String commitSha,
     required BuildStatus buildStatus,
     required List<String> waitingShas,
+    List<String> failedCommitShas = const [],
   }) {
     return ContentAwareHashBuilds.fromDocument(
       g.Document(
@@ -63,6 +64,12 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
               values: [...waitingShas.map((t) => t.toValue())],
             ),
           ),
+          if (failedCommitShas.isNotEmpty)
+            fieldFailedCommitShas: g.Value(
+              arrayValue: g.ArrayValue(
+                values: [...failedCommitShas.map((t) => t.toValue())],
+              ),
+            ),
         },
       ),
     );
@@ -76,6 +83,7 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
   static const fieldCommitSha = 'commit_sha';
   static const fieldStatus = 'status';
   static const fieldWaitingShas = 'waiting_shas';
+  static const fieldFailedCommitShas = 'failed_commit_sha';
 
   DateTime get createdOn =>
       DateTime.parse(fields[fieldCreateTimestamp]!.timestampValue!);
@@ -91,6 +99,14 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
     return [
       for (final t
           in fields[fieldWaitingShas]?.arrayValue?.values ?? <g.Value>[])
+        t.stringValue!,
+    ];
+  }
+
+  List<String> get failedCommitShas {
+    return [
+      for (final t
+          in fields[fieldFailedCommitShas]?.arrayValue?.values ?? <g.Value>[])
         t.stringValue!,
     ];
   }

--- a/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
+++ b/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
@@ -65,11 +65,7 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
             ),
           ),
           if (failedCommitShas.isNotEmpty)
-            fieldFailedCommitShas: g.Value(
-              arrayValue: g.ArrayValue(
-                values: [...failedCommitShas.map((t) => t.toValue())],
-              ),
-            ),
+            fieldFailedCommitShas: failedCommitShas.toValue(),
         },
       ),
     );

--- a/app_dart/lib/src/service/content_aware_hash_service.dart
+++ b/app_dart/lib/src/service/content_aware_hash_service.dart
@@ -239,9 +239,7 @@ interface class ContentAwareHashService {
           updateTransforms: [
             FieldTransform(
               fieldPath: ContentAwareHashBuilds.fieldFailedCommitShas,
-              appendMissingElements: ArrayValue(
-                values: [doc.commitSha.toValue()],
-              ),
+              appendMissingElements: [doc.commitSha].toArrayValue(),
             ),
           ],
         ),

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -785,6 +785,8 @@ $s
       sha: headSha,
       reason: 'Merge group was destroyed',
     );
+    // Mark content hash as invalid (if it exists)
+    await _completeArtifacts(headSha, false);
   }
 
   /// Pushes the required "Merge Queue Guard" check to the merge queue, which

--- a/app_dart/test/service/scheduler/hash_workflow_test.dart
+++ b/app_dart/test/service/scheduler/hash_workflow_test.dart
@@ -232,6 +232,31 @@ void main() {
       ).called(1);
     },
   );
+
+  test('cancelDestroyedMergeGroupTargets failes the hash document', () async {
+    firestore.putDocument(
+      ContentAwareHashBuilds(
+        createdOn: DateTime(2025, 05, 20),
+        contentHash: '65038ef4984b927fd1762ef01d35c5ecc34ff5f7',
+        commitSha: 'a' * 40,
+        buildStatus: BuildStatus.inProgress,
+        waitingShas: [],
+      ),
+    );
+
+    await scheduler.cancelDestroyedMergeGroupTargets(headSha: 'a' * 40);
+
+    expect(
+      firestore,
+      existsInStorage(ContentAwareHashBuilds.metadata, [
+        isContentAwareHashBuilds
+            .hasCommitSha('a' * 40)
+            .hasContentHash('65038ef4984b927fd1762ef01d35c5ecc34ff5f7')
+            .hasStatus(BuildStatus.failure)
+            .hasWaitingShas([]),
+      ]),
+    );
+  });
 }
 
 extension on String {

--- a/app_dart/test/src/model/_content_aware_hash_builds.dart
+++ b/app_dart/test/src/model/_content_aware_hash_builds.dart
@@ -46,4 +46,14 @@ final class ContentAwareHashBuildsMatcher
       ),
     );
   }
+
+  ContentAwareHashBuildsMatcher hasFailedCommitShas(Object? matcherOr) {
+    return ContentAwareHashBuildsMatcher._(
+      _delegate.having(
+        (status) => status.failedCommitShas,
+        'failedCommitShas',
+        matcherOr,
+      ),
+    );
+  }
 }

--- a/app_dart/test/src/service/fake_firestore_service.dart
+++ b/app_dart/test/src/service/fake_firestore_service.dart
@@ -174,10 +174,21 @@ abstract base class _FakeInMemoryFirestoreService
 
     for (final transform in updateTransforms ?? const <FieldTransform>[]) {
       final field = fields[transform.fieldPath];
-      // this is most certainly wrong as the real firestore probably(?) updates
-      // the field. We're not using it that way in the tests, so if you find
-      // yourself getting this error - congrats and welcome to the team.
       if (field == null) {
+        if (transform.appendMissingElements != null) {
+          // firestore: Append the given elements in order if they are not
+          // already present in the current field value. If the field is not an
+          // array, or if the field does not yet exist, it is first set to the
+          // empty array.
+          // https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Write#FieldTransform
+          fields[transform.fieldPath!] = Value(
+            arrayValue: transform.appendMissingElements!,
+          );
+          continue;
+        }
+        // this is most certainly wrong as the real firestore probably(?) updates
+        // the field. We're not using it that way in the tests, so if you find
+        // yourself getting this error - congrats and welcome to the team.
         throw ArgumentError.value(
           transform.fieldPath,
           'field',


### PR DESCRIPTION
fixes: flutter/flutter#172694

When a merge group is destroyed (for dequeued or invalided reasons), the corresponding content-aware hash build is now explicitly marked as failed. This short-curcuits waiting for LUCI jobs to be canceled.

When a content-aware hash build fails, it can now be taken over by a subsequent build for the same content hash. This happens when a PR is removed from the merge queue and an "engine" PR is added back - the previous failure will be restarted and "content_hash" passed to LUCI recipes.

The `ContentAwareHashBuilds` model now includes a list of `failedCommitShas` to track the history of failed attempts for a given content hash. When a new build takes over a failed one, the old commit SHA is added to this list.