### PR TITLE
Use either macOS 14 or 15

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -15,11 +15,11 @@ platform_properties:
       device_type: "none"
   mac:
     properties:
-      os: "Mac-13|Mac-14"
+      os: "Mac-14|Mac-15"
       cpu: x86
   mac_arm64:
     properties:
-      os: "Mac-13|Mac-14"
+      os: "Mac-14|Mac-15"
       cpu: arm64
   windows:
     properties:

--- a/app_dart/integration_test/data/cocoon_config.json
+++ b/app_dart/integration_test/data/cocoon_config.json
@@ -179,13 +179,13 @@
     },
     "mac": {
       "properties": {
-        "os": "Mac-13|Mac-14",
+        "os": "Mac-14|Mac-15",
         "cpu": "x86"
       }
     },
     "mac_arm64": {
       "properties": {
-        "os": "Mac-13|Mac-14",
+        "os": "Mac-14|Mac-15",
         "cpu": "arm64"
       }
     },

--- a/app_dart/integration_test/data/mock_ci.yaml
+++ b/app_dart/integration_test/data/mock_ci.yaml
@@ -15,11 +15,11 @@ platform_properties:
       device_type: "none"
   mac:
     properties:
-      os: "Mac-13|Mac-14"
+      os: "Mac-14|Mac-15"
       cpu: x86
   mac_arm64:
     properties:
-      os: "Mac-13|Mac-14"
+      os: "Mac-14|Mac-15"
       cpu: arm64
   windows:
     properties:


### PR DESCRIPTION
In order to upgrade all bots to macOS 15, we need all tests to target macOS 15.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
