### PR TITLE
Avoid assuming all failed release builders have a `config_name` property

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -10,6 +10,7 @@ import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_common/is_release_branch.dart';
 import 'package:cocoon_common/task_status.dart';
 import 'package:cocoon_server/logging.dart';
+import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart' as github;
 import 'package:github/github.dart';
@@ -1138,19 +1139,15 @@ class LuciBuildService {
         'rebuild will be triggered',
       );
     }
-    final failedBuilds = [
-      for (final build in search.builds)
-        if (const {
-          bbv2.Status.FAILURE,
-          bbv2.Status.INFRA_FAILURE,
-          bbv2.Status.CANCELED,
-        }.contains(build.status))
-          build.input.properties.fields['config_name']!.stringValue,
-    ];
-    if (failedBuilds.isEmpty) {
-      log.info('No failing builds found for $buildId, will rerun all builds');
+    final failedEngineBuilds = [..._filterFailedEngineBuilds(search.builds)];
+    if (failedEngineBuilds.isEmpty) {
+      log.info(
+        'No failing engine builds found for $buildId, will rerun all builds',
+      );
     } else {
-      log.debug('Re-running specific builders: $failedBuilds');
+      log.debug(
+        'Re-running specific engine builds: ${failedEngineBuilds.join(', ')}',
+      );
     }
 
     final result = await _buildBucketClient.scheduleBuild(
@@ -1172,9 +1169,9 @@ class LuciBuildService {
         // See https://flutter.googlesource.com/recipes/+/58bceb87e4a3d3b60e7f148c082eb262db7fd4bb/recipes/release/release_builder.py#162.
         properties: bbv2.Struct(
           fields: {
-            if (failedBuilds.isNotEmpty)
+            if (failedEngineBuilds.isNotEmpty)
               'retry_override_list': bbv2.Value(
-                stringValue: failedBuilds.join(' '),
+                stringValue: failedEngineBuilds.join(' '),
               ),
           },
         ),
@@ -1187,4 +1184,21 @@ class LuciBuildService {
     log.info('Scheduled build (attempt #$attempt): $result');
     return true;
   }
+
+  static Iterable<String> _filterFailedEngineBuilds(
+    Iterable<bbv2.Build> builds,
+  ) =>
+      builds
+          .where((b) {
+            final failed = const {
+              bbv2.Status.FAILURE,
+              bbv2.Status.INFRA_FAILURE,
+              bbv2.Status.CANCELED,
+            }.contains(b.status);
+            return failed;
+          })
+          .map((b) {
+            return b.input.properties.fields['config_name']?.stringValue;
+          })
+          .nonNulls;
 }

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -10,7 +10,6 @@ import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
 import 'package:cocoon_common/is_release_branch.dart';
 import 'package:cocoon_common/task_status.dart';
 import 'package:cocoon_server/logging.dart';
-import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart' as github;
 import 'package:github/github.dart';


### PR DESCRIPTION
This fixes a bug that @camsim99 noticed where if a non-engine build (i.e. docs generation) step failed.

It would be better to _not_ do this, and instead only re-run the docs test, but this avoids an NPE:
```txt
Null check operator used on a null value
package:cocoon_service/src/service/luci_build_service.dart 1201:60   LuciBuildService._filterFailedEngineBuilds.<fn>
dart:core                                                            new List.of
package:cocoon_service/src/service/luci_build_service.dart 1142:32   LuciBuildService.rerunDartInternalReleaseBuilder
===== asynchronous gap ===========================
test/service/luci_build_service/rerun_dart_internal_test.dart 442:5  main.<fn>

Log buffer: BufferedLogger [
  {
    "message": "rerunDartInternalReleaseBuilder(buildNumber=123 for Commit <abcdef (flutter/flutter/flutter-0.42-candidate.0)>)",
    "severity": "debug",
    "recordedAt": "2025-08-12T10:28:29.044738"
  }
]
```