### PR TITLE
feat: allow for array contains (@>) and OR filter on firestore

### DIFF
--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -27,6 +27,7 @@ const String kDocumentParent = '$kDatabase/documents';
 const String kFieldFilterOpEqual = 'EQUAL';
 const String kFieldFilterOpNotEqual = 'NOT_EQUAL';
 const String kCompositeFilterOpAnd = 'AND';
+const String kCompositeFilterOpOr = 'OR';
 const String kQueryOrderDescending = 'DESCENDING';
 
 const int kFilterStringSpaceSplitElements = 2;
@@ -39,6 +40,7 @@ const Map<String, String> kRelationMapping = <String, String>{
   '>': 'GREATER_THAN',
   '>=': 'GREATER_THAN_OR_EQUAL',
   '!=': 'NOT_EQUAL',
+  '@>': 'ARRAY_CONTAINS',
 };
 
 final kFieldMapRegExp = RegExp(

--- a/app_dart/test/src/service/fake_firestore_service_test.dart
+++ b/app_dart/test/src/service/fake_firestore_service_test.dart
@@ -745,6 +745,52 @@ void main() {
         });
         expect(query.map((q) => q.name), [endsWith('1')]);
       });
+
+      test('multiple filters with OR', () async {
+        firestore.putDocuments([
+          g.Document(
+            name: firestore.resolveDocumentName('items', '1'),
+            fields: {'is_spicy': true.toValue(), 'calories': 200.toValue()},
+          ),
+          g.Document(
+            name: firestore.resolveDocumentName('items', '2'),
+            fields: {'is_spicy': false.toValue(), 'calories': 500.toValue()},
+          ),
+          g.Document(
+            name: firestore.resolveDocumentName('items', '3'),
+            fields: {'is_spicy': false.toValue(), 'calories': 100.toValue()},
+          ),
+        ]);
+
+        final query = await firestore.query('items', {
+          'calories >=': 200,
+          'is_spicy =': true,
+        }, compositeFilterOp: kCompositeFilterOpOr);
+        expect(query.map((q) => q.name), [endsWith('1'), endsWith('2')]);
+      });
+
+      test('array_contains', () async {
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '1'),
+            fields: {
+              'an_array': [1, 2, 3].toValue(),
+            },
+          ),
+        );
+
+        firestore.putDocument(
+          g.Document(
+            name: firestore.resolveDocumentName('items', '2'),
+            fields: {
+              'an_array': ['a', 'b', 'c'].toValue(),
+            },
+          ),
+        );
+
+        final query = await firestore.query('items', {'an_array @>': 1});
+        expect(query.map((q) => q.name), [endsWith('1')]);
+      });
     });
 
     group('limit', () {


### PR DESCRIPTION
Firestore supports this natively; updating our implementation to offer it for next feature.
