### PR TITLE
feat: add rpc to fetch content hash / git hashes for query

### DIFF
--- a/app_dart/bin/gae_server.dart
+++ b/app_dart/bin/gae_server.dart
@@ -91,6 +91,11 @@ Future<void> main() async {
       firestore: firestore,
     );
 
+    final contentHashService = ContentAwareHashService(
+      config: config,
+      firestore: firestore,
+    );
+
     /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
     final scheduler = Scheduler(
       cache: cache,
@@ -99,10 +104,7 @@ Future<void> main() async {
       getFilesChanged: GithubApiGetFilesChanged(config),
       luciBuildService: luciBuildService,
       ciYamlFetcher: ciYamlFetcher,
-      contentAwareHash: ContentAwareHashService(
-        config: config,
-        firestore: firestore,
-      ),
+      contentAwareHash: contentHashService,
       firestore: firestore,
       bigQuery: bigQuery,
     );
@@ -131,6 +133,7 @@ Future<void> main() async {
       swarmingAuthProvider: swarmingAuthProvider,
       ciYamlFetcher: ciYamlFetcher,
       buildStatusService: buildStatusService,
+      contentAwareHashService: contentHashService,
     );
 
     return runAppEngine(

--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -8,12 +8,14 @@ import 'dart:math';
 import 'cocoon_service.dart';
 import 'src/request_handlers/get_engine_artifacts_ready.dart';
 import 'src/request_handlers/get_tree_status_changes.dart';
+import 'src/request_handlers/lookup_hash.dart';
 import 'src/request_handlers/trigger_workflow.dart';
 import 'src/request_handlers/update_discord_status.dart';
 import 'src/request_handlers/update_tree_status.dart';
 import 'src/service/big_query.dart';
 import 'src/service/build_status_service.dart';
 import 'src/service/commit_service.dart';
+import 'src/service/content_aware_hash_service.dart';
 import 'src/service/discord_service.dart';
 import 'src/service/scheduler/ci_yaml_fetcher.dart';
 
@@ -36,6 +38,7 @@ Server createServer({
   required Scheduler scheduler,
   required CiYamlFetcher ciYamlFetcher,
   required BuildStatusService buildStatusService,
+  required ContentAwareHashService contentAwareHashService,
 }) {
   final handlers = <String, RequestHandler>{
     '/api/check_flaky_builders': CheckFlakyBuilders(
@@ -179,6 +182,12 @@ Server createServer({
     '/api/trigger-workflow': TriggerWorkflow(
       authenticationProvider: authProvider,
       config: config,
+    ),
+
+    '/api/lookup-hash': LookupHash(
+      contentAwareHashService: contentAwareHashService,
+      config: config,
+      authenticationProvider: authProvider,
     ),
 
     /// Returns status of the framework tree.

--- a/app_dart/lib/src/model/google/grpc.g.dart
+++ b/app_dart/lib/src/model/google/grpc.g.dart
@@ -17,6 +17,6 @@ GrpcStatus _$GrpcStatusFromJson(Map<String, dynamic> json) => GrpcStatus(
 Map<String, dynamic> _$GrpcStatusToJson(GrpcStatus instance) =>
     <String, dynamic>{
       'code': instance.code,
-      'message': ?instance.message,
-      'details': ?instance.details,
+      if (instance.message case final value?) 'message': value,
+      if (instance.details case final value?) 'details': value,
     };

--- a/app_dart/lib/src/model/luci/pubsub_message.g.dart
+++ b/app_dart/lib/src/model/luci/pubsub_message.g.dart
@@ -18,8 +18,8 @@ PubSubPushMessage _$PubSubPushMessageFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$PubSubPushMessageToJson(PubSubPushMessage instance) =>
     <String, dynamic>{
-      'message': ?instance.message,
-      'subscription': ?instance.subscription,
+      if (instance.message case final value?) 'message': value,
+      if (instance.subscription case final value?) 'subscription': value,
     };
 
 PushMessage _$PushMessageFromJson(Map<String, dynamic> json) => PushMessage(
@@ -36,13 +36,15 @@ PushMessage _$PushMessageFromJson(Map<String, dynamic> json) => PushMessage(
 
 Map<String, dynamic> _$PushMessageToJson(PushMessage instance) =>
     <String, dynamic>{
-      'attributes': ?instance.attributes,
-      'data': ?_$JsonConverterToJson<String, String>(
-        instance.data,
-        const Base64Converter().toJson,
-      ),
-      'messageId': ?instance.messageId,
-      'publishTime': ?instance.publishTime,
+      if (instance.attributes case final value?) 'attributes': value,
+      if (_$JsonConverterToJson<String, String>(
+            instance.data,
+            const Base64Converter().toJson,
+          )
+          case final value?)
+        'data': value,
+      if (instance.messageId case final value?) 'messageId': value,
+      if (instance.publishTime case final value?) 'publishTime': value,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/app_dart/lib/src/request_handlers/lookup_hash.dart
+++ b/app_dart/lib/src/request_handlers/lookup_hash.dart
@@ -1,0 +1,40 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_common/rpc_model.dart' as rpc;
+
+import '../request_handling/api_request_handler.dart';
+import '../request_handling/request_handler.dart';
+import '../request_handling/response.dart';
+import '../service/content_aware_hash_service.dart';
+
+/// Aids developers in locating git hashes or content hashes.
+final class LookupHash extends ApiRequestHandler {
+  const LookupHash({
+    required ContentAwareHashService contentAwareHashService,
+    required super.config,
+    required super.authenticationProvider,
+  }) : _contentAwareHashService = contentAwareHashService;
+
+  final ContentAwareHashService _contentAwareHashService;
+
+  static const _paramHash = 'hash';
+
+  @override
+  Future<Response> get(Request request) async {
+    checkRequiredQueryParameters(request, [_paramHash]);
+
+    final hashes = await _contentAwareHashService.getBuildsByHash(
+      request.uri.queryParameters[_paramHash]!,
+    );
+
+    return Response.json([
+      for (var hash in hashes)
+        rpc.ContentHashLookup(
+          contentHash: hash.contentHash,
+          gitShas: [hash.commitSha, ...hash.waitingShas],
+        ),
+    ]);
+  }
+}

--- a/app_dart/lib/src/service/content_aware_hash_service.dart
+++ b/app_dart/lib/src/service/content_aware_hash_service.dart
@@ -402,6 +402,27 @@ interface class ContentAwareHashService {
     }
     return ContentAwareHashBuilds.fromDocument(docs.first).contentHash;
   }
+
+  /// Tries to locate and return a [ContentAwareHashBuilds] via any [hash]
+  /// found in the document.
+  Future<List<ContentAwareHashBuilds>> getBuildsByHash(String hash) async {
+    final docs = await _firestore.query(
+      ContentAwareHashBuilds.metadata.collectionId,
+      {
+        '${ContentAwareHashBuilds.fieldContentHash} =': hash,
+        '${ContentAwareHashBuilds.fieldCommitSha} =': hash,
+        '${ContentAwareHashBuilds.fieldWaitingShas} @>': hash,
+      },
+      orderMap: {
+        ContentAwareHashBuilds.fieldCreateTimestamp: kQueryOrderDescending,
+      },
+      compositeFilterOp: kCompositeFilterOpOr,
+    );
+    if (docs.isEmpty) {
+      return const [];
+    }
+    return [for (var doc in docs) ContentAwareHashBuilds.fromDocument(doc)];
+  }
 }
 
 enum MergeQueueHashStatus { wait, build, complete, ignoreJob, error }

--- a/app_dart/lib/src/service/luci_build_service/user_data.g.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.g.dart
@@ -68,6 +68,6 @@ PostsubmitUserData _$PostsubmitUserDataFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$PostsubmitUserDataToJson(PostsubmitUserData instance) =>
     <String, dynamic>{
-      'check_run_id': ?instance.checkRunId,
+      if (instance.checkRunId case final value?) 'check_run_id': value,
       'task_id': PostsubmitUserData._documentToString(instance.taskId),
     };

--- a/app_dart/test/request_handlers/lookup_hash_test.dart
+++ b/app_dart/test/request_handlers/lookup_hash_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:cocoon_common/rpc_model.dart' show ContentHashLookup;
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/content_aware_hash_builds.dart';
+import 'package:cocoon_service/src/request_handlers/lookup_hash.dart';
+import 'package:test/test.dart';
+
+import '../src/fake_config.dart';
+import '../src/request_handling/api_request_handler_tester.dart';
+import '../src/request_handling/fake_dashboard_authentication.dart';
+import '../src/service/fake_content_aware_hash_service.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  late ApiRequestHandlerTester tester;
+  late FakeConfig config;
+  late FakeContentAwareHashService contentAwareHashService;
+  late FakeDashboardAuthentication auth;
+  late LookupHash lookup;
+
+  setUp(() {
+    auth = FakeDashboardAuthentication();
+    config = FakeConfig();
+    contentAwareHashService = FakeContentAwareHashService(config: config);
+
+    tester = ApiRequestHandlerTester();
+
+    lookup = LookupHash(
+      contentAwareHashService: contentAwareHashService,
+      config: config,
+      authenticationProvider: auth,
+    );
+  });
+
+  test('searches by param hash', () async {
+    contentAwareHashService.buildsByHash['1' * 40] = ContentAwareHashBuilds(
+      createdOn: DateTime(2025, 8, 20, 12, 30),
+      contentHash: '1' * 40,
+      commitSha: 'a' * 40,
+      buildStatus: BuildStatus.success,
+      waitingShas: ['b' * 40],
+    );
+    tester.request.uri = tester.request.uri.replace(
+      queryParameters: {'hash': '1' * 40},
+    );
+
+    final hashes = await tester.get(lookup);
+
+    expect(
+      [
+        for (var object
+            in json.decode(await utf8.decodeStream(hashes.body))
+                as List<Object?>)
+          ContentHashLookup.fromJson(object as Map<String, Object?>),
+      ],
+      contains(
+        ContentHashLookup(contentHash: '1' * 40, gitShas: ['a' * 40, 'b' * 40]),
+      ),
+    );
+  });
+}

--- a/app_dart/test/server_test.dart
+++ b/app_dart/test/server_test.dart
@@ -12,6 +12,7 @@ import 'src/request_handling/fake_dashboard_authentication.dart';
 import 'src/service/fake_build_bucket_client.dart';
 import 'src/service/fake_build_status_service.dart';
 import 'src/service/fake_ci_yaml_fetcher.dart';
+import 'src/service/fake_content_aware_hash_service.dart';
 import 'src/service/fake_firestore_service.dart';
 import 'src/service/fake_gerrit_service.dart';
 import 'src/service/fake_luci_build_service.dart';
@@ -48,6 +49,9 @@ void main() {
       buildStatusService: FakeBuildStatusService(),
       firestore: firestore,
       bigQuery: bigQuery,
+      contentAwareHashService: FakeContentAwareHashService(
+        config: FakeConfig(webhookKeyValue: 'fake-secret'),
+      ),
     );
   });
 }

--- a/app_dart/test/service/content_aware_hash_service_test.dart
+++ b/app_dart/test/service/content_aware_hash_service_test.dart
@@ -435,6 +435,46 @@ void main() {
       expect(hash, isNull);
     });
   });
+
+  group('getBuildsByHash', () {
+    setUp(() {
+      firestoreService.putDocument(
+        ContentAwareHashBuilds(
+          createdOn: DateTime.now(),
+          contentHash: '1' * 40,
+          commitSha: 'a' * 40,
+          buildStatus: BuildStatus.inProgress,
+          waitingShas: ['b' * 40, 'c' * 40],
+        ),
+      );
+    });
+
+    test('returns git hashes', () async {
+      final hash = await cahs.getBuildsByHash('a' * 40);
+      expect(hash, isNotEmpty);
+      expect(hash.first.commitSha, 'a' * 40);
+      expect(hash.first.contentHash, '1' * 40);
+    });
+
+    test('returns content hashes', () async {
+      final hash = await cahs.getBuildsByHash('1' * 40);
+      expect(hash, isNotEmpty);
+      expect(hash.first.commitSha, 'a' * 40);
+      expect(hash.first.contentHash, '1' * 40);
+    });
+
+    test('returns waiting git hashes', () async {
+      final hash = await cahs.getBuildsByHash('c' * 40);
+      expect(hash, isNotEmpty);
+      expect(hash.first.commitSha, 'a' * 40);
+      expect(hash.first.contentHash, '1' * 40);
+    });
+
+    test('returns empty for not found', () async {
+      final hash = await cahs.getBuildsByHash('d' * 40);
+      expect(hash, isEmpty);
+    });
+  });
 }
 
 extension on String {

--- a/app_dart/test/src/service/fake_content_aware_hash_service.dart
+++ b/app_dart/test/src/service/fake_content_aware_hash_service.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:cocoon_service/src/model/firestore/content_aware_hash_builds.dart';
 import 'package:cocoon_service/src/model/github/workflow_job.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/content_aware_hash_service.dart';
@@ -78,5 +79,12 @@ class FakeContentAwareHashService implements ContentAwareHashService {
   @override
   Future<String?> getHashByCommitSha(String commitSha) async {
     return hashByCommit[commitSha];
+  }
+
+  final buildsByHash = <String, ContentAwareHashBuilds>{};
+
+  @override
+  Future<List<ContentAwareHashBuilds>> getBuildsByHash(String hash) async {
+    return [?buildsByHash[hash]];
   }
 }

--- a/app_dart/tool/local_server.dart
+++ b/app_dart/tool/local_server.dart
@@ -72,6 +72,8 @@ Future<void> main() async {
     firestore: firestore,
   );
 
+  final contentHashService = FakeContentAwareHashService(config: config);
+
   /// Cocoon scheduler service to manage validating commits in presubmit and postsubmit.
   final scheduler = Scheduler(
     cache: cache,
@@ -80,7 +82,7 @@ Future<void> main() async {
     getFilesChanged: GithubApiGetFilesChanged(config),
     luciBuildService: luciBuildService,
     ciYamlFetcher: ciYamlFetcher,
-    contentAwareHash: FakeContentAwareHashService(config: config),
+    contentAwareHash: contentHashService,
     firestore: firestore,
     bigQuery: bigQuery,
   );
@@ -110,6 +112,7 @@ Future<void> main() async {
     buildStatusService: buildStatusService,
     firestore: firestore,
     bigQuery: bigQuery,
+    contentAwareHashService: contentHashService,
   );
 
   return runAppEngine(

--- a/packages/cocoon_common/lib/rpc_model.dart
+++ b/packages/cocoon_common/lib/rpc_model.dart
@@ -31,6 +31,7 @@ export 'src/rpc_model/build_status_response.dart'
         BuildStatusResponse;
 export 'src/rpc_model/commit.dart' show Commit, CommitAuthor;
 export 'src/rpc_model/commit_status.dart' show CommitStatus;
+export 'src/rpc_model/content_hash_lookup.dart' show ContentHashLookup;
 export 'src/rpc_model/task.dart' show Task;
 export 'src/rpc_model/tree_status_change.dart'
     show TreeStatus, TreeStatusChange;

--- a/packages/cocoon_common/lib/src/rpc_model/content_hash_lookup.dart
+++ b/packages/cocoon_common/lib/src/rpc_model/content_hash_lookup.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+import 'base.dart';
+
+part 'content_hash_lookup.g.dart';
+
+@JsonSerializable(checked: true)
+@immutable
+final class ContentHashLookup extends Model {
+  ContentHashLookup({required this.contentHash, required this.gitShas});
+
+  factory ContentHashLookup.fromJson(Map<String, Object?> json) {
+    return _$ContentHashLookupFromJson(json);
+  }
+
+  @JsonKey(name: 'contentHash')
+  final String contentHash;
+
+  @JsonKey(name: 'gitShas')
+  final List<String> gitShas;
+
+  @override
+  Map<String, Object?> toJson() {
+    return _$ContentHashLookupToJson(this);
+  }
+}

--- a/packages/cocoon_common/lib/src/rpc_model/content_hash_lookup.g.dart
+++ b/packages/cocoon_common/lib/src/rpc_model/content_hash_lookup.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'content_hash_lookup.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ContentHashLookup _$ContentHashLookupFromJson(Map<String, dynamic> json) =>
+    $checkedCreate('ContentHashLookup', json, ($checkedConvert) {
+      final val = ContentHashLookup(
+        contentHash: $checkedConvert('contentHash', (v) => v as String),
+        gitShas: $checkedConvert(
+          'gitShas',
+          (v) => (v as List<dynamic>).map((e) => e as String).toList(),
+        ),
+      );
+      return val;
+    });
+
+Map<String, dynamic> _$ContentHashLookupToJson(ContentHashLookup instance) =>
+    <String, dynamic>{
+      'contentHash': instance.contentHash,
+      'gitShas': instance.gitShas,
+    };


### PR DESCRIPTION
When moving to content aware hashing; developers might want to know where to check out a tree given only a "hash". As the content hash and the gitsha are both 40-character hex strings, it can get confusing. This RPC will hopefully disambiguate.