### PR TITLE
Reuse existing build properties when re-running a `dart-internal` task

### DIFF
--- a/app_dart/test/service/luci_build_service/rerun_dart_internal_test.dart
+++ b/app_dart/test/service/luci_build_service/rerun_dart_internal_test.dart
@@ -111,7 +111,17 @@ void main() {
 
   test('on missing associated sub-builds warns+does a full build', () async {
     when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
-      return bbv2.Build(id: Int64(1001));
+      return bbv2.Build(
+        id: Int64(1001),
+        input: bbv2.Build_Input(
+          gitilesCommit: bbv2.GitilesCommit(
+            project: 'mirrors/flutter',
+            host: 'flutter.googlesource.com',
+            ref: 'refs/heads/flutter-0.42-candidate.0',
+            id: 'abcdef',
+          ),
+        ),
+      );
     });
 
     when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
@@ -197,7 +207,17 @@ void main() {
 
   test('reruns failed builds by config_name', () async {
     when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
-      return bbv2.Build(id: Int64(1001));
+      return bbv2.Build(
+        id: Int64(1001),
+        input: bbv2.Build_Input(
+          gitilesCommit: bbv2.GitilesCommit(
+            project: 'mirrors/flutter',
+            host: 'flutter.googlesource.com',
+            ref: 'refs/heads/flutter-0.42-candidate.0',
+            id: 'abcdef',
+          ),
+        ),
+      );
     });
 
     when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
@@ -305,7 +325,17 @@ void main() {
 
   test('reruns entire build', () async {
     when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
-      return bbv2.Build(id: Int64(1001));
+      return bbv2.Build(
+        id: Int64(1001),
+        input: bbv2.Build_Input(
+          gitilesCommit: bbv2.GitilesCommit(
+            project: 'mirrors/flutter',
+            host: 'flutter.googlesource.com',
+            ref: 'refs/heads/flutter-0.42-candidate.0',
+            id: 'abcdef',
+          ),
+        ),
+      );
     });
 
     when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {
@@ -380,7 +410,17 @@ void main() {
 
   test('fallsback to re-run all if non-engine build failed', () async {
     when(mockBuildBucketClient.getBuild(any)).thenAnswer((_) async {
-      return bbv2.Build(id: Int64(1001));
+      return bbv2.Build(
+        id: Int64(1001),
+        input: bbv2.Build_Input(
+          gitilesCommit: bbv2.GitilesCommit(
+            project: 'mirrors/flutter',
+            host: 'flutter.googlesource.com',
+            ref: 'refs/heads/flutter-0.42-candidate.0',
+            id: 'abcdef',
+          ),
+        ),
+      );
     });
 
     when(mockBuildBucketClient.searchBuilds(any)).thenAnswer((i) async {


### PR DESCRIPTION
Noticed that a prod (dart-internal) re-run did not persist builder properties or tags like other reruns do:

https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Linux%20flutter_release_builder/1001/infra

The cause is both [post-submit](https://github.com/flutter/cocoon/blob/46748739b141bbf4dbed515c81b309fba928ebcd/app_dart/lib/src/service/luci_build_service.dart#L502-L535) and [pre-submit](https://github.com/flutter/cocoon/blob/46748739b141bbf4dbed515c81b309fba928ebcd/app_dart/lib/src/service/luci_build_service.dart#L457-L465) copy existing properties, but `rerunDartInternal` does not.

This changes the logic to be more similar.