### PR TITLE
Use content-aware hashing to retrieve engine builds

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -288,8 +288,7 @@ class LuciBuildService {
 
         // Fusion *also* means "this is flutter/flutter", so determine how to specify the engine version and realm.
         switch (engineArtifacts) {
-          case SpecifiedEngineArtifacts(:final commitSha, :final flutterRealm):
-            properties['flutter_prebuilt_engine_version'] = commitSha;
+          case ContentAwareEngineArtifacts(:final flutterRealm):
             properties['flutter_realm'] = flutterRealm;
           case UnnecessaryEngineArtifacts(:final reason):
             log.debug(

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -284,8 +284,6 @@ class LuciBuildService {
       }
 
       if (isFusion) {
-        properties['is_fusion'] = 'true';
-
         // Fusion *also* means "this is flutter/flutter", so determine how to specify the engine version and realm.
         switch (engineArtifacts) {
           case ContentAwareEngineArtifacts(:final flutterRealm):
@@ -870,19 +868,11 @@ class LuciBuildService {
     processedProperties['exe_cipd_version'] = cipdVersion.version;
 
     final isFusion = commit.slug == Config.flutterSlug;
-    if (isFusion) {
-      processedProperties['is_fusion'] = 'true';
-      if (commit.branch != Config.defaultBranch(Config.flutterSlug)) {
-        processedProperties.addAll({
-          // For release candidates, use the version pinned in engine.version.
-          // https://github.com/flutter/flutter/issues/170568
-          if (!isReleaseCandidateBranch(branchName: commit.branch))
-            'flutter_prebuilt_engine_version': commit.sha,
-
-          // Prod build bucket, built during the merge queue.
-          'flutter_realm': '',
-        });
-      }
+    if (isFusion && commit.branch != Config.defaultBranch(Config.flutterSlug)) {
+      processedProperties.addAll({
+        // Prod build bucket, built during the merge queue.
+        'flutter_realm': '',
+      });
     }
     final propertiesStruct = bbv2.Struct.create();
     propertiesStruct.mergeFromProto3Json(processedProperties);
@@ -945,7 +935,6 @@ class LuciBuildService {
 
     final cipdExe = 'refs/heads/${mqBranch.branch}';
     processedProperties['exe_cipd_version'] = cipdExe;
-    processedProperties['is_fusion'] = 'true';
     processedProperties[kMergeQueueKey] = true;
     processedProperties['git_repo'] = commit.slug.name;
     if (properties != null) processedProperties.addAll(properties);

--- a/app_dart/lib/src/service/luci_build_service/engine_artifacts.dart
+++ b/app_dart/lib/src/service/luci_build_service/engine_artifacts.dart
@@ -13,30 +13,24 @@ sealed class EngineArtifacts {
   const factory EngineArtifacts.noFrameworkTests({required String reason}) =
       UnnecessaryEngineArtifacts._;
 
-  /// This build should use engine artifacts built during pre-submit (i.e. from source) for [commitSha].
-  const factory EngineArtifacts.builtFromSource({required String commitSha}) =
-      SpecifiedEngineArtifacts._builtFromSourceUsingSha;
+  /// This build should use engine artifacts built during pre-submit (i.e. from source).
+  const factory EngineArtifacts.builtFromSource() =
+      ContentAwareEngineArtifacts._buildDuringPresubmit;
 
-  /// This build should use engine artifacts built during post-submiut for [commitSha].
-  const factory EngineArtifacts.usingExistingEngine({
-    required String commitSha,
-  }) = SpecifiedEngineArtifacts._alreadyBuiltAtExistingSha;
+  /// This build should use engine artifacts built during post-submit (i.e. from a previous build).
+  const factory EngineArtifacts.usingExistingEngine() =
+      ContentAwareEngineArtifacts._builtPreviousPostsubmit;
 }
 
-/// Required [EngineArtifacts].
-final class SpecifiedEngineArtifacts extends EngineArtifacts {
-  const SpecifiedEngineArtifacts._builtFromSourceUsingSha({
-    required this.commitSha,
-  }) : isBuiltFromSource = true;
+/// Required [EngineArtifacts] that use content-aware hashing.
+final class ContentAwareEngineArtifacts extends EngineArtifacts {
+  const ContentAwareEngineArtifacts._buildDuringPresubmit()
+    : isBuiltFromSource = true;
 
-  const SpecifiedEngineArtifacts._alreadyBuiltAtExistingSha({
-    required this.commitSha,
-  }) : isBuiltFromSource = false;
+  const ContentAwareEngineArtifacts._builtPreviousPostsubmit()
+    : isBuiltFromSource = false;
 
-  /// What SHA to provide to `FLUTTER_PREBUILT_ENGINE_VERSION`.
-  final String commitSha;
-
-  /// Whether [commitSha] is built from source in the pull request.
+  /// Whether the artifacts were built from source in the pull request.
   final bool isBuiltFromSource;
 
   /// Which storage upload bucket this artifact belongs to.
@@ -46,17 +40,17 @@ final class SpecifiedEngineArtifacts extends EngineArtifacts {
 
   @override
   bool operator ==(Object other) {
-    return other is SpecifiedEngineArtifacts &&
-        commitSha == other.commitSha &&
+    return other is ContentAwareEngineArtifacts &&
         isBuiltFromSource == other.isBuiltFromSource;
   }
 
   @override
-  int get hashCode => Object.hash(commitSha, isBuiltFromSource);
+  int get hashCode =>
+      Object.hash(ContentAwareEngineArtifacts, isBuiltFromSource);
 
   @override
   String toString() {
-    return 'EngineArtifacts.${isBuiltFromSource ? 'builtFromSource' : 'usingExistingEngine'}(commitSha: $commitSha)';
+    return 'EngineArtifacts.${isBuiltFromSource ? 'builtFromSource' : 'usingExistingEngine'}';
   }
 }
 

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -416,13 +416,7 @@ class Scheduler {
           // Even though this appears to be an engine build, it could be a
           // release candidate build, where the engine artifacts are built
           // via the dart-internal builder.
-          //
-          // In either case, providing FLUTTER_PREBUILT_ENGINE_VERSION has no
-          // consequences for engine builds, as it just won't be used (it is
-          // only understood by the Flutter CLI).
-          //
-          // See https://github.com/flutter/flutter/issues/165810.
-          engineArtifacts = EngineArtifacts.usingExistingEngine(commitSha: sha);
+          engineArtifacts = const EngineArtifacts.usingExistingEngine();
         } else {
           engineArtifacts = const EngineArtifacts.noFrameworkTests(
             reason: 'This is not the flutter/flutter repository',
@@ -1240,14 +1234,10 @@ $s
         final EngineArtifacts engineArtifacts;
         if (testsToRun != _FlutterRepoTestsToRun.engineTestsAndFrameworkTests) {
           // Use the engine that this PR was branched off of.
-          engineArtifacts = EngineArtifacts.usingExistingEngine(
-            commitSha: pullRequest.base!.sha!,
-          );
+          engineArtifacts = const EngineArtifacts.usingExistingEngine();
         } else {
           // Use the engine that was built from source *for* this PR.
-          engineArtifacts = EngineArtifacts.builtFromSource(
-            commitSha: pullRequest.head!.sha!,
-          );
+          engineArtifacts = const EngineArtifacts.builtFromSource();
         }
 
         await _luciBuildService.scheduleTryBuilds(
@@ -1481,13 +1471,9 @@ $stacktrace
                   pullRequest,
                 );
                 if (opt.shouldUsePrebuiltEngine) {
-                  engineArtifacts = EngineArtifacts.usingExistingEngine(
-                    commitSha: pullRequest.base!.sha!,
-                  );
+                  engineArtifacts = const EngineArtifacts.usingExistingEngine();
                 } else {
-                  engineArtifacts = EngineArtifacts.builtFromSource(
-                    commitSha: pullRequest.head!.sha!,
-                  );
+                  engineArtifacts = const EngineArtifacts.builtFromSource();
                 }
               } else {
                 presubmitTargets = await getPresubmitTargets(pullRequest);

--- a/app_dart/test/service/luci_build_service/schedule_merge_group_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_merge_group_builds_test.dart
@@ -261,7 +261,6 @@ Matcher _isExpectedScheduleBuild({required String name}) {
         ),
         'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/master'),
         'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-        'is_fusion': bbv2.Value(stringValue: 'true'),
         'git_repo': bbv2.Value(stringValue: 'flutter'),
         'in_merge_queue': bbv2.Value(boolValue: true),
       })

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -329,7 +329,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
     });
 
     expect(scheduleBuild.dimensions, [
@@ -428,7 +427,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
     });
 
     expect(scheduleBuild.dimensions, [
@@ -532,8 +530,6 @@ void main() {
       ),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
-      // Intentionally omitted: flutter_prebuilt_engine_version
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
 
@@ -638,10 +634,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
-
-      // Experimental branches work similar to release branches.
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: '1'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
 

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -138,7 +138,6 @@ void main() {
       'git_repo': bbv2.Value(stringValue: 'flutter'),
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
     });
     expect(scheduleBuild.dimensions, [
@@ -228,7 +227,6 @@ void main() {
       'git_repo': bbv2.Value(stringValue: 'flutter'),
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
     expect(scheduleBuild.dimensions, [

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -95,9 +95,7 @@ void main() {
       luci.scheduleTryBuilds(
         pullRequest: pullRequest,
         targets: [buildTarget],
-        engineArtifacts: EngineArtifacts.builtFromSource(
-          commitSha: pullRequest.head!.sha!,
-        ),
+        engineArtifacts: const EngineArtifacts.builtFromSource(),
       ),
       completion([isTarget.hasName('Linux foo')]),
     );
@@ -141,7 +139,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: 'headsha123'),
       'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
     });
     expect(scheduleBuild.dimensions, [
@@ -187,9 +184,7 @@ void main() {
       luci.scheduleTryBuilds(
         pullRequest: pullRequest,
         targets: [buildTarget],
-        engineArtifacts: EngineArtifacts.usingExistingEngine(
-          commitSha: pullRequest.base!.sha!,
-        ),
+        engineArtifacts: const EngineArtifacts.usingExistingEngine(),
       ),
       completion([isTarget.hasName('Linux foo')]),
     );
@@ -234,7 +229,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: 'basesha123'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
     expect(scheduleBuild.dimensions, [
@@ -364,9 +358,7 @@ void main() {
         await luci.scheduleTryBuilds(
           pullRequest: generatePullRequest(repo: 'flutter', branch: 'master'),
           targets: [generateTarget(1)],
-          engineArtifacts: const EngineArtifacts.builtFromSource(
-            commitSha: 'abc123',
-          ),
+          engineArtifacts: const EngineArtifacts.builtFromSource(),
         );
 
         expect(log, isNot(loggedFallingBackToDefaultRecipe));
@@ -403,9 +395,7 @@ void main() {
             branch: '3.7.0-19.0.pre',
           ),
           targets: [generateTarget(1)],
-          engineArtifacts: const EngineArtifacts.builtFromSource(
-            commitSha: 'abc123',
-          ),
+          engineArtifacts: const EngineArtifacts.builtFromSource(),
         );
 
         expect(log, loggedFallingBackToDefaultRecipe);
@@ -444,9 +434,7 @@ void main() {
           branch: '3.7.0-19.0.pre',
         ),
         targets: [generateTarget(1)],
-        engineArtifacts: const EngineArtifacts.builtFromSource(
-          commitSha: 'abc123',
-        ),
+        engineArtifacts: const EngineArtifacts.builtFromSource(),
       );
 
       expect(log, isNot(loggedFallingBackToDefaultRecipe));

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -1848,17 +1848,10 @@ targets:
               logCrumb: 'test',
             );
 
-            // Ensure that we used the HEAD SHA as as FLUTTER_PREBUILT_ENGINE_VERSION,
-            // since the engine was built from source.
-            //
-            // See https://github.com/flutter/flutter/issues/164031.
             expect(
               engineArtifacts,
-              EngineArtifacts.builtFromSource(
-                commitSha: pullRequest.head!.sha!,
-              ),
-              reason:
-                  'Should be set to HEAD (i.e. the current SHA), since the engine was built from source.',
+              const EngineArtifacts.builtFromSource(),
+              reason: 'Should be set to build from source',
             );
           });
 
@@ -3458,10 +3451,7 @@ targets:
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
           fakeLuciBuildService.engineArtifacts,
-          EngineArtifacts.usingExistingEngine(
-            commitSha: pullRequest.base!.sha!,
-          ),
-          reason: 'Should use the base ref for the engine artifacts',
+          const EngineArtifacts.usingExistingEngine(),
         );
         expect(
           fakeLuciBuildService.scheduledTryBuilds.map((t) => t.name),
@@ -3491,10 +3481,7 @@ targets:
         await scheduler.triggerPresubmitTargets(pullRequest: pullRequest);
         expect(
           fakeLuciBuildService.engineArtifacts,
-          EngineArtifacts.usingExistingEngine(
-            commitSha: pullRequest.base!.sha!,
-          ),
-          reason: 'Should use the base ref for the engine artifacts',
+          const EngineArtifacts.usingExistingEngine(),
         );
         expect(
           fakeLuciBuildService.scheduledTryBuilds.map((t) => t.name),


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/174228.

Stops providing `FLUTTER_PREBUILT_ENGINE_VERSION` across Cocoon, implicitly (?) using the content-aware hash.