### PR TITLE
Provide a `'content_hash'` LUCI property for engine try-builds

### DIFF
--- a/app_dart/lib/src/model/google/grpc.g.dart
+++ b/app_dart/lib/src/model/google/grpc.g.dart
@@ -17,6 +17,6 @@ GrpcStatus _$GrpcStatusFromJson(Map<String, dynamic> json) => GrpcStatus(
 Map<String, dynamic> _$GrpcStatusToJson(GrpcStatus instance) =>
     <String, dynamic>{
       'code': instance.code,
-      if (instance.message case final value?) 'message': value,
-      if (instance.details case final value?) 'details': value,
+      'message': ?instance.message,
+      'details': ?instance.details,
     };

--- a/app_dart/lib/src/model/luci/pubsub_message.g.dart
+++ b/app_dart/lib/src/model/luci/pubsub_message.g.dart
@@ -18,8 +18,8 @@ PubSubPushMessage _$PubSubPushMessageFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$PubSubPushMessageToJson(PubSubPushMessage instance) =>
     <String, dynamic>{
-      if (instance.message case final value?) 'message': value,
-      if (instance.subscription case final value?) 'subscription': value,
+      'message': ?instance.message,
+      'subscription': ?instance.subscription,
     };
 
 PushMessage _$PushMessageFromJson(Map<String, dynamic> json) => PushMessage(
@@ -36,15 +36,13 @@ PushMessage _$PushMessageFromJson(Map<String, dynamic> json) => PushMessage(
 
 Map<String, dynamic> _$PushMessageToJson(PushMessage instance) =>
     <String, dynamic>{
-      if (instance.attributes case final value?) 'attributes': value,
-      if (_$JsonConverterToJson<String, String>(
-            instance.data,
-            const Base64Converter().toJson,
-          )
-          case final value?)
-        'data': value,
-      if (instance.messageId case final value?) 'messageId': value,
-      if (instance.publishTime case final value?) 'publishTime': value,
+      'attributes': ?instance.attributes,
+      'data': ?_$JsonConverterToJson<String, String>(
+        instance.data,
+        const Base64Converter().toJson,
+      ),
+      'messageId': ?instance.messageId,
+      'publishTime': ?instance.publishTime,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -227,6 +227,7 @@ class LuciBuildService {
     required List<Target> targets,
     required github.PullRequest pullRequest,
     required EngineArtifacts engineArtifacts,
+    String? contentHash,
   }) async {
     if (targets.isEmpty) {
       return targets;
@@ -262,6 +263,9 @@ class LuciBuildService {
       );
 
       final properties = target.getProperties();
+      if (contentHash != null) {
+        properties['content_hash'] = contentHash;
+      }
       properties.putIfAbsent(
         'git_branch',
         () => pullRequest.base!.ref!.replaceAll('refs/heads/', ''),

--- a/app_dart/lib/src/service/luci_build_service/user_data.g.dart
+++ b/app_dart/lib/src/service/luci_build_service/user_data.g.dart
@@ -24,7 +24,7 @@ _PresubmitUserData _$PresubmitUserDataFromJson(Map<String, dynamic> json) =>
           ),
           checkSuiteId: $checkedConvert(
             'check_suite_id',
-            (v) => (v as num).toInt(),
+            (v) => (v as num?)?.toInt() ?? 0,
           ),
         );
         return val;
@@ -68,6 +68,6 @@ PostsubmitUserData _$PostsubmitUserDataFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$PostsubmitUserDataToJson(PostsubmitUserData instance) =>
     <String, dynamic>{
-      if (instance.checkRunId case final value?) 'check_run_id': value,
+      'check_run_id': ?instance.checkRunId,
       'task_id': PostsubmitUserData._documentToString(instance.taskId),
     };

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -96,6 +96,7 @@ void main() {
         pullRequest: pullRequest,
         targets: [buildTarget],
         engineArtifacts: const EngineArtifacts.builtFromSource(),
+        contentHash: 'abc123def456',
       ),
       completion([isTarget.hasName('Linux foo')]),
     );
@@ -139,6 +140,7 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
+      'content_hash': bbv2.Value(stringValue: 'abc123def456'),
     });
     expect(scheduleBuild.dimensions, [
       isA<bbv2.RequestedDimension>()

--- a/app_dart/test/src/utilities/mocks.mocks.dart
+++ b/app_dart/test/src/utilities/mocks.mocks.dart
@@ -4049,12 +4049,14 @@ class MockLuciBuildService extends _i1.Mock implements _i17.LuciBuildService {
     required List<_i28.Target>? targets,
     required _i7.PullRequest? pullRequest,
     required _i29.EngineArtifacts? engineArtifacts,
+    String? contentHash,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#scheduleTryBuilds, [], {
               #targets: targets,
               #pullRequest: pullRequest,
               #engineArtifacts: engineArtifacts,
+              #contentHash: contentHash,
             }),
             returnValue: _i13.Future<List<_i28.Target>>.value(<_i28.Target>[]),
           )


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/174244.

I was trying to debug why, on presubmit (example: https://github.com/flutter/flutter/pull/174236#issuecomment-3212328062), we were not uploading engine artifacts by content-hash (meaning my changes to a tool to download artifacts from a content-hash instead of a git commit SHA were not working).

This is my best attempt to, if available, provide a `'content_hash'` property, similar to what is being done in the [release builder](https://flutter.googlesource.com/recipes/+/55c85973bd371f314a4f7cebc3f18bdf3db6f8a6/recipes/release/release_builder.py#234) and [in the merge queue ](https://github.com/flutter/cocoon/blob/1bf9fb9d226c79655388ef9d6ee7ce372ceea0d4/app_dart/lib/src/service/scheduler.dart#L705-L707) (though, the merge queue implementation also seems broken). It should start providing a property, which [the `recipes/engine_v2/builder` recipe will use to upload it to GCS](https://flutter.googlesource.com/recipes/+/55c85973bd371f314a4f7cebc3f18bdf3db6f8a6/recipes/engine_v2/builder.py#289).

Added minimal tests - it's so hard to incrementally test `Scheduler`, we should refactor this file at some point 😢 