### PR TITLE
Always provide a git SHA of an engine to use if the try-bots built the engine for the commit

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -284,8 +284,10 @@ class LuciBuildService {
         switch (engineArtifacts) {
           case SpecifiedEngineArtifacts(:final commitSha, :final flutterRealm):
             properties.addAll({
-              // For release candidates, let the flutter tool pick the right engine.
-              if (!isReleaseCandidateBranch(branchName: commitBranch))
+              // If we've touched the engine, we must use the current git sha's uploaded engine artifacts.
+              // Otherwise, let the flutter tool find the previously built artfiacts (using content-aware hashing).
+              // TODO(matanlurey): Review with jtmcdole to ensure this is correct.
+              if (engineArtifacts.isBuiltFromSource)
                 'flutter_prebuilt_engine_version': commitSha,
               'flutter_realm': flutterRealm,
             });

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -234,7 +234,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
       'is_fusion': bbv2.Value(stringValue: 'true'),
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: 'basesha123'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
     expect(scheduleBuild.dimensions, [


### PR DESCRIPTION
https://github.com/flutter/cocoon/pull/4844 was partially correct.

However, PRs such as https://github.com/flutter/flutter/pull/174310 are still blocked because they touch the engine, and try-bots (as of currently) only upload engines to a git SHA, not a content hash. This PR relaxes the try-bot logic to continue to provide the current SHA as "this is the engine" if the engine is being built from source.

Implicitly, it will no longer provide `FLUTTER_PREBUILT_ENGINE_VERSION=` for the `master` branch, if and only if the engine is not being touched. That means `flutter <any command>` will start to download the engine using the content hash, which should be fine.