### PR TITLE
Let the flutter tool resolve engines on post-submit

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -875,10 +875,6 @@ class LuciBuildService {
       processedProperties['is_fusion'] = 'true';
       if (commit.branch != Config.defaultBranch(Config.flutterSlug)) {
         processedProperties.addAll({
-          // For release candidates, let the flutter tool pick the right engine.
-          if (!isReleaseCandidateBranch(branchName: commit.branch))
-            'flutter_prebuilt_engine_version': commit.sha,
-
           // Prod build bucket, built during the merge queue.
           'flutter_realm': '',
         });

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -7,7 +7,6 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:buildbucket/buildbucket_pb.dart' as bbv2;
-import 'package:cocoon_common/is_release_branch.dart';
 import 'package:cocoon_common/task_status.dart';
 import 'package:cocoon_server/logging.dart';
 import 'package:fixnum/fixnum.dart';

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -641,7 +641,6 @@ void main() {
       'is_fusion': bbv2.Value(stringValue: 'true'),
 
       // Experimental branches work similar to release branches.
-      'flutter_prebuilt_engine_version': bbv2.Value(stringValue: '1'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
 


### PR DESCRIPTION
We weren't sure why we are still doing this post content-aware hasing.