### PR TITLE
Remove now unused `is_fusion` builder properties

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -278,8 +278,6 @@ class LuciBuildService {
       }
 
       if (isFusion) {
-        properties['is_fusion'] = 'true';
-
         // Fusion *also* means "this is flutter/flutter", so determine how to specify the engine version and realm.
         switch (engineArtifacts) {
           case SpecifiedEngineArtifacts(:final commitSha, :final flutterRealm):
@@ -872,7 +870,6 @@ class LuciBuildService {
 
     final isFusion = commit.slug == Config.flutterSlug;
     if (isFusion) {
-      processedProperties['is_fusion'] = 'true';
       if (commit.branch != Config.defaultBranch(Config.flutterSlug)) {
         processedProperties.addAll({
           // For release candidates, let the flutter tool pick the right engine.
@@ -945,7 +942,6 @@ class LuciBuildService {
 
     final cipdExe = 'refs/heads/${mqBranch.branch}';
     processedProperties['exe_cipd_version'] = cipdExe;
-    processedProperties['is_fusion'] = 'true';
     processedProperties[kMergeQueueKey] = true;
     processedProperties['git_repo'] = commit.slug.name;
     if (properties != null) processedProperties.addAll(properties);

--- a/app_dart/test/service/luci_build_service/schedule_merge_group_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_merge_group_builds_test.dart
@@ -261,7 +261,6 @@ Matcher _isExpectedScheduleBuild({required String name}) {
         ),
         'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/master'),
         'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-        'is_fusion': bbv2.Value(stringValue: 'true'),
         'git_repo': bbv2.Value(stringValue: 'flutter'),
         'in_merge_queue': bbv2.Value(boolValue: true),
       })

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -329,7 +329,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
     });
 
     expect(scheduleBuild.dimensions, [
@@ -428,7 +427,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
     });
 
     expect(scheduleBuild.dimensions, [
@@ -532,7 +530,6 @@ void main() {
       ),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       // Intentionally omitted: flutter_prebuilt_engine_version
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
@@ -638,7 +635,6 @@ void main() {
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'os': bbv2.Value(stringValue: 'debian-10.12'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
 
       // Experimental branches work similar to release branches.
       'flutter_prebuilt_engine_version': bbv2.Value(stringValue: '1'),

--- a/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_try_builds_test.dart
@@ -140,7 +140,6 @@ void main() {
       'git_repo': bbv2.Value(stringValue: 'flutter'),
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       'flutter_prebuilt_engine_version': bbv2.Value(stringValue: 'headsha123'),
       'flutter_realm': bbv2.Value(stringValue: 'flutter_archives_v2'),
     });
@@ -233,7 +232,6 @@ void main() {
       'git_repo': bbv2.Value(stringValue: 'flutter'),
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
     expect(scheduleBuild.dimensions, [
@@ -326,7 +324,6 @@ void main() {
       'git_repo': bbv2.Value(stringValue: 'flutter'),
       'exe_cipd_version': bbv2.Value(stringValue: 'refs/heads/main'),
       'recipe': bbv2.Value(stringValue: 'devicelab/devicelab'),
-      'is_fusion': bbv2.Value(stringValue: 'true'),
       'flutter_realm': bbv2.Value(stringValue: ''),
     });
     expect(scheduleBuild.dimensions, [


### PR DESCRIPTION
These are no longer processed by LUCI recipes, including those branched for 3.35 and 3.36.