### PR TITLE
Remove unused field `Target.timeoutInMinutes`

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -117,9 +117,6 @@ final class Target {
   /// Name of the target.
   String get name => _value.name;
 
-  /// Timeout in minutes.
-  int get timeoutInMinutes => _value.timeout;
-
   /// Scheduler system of the target.
   pb.SchedulerSystem get scheduler => _value.scheduler;
 


### PR DESCRIPTION
Discovered during https://github.com/flutter/flutter/issues/171023.