### PR TITLE
Remove references to js_util

### DIFF
--- a/dashboard/lib/widgets/sign_in_button/sign_in_button.dart
+++ b/dashboard/lib/widgets/sign_in_button/sign_in_button.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 export 'sign_in_button_native.dart'
-    if (dart.library.js_util) 'sign_in_button_web.dart';
+    if (dart.library.js_interop) 'sign_in_button_web.dart';


### PR DESCRIPTION
Flutter has already migrated from dart:js_util to dart:js_interop (which is unsupported by dart2wasm). This migrates a remaining reference to js_util which will be broken when dart2wasm drops the library entirely.