### PR TITLE
docs: adding a note about running ACT with "bind" feature

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -41,6 +41,12 @@ flutter test --update-goldens
 
 For compatibility reasons, only a Linux host is supported.
 
+You could run the tests locally with ACT to compare and update diffs:
+
+```shell
+act --container-architecture linux/amd64 -b  -W .github/workflows/dashboard_tests.yaml
+```
+
 <details>
 
 <summary>Workaround using <code>tool/update_goldens_from_luci.dart</code></summary>


### PR DESCRIPTION
If you run ACT locally (on a mac or windows), this will produce the same images that are compared in workflows. A folder will be made available to you to review:

```shell
dashboard/test/failures
├── build_dashboard.defaultPropertySheet.dark_isolatedDiff.png
├── build_dashboard.defaultPropertySheet.dark_maskedDiff.png
├── build_dashboard.defaultPropertySheet.dark_masterImage.png
└── build_dashboard.defaultPropertySheet.dark_testImage.png
```