### PR TITLE
Rename 'Execution Log' to 'Execution Details' in presubmit view

### DIFF
--- a/dashboard/lib/views/presubmit_view.dart
+++ b/dashboard/lib/views/presubmit_view.dart
@@ -24,7 +24,7 @@ import '../widgets/task_box.dart';
 
 /// A detailed monitoring view for a specific Pull Request (PR) or commit SHA.
 ///
-/// This view displays CI job statuses and execution logs.
+/// This view displays CI job statuses and execution details.
 final class PreSubmitView extends StatefulWidget {
   const PreSubmitView({
     super.key,
@@ -434,7 +434,7 @@ class _LogViewerPaneState extends State<_LogViewerPane> {
               child: Row(
                 children: [
                   Text(
-                    'Execution Log',
+                    'Execution Details',
                     style: TextStyle(fontWeight: FontWeight.w600),
                   ),
                   Spacer(),
@@ -457,7 +457,10 @@ class _LogViewerPaneState extends State<_LogViewerPane> {
                 width: double.infinity,
                 child: SingleChildScrollView(
                   child: Text(
-                    selectedJob.summary ?? 'No log summary available',
+                    selectedJob.summary
+                        ?? (selectedJob.status == 'Succeeded'
+                            ? '$jobName Executed Successfully. Click "View more details on LUCI UI" button below for more details.'
+                            : 'No execution details available'),
                     style: const TextStyle(
                       fontFamily: 'monospace',
                       fontSize: 13,


### PR DESCRIPTION
## Summary

- Renames the "Execution Log" section header to "Execution Details" in the presubmit view
- Adds a success message for completed jobs when no summary is available: `[Job Name] Executed Successfully. Click "View more details on LUCI UI" button below for more details.`
- Updates the fallback text from "No log summary available" to "No execution details available"

Fixes flutter/flutter#184360

## Test Plan

- All 14 existing tests in `dashboard/test/views/presubmit_view_test.dart` pass
- All 2 existing tests in `dashboard/test/views/presubmit_filter_view_test.dart` pass
- Verified the success message logic: when `selectedJob.status == 'Succeeded'` and `summary` is null, the new success message is displayed; otherwise "No execution details available" is shown