### PR TITLE
Add pub roller to autoroller list

### DIFF
--- a/app_dart/lib/src/service/config.dart
+++ b/app_dart/lib/src/service/config.dart
@@ -430,6 +430,7 @@ interface class Config extends DynamicallyUpdatedConfig {
     'engine-flutter-autoroll',
     'dependabot',
     'dependabot[bot]',
+    'flutter-pub-roller-bot',
   };
 
   Future<String> generateGithubToken(gh.RepositorySlug slug) async {

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -92,6 +92,7 @@ void main() {
         'engine-flutter-autoroll',
         'dependabot',
         'dependabot[bot]',
+        'flutter-pub-roller-bot',
       },
       wrongHeadBranchPullRequestMessageValue:
           'wrongHeadBranchPullRequestMessage',
@@ -885,6 +886,7 @@ void main() {
           'skia-flutter-autoroll',
           'dependabot',
           'engine-flutter-autoroll',
+          'flutter-pub-roller-bot',
         };
 
         for (var element in inputs) {
@@ -1732,6 +1734,7 @@ void foo() {
           'engine-flutter-autoroll',
           'dependabot',
           'dependabot[bot]',
+          'flutter-pub-roller-bot',
         };
 
         for (var element in inputs) {

--- a/auto_submit/lib/service/config.dart
+++ b/auto_submit/lib/service/config.dart
@@ -134,6 +134,7 @@ class Config {
     'dependabot[bot]',
     'dependabot',
     'DartDevtoolWorkflowBot',
+    'flutter-pub-roller-bot',
   };
 
   /// Repository configuration variables

--- a/auto_submit/test/src/service/fake_config.dart
+++ b/auto_submit/test/src/service/fake_config.dart
@@ -74,6 +74,7 @@ class FakeConfig extends Config {
         'engine-flutter-autoroll',
         'dependabot[bot]',
         'dependabot',
+        'flutter-pub-roller-bot',
       };
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/183617
The flutter-pub-roller-bot was omitted from the list of autorollers.  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
