### PR TITLE
pin sign_in_button to 4.0.1

### DIFF
--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -28,7 +28,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_app_icons: 0.1.1 # Rolled by dependabot
-  font_awesome_flutter: ^10.12.0
   github: ^9.25.0
   google_sign_in: ^7.0.0
   google_sign_in_platform_interface: ^3.0.0
@@ -39,7 +38,8 @@ dependencies:
   json_annotation: ^4.9.0
   meta: any # Match Flutter SDK
   provider: 6.1.5 # Rolled by dependabot
-  sign_in_button: ^4.0.1
+  # TODO(chunhtai): Remove this pin once sign_in_button is updated to use font_awesome_flutter >= 11.0.0
+  sign_in_button: 4.0.1
   truncate: 3.0.1 # Rolled by dependabot
   url_launcher: 6.3.2 # Rolled by dependabot
   url_launcher_platform_interface: 2.3.2 # Rolled by dependabot

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_app_icons: 0.1.1 # Rolled by dependabot
+  font_awesome_flutter: ^10.12.0
   github: ^9.25.0
   google_sign_in: ^7.0.0
   google_sign_in_platform_interface: ^3.0.0

--- a/dashboard/pubspec.yaml
+++ b/dashboard/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   json_annotation: ^4.9.0
   meta: any # Match Flutter SDK
   provider: 6.1.5 # Rolled by dependabot
-  # TODO(chunhtai): Remove this pin once sign_in_button is updated to use font_awesome_flutter >= 11.0.0
+  # TODO(chunhtai): Avoid using pinning once sign_in_button is updated to use font_awesome_flutter >= 11.0.0
   sign_in_button: 4.0.1
   truncate: 3.0.1 # Rolled by dependabot
   url_launcher: 6.3.2 # Rolled by dependabot


### PR DESCRIPTION
sign_in_button 4.1.0 uses a range version for font_awesome_flutter, but it doesn't work with font_awesome_flutter v11
https://github.com/juliansteenbakker/sign_in_button/blob/cf597c72df3c1925680f824041b74dc32166c79c/pubspec.yaml#L15

pin the sign_in_button to 4.0.1

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
