### PR TITLE
Lookup for sha in presubmit_guards if it is not found in ciStaging

### DIFF
--- a/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
+++ b/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
@@ -8,6 +8,7 @@ import '../../cocoon_service.dart';
 import '../model/firestore/ci_staging.dart';
 import '../request_handling/exceptions.dart';
 import '../request_handling/public_api_request_handler.dart';
+import '../service/firestore/unified_check_run.dart';
 
 /// Query if engine artifacts are ready for a given commit SHA.
 ///
@@ -40,9 +41,11 @@ final class GetEngineArtifactsReady extends PublicApiRequestHandler {
       throw const BadRequestException('Missing query parameter: "$_paramSha"');
     }
 
-    final CiStaging ciStaging;
+    var failed = 0;
+    var remaining = 0;
+    var found = false;
     try {
-      ciStaging = await CiStaging.fromFirestore(
+      final ciStaging = await CiStaging.fromFirestore(
         firestoreService: _firestore,
         documentName: CiStaging.documentNameFor(
           slug: Config.flutterSlug,
@@ -50,18 +53,50 @@ final class GetEngineArtifactsReady extends PublicApiRequestHandler {
           stage: CiStage.fusionEngineBuild,
         ),
       );
+      failed = ciStaging.failed;
+      remaining = ciStaging.remaining;
+      found = true;
     } on DetailedApiRequestError catch (e) {
-      if (e.status == HttpStatus.notFound) {
-        throw NotFoundException('No engine SHA found for "$commitSha"');
+      if (e.status != HttpStatus.notFound) {
+        rethrow;
       }
-      rethrow;
+    }
+    // if not found in ciStaging document, check if there are any
+    // presubmit guards for this sha. This is needed for unified check-run flow.
+    if (!found) {
+      final guards = await UnifiedCheckRun.getPresubmitGuardsForCommitSha(
+        firestoreService: _firestore,
+        slug: Config.flutterSlug,
+        commitSha: commitSha,
+      );
+      if (guards.isNotEmpty) {
+        found = true;
+        // If Guard exists for `fusion` only consider that stage is successful
+        // since empty guard is not stored for `engine` like it is in ciStaging.
+        remaining =
+            guards
+                .where((g) => g.stage == CiStage.fusionEngineBuild)
+                .firstOrNull
+                ?.remainingJobs ??
+            0;
+        failed =
+            guards
+                .where((g) => g.stage == CiStage.fusionEngineBuild)
+                .firstOrNull
+                ?.failedJobs ??
+            0;
+      }
     }
 
-    if (ciStaging.failed > 0) {
+    if (!found) {
+      throw NotFoundException('No engine SHA found for "$commitSha"');
+    }
+
+    if (failed > 0) {
       return Response.json(_GetEngineArtifactsResponse.failed);
     }
 
-    if (ciStaging.remaining > 0) {
+    if (remaining > 0) {
       return Response.json(_GetEngineArtifactsResponse.pending);
     }
 

--- a/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
+++ b/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
@@ -73,18 +73,11 @@ final class GetEngineArtifactsReady extends PublicApiRequestHandler {
         found = true;
         // If Guard exists for `fusion` only consider that stage is successful
         // since empty guard is not stored for `engine` like it is in ciStaging.
-        remaining =
-            guards
-                .where((g) => g.stage == CiStage.fusionEngineBuild)
-                .firstOrNull
-                ?.remainingJobs ??
-            0;
-        failed =
-            guards
-                .where((g) => g.stage == CiStage.fusionEngineBuild)
-                .firstOrNull
-                ?.failedJobs ??
-            0;
+        final engineGuard = guards
+            .where((g) => g.stage == CiStage.fusionEngineBuild)
+            .firstOrNull;
+        remaining = engineGuard?.remainingJobs ?? 0;
+        failed = engineGuard?.failedJobs ?? 0;
       }
     }
 

--- a/app_dart/test/request_handlers/get_engine_artifacts_ready_test.dart
+++ b/app_dart/test/request_handlers/get_engine_artifacts_ready_test.dart
@@ -131,4 +131,106 @@ void main() {
     await expectLater(tester.get(handler), completes);
     await expectLater(decodeHandlerBody(), completion({'status': 'failed'}));
   });
+
+  group('when not found in ciStaging, checks presubmit guards', () {
+    test(
+      'returns "complete" when guard for fusionEngineBuild is successful',
+      () async {
+        tester.request.uri = tester.request.uri.replace(
+          queryParameters: {'sha': 'abc123'},
+        );
+
+        final guard = generatePresubmitGuard(
+          slug: Config.flutterSlug,
+          headSha: 'abc123',
+          stage: CiStage.fusionEngineBuild,
+          remainingJobs: 0,
+          failedJobs: 0,
+        );
+
+        firestore.putDocuments([guard]);
+
+        await expectLater(tester.get(handler), completes);
+        await expectLater(
+          decodeHandlerBody(),
+          completion({'status': 'complete'}),
+        );
+      },
+    );
+
+    test(
+      'returns "pending" when guard for fusionEngineBuild is pending',
+      () async {
+        tester.request.uri = tester.request.uri.replace(
+          queryParameters: {'sha': 'abc123'},
+        );
+
+        final guard = generatePresubmitGuard(
+          slug: Config.flutterSlug,
+          headSha: 'abc123',
+          stage: CiStage.fusionEngineBuild,
+          remainingJobs: 1,
+          failedJobs: 0,
+        );
+
+        firestore.putDocuments([guard]);
+
+        await expectLater(tester.get(handler), completes);
+        await expectLater(
+          decodeHandlerBody(),
+          completion({'status': 'pending'}),
+        );
+      },
+    );
+
+    test(
+      'returns "failed" when guard for fusionEngineBuild is failed',
+      () async {
+        tester.request.uri = tester.request.uri.replace(
+          queryParameters: {'sha': 'abc123'},
+        );
+
+        final guard = generatePresubmitGuard(
+          slug: Config.flutterSlug,
+          headSha: 'abc123',
+          stage: CiStage.fusionEngineBuild,
+          remainingJobs: 0,
+          failedJobs: 1,
+        );
+
+        firestore.putDocuments([guard]);
+
+        await expectLater(tester.get(handler), completes);
+        await expectLater(
+          decodeHandlerBody(),
+          completion({'status': 'failed'}),
+        );
+      },
+    );
+
+    test(
+      'returns "complete" when guards exist but none for fusionEngineBuild',
+      () async {
+        tester.request.uri = tester.request.uri.replace(
+          queryParameters: {'sha': 'abc123'},
+        );
+
+        final guard = generatePresubmitGuard(
+          slug: Config.flutterSlug,
+          headSha: 'abc123',
+          stage: CiStage.fusionTests,
+          remainingJobs: 1,
+          failedJobs: 0,
+        );
+
+        firestore.putDocuments([guard]);
+
+        await expectLater(tester.get(handler), completes);
+        await expectLater(
+          decodeHandlerBody(),
+          completion({'status': 'complete'}),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
Lookup for sha in `presubmit_guards` if it is not found in `ciStaging` in `GetEngineArtifactsReady` api.

Fix: https://github.com/flutter/flutter/issues/184530