### PR TITLE
Gracefully handle failure to acknowledge a pubsub message.

### DIFF
--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -59,15 +59,21 @@ class PubSub {
   ///
   /// The PubSub system can remove the relevant messages from the subscription.
   Future<void> acknowledge(String subscription, String ackId) async {
-    final Client httpClient = await clientViaApplicationDefaultCredentials(
-      scopes: <String>[pubsub.PubsubApi.pubsubScope],
-    );
-    final pubsubApi = pubsub.PubsubApi(httpClient);
-    final ackIds = <String>[ackId];
-    final acknowledgeRequest = pubsub.AcknowledgeRequest(ackIds: ackIds);
-    await pubsubApi.projects.subscriptions.acknowledge(
-      acknowledgeRequest,
-      '${Config.pubsubSubscriptionsPrefix}/$subscription',
-    );
+    try {
+      final Client httpClient = await clientViaApplicationDefaultCredentials(
+        scopes: <String>[pubsub.PubsubApi.pubsubScope],
+      );
+      final pubsubApi = pubsub.PubsubApi(httpClient);
+      final ackIds = <String>[ackId];
+      final acknowledgeRequest = pubsub.AcknowledgeRequest(ackIds: ackIds);
+      await pubsubApi.projects.subscriptions.acknowledge(
+        acknowledgeRequest,
+        '${Config.pubsubSubscriptionsPrefix}/$subscription',
+      );
+    } catch (e) {
+      log.warning(
+        'Failed to acknowledge message $ackId for subscription $subscription: $e',
+      );
+    }
   }
 }

--- a/auto_submit/lib/request_handling/pubsub.dart
+++ b/auto_submit/lib/request_handling/pubsub.dart
@@ -71,7 +71,7 @@ class PubSub {
         '${Config.pubsubSubscriptionsPrefix}/$subscription',
       );
     } catch (e) {
-      log.warning(
+      log.error(
         'Failed to acknowledge message $ackId for subscription $subscription: $e',
       );
     }

--- a/auto_submit/test/request_handling/pubsub_test.dart
+++ b/auto_submit/test/request_handling/pubsub_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2026 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:auto_submit/request_handling/pubsub.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PubSub', () {
+    test('acknowledge handles exceptions gracefully', () async {
+      const pubsub = PubSub();
+      // This should not throw even if credentials are missing or API fails.
+      await expectLater(
+        pubsub.acknowledge('test-sub', 'test-ack-id'),
+        completes,
+      );
+    });
+  });
+}


### PR DESCRIPTION
If the pubsub message has expired for whatever reason, we should catch the exception and continue with the rest of the code path.