### PR TITLE
Bubble up more descriptive logs from GitHub when enqueuing a PR fails.

### DIFF
--- a/auto_submit/lib/service/graphql_service.dart
+++ b/auto_submit/lib/service/graphql_service.dart
@@ -46,7 +46,17 @@ class GraphQlService {
 
     if (queryResult.hasException) {
       log.error('GraphQL query failed', queryResult.exception);
-      throw const BadRequestException('GraphQL query failed');
+      final exception = queryResult.exception!;
+      final errors = exception.graphqlErrors;
+      String errorMessage;
+      if (errors.isNotEmpty) {
+        errorMessage = errors.map((e) => e.message).join(', ');
+      } else if (exception.linkException != null) {
+        errorMessage = exception.linkException.toString();
+      } else {
+        errorMessage = 'GraphQL query failed';
+      }
+      throw BadRequestException(errorMessage);
     }
     return queryResult.data!;
   }
@@ -67,7 +77,17 @@ class GraphQlService {
 
     if (queryResult.hasException) {
       log.error('GraphQL mutate failed', queryResult.exception);
-      throw const BadRequestException('GraphQL mutate failed');
+      final exception = queryResult.exception!;
+      final errors = exception.graphqlErrors;
+      String errorMessage;
+      if (errors.isNotEmpty) {
+        errorMessage = errors.map((e) => e.message).join(', ');
+      } else if (exception.linkException != null) {
+        errorMessage = exception.linkException.toString();
+      } else {
+        errorMessage = 'GraphQL mutate failed';
+      }
+      throw BadRequestException(errorMessage);
     }
     return queryResult.data!;
   }

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -627,7 +627,14 @@ This is the second line in a paragraph.''');
         return QueryResult(
           options: options,
           source: QueryResultSource.network,
-          exception: OperationException(),
+          exception: OperationException(
+            graphqlErrors: <GraphQLError>[
+              const GraphQLError(
+                message:
+                    'Pull request New changes require approval from someone other than Piinks because they were the last pusher.',
+              ),
+            ],
+          ),
         );
       };
 
@@ -648,7 +655,7 @@ This is the second line in a paragraph.''');
       expect(
         result.message,
         contains(
-          'Failed to enqueue flutter/flutter/42 with HTTP 400: GraphQL mutate failed',
+          'Failed to enqueue flutter/flutter/42 with HTTP 400: Pull request New changes require approval from someone other than Piinks because they were the last pusher.',
         ),
       );
     });


### PR DESCRIPTION
GitHub does provide useful and descriptive messages when there is some issue with enqueuing the PR into the merge queue. Unfortunately, right now we're just saying `400 GraphQL mutate failed` which doesn't help the user figure out how to unblock their PR. This change adds the info from the GitHub response in to the message.