### PR TITLE
Add an explicit checkrun which indicates that the CICD label needs to be added.

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -203,10 +203,12 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
             pullRequestEvent.changes!.base != null) {
           await _addCICDForRollersAndMembers(pullRequestEvent);
         }
+        await scheduler.createAwaitingCicdLabelCheckRun(slug, pr.head!.sha!);
         await _checkForTests(pullRequestEvent);
         break;
       case 'opened':
         await _addCICDForRollersAndMembers(pullRequestEvent);
+        await scheduler.createAwaitingCicdLabelCheckRun(slug, pr.head!.sha!);
         await _checkForTests(pullRequestEvent);
         await _tryReleaseApproval(pullRequestEvent);
         break;
@@ -224,6 +226,10 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
           if (Config.kCicdLabelIds.contains(label.id) &&
               label.name == Config.kCicdLabel) {
             log.info('new CICD label added - scheduling tests');
+            await scheduler.resolveAwaitingCicdLabelCheckRun(
+              slug,
+              pr.head!.sha!,
+            );
             await _scheduleIfMergeable(pullRequestEvent);
           }
         }

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -841,6 +841,57 @@ $s
     );
   }
 
+  /// Creates a pending check run for "Awaiting CICD label" if it doesn't exist.
+  Future<CheckRun?> createAwaitingCicdLabelCheckRun(
+    RepositorySlug slug,
+    String headSha,
+  ) async {
+    final githubService = await _config.createGithubService(slug);
+    final existing = await githubService.getCheckRunsFiltered(
+      slug: slug,
+      ref: headSha,
+      checkName: 'Awaiting CICD label',
+    );
+    if (existing.isEmpty) {
+      return _githubChecksService.githubChecksUtil.createCheckRun(
+        _config,
+        slug,
+        headSha,
+        'Awaiting CICD label',
+        output: const CheckRunOutput(
+          title: 'Awaiting CICD label',
+          summary: 'This PR is awaiting the CICD label to start tests.',
+        ),
+      );
+    }
+    return null;
+  }
+
+  /// Resolves the pending check run for "Awaiting CICD label".
+  Future<void> resolveAwaitingCicdLabelCheckRun(
+    RepositorySlug slug,
+    String headSha,
+  ) async {
+    final githubService = await _config.createGithubService(slug);
+    final guard = (await githubService.getCheckRunsFiltered(
+      slug: slug,
+      ref: headSha,
+      checkName: 'Awaiting CICD label',
+    )).singleOrNull;
+    if (guard != null) {
+      await githubService.updateCheckRun(
+        slug: slug,
+        checkRun: guard,
+        status: CheckRunStatus.completed,
+        conclusion: CheckRunConclusion.success,
+        output: const CheckRunOutput(
+          title: 'Awaiting CICD label',
+          summary: 'CICD label added.',
+        ),
+      );
+    }
+  }
+
   /// Completes the "Merge Queue Guard" check run.
   ///
   /// If the guard is guarding a merge group, this immediately makes the merge

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -3859,5 +3859,114 @@ void foo() {
         );
       },
     );
+
+    test(
+      'opened PR without CICD label creates "Awaiting CICD label" checkrun',
+      () async {
+        githubService.checkRunsMock = '{"total_count": 0, "check_runs": [{}]}';
+        tester.message = generateGithubWebhookMessage(
+          action: 'opened',
+          withCicdLabel: false,
+        );
+
+        await tester.post(webhook);
+
+        verify(
+          mockGithubChecksUtil.createCheckRun(
+            any,
+            any,
+            any,
+            'Awaiting CICD label',
+            output: anyNamed('output'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'opened PR with CICD label STILL creates "Awaiting CICD label" checkrun if not exists',
+      () async {
+        githubService.checkRunsMock = '{"total_count": 0, "check_runs": [{}]}';
+        tester.message = generateGithubWebhookMessage(
+          action: 'opened',
+          withCicdLabel: true,
+        );
+
+        await tester.post(webhook);
+
+        verify(
+          mockGithubChecksUtil.createCheckRun(
+            any,
+            any,
+            any,
+            'Awaiting CICD label',
+            output: anyNamed('output'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'edited PR without CICD label creates "Awaiting CICD label" checkrun if not exists',
+      () async {
+        githubService.checkRunsMock = '{"total_count": 0, "check_runs": [{}]}';
+        tester.message = generateGithubWebhookMessage(
+          action: 'edited',
+          withCicdLabel: false,
+        );
+
+        await tester.post(webhook);
+
+        verify(
+          mockGithubChecksUtil.createCheckRun(
+            any,
+            any,
+            any,
+            'Awaiting CICD label',
+            output: anyNamed('output'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'labeled event with CICD label resolves "Awaiting CICD label" checkrun',
+      () async {
+        githubService.checkRunsMock = '''{
+        "total_count": 1,
+        "check_runs": [
+          {
+            "id": 1,
+            "name": "Awaiting CICD label",
+            "head_sha": "be6ff099a4ee56e152a5fa2f37edd10f79d1269a",
+            "status": "in_progress",
+            "started_at": "2018-05-04T01:14:52Z",
+            "conclusion": null,
+            "check_suite": {
+              "id": 5
+            }
+          }
+        ]
+      }''';
+
+        tester.message = generateGithubWebhookMessage(
+          action: 'labeled',
+          labeledLabel: labelEventMap,
+          withCicdLabel: true,
+        );
+
+        await tester.post(webhook);
+
+        expect(githubService.checkRunUpdates.length, 1);
+        expect(
+          githubService.checkRunUpdates.first.status,
+          CheckRunStatus.completed,
+        );
+        expect(
+          githubService.checkRunUpdates.first.conclusion,
+          CheckRunConclusion.success,
+        );
+      },
+    );
   });
 }

--- a/packages/cocoon_integration_test/lib/src/fakes/fake_github_service.dart
+++ b/packages/cocoon_integration_test/lib/src/fakes/fake_github_service.dart
@@ -216,6 +216,9 @@ class FakeGithubService implements GithubService {
 
   @override
   Future<List<CheckRun>> getCheckRuns(RepositorySlug slug, String ref) async {
+    if (checkRunsMock == null) {
+      return <CheckRun>[];
+    }
     final rawBody = json.decode(checkRunsMock!) as Map<String, dynamic>;
     final checkRunsBody = rawBody['check_runs']! as List<dynamic>;
     final checkRuns = <CheckRun>[];


### PR DESCRIPTION
It's very easy to forget to add the CICD label, and it isn't always clear that is what our checkruns are waiting on. This adds an explicit checkrun that says that we are waiting on the CICD label.