### PR TITLE
[auto_submit] Improve enqueue failure message to hint at missing CI labels

### DIFF
--- a/auto_submit/lib/service/validation_service.dart
+++ b/auto_submit/lib/service/validation_service.dart
@@ -108,7 +108,10 @@ ${pullRequest.title!.replaceFirst('Revert "Revert', 'Reland')}
       }, retryIf: (Exception e) => e is RetryableException);
     } catch (e, s) {
       final message =
-          'Failed to enqueue ${slug.fullName}/${restPullRequest.number} with $e';
+          'Failed to enqueue ${slug.fullName}/${restPullRequest.number} with $e. '
+          'If CI checks have not been triggered, please ensure the appropriate '
+          'CI labels have been added before using the '
+          "'${Config.kAutosubmitLabel}' label.";
       log.error(message, e, s);
       return (result: false, message: message, method: SubmitMethod.enqueue);
     }

--- a/auto_submit/test/service/pull_request_validation_service_test.dart
+++ b/auto_submit/test/service/pull_request_validation_service_test.dart
@@ -660,6 +660,52 @@ This is the second line in a paragraph.''');
       );
     });
 
+    test(
+      'Fails to enqueue with helpful hint when GraphQL returns opaque error',
+      () async {
+        slug = RepositorySlug('flutter', 'flutter');
+
+        githubGraphQLClient.queryResultForOptions = (QueryOptions options) {
+          return QueryResult(
+            options: options,
+            source: QueryResultSource.network,
+            data: {
+              'repository': {
+                'pullRequest': {'id': 'PR_blahblah'},
+              },
+            },
+          );
+        };
+
+        githubGraphQLClient.mutateResultForOptions = (MutationOptions options) {
+          return QueryResult(
+            options: options,
+            source: QueryResultSource.network,
+            exception: OperationException(),
+          );
+        };
+
+        final pullRequest = generatePullRequest(
+          prNumber: 42,
+          repoName: slug.name,
+          title: 'Test PR',
+          mergeable: true,
+        );
+
+        final result = await validationService.submitPullRequest(
+          config: config,
+          pullRequest: pullRequest,
+        );
+
+        expect(result.result, isFalse);
+        expect(result.message, contains('Failed to enqueue flutter/flutter/42'));
+        expect(
+          result.message,
+          contains('CI labels have been added before using the'),
+        );
+      },
+    );
+
     test('Jumps the queue for emergency pull requests', () async {
       slug = RepositorySlug('flutter', 'flutter');
       final prTitle = 'This pull request should fail to enqueueueueueueueueueu';


### PR DESCRIPTION
When a PR is added to the merge queue but required CI checks have not been triggered (e.g. missing CI labels), the enqueue call fails with an opaque HTTP 400 error that gives no actionable guidance. The error previously read:

auto label is removed for flutter/flutter/183971, Failed to enqueue flutter/flutter/183971 with HTTP 400: GraphQL mutate failed.

This PR appends a hint to that message telling the author to verify CI labels have been added before using the autosubmit label.

Fixes flutter/flutter#184848

Pre-launch Checklist
 I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
 I read the [Tree Hygiene] wiki page, which explains my responsibilities.
 I read the [Flutter Style Guide] recently, and have followed its advice.
 I signed the [CLA].
 I listed at least one issue that this PR fixes in the description above.
 I updated/added relevant documentation (doc comments with ///).
 I added new tests to check the change I am making, or this PR is [test-exempt].
 All existing and new tests are passing.