### PR TITLE
Add logs for checking of team membership

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -594,10 +594,12 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
       author,
       slug.owner,
     );
+    log.debug('isRoller=$isRoller, isFlutterHacker=$isFlutterHacker');
 
     if (config.supportedRepos.contains(slug) && (isRoller || isFlutterHacker)) {
       final gitHubClient = await config.createGitHubClient(pullRequest: pr);
       await gitHubClient.issues.addLabelsToIssue(slug, pr.number!, ['CICD']);
+      log.debug('Added CICD label to PR $pr.number');
     }
   }
 

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -126,7 +126,9 @@ class GithubService {
       );
       return teamMembershipState.isActive;
     } on GitHubError catch (e) {
-      log.debug('Failed to check team membership: $e');
+      log.debug(
+        'Failed to check team membership for team $team and user $user, org $org: $e',
+      );
       return false;
     }
   }

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -121,8 +121,10 @@ class GithubService {
     try {
       final teamMembershipState = await github.organizations
           .getTeamMembershipByName(org, team, user);
+      log.debug('Team membership state: $teamMembershipState');
       return teamMembershipState.isActive;
-    } on GitHubError {
+    } on GitHubError catch (e) {
+      log.debug('Failed to check team membership: $e');
       return false;
     }
   }

--- a/app_dart/lib/src/service/github_service.dart
+++ b/app_dart/lib/src/service/github_service.dart
@@ -121,7 +121,9 @@ class GithubService {
     try {
       final teamMembershipState = await github.organizations
           .getTeamMembershipByName(org, team, user);
-      log.debug('Team membership state: $teamMembershipState');
+      log.debug(
+        'Team membership state for team $team and user $user, org $org: $teamMembershipState',
+      );
       return teamMembershipState.isActive;
     } on GitHubError catch (e) {
       log.debug('Failed to check team membership: $e');


### PR DESCRIPTION
Determine why we aren't adding the label. Gemini suggested it's possible the token doesn't have `read:org` or `read:discussion` scope, either way these logs may be helpful.

