### PR TITLE
Update the bot check to recognise Swift tests

### DIFF
--- a/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
+++ b/app_dart/lib/src/request_handlers/github/webhook_subscription.dart
@@ -838,7 +838,7 @@ final class GithubWebhookSubscription extends SubscriptionHandler {
 
   bool _isAnEngineTest(String filename) {
     final engineTestRegExp = RegExp(
-      r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py)$',
+      r'(tests?|benchmarks?)\.(dart|java|mm|m|cc|sh|py|swift)$',
     );
     return filename.contains('IosBenchmarks') ||
         filename.contains('IosUnitTests') ||

--- a/app_dart/test/request_handlers/github/webhook_subscription_test.dart
+++ b/app_dart/test/request_handlers/github/webhook_subscription_test.dart
@@ -803,6 +803,40 @@ void main() {
       ).called(1);
     });
 
+    test('Fusion labels engine PRs, comment if no tests for Swift', () async {
+      const issueNumber = 124;
+
+      tester.message = generateGithubWebhookMessage(
+        action: 'opened',
+        number: issueNumber,
+      );
+      when(
+        pullRequestsService.listFiles(Config.flutterSlug, issueNumber),
+      ).thenAnswer(
+        (_) => Stream<PullRequestFile>.fromIterable([
+          PullRequestFile()..filename = 'engine/src/flutter/fu.swift',
+        ]),
+      );
+
+      when(
+        issuesService.listCommentsByIssue(Config.flutterSlug, issueNumber),
+      ).thenAnswer(
+        (_) => Stream<IssueComment>.value(
+          IssueComment()..body = 'some other comment',
+        ),
+      );
+
+      await tester.post(webhook);
+
+      verify(
+        issuesService.createComment(
+          Config.flutterSlug,
+          issueNumber,
+          argThat(contains(config.missingTestsPullRequestMessageValue)),
+        ),
+      ).called(1);
+    });
+
     test('Fusion labels engine PRs, no comment for tests', () async {
       // Note: engine doesn't add any labels, so we're only looking for comments
       const issueNumber = 123;
@@ -1940,6 +1974,11 @@ void foo() {
           // Java tests.
           'engine/src/flutter/shell/platform/android/io/flutter/Blah.java',
           'engine/src/flutter/shell/platform/android/test/io/flutter/BlahTest.java',
+        ],
+        <String>[
+          // Swift tests.
+          'engine/src/flutter/shell/platform/darwin/ios/framework/Source/Blah.swift',
+          'engine/src/flutter/shell/platform/darwin/ios/framework/Source/BlahTest.swift',
         ],
         <String>[
           // Script tests.


### PR DESCRIPTION
Files ending in `Test.swift` are now recognised as valid tests. Previously, we checked for extensions like `.mm`, `.cc`, `.dart`, etc., but did not include `.swift`. This change ensures that Swift files are also covered.

Fixes: https://github.com/flutter/flutter/issues/185194

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [S] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
