### PR TITLE
[flutter-gold] Consider neutral checks completed

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -161,7 +161,7 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
         }
         const successfulConclusion = {'SUCCESS', 'NEUTRAL'};
 
-        if (checkRun['status']?.toUpperCase() != 'completed' ||
+        if (checkRun['status']?.toUpperCase() != 'COMPLETED' ||
             !successfulConclusion.contains(
               checkRun['conclusion']?.toUpperCase(),
             )) {

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -136,7 +136,6 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
       checkRuns = checkRuns ?? <Map<String, dynamic>>[];
       log.debug('This PR has ${checkRuns.length} checks.');
       for (var checkRun in checkRuns) {
-        log.debug('Check run: $checkRun');
         final name = checkRun['name'].toLowerCase() as String;
         if (slug == Config.flutterSlug) {
           if (const <String>[
@@ -160,8 +159,13 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
             runsGoldenFileTests = true;
           }
         }
-        if (checkRun['conclusion'] == null ||
-            checkRun['conclusion'].toUpperCase() != 'SUCCESS') {
+        if (checkRun['status']?.toUpperCase() != 'COMPLETED' ||
+            checkRun['conclusion'] == null ||
+            !<String>[
+              'SUCCESS',
+              'NEUTRAL',
+            ].contains(checkRun['conclusion'].toUpperCase())) {
+          log.debug('Incomplete check run: $checkRun');
           incompleteChecks.add(name);
         }
       }

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -159,12 +159,10 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
             runsGoldenFileTests = true;
           }
         }
-        if (checkRun['status']?.toUpperCase() != 'COMPLETED' ||
-            checkRun['conclusion'] == null ||
-            !<String>[
-              'SUCCESS',
-              'NEUTRAL',
-            ].contains(checkRun['conclusion'].toUpperCase())) {
+        const successfulConclusion = {'SUCCESS', 'NEUTRAL'};
+
+        if (checkRun['status']?.toUpperCase() != 'completed' ||
+            !successfulConclusion.contains(checkRun['conclusion']?.toUpperCase())) {
           log.debug('Incomplete check run: $checkRun');
           incompleteChecks.add(name);
         }

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -162,7 +162,9 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
         const successfulConclusion = {'SUCCESS', 'NEUTRAL'};
 
         if (checkRun['status']?.toUpperCase() != 'completed' ||
-            !successfulConclusion.contains(checkRun['conclusion']?.toUpperCase())) {
+            !successfulConclusion.contains(
+              checkRun['conclusion']?.toUpperCase(),
+            )) {
           log.debug('Incomplete check run: $checkRun');
           incompleteChecks.add(name);
         }

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -362,6 +362,64 @@ void main() {
       });
 
       test(
+        'same commit, neutral checks complete, last status complete',
+        () async {
+          // Same commit
+          final pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+
+          firestore.putDocument(
+            newGithubGoldStatus(
+              slug,
+              pr,
+              GithubGoldStatus.statusCompleted,
+              'abc',
+              config.flutterGoldSuccessValue!,
+            ),
+          );
+
+          // Neutral checks complete
+          checkRuns = <dynamic>[
+            <String, String>{
+              'name': 'framework',
+              'status': 'completed',
+              'conclusion': 'neutral',
+            },
+            <String, String>{
+              'name': 'web engine',
+              'status': 'completed',
+              'conclusion': 'neutral',
+            },
+          ];
+
+          final body = await tester.get(handler);
+          expect(body, same(Response.emptyOk));
+          expect(
+            firestore,
+            existsInStorage(fs.GithubGoldStatus.metadata, [
+              isGithubGoldStatus.hasUpdates(0),
+            ]),
+          );
+          expect(log, hasNoWarningsOrHigher);
+
+          // Should not apply labels or make comments
+          verifyNever(
+            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
+              kGoldenFileLabel,
+            ]),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        },
+      );
+
+      test(
         'same commit, checks complete, last status & gold status is running/awaiting triage, should not comment',
         () async {
           // Same commit
@@ -1160,7 +1218,7 @@ void main() {
         checkRuns = <dynamic>[
           <String, String>{
             'name': 'framework',
-            'completed': 'in_progress',
+            'status': 'completed',
             'conclusion': 'success',
           },
         ];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/185832

This PR improves how Flutter Gold status updates are computed by accounting for completed checks that end in a `NEUTRAL` conclusion (alongside `SUCCESS`). It also streamlines logging and fortifies the check status evaluation.

* Updates the evaluation logic so that PR checks ending in NEUTRAL are no longer grouped alongside incomplete or failing tests.
*  Added explicit status verification for check runs. If a check run does not have the status 'COMPLETED', it is now safely and reliably classified as incomplete.
* Moved the log.debug statement to only capture check runs that are truly incomplete or failing, significantly reducing log output noise.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
