### PR TITLE
When properties are extracted from a target configuration, exclude properties that affect source locations used by LUCI recipes

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -189,6 +189,13 @@ final class Target {
         .toList();
     mergedProperties['bringup'] = _value.bringup;
 
+    // Do not allow configurations to set values of properties that affect the
+    // location of the sources checked out by the LUCI recipes.
+    const checkoutProperties = <String>['git_ref', 'git_url'];
+    for (var property in checkoutProperties) {
+      mergedProperties.remove(property);
+    }
+
     return mergedProperties;
   }
 

--- a/app_dart/test/model/ci_yaml/target_test.dart
+++ b/app_dart/test/model/ci_yaml/target_test.dart
@@ -147,6 +147,22 @@ void main() {
         );
         expect(target.tags, isEmpty);
       });
+
+      test('properties that affect source checkouts are filtered', () {
+        final target = generateTarget(
+          1,
+          platform: 'Linux_build_test',
+          properties: <String, String>{
+            'git_url': 'https://github.com/flutter/flutter',
+            'git_ref': 'refs/pull/12345/head',
+            'recipe': 'devicelab/devicelab',
+          },
+        );
+        final properties = target.getProperties();
+        expect(properties, contains('recipe'));
+        expect(properties, isNot(contains('git_url')));
+        expect(properties, isNot(contains('git_ref')));
+      });
     });
 
     group('dimensions', () {


### PR DESCRIPTION
These properties should only be set by Cocoon's build scheduler.

See http://b/509842706