### PR TITLE
Do not immediately unlock `Flutter Presubmits` on non-fusion repos for unified check run flow

### DIFF
--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -366,7 +366,7 @@ class Scheduler {
     do {
       try {
         final sha = pullRequest.head!.sha!;
-        if (!isFusion) {
+        if (!isFusion && !isUnifiedCheckRun) {
           unlockMergeGroup = true;
         }
 

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -2813,6 +2813,26 @@ targets:
           expect(guard.stage, CiStage.genericTests);
           expect(guard.commitSha, pr.head!.sha);
           expect(guard.jobs['Linux A'], TaskStatus.waitingForBackfill);
+
+          // Verify that the "Flutter Presubmits" check run is not immediately succeeded.
+          verifyNever(
+            mockGithubChecksUtil.updateCheckRun(
+              any,
+              any,
+              argThat(
+                isA<CheckRun>().having(
+                  (c) => c.name,
+                  'name',
+                  Config.kFlutterPresubmitsName,
+                ),
+              ),
+              status: CheckRunStatus.completed,
+              conclusion: CheckRunConclusion.success,
+              output: anyNamed('output'),
+              actions: anyNamed('actions'),
+              detailsUrl: anyNamed('detailsUrl'),
+            ),
+          );
         },
       );
 


### PR DESCRIPTION
Modified `triggerPresubmitTargets` event handler logic to do not immediately unlock `MergeQueueGuard` for non-fusion repositories if the unified check run flow is enabled

fix: https://github.com/flutter/flutter/issues/187458