### PR TITLE
Change Docker build context to `cloud_build/flutter_agy_docker`

### DIFF
--- a/cloud_build/flutter_agy_docker/cloudbuild.yaml
+++ b/cloud_build/flutter_agy_docker/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
       # Also tag it as latest in Artifact Registry
       - '-t'
       - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
-      - '.'
+      - 'cloud_build/flutter_agy_docker'
 
 # Define the default version here so manual triggers still work
 substitutions:


### PR DESCRIPTION
This works if you run the cloud build command in the folder, but Cloud Console needs to know the directory though


After this change we can setup a schedule.