### PR TITLE
docs(docker): add FAQ for using git worktrees

### DIFF
--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -185,7 +185,8 @@ RUN mkdir -p /home/coder/.vim/pack/dart-lang/start && \
 
 RUN git config --global --add safe.directory /app && \
     git config --global core.editor vim && \
-    git config --global pull.rebase true
+    git config --global pull.rebase true && \
+    git config --global worktree.useRelativePaths true
 
 WORKDIR /app
 ENTRYPOINT [ "/usr/bin/byobu" ]

--- a/cloud_build/flutter_agy_docker/README.md
+++ b/cloud_build/flutter_agy_docker/README.md
@@ -112,3 +112,16 @@ Install the following extensions in VS Code:
 3. Once the SSH connection is established, open the Command Palette again.
 4. Select **Dev Containers: Attach to Running Container...**
 5. Choose the running container on the remote machine.
+
+## 7. FAQ & Troubleshooting
+
+### Using Git Worktrees
+
+When using Git worktrees within the container, you must configure Git to use relative paths. Failure to do so may result in broken worktree references because absolute paths differ between the host and the container.
+
+To configure relative paths and repair any existing broken worktrees, run the following command:
+
+```shell
+git config --global worktree.useRelativePaths true && git worktree repair
+```
+

--- a/cloud_build/flutter_agy_docker/README.md
+++ b/cloud_build/flutter_agy_docker/README.md
@@ -119,7 +119,7 @@ Install the following extensions in VS Code:
 
 When using Git worktrees within the container, you must configure Git to use relative paths. Failure to do so may result in broken worktree references because absolute paths differ between the host and the container.
 
-To configure relative paths and repair any existing broken worktrees, run the following command:
+To configure Git to use relative paths, run the following command or ensure it's set in your container:
 
 ```shell
 git config --global worktree.useRelativePaths true && git worktree repair

--- a/cloud_build/flutter_agy_docker/README.md
+++ b/cloud_build/flutter_agy_docker/README.md
@@ -117,11 +117,12 @@ Install the following extensions in VS Code:
 
 ### Using Git Worktrees
 
-When using Git worktrees within the container, you must configure Git to use relative paths. Failure to do so may result in broken worktree references because absolute paths differ between the host and the container.
+When using Git worktrees with this container, you must configure Git to use relative paths. Failure to do so will result in broken worktree references because absolute paths differ between your host machine and the container.
 
-To configure Git to use relative paths, run the following command or ensure it's set in your container:
+To configure Git to use relative paths, run the following command on your **host machine** (not inside the container):
 
 ```shell
 git config --global worktree.useRelativePaths true && git worktree repair
 ```
 
+After repairing, ensure you run `podman run` (or `coder-up`) from the **root of the worktree** so that the container mounts the correct paths.

--- a/cloud_build/flutter_agy_docker/README.md
+++ b/cloud_build/flutter_agy_docker/README.md
@@ -119,7 +119,7 @@ Install the following extensions in VS Code:
 
 When using Git worktrees with this container, you must configure Git to use relative paths. Failure to do so will result in broken worktree references because absolute paths differ between your host machine and the container.
 
-To configure Git to use relative paths, run the following command on your **host machine** (not inside the container):
+To configure Git to use relative paths, run the following command on your **host machine** (not inside the container) from within your Git repository:
 
 ```shell
 git config --global worktree.useRelativePaths true && git worktree repair


### PR DESCRIPTION
Added a new FAQ & Troubleshooting section to the flutter_agy_docker README.
This section explains how to configure Git to use relative paths for worktrees
when working within the container to prevent broken worktree references.

Also make sure the next image has this turned on so when you type "gwta fu" you get a ".git" that is relative.