### PR TITLE
build(docker): split flutter image into base and dev images

### DIFF
--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -14,7 +14,6 @@ ARG CACHE_BUSTER=1
 # 2. OS Dependencies & Upgrades
 RUN set -eux; \
     apt-get update; \
-    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
         ca-certificates curl dnsutils dos2unix openssh-client unzip \
         tmux byobu vim sudo xz-utils tzdata locales jq ripgrep \

--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -2,144 +2,54 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# This is a highly opinionated docker container aimed at getting a developer
-# up and running with antigravity in a sandbox, instantly.
-
-# Build:
-#   x86: docker build -t flutter_docker .
-#   Apple Silicon: podman build --platform linux/amd64 -t flutter_docker .
-#   Different version of fluttr: podman build --platform linux/amd64 --build-arg FLUTTER_VERSION=3.45.0 -t flutter_docker:3.45.0 .
-#
-# Run:
-#   Apple Silicon: podman run --platform linux/amd64 -it -v "${PWD}:/app" -v "dart_tool_cache:/app/.dart_tool"  -v "dart_build_cache:/app/build" -v "$USER/.gemini:/home/coder/.gemini" flutter_docker:latest
-#   x86: docker run -it -v ".:/app" -v 'dart_tool_cache:/app/.dart_tool'  -v "dart_build_cache:/app/build"  -v "$USER/.gemini:/home/coder/.gemini" flutter_docker:latest
-#
-# Doing something work worktrees - work in progress?
-# 1. Make sure you have relative paths setup.
-#   git config --global worktree.useRelativePaths true
-#   git worktree repair
-# 2. Run one of the commands above, but from the worktree folder.
-#
-# Versions:
-#   * latest: 3.44.2
-#   * previous: permissions on ~/.gemini to fix tool calling
-#   * previous: better handling of .dart_tool - see run commands above! flutter 3.44.1. allow my user to sudo
-#   * previous: fix tmux key bindings. add less and rsync
-#   * previous: `agyolo`!, -homebrew, +vim dart plugin, native yq/gh/jq, less RUN steps
-#   * previous: zsh, omyzsh, homebrew.
-#   * previous: multi-stage build for flutter tooling. byobu/tmux, git, jq.
-
-# ==========================================
-# STAGE 1: The Heavy Downloader - flutter and its tools are heavy
-# ==========================================
-FROM ubuntu:24.04 AS flutter-fetcher
-
-# 1. Define the ARG with a fallback default version
+# Start from the custom flutter_base image.
 ARG FLUTTER_VERSION="3.44.2"
+FROM us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:${FLUTTER_VERSION}
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        curl ca-certificates xz-utils git unzip && \
-    rm -rf /var/lib/apt/lists/*
+USER root
 
-RUN useradd -m builder && \
-    mkdir -p /opt && \
-    chown builder:builder /opt
-USER builder
-WORKDIR /opt
+# 1. The Cache Buster: Changing this value forces Docker to fetch fresh OS updates
+ARG CACHE_BUSTER=1
 
-# This layer caches permanently until you change the URL.
-# It is completely immune to changes in your main image.
-RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz | tar -xJ
-
-# 2. Lock in configuration and force the massive SDK downloads
-ENV PATH="/opt/flutter/bin:${PATH}"
-RUN flutter config \
-        --enable-web \
-        --no-enable-linux-desktop \
-        --no-enable-macos-desktop \
-        --no-enable-windows-desktop \
-        --no-enable-android \
-        --no-enable-ios \
-        --no-enable-fuchsia && \
-    # Precache pulls down the engine binaries, Dart SDK, and web tools
-    flutter precache --web && \
-    flutter --version
-
-# ==========================================
-# STAGE 2: The OS - which should mostly have an OCI layer already.
-# ==========================================
-FROM ubuntu:24.04
-
-# 1. Environment Variables (Rarely change, define early)
-ENV TZ="America/Los_Angeles" \
-    DEBIAN_FRONTEND=noninteractive \
-    FLUTTER_ROOT="/opt/flutter" \
-    PATH="/opt/flutter/bin:/home/coder/.local/bin:${PATH}" \
-    LANG="en_US.UTF-8" \
-    LANGUAGE="en_US:en" \
-    LC_ALL="en_US.UTF-8" \
-    TERM="xterm-256color" \
-    COLORTERM="truecolor" \
-    SHELL="/usr/bin/zsh"
-
-# 2. OS Dependencies (Heavy layer, cache as much as possible)
+# 2. OS Dependencies & Upgrades
 RUN set -eux; \
     apt-get update; \
+    apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
         ca-certificates curl dnsutils dos2unix openssh-client unzip \
         tmux byobu vim sudo xz-utils tzdata locales jq ripgrep \
         fd-find fzf bat btop zsh build-essential procps file wget \
         less rsync software-properties-common lrzsz; \
-    # Install trzsz via PPA
+    # trzsz: Modern SSH File Transfer and Remote Terminal Tools
     add-apt-repository ppa:trzsz/ppa -y; \
+    # latest git version needed for relative worktrees
     add-apt-repository ppa:git-core/ppa -y; \
     apt-get update; \
     apt-get install -y trzsz git; \
-    # install github
+    # install the github `gh` tool
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg; \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null; \
     apt-get update && apt-get install -y gh; \
-    # binary yq
+    # install yq, a YAML/XML/TOML processor like jq
     wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64; \
     chmod a+x /usr/local/bin/yq; \
     locale-gen en_US.UTF-8; \
     ln -s $(which fdfind) /usr/local/bin/fd; \
+    # cat, but better
     ln -s $(which batcat) /usr/local/bin/bat; \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone; \
     rm -rf /var/lib/apt/lists/*; \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# 3. User setup and directory creation
-# Evict the default ubuntu user to free up UID/GID 1000
-# Using -m automatically creates the home directory securely.
-RUN (userdel -r ubuntu 2>/dev/null || true) && \
-    groupadd -g 1000 coder && \
-    useradd -u 1000 -g 1000 -m coder && \
-    mkdir -p /app /opt/flutter /home/linuxbrew/.linuxbrew && \
-    chown -R coder:coder /app /opt /home/linuxbrew
-
-# 4. Import the FULLY HYDRATED Flutter SDK from Stage 1
-# This takes about 1 second and skips all network traffic.
-COPY --from=flutter-fetcher --chown=coder:coder /opt/flutter /opt/flutter
-
-# Switch context to the non-root user for the remaining installations
 USER coder
 
-# or --disable-analytics if running as CICD
-RUN flutter --enable-analytics && dart --enable-analytics
-
-# 5. Install Oh My Zsh unattended so it doesn't halt the Docker build
+# 3. Development Tools
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-
-# Set these after USER
 ENV PATH="/home/coder/.pub-cache/bin:${PATH}"
-
-# 6. User-specific CLI tools
 RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
 
-# 7. User Configuration (Highly volatile, keep at the very bottom)
+# 4. User Configurations
 RUN mkdir -p /home/coder/.config/byobu && \
     touch /home/coder/.config/byobu/.welcome-displayed && \
     { \

--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 # Start from the custom flutter_base image.
-ARG FLUTTER_VERSION="3.44.2"
+ARG FLUTTER_VERSION="3.44.3"
 FROM us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:${FLUTTER_VERSION}
 
 USER root

--- a/cloud_build/flutter_agy_docker/Dockerfile.base
+++ b/cloud_build/flutter_agy_docker/Dockerfile.base
@@ -1,0 +1,55 @@
+# Copyright 2022 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# ==========================================
+# STAGE 1: The Heavy Downloader
+# ==========================================
+FROM ubuntu:24.04 AS flutter-fetcher
+
+# 1. Define the ARG with a fallback default version
+ARG FLUTTER_VERSION="3.44.2"
+
+ENV TZ="America/Los_Angeles" \
+    DEBIAN_FRONTEND=noninteractive \
+    FLUTTER_ROOT="/opt/flutter" \
+    PATH="/opt/flutter/bin:/home/coder/.local/bin:${PATH}" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US:en" \
+    LC_ALL="en_US.UTF-8" \
+    TERM="xterm-256color" \
+    COLORTERM="truecolor" \
+    SHELL="/usr/bin/zsh"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl ca-certificates xz-utils git unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Evict the default ubuntu user and create the target user
+RUN (userdel -r ubuntu 2>/dev/null || true) && \
+    groupadd -g 1000 coder && \
+    useradd -u 1000 -g 1000 -m coder && \
+    mkdir -p /app /opt/flutter /home/linuxbrew/.linuxbrew && \
+    chown -R coder:coder /app /opt /home/linuxbrew
+
+USER coder
+
+WORKDIR /opt
+
+RUN curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz | tar -xJ
+
+# 2. Lock in configuration and force the massive SDK downloads
+ENV PATH="/opt/flutter/bin:${PATH}"
+RUN flutter config \
+        --enable-web \
+        --no-enable-linux-desktop \
+        --no-enable-macos-desktop \
+        --no-enable-windows-desktop \
+        --no-enable-android \
+        --no-enable-ios \
+        --no-enable-fuchsia && \
+    flutter precache --web && \
+    flutter --version && \
+    flutter --enable-analytics && dart --enable-analytics
+

--- a/cloud_build/flutter_agy_docker/Dockerfile.base
+++ b/cloud_build/flutter_agy_docker/Dockerfile.base
@@ -8,7 +8,7 @@
 FROM ubuntu:24.04 AS flutter-fetcher
 
 # 1. Define the ARG with a fallback default version
-ARG FLUTTER_VERSION="3.44.2"
+ARG FLUTTER_VERSION="3.44.3"
 
 ENV TZ="America/Los_Angeles" \
     DEBIAN_FRONTEND=noninteractive \

--- a/cloud_build/flutter_agy_docker/Dockerfile.base
+++ b/cloud_build/flutter_agy_docker/Dockerfile.base
@@ -52,4 +52,3 @@ RUN flutter config \
     flutter precache --web && \
     flutter --version && \
     flutter --enable-analytics && dart --enable-analytics
-

--- a/cloud_build/flutter_agy_docker/cloudbuild.yaml
+++ b/cloud_build/flutter_agy_docker/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
       - '-t'
       - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest'
       - '-f'
-      - 'Dockerfile.base'
+      - 'cloud_build/flutter_agy_docker/Dockerfile.base'
       - 'cloud_build/flutter_agy_docker'
 
   # ==========================================
@@ -47,7 +47,7 @@ steps:
       - '-t'
       - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
       - '-f'
-      - 'Dockerfile'
+      - 'cloud_build/flutter_agy_docker/Dockerfile'
       - 'cloud_build/flutter_agy_docker'
 
 substitutions:

--- a/cloud_build/flutter_agy_docker/cloudbuild.yaml
+++ b/cloud_build/flutter_agy_docker/cloudbuild.yaml
@@ -1,34 +1,62 @@
+# Copyright 2022 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 steps:
-  # Try to pull the latest image for caching
+  # ==========================================
+  # STEP 1: Build the Static Base Image
+  # ==========================================
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args:
-      - '-c'
-      - 'docker pull us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest || exit 0'
+    args: ['-c', 'docker pull us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest || exit 0']
 
-  # Do the build
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
-      # Use the cache, maybe.
       - '--cache-from'
-      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
-      # Pass the Cloud Build substitution into the Dockerfile ARG
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest'
       - '--build-arg'
       - 'FLUTTER_VERSION=$_FLUTTER_VERSION'
-      # Tag it with the specific version in Artifact Registry
       - '-t'
-      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:$_FLUTTER_VERSION'
-      # Also tag it as latest in Artifact Registry
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:$_FLUTTER_VERSION'
       - '-t'
-      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest'
+      - '-f'
+      - 'Dockerfile.base'
       - 'cloud_build/flutter_agy_docker'
 
-# Define the default version here so manual triggers still work
-substitutions:
-  _FLUTTER_VERSION: "3.44.2"
+  # ==========================================
+  # STEP 2: Build the Auto-Updating Dev Image
+  # ==========================================
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker pull us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest || exit 0']
 
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--cache-from'
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
+      - '--build-arg'
+      - 'FLUTTER_VERSION=$_FLUTTER_VERSION'
+      # Force apt-get to run by injecting the unique build ID
+      - '--build-arg'
+      - 'CACHE_BUSTER=$BUILD_ID'
+      - '-t'
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:$_FLUTTER_VERSION'
+      - '-t'
+      - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
+      - '-f'
+      - 'Dockerfile'
+      - 'cloud_build/flutter_agy_docker'
+
+substitutions:
+  _FLUTTER_VERSION: "3.44.3"
+
+# Push both the base and the final developer image to the registry
 images:
+  - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:$_FLUTTER_VERSION'
+  - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest'
   - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:$_FLUTTER_VERSION'
   - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
 


### PR DESCRIPTION
Why? Improves caching - flutter maybe has an update weekly; os / antigravity release more often.

- Create `Dockerfile.base` to handle heavy Flutter SDK downloads and configuration.
- Update `Dockerfile` to focus on user configuration and development tools, removing the heavy fetcher stage.
- Update `cloudbuild.yaml` to implement a multi-step build, creating the static base image first, then the auto-updating dev image.
- Inject a `CACHE_BUSTER` build argument in `cloudbuild.yaml` to force `apt-get` updates on the dev image