### PR TITLE
feat: add skill update script and fix docker build context

### DIFF
--- a/analyze/analyze.dart
+++ b/analyze/analyze.dart
@@ -224,6 +224,7 @@ const Set<String> kExecutableAllowlist = <String>{
   'cloud_build/deploy_auto_submit.sh',
   'cloud_build/deploy_cron_jobs.sh',
   'cloud_build/get_docker_image_provenance.sh',
+  'cloud_build/flutter_agy_docker/update_skills.sh',
   'cloud_build/verify_provenance.sh',
   'dev/provision_salt.sh',
   'dev/prs_to_main.sh',

--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -41,6 +41,9 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+COPY update_skills.sh /usr/local/bin/update_skills.sh
+RUN chmod +x /usr/local/bin/update_skills.sh
+
 USER coder
 
 # 3. Development Tools

--- a/cloud_build/flutter_agy_docker/Dockerfile
+++ b/cloud_build/flutter_agy_docker/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 COPY update_skills.sh /usr/local/bin/update_skills.sh
-RUN chmod +x /usr/local/bin/update_skills.sh
+RUN dos2unix /usr/local/bin/update_skills.sh && chmod +x /usr/local/bin/update_skills.sh && chmod +x /usr/local/bin/update_skills.sh
 
 USER coder
 

--- a/cloud_build/flutter_agy_docker/cloudbuild.yaml
+++ b/cloud_build/flutter_agy_docker/cloudbuild.yaml
@@ -11,6 +11,7 @@ steps:
     args: ['-c', 'docker pull us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest || exit 0']
 
   - name: 'gcr.io/cloud-builders/docker'
+    dir: 'cloud_build/flutter_agy_docker/'
     args:
       - 'build'
       - '--cache-from'
@@ -22,8 +23,8 @@ steps:
       - '-t'
       - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_base:latest'
       - '-f'
-      - 'cloud_build/flutter_agy_docker/Dockerfile.base'
-      - 'cloud_build/flutter_agy_docker'
+      - 'Dockerfile.base'
+      - '.'
 
   # ==========================================
   # STEP 2: Build the Auto-Updating Dev Image
@@ -33,6 +34,7 @@ steps:
     args: ['-c', 'docker pull us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest || exit 0']
 
   - name: 'gcr.io/cloud-builders/docker'
+    dir: 'cloud_build/flutter_agy_docker/'
     args:
       - 'build'
       - '--cache-from'
@@ -47,8 +49,8 @@ steps:
       - '-t'
       - 'us-docker.pkg.dev/flutter-infra/flutter-infra/flutter_docker:latest'
       - '-f'
-      - 'cloud_build/flutter_agy_docker/Dockerfile'
-      - 'cloud_build/flutter_agy_docker'
+      - 'Dockerfile'
+      - '.'
 
 substitutions:
   _FLUTTER_VERSION: "3.44.3"

--- a/cloud_build/flutter_agy_docker/update_skills.sh
+++ b/cloud_build/flutter_agy_docker/update_skills.sh
@@ -63,10 +63,10 @@ UPDATED_SKILLS=0
 
 for REPO in "${REPOS[@]}"; do
   CHECKED_REPOS=$((CHECKED_REPOS + 1))
-  
+
   # Fetch latest SHA using git ls-remote (very fast, no full clone needed)
   LATEST_SHA=$(git ls-remote "https://github.com/$REPO" HEAD | awk '{print $1}')
-  
+
   if [ -z "$LATEST_SHA" ]; then
     echo "[-] Failed to fetch latest SHA for $REPO"
     continue
@@ -94,23 +94,23 @@ for REPO in "${REPOS[@]}"; do
   # Now check if there is a skills folder in the repo
   if [ -d "$REPO_TMP/skills" ]; then
     REPO_UPDATED=0
-    
+
     # Use git ls-tree to get hashes of all folders in skills/
     # Output format: 040000 tree <hash>    skills/<name>
     while read -r _ _ SKILL_HASH SKILL_PATH; do
       SKILL_NAME=$(basename "$SKILL_PATH")
       SKILL_TMP="$REPO_TMP/$SKILL_PATH"
-      
+
       # Make sure it's actually a directory
       [ -d "$SKILL_TMP" ] || continue
-      
+
       SKILL_VERSION_FILE="$TARGET_DIR/.versions/${REPO_SAFE_NAME}_${SKILL_NAME}.sha"
-      
+
       CURRENT_SKILL_HASH=""
       if [ -f "$SKILL_VERSION_FILE" ]; then
         CURRENT_SKILL_HASH=$(cat "$SKILL_VERSION_FILE")
       fi
-      
+
       if [ "$SKILL_HASH" != "$CURRENT_SKILL_HASH" ]; then
         # Action required
         if [ -e "$TARGET_DIR/$SKILL_NAME" ] && [ -z "$CURRENT_SKILL_HASH" ] && [ "$FORCE_OVERRIDE" -eq 0 ]; then
@@ -121,18 +121,18 @@ for REPO in "${REPOS[@]}"; do
         rm -rf "$TARGET_DIR/$SKILL_NAME"
         cp -R "$SKILL_TMP" "$TARGET_DIR/"
         echo "$SKILL_HASH" > "$SKILL_VERSION_FILE"
-        
+
         if [ -z "$CURRENT_SKILL_HASH" ]; then
           echo "    - @[$TARGET_DIR/$SKILL_NAME] was added"
         else
           echo "    - @[$TARGET_DIR/$SKILL_NAME] was updated"
         fi
-        
+
         UPDATED_SKILLS=$((UPDATED_SKILLS + 1))
         REPO_UPDATED=1
       fi
     done < <(cd "$REPO_TMP" && git ls-tree HEAD skills/)
-    
+
     # Save the repo SHA so we don't redownload next time unless it changes
     echo "$LATEST_SHA" > "$VERSION_FILE"
     if [ "$REPO_UPDATED" -eq 1 ]; then

--- a/cloud_build/flutter_agy_docker/update_skills.sh
+++ b/cloud_build/flutter_agy_docker/update_skills.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -e
+
+# Configuration
+# Allow appending custom repositories via AGY_SKILL_REPOS env var
+# Example: export AGY_SKILL_REPOS="myorg/skills another/skills"
+USER_REPOS=(${AGY_SKILL_REPOS:-})
+REPOS=(
+  "flutter/skills"
+  "dart-lang/skills"
+  "kevmoo/dash_skills"
+  "${USER_REPOS[@]}"
+)
+
+# Parse arguments
+TARGET_DIR="$HOME/.gemini/config/skills"
+if [[ "$1" == "--local" ]]; then
+  TARGET_DIR=".agents/skills"
+fi
+
+mkdir -p "$TARGET_DIR/.versions"
+TMP_DIR=$(mktemp -d)
+
+# Cleanup trap
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Updating skills in $TARGET_DIR..."
+echo "----------------------------------------"
+
+UPDATED_REPOS=0
+CHECKED_REPOS=0
+UPDATED_SKILLS=0
+
+for REPO in "${REPOS[@]}"; do
+  CHECKED_REPOS=$((CHECKED_REPOS + 1))
+  
+  # Fetch latest SHA using git ls-remote (very fast, no full clone needed)
+  LATEST_SHA=$(git ls-remote "https://github.com/$REPO" HEAD | awk '{print $1}')
+  
+  if [ -z "$LATEST_SHA" ]; then
+    echo "[-] Failed to fetch latest SHA for $REPO"
+    continue
+  fi
+
+  # Check existing version
+  REPO_SAFE_NAME=$(echo "$REPO" | tr '/' '_')
+  VERSION_FILE="$TARGET_DIR/.versions/$REPO_SAFE_NAME.sha"
+  CURRENT_SHA=""
+  if [ -f "$VERSION_FILE" ]; then
+    CURRENT_SHA=$(cat "$VERSION_FILE")
+  fi
+
+  if [ "$LATEST_SHA" == "$CURRENT_SHA" ]; then
+    echo "[=] $REPO is up to date."
+    continue
+  fi
+
+  echo "[+] Checking $REPO..."
+
+  # Download via git clone --depth=1
+  REPO_TMP="$TMP_DIR/$REPO"
+  git clone --depth=1 --quiet "https://github.com/$REPO" "$REPO_TMP"
+
+  # Now check if there is a skills folder in the repo
+  if [ -d "$REPO_TMP/skills" ]; then
+    REPO_UPDATED=0
+    
+    # Use git ls-tree to get hashes of all folders in skills/
+    # Output format: 040000 tree <hash>    skills/<name>
+    while read -r _ _ SKILL_HASH SKILL_PATH; do
+      SKILL_NAME=$(basename "$SKILL_PATH")
+      SKILL_TMP="$REPO_TMP/$SKILL_PATH"
+      
+      # Make sure it's actually a directory
+      [ -d "$SKILL_TMP" ] || continue
+      
+      SKILL_VERSION_FILE="$TARGET_DIR/.versions/${REPO_SAFE_NAME}_${SKILL_NAME}.sha"
+      
+      CURRENT_SKILL_HASH=""
+      if [ -f "$SKILL_VERSION_FILE" ]; then
+        CURRENT_SKILL_HASH=$(cat "$SKILL_VERSION_FILE")
+      fi
+      
+      if [ "$SKILL_HASH" != "$CURRENT_SKILL_HASH" ]; then
+        # Action required
+        rm -rf "$TARGET_DIR/$SKILL_NAME"
+        cp -R "$SKILL_TMP" "$TARGET_DIR/"
+        echo "$SKILL_HASH" > "$SKILL_VERSION_FILE"
+        
+        if [ -z "$CURRENT_SKILL_HASH" ]; then
+          echo "    - @[$TARGET_DIR/$SKILL_NAME] was added"
+        else
+          echo "    - @[$TARGET_DIR/$SKILL_NAME] was updated"
+        fi
+        
+        UPDATED_SKILLS=$((UPDATED_SKILLS + 1))
+        REPO_UPDATED=1
+      fi
+    done < <(cd "$REPO_TMP" && git ls-tree HEAD skills/)
+    
+    # Save the repo SHA so we don't redownload next time unless it changes
+    echo "$LATEST_SHA" > "$VERSION_FILE"
+    if [ "$REPO_UPDATED" -eq 1 ]; then
+      UPDATED_REPOS=$((UPDATED_REPOS + 1))
+    fi
+  else
+    echo "[-] No 'skills' directory found in $REPO"
+  fi
+done
+
+echo "----------------------------------------"
+echo "Summary:"
+echo "Checked $CHECKED_REPOS repositories."
+if [ "$UPDATED_SKILLS" -eq 0 ]; then
+  echo "All skills are up to date."
+else
+  echo "Updated/Added $UPDATED_SKILLS skills across $UPDATED_REPOS repositories."
+fi
+echo "Skills available in: $TARGET_DIR"

--- a/cloud_build/flutter_agy_docker/update_skills.sh
+++ b/cloud_build/flutter_agy_docker/update_skills.sh
@@ -21,9 +21,32 @@ REPOS=(
 
 # Parse arguments
 TARGET_DIR="$HOME/.gemini/config/skills"
-if [[ "$1" == "--local" ]]; then
-  TARGET_DIR=".agents/skills"
-fi
+FORCE_OVERRIDE=0
+SKIP_GIT_CHECK=0
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --local)
+      TARGET_DIR=".agents/skills"
+      ;;
+    --force|-f)
+      FORCE_OVERRIDE=1
+      ;;
+    --skip-git-check|-s)
+      SKIP_GIT_CHECK=1
+      ;;
+    -*)
+      # Handle combined short flags
+      if [[ "$1" == *f* ]]; then
+        FORCE_OVERRIDE=1
+      fi
+      if [[ "$1" == *s* ]]; then
+        SKIP_GIT_CHECK=1
+      fi
+      ;;
+  esac
+  shift
+done
 
 mkdir -p "$TARGET_DIR/.versions"
 TMP_DIR=$(mktemp -d)
@@ -57,7 +80,7 @@ for REPO in "${REPOS[@]}"; do
     CURRENT_SHA=$(cat "$VERSION_FILE")
   fi
 
-  if [ "$LATEST_SHA" == "$CURRENT_SHA" ]; then
+  if [ "$LATEST_SHA" == "$CURRENT_SHA" ] && [ "$SKIP_GIT_CHECK" -eq 0 ]; then
     echo "[=] $REPO is up to date."
     continue
   fi
@@ -90,6 +113,11 @@ for REPO in "${REPOS[@]}"; do
       
       if [ "$SKILL_HASH" != "$CURRENT_SKILL_HASH" ]; then
         # Action required
+        if [ -e "$TARGET_DIR/$SKILL_NAME" ] && [ -z "$CURRENT_SKILL_HASH" ] && [ "$FORCE_OVERRIDE" -eq 0 ]; then
+          echo "[!] Warning: $TARGET_DIR/$SKILL_NAME already exists but is not tracked by this tool. Skipping."
+          continue
+        fi
+
         rm -rf "$TARGET_DIR/$SKILL_NAME"
         cp -R "$SKILL_TMP" "$TARGET_DIR/"
         echo "$SKILL_HASH" > "$SKILL_VERSION_FILE"

--- a/cloud_build/flutter_agy_docker/update_skills.sh
+++ b/cloud_build/flutter_agy_docker/update_skills.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Fail immediately if asking for authorization
+GIT_TERMINAL_PROMPT=0
+
 # Configuration
 # Allow appending custom repositories via AGY_SKILL_REPOS env var
 # Example: export AGY_SKILL_REPOS="myorg/skills another/skills"


### PR DESCRIPTION
This commit introduces a new script for updating agent skills. Just run `update_skills.sh` and it will download to your mapped `~/.gemini` folder (or the `.agents/skills` in your current working directory with `--local`).

- **update_skills.sh**: Added a script to efficiently fetch and update agent skills from known GitHub repositories (flutter/skills, dart-lang/skills, kevmoo/dash_skills). Features include:
  - Support for global (`~/.gemini/config/skills`) or local (`.agents/skills`) installations.
  - Avoids full clones by utilizing `git ls-remote` for commit checks.
  - Uses `git ls-tree` to track individual skill hashes and only update what changed.
- **Dockerfile**: Added `update_skills.sh` to `/usr/local/bin` and made it executable.
- **cloudbuild.yaml**: Fixed the Docker build steps by explicitly setting `dir: 'cloud_build/flutter_agy_docker/'` and using relative paths for the Dockerfile and build context, resolving potential build context issues.


```shell
$ update_skills.sh
Updating skills in /home/coder/.gemini/config/skills...
----------------------------------------
[=] flutter/skills is up to date.
[=] dart-lang/skills is up to date.
[=] kevmoo/dash_skills is up to date.
----------------------------------------
Summary:
Checked 3 repositories.
All skills are up to date.
Skills available in: /home/coder/.gemini/config/skill
```