### PR TITLE
fix: prevent redundant presubmit builds by checking for existing LUCI…

### DIFF
--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -50,8 +50,6 @@ class LuciBuildService {
        _firestore = firestore;
 
   final BuildBucketClient _buildBucketClient;
-  @visibleForTesting
-  BuildBucketClient get buildBucketClient => _buildBucketClient;
   final CacheService _cache;
   final Config _config;
   final GithubChecksUtil _githubChecksUtil;

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -50,6 +50,8 @@ class LuciBuildService {
        _firestore = firestore;
 
   final BuildBucketClient _buildBucketClient;
+  @visibleForTesting
+  BuildBucketClient get buildBucketClient => _buildBucketClient;
   final CacheService _cache;
   final Config _config;
   final GithubChecksUtil _githubChecksUtil;
@@ -109,6 +111,21 @@ class LuciBuildService {
           slugOwner: slug.owner,
           slugName: slug.name,
         ),
+        UserAgentBuildTag.flutterCocoon,
+      ]),
+    );
+  }
+
+  /// Fetches an Iterable of try BuildBucket [Build]s for a given [sha].
+  Future<Iterable<bbv2.Build>> getTryBuildsBySha({
+    required String sha,
+    String? builderName,
+  }) async {
+    return _getBuilds(
+      builderName: builderName,
+      bucket: 'try',
+      tags: BuildTags([
+        ByPresubmitCommitBuildSetBuildTag(commitSha: sha),
         UserAgentBuildTag.flutterCocoon,
       ]),
     );

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -336,6 +336,21 @@ class Scheduler {
     String reason = 'Newer commit available',
     List<String>? builderTriggerList,
   }) async {
+    // To avoid re-running all checks if the CICD label is removed and added
+    // after presubmits have started, check if builds already exist for the
+    // current SHA. If builds already exist, there is no need to cancel them
+    // and create new ones.
+    final tryBuilds = await _luciBuildService.getTryBuildsBySha(
+      sha: pullRequest.head!.sha!,
+    );
+    if (tryBuilds.isNotEmpty) {
+      return;
+    }
+
+    final isUnifiedCheckRun = _config.flags.isUnifiedCheckRunFlowEnabledForUser(
+      pullRequest.user!.login!,
+    );
+    
     // Always cancel running builds so we don't ever schedule duplicates.
     log.info(
       'Attempting to cancel existing presubmit targets for ${pullRequest.number}',
@@ -343,10 +358,6 @@ class Scheduler {
     await cancelPreSubmitTargets(pullRequest: pullRequest, reason: reason);
 
     final slug = pullRequest.base!.repo!.slug();
-
-    final isUnifiedCheckRun = _config.flags.isUnifiedCheckRunFlowEnabledForUser(
-      pullRequest.user!.login!,
-    );
 
     // The MQ only waits for "required status checks" before deciding whether to
     // merge the PR into the target branch. This required check added to both

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -350,7 +350,7 @@ class Scheduler {
     final isUnifiedCheckRun = _config.flags.isUnifiedCheckRunFlowEnabledForUser(
       pullRequest.user!.login!,
     );
-    
+
     // Always cancel running builds so we don't ever schedule duplicates.
     log.info(
       'Attempting to cancel existing presubmit targets for ${pullRequest.number}',

--- a/app_dart/lib/src/service/scheduler.dart
+++ b/app_dart/lib/src/service/scheduler.dart
@@ -340,10 +340,12 @@ class Scheduler {
     // after presubmits have started, check if builds already exist for the
     // current SHA. If builds already exist, there is no need to cancel them
     // and create new ones.
-    final tryBuilds = await _luciBuildService.getTryBuildsBySha(
-      sha: pullRequest.head!.sha!,
-    );
+    final sha = pullRequest.head!.sha!;
+    final tryBuilds = await _luciBuildService.getTryBuildsBySha(sha: sha);
     if (tryBuilds.isNotEmpty) {
+      log.info(
+        'CICD label was already applied to pr:${pullRequest.number} for sha:$sha and ${tryBuilds.length} jobs have been already scheduled, skipping.',
+      );
       return;
     }
 
@@ -364,11 +366,11 @@ class Scheduler {
     // the PR and to the merge group, and so it must be completed in both cases.
     final lock = await lockMergeGroupChecks(
       slug,
-      pullRequest.head!.sha!,
+      sha,
       // Override details url of merge queue guard check for users with unified
       // check run flow enabled
       detailsUrl: isUnifiedCheckRun
-          ? 'https://flutter-dashboard.appspot.com/#/presubmit?repo=${slug.name}&sha=${pullRequest.head!.sha}'
+          ? 'https://flutter-dashboard.appspot.com/#/presubmit?repo=${slug.name}&sha=$sha'
           : null,
       isUnifiedCheckRun: isUnifiedCheckRun,
     );
@@ -385,7 +387,6 @@ class Scheduler {
     final isPackages = slug == Config.packagesSlug;
     do {
       try {
-        final sha = pullRequest.head!.sha!;
         if (!isFusion && !(isPackages && isUnifiedCheckRun)) {
           unlockMergeGroup = true;
         }
@@ -532,10 +533,10 @@ class Scheduler {
     // there are situations (see code above) when it needs to be unlocked
     // immediately.
     if (unlockMergeGroup) {
-      await unlockMergeQueueGuard(slug, pullRequest.head!.sha!, lock);
+      await unlockMergeQueueGuard(slug, sha, lock);
     }
     log.info(
-      'Finished triggering builds for: pr ${pullRequest.number}, commit ${pullRequest.base!.sha}, branch ${pullRequest.head!.ref} and slug $slug}',
+      'Finished triggering builds for: pr ${pullRequest.number}, commit $sha, branch ${pullRequest.head!.ref} and slug $slug}',
     );
   }
 

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -771,12 +771,13 @@ void main() {
           ).thenAnswer((_) async => []);
           final mockGithubClient = MockGitHub();
           config = FakeConfig(githubService: mockGithubService);
+          final fakeBb = FakeBuildBucketClient();
           final fakeLuci = FakeLuciBuildService(
             config: config,
             githubChecksUtil: mockGithubChecksUtil,
             firestore: firestore,
+            buildBucketClient: fakeBb,
           );
-          final fakeBb = fakeLuci.buildBucketClient as FakeBuildBucketClient;
           fakeBb.batchResponse = (request, _) async {
             return bbv2.BatchResponse(
               responses: [

--- a/app_dart/test/service/scheduler_test.dart
+++ b/app_dart/test/service/scheduler_test.dart
@@ -659,6 +659,15 @@ void main() {
     group('process check run', () {
       test('rerequested ci.yaml check retriggers presubmit', () async {
         final mockGithubService = MockGithubService();
+        when(
+          mockGithubService.getCheckRunsFiltered(
+            slug: anyNamed('slug'),
+            ref: anyNamed('ref'),
+            checkName: anyNamed('checkName'),
+            status: anyNamed('status'),
+            filter: anyNamed('filter'),
+          ),
+        ).thenAnswer((_) async => []);
         final mockGithubClient = MockGitHub();
         config = FakeConfig(githubService: mockGithubService);
         scheduler = Scheduler(
@@ -746,6 +755,101 @@ void main() {
           mockGithubChecksUtil.createCheckRun(any, any, any, any),
         ).called(1);
       });
+
+      test(
+        'check runs are not canceled and not created new if build exists for current sha',
+        () async {
+          final mockGithubService = MockGithubService();
+          when(
+            mockGithubService.getCheckRunsFiltered(
+              slug: anyNamed('slug'),
+              ref: anyNamed('ref'),
+              checkName: anyNamed('checkName'),
+              status: anyNamed('status'),
+              filter: anyNamed('filter'),
+            ),
+          ).thenAnswer((_) async => []);
+          final mockGithubClient = MockGitHub();
+          config = FakeConfig(githubService: mockGithubService);
+          final fakeLuci = FakeLuciBuildService(
+            config: config,
+            githubChecksUtil: mockGithubChecksUtil,
+            firestore: firestore,
+          );
+          final fakeBb = fakeLuci.buildBucketClient as FakeBuildBucketClient;
+          fakeBb.batchResponse = (request, _) async {
+            return bbv2.BatchResponse(
+              responses: [
+                bbv2.BatchResponse_Response(
+                  searchBuilds: bbv2.SearchBuildsResponse(
+                    builds: [bbv2.Build(id: Int64(1))],
+                  ),
+                ),
+              ],
+            );
+          };
+          scheduler = Scheduler(
+            githubService: config.githubService ?? FakeGithubService(),
+            cache: cache,
+            config: config,
+            githubChecksService: GithubChecksService(
+              config,
+              githubChecksUtil: mockGithubChecksUtil,
+            ),
+            getFilesChanged: getFilesChanged,
+            ciYamlFetcher: ciYamlFetcher,
+            luciBuildService: fakeLuci,
+            contentAwareHash: fakeContentAwareHash,
+            firestore: firestore,
+            bigQuery: bigQuery,
+          );
+          when(mockGithubService.github).thenReturn(mockGithubClient);
+          when(
+            mockGithubService.searchIssuesAndPRs(
+              any,
+              any,
+              sort: anyNamed('sort'),
+              pages: anyNamed('pages'),
+            ),
+          ).thenAnswer((_) async => [generateIssue(3)]);
+          when(
+            mockGithubChecksUtil.listCheckSuitesForRef(
+              any,
+              any,
+              ref: anyNamed('ref'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              // From check_run.check_suite.id in [checkRunString].
+              generateCheckSuite(668083231),
+            ],
+          );
+          when(mockGithubService.getPullRequest(any, any)).thenAnswer(
+            (_) async => generatePullRequest(repo: 'packages', branch: 'main'),
+          );
+          getFilesChanged.cannedFiles = ['abc/def'];
+          final checkRunEventJson =
+              jsonDecode(checkRunString(repository: 'flutter'))
+                  as Map<String, dynamic>;
+          checkRunEventJson['check_run']['name'] = Config.kCiYamlCheckName;
+          final checkRunEvent = cocoon_checks.CheckRunEvent.fromJson(
+            checkRunEventJson,
+          );
+          expect(
+            await scheduler.processCheckRun(checkRunEvent),
+            const ProcessCheckRunResult.success(),
+          );
+          verifyNever(
+            mockGithubChecksUtil.createCheckRun(
+              any,
+              any,
+              any,
+              any,
+              output: anyNamed('output'),
+            ),
+          );
+        },
+      );
 
       test(
         'rerequested fusion (engine) ci.yaml check retriggers presubmit',
@@ -3023,6 +3127,15 @@ targets:
         'triggers all presubmit build checks when diff cannot be found',
         () async {
           final mockGithubService = MockGithubService();
+          when(
+            mockGithubService.getCheckRunsFiltered(
+              slug: anyNamed('slug'),
+              ref: anyNamed('ref'),
+              checkName: anyNamed('checkName'),
+              status: anyNamed('status'),
+              filter: anyNamed('filter'),
+            ),
+          ).thenAnswer((_) async => []);
           getFilesChanged.cannedFiles = null;
           scheduler = Scheduler(
             githubService: config.githubService ?? FakeGithubService(),
@@ -3293,7 +3406,22 @@ targets:
         ).thenAnswer((inv) async {
           return [];
         });
+        when(
+          luci.getTryBuildsBySha(
+            sha: anyNamed('sha'),
+            builderName: anyNamed('builderName'),
+          ),
+        ).thenAnswer((_) async => []);
         final mockGithubService = MockGithubService();
+        when(
+          mockGithubService.getCheckRunsFiltered(
+            slug: anyNamed('slug'),
+            ref: anyNamed('ref'),
+            checkName: anyNamed('checkName'),
+            status: anyNamed('status'),
+            filter: anyNamed('filter'),
+          ),
+        ).thenAnswer((_) async => []);
         final checkRuns = <CheckRun>[];
         when(
           mockGithubChecksUtil.createCheckRun(
@@ -3958,6 +4086,15 @@ targets:
 
       setUp(() {
         mockGithubService = MockGithubService();
+        when(
+          mockGithubService.getCheckRunsFiltered(
+            slug: anyNamed('slug'),
+            ref: anyNamed('ref'),
+            checkName: anyNamed('checkName'),
+            status: anyNamed('status'),
+            filter: anyNamed('filter'),
+          ),
+        ).thenAnswer((_) async => []);
         fakeLuciBuildService = _CapturingFakeLuciBuildService();
         ciYamlFetcher.setCiYamlFrom(
           singleCiYamlWithLinuxAnalyze,
@@ -4093,6 +4230,7 @@ targets:
       late _CapturingFakeLuciBuildService fakeLuciBuildService;
 
       setUp(() {
+        config.githubService = FakeGithubService();
         fakeLuciBuildService = _CapturingFakeLuciBuildService();
         scheduler = Scheduler(
           githubService: config.githubService ?? FakeGithubService(),
@@ -4540,4 +4678,10 @@ final class _CapturingFakeLuciBuildService extends Fake
     required PullRequest pullRequest,
     required String reason,
   }) async {}
+
+  @override
+  Future<Iterable<bbv2.Build>> getTryBuildsBySha({
+    required String sha,
+    String? builderName,
+  }) async => [];
 }

--- a/packages/cocoon_integration_test/lib/src/fakes/fake_build_bucket_client.dart
+++ b/packages/cocoon_integration_test/lib/src/fakes/fake_build_bucket_client.dart
@@ -148,36 +148,40 @@ class FakeBuildBucketClient extends BuildBucketClient {
           ),
         );
       } else if (request.hasSearchBuilds()) {
+        final isPresubmitShaQuery = request.searchBuilds.predicate.tags
+            .any((p) => p.value.startsWith('sha/git/'));
         // Note that you cannot get builds from the searchBuildResponse.
         batchResponseResponses.add(
           bbv2.BatchResponse_Response(
             searchBuilds: bbv2.SearchBuildsResponse(
-              builds: <bbv2.Build>[
-                bbv2.Build(
-                  id: Int64(123),
-                  builder: bbv2.BuilderID(
-                    builder: 'builder_abc',
-                    bucket: 'try',
-                    project: 'flutter',
-                  ),
-                  tags: <bbv2.StringPair>[
-                    bbv2.StringPair(key: 'buildset', value: 'pr/git/12345'),
-                    bbv2.StringPair(
-                      key: 'cipd_version',
-                      value: 'refs/heads/main',
-                    ),
-                    bbv2.StringPair(
-                      key: 'github_link',
-                      value: 'https://github/flutter/flutter/pull/1',
-                    ),
-                  ],
-                  input: bbv2.Build_Input(
-                    properties: bbv2.Struct(
-                      fields: {'bringup': bbv2.Value(stringValue: 'true')},
-                    ),
-                  ),
-                ),
-              ],
+              builds: isPresubmitShaQuery
+                  ? <bbv2.Build>[]
+                  : <bbv2.Build>[
+                      bbv2.Build(
+                        id: Int64(123),
+                        builder: bbv2.BuilderID(
+                          builder: 'builder_abc',
+                          bucket: 'try',
+                          project: 'flutter',
+                        ),
+                        tags: <bbv2.StringPair>[
+                          bbv2.StringPair(key: 'buildset', value: 'pr/git/12345'),
+                          bbv2.StringPair(
+                            key: 'cipd_version',
+                            value: 'refs/heads/main',
+                          ),
+                          bbv2.StringPair(
+                            key: 'github_link',
+                            value: 'https://github/flutter/flutter/pull/1',
+                          ),
+                        ],
+                        input: bbv2.Build_Input(
+                          properties: bbv2.Struct(
+                            fields: {'bringup': bbv2.Value(stringValue: 'true')},
+                          ),
+                        ),
+                      ),
+                    ],
             ),
           ),
         );

--- a/packages/cocoon_integration_test/lib/src/fakes/fake_build_bucket_client.dart
+++ b/packages/cocoon_integration_test/lib/src/fakes/fake_build_bucket_client.dart
@@ -148,8 +148,9 @@ class FakeBuildBucketClient extends BuildBucketClient {
           ),
         );
       } else if (request.hasSearchBuilds()) {
-        final isPresubmitShaQuery = request.searchBuilds.predicate.tags
-            .any((p) => p.value.startsWith('sha/git/'));
+        final isPresubmitShaQuery = request.searchBuilds.predicate.tags.any(
+          (p) => p.value.startsWith('sha/git/'),
+        );
         // Note that you cannot get builds from the searchBuildResponse.
         batchResponseResponses.add(
           bbv2.BatchResponse_Response(
@@ -165,7 +166,10 @@ class FakeBuildBucketClient extends BuildBucketClient {
                           project: 'flutter',
                         ),
                         tags: <bbv2.StringPair>[
-                          bbv2.StringPair(key: 'buildset', value: 'pr/git/12345'),
+                          bbv2.StringPair(
+                            key: 'buildset',
+                            value: 'pr/git/12345',
+                          ),
                           bbv2.StringPair(
                             key: 'cipd_version',
                             value: 'refs/heads/main',
@@ -177,7 +181,9 @@ class FakeBuildBucketClient extends BuildBucketClient {
                         ],
                         input: bbv2.Build_Input(
                           properties: bbv2.Struct(
-                            fields: {'bringup': bbv2.Value(stringValue: 'true')},
+                            fields: {
+                              'bringup': bbv2.Value(stringValue: 'true'),
+                            },
                           ),
                         ),
                       ),

--- a/packages/cocoon_integration_test/lib/src/utilities/mocks.mocks.dart
+++ b/packages/cocoon_integration_test/lib/src/utilities/mocks.mocks.dart
@@ -925,6 +925,19 @@ class MockConfig extends _i1.Mock implements _i2.Config {
           as _i13.Future<String>);
 
   @override
+  _i13.Future<String> get geminiLogAnalyzerKey =>
+      (super.noSuchMethod(
+            Invocation.getter(#geminiLogAnalyzerKey),
+            returnValue: _i13.Future<String>.value(
+              _i20.dummyValue<String>(
+                this,
+                Invocation.getter(#geminiLogAnalyzerKey),
+              ),
+            ),
+          )
+          as _i13.Future<String>);
+
+  @override
   String get wrongBaseBranchPullRequestMessage =>
       (super.noSuchMethod(
             Invocation.getter(#wrongBaseBranchPullRequestMessage),
@@ -4102,6 +4115,20 @@ class MockLuciBuildService extends _i1.Mock implements _i17.LuciBuildService {
       (super.noSuchMethod(
             Invocation.method(#getTryBuildsByPullRequest, [], {
               #pullRequest: pullRequest,
+            }),
+            returnValue: _i13.Future<Iterable<_i6.Build>>.value(<_i6.Build>[]),
+          )
+          as _i13.Future<Iterable<_i6.Build>>);
+
+  @override
+  _i13.Future<Iterable<_i6.Build>> getTryBuildsBySha({
+    required String? sha,
+    String? builderName,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getTryBuildsBySha, [], {
+              #sha: sha,
+              #builderName: builderName,
             }),
             returnValue: _i13.Future<Iterable<_i6.Build>>.value(<_i6.Build>[]),
           )


### PR DESCRIPTION
To avoid re-running all checks if the CICD label is removed and added after presubmits have started, check if builds already exist for the current SHA. If builds already exist, there is no need to cancel them and create new ones.

fix: https://github.com/flutter/flutter/issues/188126