### PR TITLE
fix: add install of jq to orchestrator

### DIFF
--- a/cloud_build/flutter_agy_docker/orchestrator.yaml
+++ b/cloud_build/flutter_agy_docker/orchestrator.yaml
@@ -11,6 +11,8 @@ steps:
       - |
         set -euo pipefail
 
+        apt-get update && apt-get install -y jq
+
         echo "Fetching Flutter release data for channel: $_CHANNEL..."
 
         # 1. Fetch latest version for the specified channel (stable or beta)


### PR DESCRIPTION
Two AI reviews suggested "jq" was included; it was in fact a lie.

Ran the cloud-sdk image locally in docker with this and it was able to work. Triggered remotely and waiting for confirmation