### PR TITLE
Polishing

### DIFF
--- a/app_dart/lib/server.dart
+++ b/app_dart/lib/server.dart
@@ -9,7 +9,7 @@ import 'src/request_handlers/analyze_logs.dart';
 import 'src/request_handlers/get_engine_artifacts_ready.dart';
 import 'src/request_handlers/get_presubmit_guard.dart';
 import 'src/request_handlers/get_presubmit_guard_summaries.dart';
-import 'src/request_handlers/get_presubmit_jobs.dart';
+import 'src/request_handlers/get_presubmit_job.dart';
 import 'src/request_handlers/get_tree_status_changes.dart';
 import 'src/request_handlers/github_webhook_replay.dart';
 import 'src/request_handlers/lookup_hash.dart';
@@ -218,7 +218,7 @@ Server createServer({
       config: config,
       firestore: firestore,
     ),
-    '/api/public/get-presubmit-jobs': GetPresubmitJobs(
+    '/api/public/get-presubmit-job': GetPresubmitJob(
       config: config,
       firestore: firestore,
     ),

--- a/app_dart/lib/src/request_handlers/get_presubmit_guard.dart
+++ b/app_dart/lib/src/request_handlers/get_presubmit_guard.dart
@@ -89,7 +89,7 @@ final class GetPresubmitGuard extends PublicApiRequestHandler {
           rpc_model.PresubmitGuardStage(
             name: g.stage.name,
             createdAt: g.creationTime,
-            builds: g.jobs,
+            jobs: g.jobs,
           ),
       ],
     );

--- a/app_dart/lib/src/request_handlers/get_presubmit_job.dart
+++ b/app_dart/lib/src/request_handlers/get_presubmit_job.dart
@@ -11,7 +11,7 @@ import '../../cocoon_service.dart';
 import '../request_handling/public_api_request_handler.dart';
 import '../service/firestore/unified_check_run.dart';
 
-/// Returns all jobs for a specific presubmit job.
+/// Returns all runs for a specific presubmit job.
 ///
 /// GET: /api/public/get-presubmit-job
 ///

--- a/app_dart/lib/src/request_handlers/get_presubmit_job.dart
+++ b/app_dart/lib/src/request_handlers/get_presubmit_job.dart
@@ -11,7 +11,7 @@ import '../../cocoon_service.dart';
 import '../request_handling/public_api_request_handler.dart';
 import '../service/firestore/unified_check_run.dart';
 
-/// Returns all runs for a specific presubmit job.
+/// Returns all attempts for a specific presubmit job.
 ///
 /// GET: /api/public/get-presubmit-job
 ///

--- a/app_dart/lib/src/request_handlers/get_presubmit_job.dart
+++ b/app_dart/lib/src/request_handlers/get_presubmit_job.dart
@@ -13,7 +13,7 @@ import '../service/firestore/unified_check_run.dart';
 
 /// Returns all jobs for a specific presubmit job.
 ///
-/// GET: /api/public/get-presubmit-jobs
+/// GET: /api/public/get-presubmit-job
 ///
 /// Parameters:
 ///   check_run_id: (int in query) mandatory. The GitHub Check Run ID.
@@ -33,8 +33,8 @@ import '../service/firestore/unified_check_run.dart';
 ///     "summary": "Check passed"
 ///   }
 /// ]
-final class GetPresubmitJobs extends PublicApiRequestHandler {
-  const GetPresubmitJobs({
+final class GetPresubmitJob extends PublicApiRequestHandler {
+  const GetPresubmitJob({
     required super.config,
     required FirestoreService firestore,
   }) : _firestore = firestore;

--- a/app_dart/test/request_handlers/get_presubmit_guard_test.dart
+++ b/app_dart/test/request_handlers/get_presubmit_guard_test.dart
@@ -105,10 +105,10 @@ void main() {
     expect(stages.length, 2);
 
     final fusionStage = stages.firstWhere((s) => s.name == 'fusion');
-    expect(fusionStage.builds, {'test1': TaskStatus.succeeded});
+    expect(fusionStage.jobs, {'test1': TaskStatus.succeeded});
 
     final engineStage = stages.firstWhere((s) => s.name == 'engine');
-    expect(engineStage.builds, {'engine1': TaskStatus.inProgress});
+    expect(engineStage.jobs, {'engine1': TaskStatus.inProgress});
   });
 
   test('guardStatus is Failed if any stage has failed builds', () async {

--- a/app_dart/test/request_handlers/get_presubmit_job_test.dart
+++ b/app_dart/test/request_handlers/get_presubmit_job_test.dart
@@ -10,7 +10,7 @@ import 'package:cocoon_integration_test/testing.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/cocoon_service.dart';
 import 'package:cocoon_service/src/model/firestore/presubmit_job.dart' as fs;
-import 'package:cocoon_service/src/request_handlers/get_presubmit_jobs.dart';
+import 'package:cocoon_service/src/request_handlers/get_presubmit_job.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:github/github.dart';
 import 'package:test/test.dart';
@@ -18,18 +18,18 @@ import 'package:test/test.dart';
 import '../src/request_handling/request_handler_tester.dart';
 
 void main() {
-  group('GetPresubmitJobs', () {
+  group('GetPresubmitJob', () {
     useTestLoggerPerTest();
     late FakeConfig config;
     late RequestHandlerTester tester;
-    late GetPresubmitJobs handler;
+    late GetPresubmitJob handler;
     late FakeFirestoreService firestoreService;
 
     setUp(() {
       config = FakeConfig();
       tester = RequestHandlerTester();
       firestoreService = FakeFirestoreService();
-      handler = GetPresubmitJobs(config: config, firestore: firestoreService);
+      handler = GetPresubmitJob(config: config, firestore: firestoreService);
     });
 
     Future<List<PresubmitJobResponse>?> getPresubmitJobResponse(

--- a/dashboard/lib/service/appengine_cocoon.dart
+++ b/dashboard/lib/service/appengine_cocoon.dart
@@ -357,7 +357,7 @@ class AppEngineCocoonService implements CocoonService {
       'owner': owner,
     };
     final getChecksUrl = apiEndpoint(
-      '/api/public/get-presubmit-jobs',
+      '/api/public/get-presubmit-job',
       queryParameters: queryParameters,
     );
 
@@ -365,7 +365,7 @@ class AppEngineCocoonService implements CocoonService {
 
     if (response.statusCode != HttpStatus.ok) {
       return CocoonResponse.error(
-        '/api/public/get-presubmit-jobs returned ${response.statusCode}',
+        '/api/public/get-presubmit-job returned ${response.statusCode}',
         statusCode: response.statusCode,
       );
     }

--- a/dashboard/lib/state/presubmit.dart
+++ b/dashboard/lib/state/presubmit.dart
@@ -692,8 +692,7 @@ class PresubmitState extends ChangeNotifier {
     // Only allow re-run if the job failed
     final stage = _guardResponse?.stages.firstWhere(
       (s) => s.jobs.containsKey(jobName),
-      orElse: () =>
-          const PresubmitGuardStage(name: '', createdAt: 0, jobs: {}),
+      orElse: () => const PresubmitGuardStage(name: '', createdAt: 0, jobs: {}),
     );
     final status = stage?.jobs[jobName];
     return status == TaskStatus.failed || status == TaskStatus.infraFailure;

--- a/dashboard/lib/state/presubmit.dart
+++ b/dashboard/lib/state/presubmit.dart
@@ -292,9 +292,9 @@ class PresubmitState extends ChangeNotifier {
       String? topMost;
       for (final stage in filtered.stages) {
         if (stage.jobs.isNotEmpty) {
-          final sortedBuilds = stage.jobs.entries.toList()
+          final sortedJobs = stage.jobs.entries.toList()
             ..sort((a, b) => compareTasks(a.key, a.value, b.key, b.value));
-          topMost = sortedBuilds.first.key;
+          topMost = sortedJobs.first.key;
           break;
         }
       }

--- a/dashboard/lib/state/presubmit.dart
+++ b/dashboard/lib/state/presubmit.dart
@@ -218,7 +218,7 @@ class PresubmitState extends ChangeNotifier {
     }
     // Check if there are any failed jobs
     return _guardResponse?.stages.any(
-          (s) => s.builds.values.any(
+          (s) => s.jobs.values.any(
             (status) =>
                 status == TaskStatus.failed ||
                 status == TaskStatus.infraFailure,
@@ -264,7 +264,7 @@ class PresubmitState extends ChangeNotifier {
     final filtered = filteredGuardResponse;
     if (filtered == null ||
         filtered.stages.isEmpty ||
-        filtered.stages.every((s) => s.builds.isEmpty)) {
+        filtered.stages.every((s) => s.jobs.isEmpty)) {
       _selectedJob = null;
       _jobs = null;
       return;
@@ -275,7 +275,7 @@ class PresubmitState extends ChangeNotifier {
     final currentJob = selectedJob;
     if (currentJob != null) {
       for (final stage in filtered.stages) {
-        if (stage.builds.containsKey(currentJob)) {
+        if (stage.jobs.containsKey(currentJob)) {
           isVisible = true;
           break;
         }
@@ -291,8 +291,8 @@ class PresubmitState extends ChangeNotifier {
       // Select first available job based on UI sorting
       String? topMost;
       for (final stage in filtered.stages) {
-        if (stage.builds.isNotEmpty) {
-          final sortedBuilds = stage.builds.entries.toList()
+        if (stage.jobs.isNotEmpty) {
+          final sortedBuilds = stage.jobs.entries.toList()
             ..sort((a, b) => compareTasks(a.key, a.value, b.key, b.value));
           topMost = sortedBuilds.first.key;
           break;
@@ -317,7 +317,7 @@ class PresubmitState extends ChangeNotifier {
 
     final newAvailablePlatforms = <String>{};
     for (final stage in response.stages) {
-      for (final jobName in stage.builds.keys) {
+      for (final jobName in stage.jobs.keys) {
         newAvailablePlatforms.add(jobName.split(' ').first);
       }
     }
@@ -348,8 +348,8 @@ class PresubmitState extends ChangeNotifier {
 
     final filteredStages = <PresubmitGuardStage>[];
     for (final stage in response.stages) {
-      final filteredBuilds = <String, TaskStatus>{};
-      for (final entry in stage.builds.entries) {
+      final filteredJobs = <String, TaskStatus>{};
+      for (final entry in stage.jobs.entries) {
         final jobName = entry.key;
         final status = entry.value;
 
@@ -377,15 +377,15 @@ class PresubmitState extends ChangeNotifier {
           }
         }
 
-        filteredBuilds[jobName] = status;
+        filteredJobs[jobName] = status;
       }
 
-      if (filteredBuilds.isNotEmpty) {
+      if (filteredJobs.isNotEmpty) {
         filteredStages.add(
           PresubmitGuardStage(
             name: stage.name,
             createdAt: stage.createdAt,
-            builds: filteredBuilds,
+            jobs: filteredJobs,
           ),
         );
       }
@@ -691,11 +691,11 @@ class PresubmitState extends ChangeNotifier {
     }
     // Only allow re-run if the job failed
     final stage = _guardResponse?.stages.firstWhere(
-      (s) => s.builds.containsKey(jobName),
+      (s) => s.jobs.containsKey(jobName),
       orElse: () =>
-          const PresubmitGuardStage(name: '', createdAt: 0, builds: {}),
+          const PresubmitGuardStage(name: '', createdAt: 0, jobs: {}),
     );
-    final status = stage?.builds[jobName];
+    final status = stage?.jobs[jobName];
     return status == TaskStatus.failed || status == TaskStatus.infraFailure;
   }
 

--- a/dashboard/lib/state/presubmit.dart
+++ b/dashboard/lib/state/presubmit.dart
@@ -211,7 +211,7 @@ class PresubmitState extends ChangeNotifier {
         (_jobNameFilter != null && _jobNameFilter!.isNotEmpty);
   }
 
-  /// Whether the user can trigger "Re-run failed" for all jobs.
+  /// Whether the user can trigger "Re-run failed" for all failed jobs.
   bool get canRerunAllFailedJobs {
     if (!authService.isAuthenticated || isLoading || _isRerunningAll) {
       return false;

--- a/dashboard/lib/views/presubmit_view.dart
+++ b/dashboard/lib/views/presubmit_view.dart
@@ -856,7 +856,7 @@ class _JobsSidebarState extends State<_JobsSidebar> {
 
   void _updateSortedBuilds() {
     _sortedBuildsPerStage = widget.guardResponse.stages.map((stage) {
-      return stage.builds.entries.toList()
+      return stage.jobs.entries.toList()
         ..sort((a, b) => compareTasks(a.key, a.value, b.key, b.value));
     }).toList();
   }

--- a/dashboard/lib/views/presubmit_view.dart
+++ b/dashboard/lib/views/presubmit_view.dart
@@ -819,12 +819,12 @@ class _JobsSidebar extends StatefulWidget {
 
 class _JobsSidebarState extends State<_JobsSidebar> {
   final ScrollController _scrollController = ScrollController();
-  late List<List<MapEntry<String, TaskStatus>>> _sortedBuildsPerStage;
+  late List<List<MapEntry<String, TaskStatus>>> _sortedJobsPerStage;
 
   @override
   void initState() {
     super.initState();
-    _updateSortedBuilds();
+    _updateSortedJobs();
     _selectFirstJob();
   }
 
@@ -832,7 +832,7 @@ class _JobsSidebarState extends State<_JobsSidebar> {
   void didUpdateWidget(_JobsSidebar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.guardResponse != oldWidget.guardResponse) {
-      _updateSortedBuilds();
+      _updateSortedJobs();
     }
     if (widget.selectedJob == null) {
       _selectFirstJob();
@@ -841,7 +841,7 @@ class _JobsSidebarState extends State<_JobsSidebar> {
 
   void _selectFirstJob() {
     if (widget.isMobile || widget.selectedJob != null) return;
-    for (final stage in _sortedBuildsPerStage) {
+    for (final stage in _sortedJobsPerStage) {
       if (stage.isNotEmpty) {
         final firstJob = stage.first.key;
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -854,8 +854,8 @@ class _JobsSidebarState extends State<_JobsSidebar> {
     }
   }
 
-  void _updateSortedBuilds() {
-    _sortedBuildsPerStage = widget.guardResponse.stages.map((stage) {
+  void _updateSortedJobs() {
+    _sortedJobsPerStage = widget.guardResponse.stages.map((stage) {
       return stage.jobs.entries.toList()
         ..sort((a, b) => compareTasks(a.key, a.value, b.key, b.value));
     }).toList();
@@ -885,7 +885,7 @@ class _JobsSidebarState extends State<_JobsSidebar> {
                 itemCount: widget.guardResponse.stages.length,
                 itemBuilder: (context, stageIndex) {
                   final stage = widget.guardResponse.stages[stageIndex];
-                  final sortedBuilds = _sortedBuildsPerStage[stageIndex];
+                  final sortedJobs = _sortedJobsPerStage[stageIndex];
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -908,7 +908,7 @@ class _JobsSidebarState extends State<_JobsSidebar> {
                           ),
                         ),
                       ),
-                      ...sortedBuilds.map((entry) {
+                      ...sortedJobs.map((entry) {
                         final isSelected = widget.selectedJob == entry.key;
                         return _JobItem(
                           name: entry.key,

--- a/dashboard/lib/widgets/filter_dialog.dart
+++ b/dashboard/lib/widgets/filter_dialog.dart
@@ -112,7 +112,7 @@ class _FilterDialogState extends State<FilterDialog> {
     final filteredCount =
         presubmitState.filteredGuardResponse?.stages.fold<int>(
           0,
-          (prev, stage) => prev + stage.builds.length,
+          (prev, stage) => prev + stage.jobs.length,
         ) ??
         0;
 

--- a/dashboard/test/integration/get_presubmit_checks_test.dart
+++ b/dashboard/test/integration/get_presubmit_checks_test.dart
@@ -101,7 +101,7 @@ void main() {
       expect(response.error, isNull);
       expect(response.data, hasLength(2));
 
-      // Should be ordered by attempt number descending (default behavior of GetPresubmitJobsHandler)
+      // Should be ordered by attempt number descending (default behavior of GetPresubmitJobHandler)
       // I need to verify the order.
       // Based on `UnifiedCheckRun.getPresubmitJobDetails`:
       // `orderMap: const { PresubmitJob.fieldAttemptNumber: kQueryOrderDescending }`

--- a/dashboard/test/integration/get_presubmit_job_test.dart
+++ b/dashboard/test/integration/get_presubmit_job_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:github/github.dart';
 
 void main() {
-  group('Integration: Get Presubmit Jobs', () {
+  group('Integration: Get Presubmit Job', () {
     late IntegrationServer server;
     late IntegrationHttpClient client;
     late AppEngineCocoonService service;

--- a/dashboard/test/integration/get_presubmit_job_test.dart
+++ b/dashboard/test/integration/get_presubmit_job_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:github/github.dart';
 
 void main() {
-  group('Integration: Get Presubmit Checks', () {
+  group('Integration: Get Presubmit Jobs', () {
     late IntegrationServer server;
     late IntegrationHttpClient client;
     late AppEngineCocoonService service;
@@ -32,7 +32,7 @@ void main() {
       expect(response.statusCode, 404);
     });
 
-    test('returns presubmit check details', () async {
+    test('returns presubmit job details', () async {
       final now = DateTime.now();
       final check = PresubmitJob(
         slug: RepositorySlug('flutter', 'flutter'),
@@ -65,9 +65,9 @@ void main() {
       expect(result.summary, 'Build succeeded');
     });
 
-    test('returns multiple attempts for same build', () async {
+    test('returns multiple attempts for same job', () async {
       final now = DateTime.now();
-      final checkAttempt1 = PresubmitJob(
+      final attempt1 = PresubmitJob(
         slug: RepositorySlug('flutter', 'flutter'),
         checkRunId: 789,
         jobName: 'mac_ios',
@@ -80,7 +80,7 @@ void main() {
         summary: 'Build failed',
       );
 
-      final checkAttempt2 = PresubmitJob(
+      final attempt2 = PresubmitJob(
         slug: RepositorySlug('flutter', 'flutter'),
         checkRunId: 789,
         jobName: 'mac_ios',
@@ -91,7 +91,7 @@ void main() {
         summary: 'Retry succeeded',
       );
 
-      server.firestore.putDocuments([checkAttempt1, checkAttempt2]);
+      server.firestore.putDocuments([attempt1, attempt2]);
 
       final response = await service.fetchPresubmitJobDetails(
         checkRunId: 789,
@@ -101,11 +101,7 @@ void main() {
       expect(response.error, isNull);
       expect(response.data, hasLength(2));
 
-      // Should be ordered by attempt number descending (default behavior of GetPresubmitJobHandler)
-      // I need to verify the order.
-      // Based on `UnifiedCheckRun.getPresubmitJobDetails`:
-      // `orderMap: const { PresubmitJob.fieldAttemptNumber: kQueryOrderDescending }`
-
+      // Should be ordered by attempt number descending
       expect(response.data![0].attemptNumber, 2);
       expect(response.data![0].status, TaskStatus.succeeded);
 

--- a/dashboard/test/logic/presubmit_guard_test.dart
+++ b/dashboard/test/logic/presubmit_guard_test.dart
@@ -19,7 +19,7 @@ void main() {
           {
             'name': 'fusion',
             'created_at': 123456789,
-            'builds': {'test1': 'Succeeded', 'test2': 'In Progress'},
+            'jobs': {'test1': 'Succeeded', 'test2': 'In Progress'},
           },
         ],
       };
@@ -32,8 +32,8 @@ void main() {
       expect(response.guardStatus, GuardStatus.inProgress);
       expect(response.stages.length, 1);
       expect(response.stages[0].name, 'fusion');
-      expect(response.stages[0].builds['test1'], TaskStatus.succeeded);
-      expect(response.stages[0].builds['test2'], TaskStatus.inProgress);
+      expect(response.stages[0].jobs['test1'], TaskStatus.succeeded);
+      expect(response.stages[0].jobs['test2'], TaskStatus.inProgress);
     });
   });
 

--- a/dashboard/test/service/presubmit_service_test.dart
+++ b/dashboard/test/service/presubmit_service_test.dart
@@ -23,7 +23,7 @@ void main() {
           {
             'name': 'fusion',
             'created_at': 123456789,
-            'builds': {'test1': 'Succeeded'},
+            'jobs': {'test1': 'Succeeded'},
           },
         ],
       };

--- a/dashboard/test/service/presubmit_service_test.dart
+++ b/dashboard/test/service/presubmit_service_test.dart
@@ -75,7 +75,7 @@ void main() {
 
       service = AppEngineCocoonService(
         client: MockClient((Request request) async {
-          expect(request.url.path, '/api/public/get-presubmit-jobs');
+          expect(request.url.path, '/api/public/get-presubmit-job');
           return Response(jsonEncode(checkData), 200);
         }),
       );

--- a/dashboard/test/state/presubmit_filter_test.dart
+++ b/dashboard/test/state/presubmit_filter_test.dart
@@ -114,7 +114,7 @@ void main() {
         PresubmitGuardStage(
           name: 'stage1',
           createdAt: 0,
-          builds: {
+          jobs: {
             'linux test1': TaskStatus.succeeded,
             'linux test2': TaskStatus.failed,
             'mac test1': TaskStatus.succeeded,
@@ -129,8 +129,8 @@ void main() {
     // Filter by status
     presubmitState.updateFilters(statuses: {TaskStatus.failed});
     var filtered = presubmitState.filteredGuardResponse!;
-    expect(filtered.stages[0].builds.length, 1);
-    expect(filtered.stages[0].builds.keys.first, 'linux test2');
+    expect(filtered.stages[0].jobs.length, 1);
+    expect(filtered.stages[0].jobs.keys.first, 'linux test2');
 
     // Filter by platform
     presubmitState.updateFilters(
@@ -138,8 +138,8 @@ void main() {
       platforms: {'mac'},
     );
     filtered = presubmitState.filteredGuardResponse!;
-    expect(filtered.stages[0].builds.length, 1);
-    expect(filtered.stages[0].builds.keys.first, 'mac test1');
+    expect(filtered.stages[0].jobs.length, 1);
+    expect(filtered.stages[0].jobs.keys.first, 'mac test1');
 
     // Filter by regex
     presubmitState.updateFilters(
@@ -147,8 +147,8 @@ void main() {
       jobNameFilter: 'test2',
     );
     filtered = presubmitState.filteredGuardResponse!;
-    expect(filtered.stages[0].builds.length, 1);
-    expect(filtered.stages[0].builds.keys.first, 'linux test2');
+    expect(filtered.stages[0].jobs.length, 1);
+    expect(filtered.stages[0].jobs.keys.first, 'linux test2');
 
     // All filters
     presubmitState.updateFilters(
@@ -157,8 +157,8 @@ void main() {
       jobNameFilter: 'test1',
     );
     filtered = presubmitState.filteredGuardResponse!;
-    expect(filtered.stages[0].builds.length, 1);
-    expect(filtered.stages[0].builds.keys.first, 'linux test1');
+    expect(filtered.stages[0].jobs.length, 1);
+    expect(filtered.stages[0].jobs.keys.first, 'linux test1');
   });
 
   test('ensureValidSelection auto-selects top-most job on filter change', () {
@@ -171,7 +171,7 @@ void main() {
         PresubmitGuardStage(
           name: 'stage1',
           createdAt: 0,
-          builds: {
+          jobs: {
             'linux test1': TaskStatus.succeeded,
             'linux test2': TaskStatus.failed,
           },

--- a/dashboard/test/state/presubmit_test.dart
+++ b/dashboard/test/state/presubmit_test.dart
@@ -498,7 +498,7 @@ void main() {
           PresubmitGuardStage(
             name: 'stage1',
             createdAt: 0,
-            builds: {'Mac my_job': TaskStatus.succeeded},
+            jobs: {'Mac my_job': TaskStatus.succeeded},
           ),
         ],
       );

--- a/dashboard/test/views/presubmit_filter_view_test.dart
+++ b/dashboard/test/views/presubmit_filter_view_test.dart
@@ -141,7 +141,7 @@ void main() {
         PresubmitGuardStage(
           name: 'stage1',
           createdAt: 0,
-          builds: {'linux test': TaskStatus.succeeded},
+          jobs: {'linux test': TaskStatus.succeeded},
         ),
       ],
     );
@@ -187,7 +187,7 @@ void main() {
         PresubmitGuardStage(
           name: 'stage1',
           createdAt: 0,
-          builds: {
+          jobs: {
             'linux test': TaskStatus.succeeded,
             'mac test': TaskStatus.failed,
           },

--- a/dashboard/test/views/presubmit_view_test.dart
+++ b/dashboard/test/views/presubmit_view_test.dart
@@ -230,7 +230,7 @@ void main() {
         PresubmitGuardStage(
           name: 'Engine',
           createdAt: 0,
-          builds: {'Mac mac_host_engine 1': TaskStatus.failed},
+          jobs: {'Mac mac_host_engine 1': TaskStatus.failed},
         ),
       ],
     );
@@ -320,7 +320,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'Mac mac_host_engine 1': TaskStatus.failed},
+            jobs: {'Mac mac_host_engine 1': TaskStatus.failed},
           ),
         ],
       );
@@ -409,7 +409,7 @@ void main() {
         PresubmitGuardStage(
           name: 'Engine',
           createdAt: 0,
-          builds: {'Mac mac_host_engine 1': TaskStatus.failed},
+          jobs: {'Mac mac_host_engine 1': TaskStatus.failed},
         ),
       ],
     );
@@ -502,7 +502,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'Mac mac_host_engine 1': TaskStatus.failed},
+            jobs: {'Mac mac_host_engine 1': TaskStatus.failed},
           ),
         ],
       );
@@ -603,7 +603,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'Mac mac_host_engine 1': TaskStatus.failed},
+            jobs: {'Mac mac_host_engine 1': TaskStatus.failed},
           ),
         ],
       );
@@ -698,7 +698,7 @@ void main() {
         PresubmitGuardStage(
           name: 'Engine',
           createdAt: 0,
-          builds: {'Mac mac_host_engine': TaskStatus.succeeded},
+          jobs: {'Mac mac_host_engine': TaskStatus.succeeded},
         ),
       ],
       guardStatus: GuardStatus.succeeded,
@@ -869,7 +869,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'linux_bot': TaskStatus.failed},
+            jobs: {'linux_bot': TaskStatus.failed},
           ),
         ],
       );
@@ -927,7 +927,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'linux_bot': TaskStatus.failed},
+            jobs: {'linux_bot': TaskStatus.failed},
           ),
         ],
       );
@@ -981,7 +981,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'linux_bot': TaskStatus.failed},
+            jobs: {'linux_bot': TaskStatus.failed},
           ),
         ],
       );
@@ -1057,7 +1057,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {
+            jobs: {
               'succeeded_z': TaskStatus.succeeded,
               'failed_b': TaskStatus.failed,
               'infra_c': TaskStatus.infraFailure,
@@ -1155,7 +1155,7 @@ void main() {
             PresubmitGuardStage(
               name: 'Engine',
               createdAt: 0,
-              builds: {
+              jobs: {
                 'linux_analyze': TaskStatus.succeeded,
                 'linux_bot': TaskStatus.failed,
                 'mac_bot': TaskStatus.inProgress,
@@ -1215,7 +1215,7 @@ void main() {
             PresubmitGuardStage(
               name: 'Engine',
               createdAt: 0,
-              builds: {
+              jobs: {
                 'linux_analyze': TaskStatus.succeeded,
                 'linux_bot': TaskStatus.failed,
                 'mac_bot': TaskStatus.inProgress,
@@ -1276,7 +1276,7 @@ void main() {
           PresubmitGuardStage(
             name: 'Engine',
             createdAt: 0,
-            builds: {'Mac mac_host_engine 1': TaskStatus.succeeded},
+            jobs: {'Mac mac_host_engine 1': TaskStatus.succeeded},
           ),
         ],
       );

--- a/dashboard/test/widgets/filter_dialog_test.dart
+++ b/dashboard/test/widgets/filter_dialog_test.dart
@@ -50,7 +50,7 @@ void main() {
         PresubmitGuardStage(
           name: 'stage1',
           createdAt: 0,
-          builds: {
+          jobs: {
             'linux test1': TaskStatus.succeeded,
             'mac test1': TaskStatus.failed,
           },

--- a/packages/cocoon_common/lib/src/rpc_model/presubmit_guard.dart
+++ b/packages/cocoon_common/lib/src/rpc_model/presubmit_guard.dart
@@ -54,14 +54,14 @@ final class PresubmitGuardResponse {
 
 /// Represents a single stage in a presubmit guard.
 ///
-/// A stage groups related builds (tasks) together, for example, 'fusion' or 'engine'.
+/// A stage groups related jobs (tasks) together, for example, 'fusion' or 'engine'.
 @immutable
 @JsonSerializable(fieldRename: FieldRename.snake)
 final class PresubmitGuardStage {
   const PresubmitGuardStage({
     required this.name,
     required this.createdAt,
-    required this.builds,
+    required this.jobs,
   });
 
   /// The name of the stage (e.g., 'fusion', 'engine').
@@ -70,8 +70,8 @@ final class PresubmitGuardStage {
   /// The creation timestamp of this stage in milliseconds since the epoch.
   final int createdAt;
 
-  /// Map of build names to their current statuses.
-  final Map<String, TaskStatus> builds;
+  /// Map of job names to their current statuses.
+  final Map<String, TaskStatus> jobs;
 
   /// Creates a [PresubmitGuardStage] from a JSON map.
   factory PresubmitGuardStage.fromJson(Map<String, Object?> json) =>

--- a/packages/cocoon_common/lib/src/rpc_model/presubmit_guard.g.dart
+++ b/packages/cocoon_common/lib/src/rpc_model/presubmit_guard.g.dart
@@ -41,7 +41,7 @@ PresubmitGuardStage _$PresubmitGuardStageFromJson(Map<String, dynamic> json) =>
     PresubmitGuardStage(
       name: json['name'] as String,
       createdAt: (json['created_at'] as num).toInt(),
-      builds: (json['builds'] as Map<String, dynamic>).map(
+      jobs: (json['jobs'] as Map<String, dynamic>).map(
         (k, e) => MapEntry(k, $enumDecode(_$TaskStatusEnumMap, e)),
       ),
     );
@@ -51,7 +51,7 @@ Map<String, dynamic> _$PresubmitGuardStageToJson(
 ) => <String, dynamic>{
   'name': instance.name,
   'created_at': instance.createdAt,
-  'builds': instance.builds,
+  'jobs': instance.jobs,
 };
 
 const _$TaskStatusEnumMap = {


### PR DESCRIPTION
renamed:
 - `get-presubmit-jobs` to `get-presubmit-job` since it returns run details of one job
 - `builds` to `jobs` in get-presubmit-guard response