### PR TITLE
Eliminate redundant `getDocument` errors in Firestore.

### DIFF
--- a/app_dart/lib/src/model/firestore/account.dart
+++ b/app_dart/lib/src/model/firestore/account.dart
@@ -5,7 +5,6 @@
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:path/path.dart' as p;
 
-import '../../request_handling/http_utils.dart';
 import '../../service/firestore.dart';
 import 'base.dart';
 
@@ -27,18 +26,10 @@ final class Account extends AppDocument<Account> {
     FirestoreService firestore, {
     required String email,
   }) async {
-    final g.Document document;
-    try {
-      document = await firestore.getDocument(
-        p.posix.join(kDatabase, 'documents', metadata.collectionId, email),
-      );
-    } on g.DetailedApiRequestError catch (e) {
-      if (e.status == HttpStatus.notFound) {
-        return null;
-      }
-      rethrow;
-    }
-    return Account.fromDocument(document);
+    final document = await firestore.getDocumentOrNull(
+      p.posix.join(kDatabase, 'documents', metadata.collectionId, email),
+    );
+    return document == null ? null : Account.fromDocument(document);
   }
 
   /// Creates a new account with the given [email].

--- a/app_dart/lib/src/model/firestore/ci_staging.dart
+++ b/app_dart/lib/src/model/firestore/ci_staging.dart
@@ -101,7 +101,7 @@ final class CiStaging extends AppDocument<CiStaging> {
     return '$kDocumentParent/$_collectionId/${docId.documentId}';
   }
 
-  /// Lookup [Commit] from Firestore.
+  /// Lookup [CiStaging] from Firestore.
   ///
   /// Use [documentNameFor] to get the correct [documentName]
   static Future<CiStaging> fromFirestore({
@@ -110,6 +110,17 @@ final class CiStaging extends AppDocument<CiStaging> {
   }) async {
     final document = await firestoreService.getDocument(documentName);
     return CiStaging.fromDocument(document);
+  }
+
+  /// Lookup [CiStaging] from Firestore, or return `null` if not found.
+  ///
+  /// Use [documentNameFor] to get the correct [documentName].
+  static Future<CiStaging?> fromFirestoreOrNull({
+    required FirestoreService firestoreService,
+    required String documentName,
+  }) async {
+    final document = await firestoreService.getDocumentOrNull(documentName);
+    return document == null ? null : CiStaging.fromDocument(document);
   }
 
   /// Queries for [CiStaging] records by [slug] and [sha].

--- a/app_dart/lib/src/model/firestore/commit.dart
+++ b/app_dart/lib/src/model/firestore/commit.dart
@@ -69,15 +69,8 @@ final class Commit extends AppDocument<Commit> {
     required String sha,
   }) async {
     final documentName = p.join(kDatabase, 'documents', collectionId, sha);
-    try {
-      final document = await firestore.getDocument(documentName);
-      return Commit._(document.fields!, name: document.name!);
-    } on DetailedApiRequestError catch (e) {
-      if (e.status == HttpStatus.notFound) {
-        return null;
-      }
-      rethrow;
-    }
+    final document = await firestore.getDocumentOrNull(documentName);
+    return document == null ? null : Commit.fromDocument(document);
   }
 
   factory Commit({

--- a/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
+++ b/app_dart/lib/src/model/firestore/content_aware_hash_builds.dart
@@ -5,7 +5,6 @@
 import 'package:googleapis/firestore/v1.dart' as g;
 import 'package:path/path.dart' as p;
 
-import '../../request_handling/http_utils.dart';
 import '../../service/firestore.dart';
 import 'base.dart';
 
@@ -30,16 +29,12 @@ final class ContentAwareHashBuilds extends AppDocument<ContentAwareHashBuilds> {
     FirestoreService firestore, {
     required String contentHash,
   }) async {
-    final g.Document document;
-    try {
-      document = await firestore.getDocument(documentPathFor(contentHash));
-    } on g.DetailedApiRequestError catch (e) {
-      if (e.status == HttpStatus.notFound) {
-        return null;
-      }
-      rethrow;
-    }
-    return ContentAwareHashBuilds.fromDocument(document);
+    final document = await firestore.getDocumentOrNull(
+      documentPathFor(contentHash),
+    );
+    return document == null
+        ? null
+        : ContentAwareHashBuilds.fromDocument(document);
   }
 
   factory ContentAwareHashBuilds({

--- a/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
+++ b/app_dart/lib/src/request_handlers/get_engine_artifacts_ready.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:googleapis/firestore/v1.dart';
-
 import '../../cocoon_service.dart';
 import '../model/firestore/ci_staging.dart';
 import '../request_handling/exceptions.dart';
@@ -44,22 +42,18 @@ final class GetEngineArtifactsReady extends PublicApiRequestHandler {
     var failed = 0;
     var remaining = 0;
     var found = false;
-    try {
-      final ciStaging = await CiStaging.fromFirestore(
-        firestoreService: _firestore,
-        documentName: CiStaging.documentNameFor(
-          slug: Config.flutterSlug,
-          sha: commitSha,
-          stage: CiStage.fusionEngineBuild,
-        ),
-      );
+    final ciStaging = await CiStaging.fromFirestoreOrNull(
+      firestoreService: _firestore,
+      documentName: CiStaging.documentNameFor(
+        slug: Config.flutterSlug,
+        sha: commitSha,
+        stage: CiStage.fusionEngineBuild,
+      ),
+    );
+    if (ciStaging != null) {
       failed = ciStaging.failed;
       remaining = ciStaging.remaining;
       found = true;
-    } on DetailedApiRequestError catch (e) {
-      if (e.status != HttpStatus.notFound) {
-        rethrow;
-      }
     }
     // if not found in ciStaging document, check if there are any
     // presubmit guards for this sha. This is needed for unified check-run flow.

--- a/app_dart/lib/src/service/firestore.dart
+++ b/app_dart/lib/src/service/firestore.dart
@@ -353,6 +353,32 @@ class FirestoreService with FirestoreQueries {
     );
   }
 
+  /// Batch gets documents by [names].
+  ///
+  /// Unlike [getDocument], Firestore returns 200 OK even if documents are missing.
+  Future<BatchGetDocumentsResponse> batchGetDocuments(
+    List<String> names, {
+    Transaction? transaction,
+  }) async {
+    final request = BatchGetDocumentsRequest(
+      documents: names,
+      transaction: transaction?.identifier,
+    );
+    return _api.projects.databases.documents.batchGet(request, kDatabase);
+  }
+
+  /// Gets a document based on [name], or returns `null` if the document does not exist.
+  ///
+  /// Uses [batchGetDocuments] so that non-existent documents do not produce 404
+  /// errors in Firestore / GCP monitoring logs.
+  Future<Document?> getDocumentOrNull(
+    String name, {
+    Transaction? transaction,
+  }) async {
+    final response = await batchGetDocuments([name], transaction: transaction);
+    return response.firstOrNull?.found;
+  }
+
   /// Creates a document.
   ///
   /// A document name is automatically generated if [documentId] is omitted.

--- a/app_dart/lib/src/service/pull_request_manager.dart
+++ b/app_dart/lib/src/service/pull_request_manager.dart
@@ -269,8 +269,8 @@ class PullRequestManager {
     String latestSha;
     String? scheduledSha;
 
-    try {
-      final doc = await firestore.getDocument(name);
+    final doc = await firestore.getDocumentOrNull(name);
+    if (doc != null) {
       final state = PullRequestState.fromDocument(doc);
       isPrivileged = state.isPrivileged ?? false;
       latestSha = state.latestSha ?? event.pullRequest!.head!.sha!;
@@ -278,11 +278,7 @@ class PullRequestManager {
       log.info(
         'Hydrated PullRequestManager for $slug/$prNumber: isPrivileged=$isPrivileged, latestSha=$latestSha, scheduledSha=$scheduledSha',
       );
-    } on DetailedApiRequestError catch (e) {
-      if (e.status != HttpStatus.notFound) {
-        rethrow;
-      }
-
+    } else {
       // Document not found, initialize as new
       final pr = event.pullRequest!;
       final author = pr.user!.login!;

--- a/app_dart/test/model/firestore/account_test.dart
+++ b/app_dart/test/model/firestore/account_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_integration_test/testing.dart';
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/account.dart';
+import 'package:test/test.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  late FakeFirestoreService firestoreService;
+
+  setUp(() {
+    firestoreService = FakeFirestoreService();
+  });
+
+  test('getByEmail returns account when exists, null otherwise', () async {
+    final account = Account(email: 'user@example.com');
+    firestoreService.putDocument(account);
+
+    final found = await Account.getByEmail(
+      firestoreService,
+      email: 'user@example.com',
+    );
+    expect(found, isNotNull);
+    expect(found!.email, 'user@example.com');
+
+    final notFound = await Account.getByEmail(
+      firestoreService,
+      email: 'missing@example.com',
+    );
+    expect(notFound, isNull);
+  });
+}

--- a/app_dart/test/model/firestore/commit_test.dart
+++ b/app_dart/test/model/firestore/commit_test.dart
@@ -27,4 +27,25 @@ void main() {
     expect(resultedCommit.name, storedCommit.name);
     expect(resultedCommit.fields, storedCommit.fields);
   });
+
+  test(
+    'tryFromFirestoreBySha returns commit when exists, null otherwise',
+    () async {
+      final storedCommit = generateFirestoreCommit(1);
+      firestoreService.putDocument(storedCommit);
+
+      final found = await Commit.tryFromFirestoreBySha(
+        firestoreService,
+        sha: storedCommit.sha,
+      );
+      expect(found, isNotNull);
+      expect(found!.sha, storedCommit.sha);
+
+      final notFound = await Commit.tryFromFirestoreBySha(
+        firestoreService,
+        sha: 'nonexistent_sha',
+      );
+      expect(notFound, isNull);
+    },
+  );
 }

--- a/app_dart/test/model/firestore/content_aware_hash_builds_test.dart
+++ b/app_dart/test/model/firestore/content_aware_hash_builds_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2024 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cocoon_integration_test/testing.dart';
+import 'package:cocoon_server_test/test_logging.dart';
+import 'package:cocoon_service/src/model/firestore/content_aware_hash_builds.dart';
+import 'package:test/test.dart';
+
+void main() {
+  useTestLoggerPerTest();
+
+  late FakeFirestoreService firestoreService;
+
+  setUp(() {
+    firestoreService = FakeFirestoreService();
+  });
+
+  test(
+    'getByContentHash returns document when exists, null otherwise',
+    () async {
+      final build = ContentAwareHashBuilds(
+        createdOn: DateTime.utc(2024, 1, 1),
+        contentHash: 'hash123',
+        commitSha: 'sha123',
+        buildStatus: BuildStatus.success,
+        waitingShas: ['sha456'],
+      );
+      firestoreService.putDocument(build);
+
+      final found = await ContentAwareHashBuilds.getByContentHash(
+        firestoreService,
+        contentHash: 'hash123',
+      );
+      expect(found, isNotNull);
+      expect(found!.contentHash, 'hash123');
+      expect(found.commitSha, 'sha123');
+      expect(found.status, BuildStatus.success);
+
+      final notFound = await ContentAwareHashBuilds.getByContentHash(
+        firestoreService,
+        contentHash: 'missing_hash',
+      );
+      expect(notFound, isNull);
+    },
+  );
+}

--- a/app_dart/test/service/firestore_test.dart
+++ b/app_dart/test/service/firestore_test.dart
@@ -80,5 +80,45 @@ void main() {
       );
       expect(notFound, isNull);
     });
+
+    test('batchGetDocuments returns found and missing documents', () async {
+      final doc1 = Document(
+        name: firestore.resolveDocumentName('tasks', 'task1'),
+        fields: {'key': 'val1'.toValue()},
+      );
+      firestore.putDocument(doc1);
+
+      final missingName = firestore.resolveDocumentName('tasks', 'task2');
+      final response = await firestore.batchGetDocuments([
+        doc1.name!,
+        missingName,
+      ]);
+
+      expect(response, hasLength(2));
+      expect(response[0].found, isNotNull);
+      expect(response[0].found!.name, doc1.name);
+      expect(response[1].missing, missingName);
+      expect(response[1].found, isNull);
+    });
+
+    test(
+      'getDocumentOrNull returns document when exists, null otherwise',
+      () async {
+        final doc1 = Document(
+          name: firestore.resolveDocumentName('tasks', 'task1'),
+          fields: {'key': 'val1'.toValue()},
+        );
+        firestore.putDocument(doc1);
+
+        final result = await firestore.getDocumentOrNull(doc1.name!);
+        expect(result, isNotNull);
+        expect(result!.name, doc1.name);
+
+        final notFound = await firestore.getDocumentOrNull(
+          firestore.resolveDocumentName('tasks', 'does_not_exist'),
+        );
+        expect(notFound, isNull);
+      },
+    );
   });
 }

--- a/packages/cocoon_integration_test/lib/src/fakes/fake_firestore_service.dart
+++ b/packages/cocoon_integration_test/lib/src/fakes/fake_firestore_service.dart
@@ -378,6 +378,42 @@ abstract base class _FakeInMemoryFirestoreService
   }
 
   @override
+  Future<BatchGetDocumentsResponse> batchGetDocuments(
+    List<String> names, {
+    Transaction? transaction,
+  }) async {
+    final response = <BatchGetDocumentsResponseElement>[];
+    for (final name in names) {
+      final doc = tryPeekDocumentByName(name);
+      if (doc != null) {
+        response.add(
+          BatchGetDocumentsResponseElement(
+            found: doc,
+            readTime: _now().toIso8601String(),
+          ),
+        );
+      } else {
+        response.add(
+          BatchGetDocumentsResponseElement(
+            missing: name,
+            readTime: _now().toIso8601String(),
+          ),
+        );
+      }
+    }
+    return response;
+  }
+
+  @override
+  Future<Document?> getDocumentOrNull(
+    String name, {
+    Transaction? transaction,
+  }) async {
+    final response = await batchGetDocuments([name], transaction: transaction);
+    return response.firstOrNull?.found;
+  }
+
+  @override
   Future<Document> createDocument(
     Document document, {
     required String collectionId,

--- a/packages/cocoon_integration_test/test/fake_firestore_service_test.dart
+++ b/packages/cocoon_integration_test/test/fake_firestore_service_test.dart
@@ -950,4 +950,50 @@ void main() {
       });
     });
   });
+
+  group('batchGetDocuments', () {
+    test('returns found documents and missing documents', () async {
+      final doc1 = firestore.putDocument(
+        g.Document(
+          name: firestore.resolveDocumentName('messages', 'doc1'),
+          fields: {'text': 'hello'.toValue()},
+        ),
+      );
+
+      final missingPath = firestore.resolveDocumentName('messages', 'doc2');
+      final response = await firestore.batchGetDocuments([
+        doc1.name!,
+        missingPath,
+      ]);
+
+      expect(response, hasLength(2));
+      expect(response[0].found?.name, doc1.name);
+      expect(response[0].found?.fields?['text']?.stringValue, 'hello');
+      expect(response[0].missing, isNull);
+      expect(response[1].found, isNull);
+      expect(response[1].missing, missingPath);
+    });
+  });
+
+  group('getDocumentOrNull', () {
+    test('returns document if it exists', () async {
+      final doc = firestore.putDocument(
+        g.Document(
+          name: firestore.resolveDocumentName('messages', 'doc1'),
+          fields: {'text': 'hello'.toValue()},
+        ),
+      );
+
+      final result = await firestore.getDocumentOrNull(doc.name!);
+      expect(result?.name, doc.name);
+      expect(result?.fields?['text']?.stringValue, 'hello');
+    });
+
+    test('returns null if document does not exist', () async {
+      final result = await firestore.getDocumentOrNull(
+        firestore.resolveDocumentName('messages', 'nonexistent'),
+      );
+      expect(result, isNull);
+    });
+  });
 }


### PR DESCRIPTION
Looking through our GCP logs, a large portion of our errors are coming from calls to get documents from firestore where the document is not found. In many cases, we actually handle this 404 error gracefully and proceed without issue. However, this interaction still causes Firestore itself to log an error, even though cocoon handles it just fine.

This change adds a convenience method `getDocumentOrNull` which uses the batch document fetch API instead, which always returns a 200, and if the document is not found, just returns an empty list. I went through and found all the places we were catching the 404 error from fetching a document and used this method instead. This should eliminate a lot of these errors in our GCP logs.