### PR TITLE
[flutter-gold] Support unified check run Dashboard Checks in push_gold_status_to_github

### DIFF
--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -137,28 +137,9 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
       log.debug('This PR has ${checkRuns.length} checks.');
       for (var checkRun in checkRuns) {
         final name = checkRun['name'].toLowerCase() as String;
-        if (slug == Config.flutterSlug) {
-          if (name.contains(Config.kDashboardCheckName.toLowerCase()) ||
-              const <String>[
-                // Framework test shards that run golden file tests
-                'framework',
-                'misc',
-
-                // Engine test shards that run golden file tests
-                // Monorepo
-                'linux_android_emulator',
-                'linux_host_engine',
-                'linux_web_engine',
-                'mac_host_engine',
-                'mac_unopt',
-
-                // Integration test shards that run golden file tests
-                'android_engine_vulkan_tests',
-                'android_engine_opengles_tests',
-                'flutter_driver_android_test',
-              ].any(name.contains)) {
-            runsGoldenFileTests = true;
-          }
+        if (slug == Config.flutterSlug &&
+            name.contains(Config.kDashboardCheckName.toLowerCase())) {
+          runsGoldenFileTests = true;
         }
         const successfulConclusion = {'SUCCESS', 'NEUTRAL'};
 

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -138,27 +138,25 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
       for (var checkRun in checkRuns) {
         final name = checkRun['name'].toLowerCase() as String;
         if (slug == Config.flutterSlug) {
-          if (const <String>[
-            // Unified check run
-            'dashboard checks',
+          if (name.contains(Config.kDashboardCheckName.toLowerCase()) ||
+              const <String>[
+                // Framework test shards that run golden file tests
+                'framework',
+                'misc',
 
-            // Framework test shards that run golden file tests
-            'framework',
-            'misc',
+                // Engine test shards that run golden file tests
+                // Monorepo
+                'linux_android_emulator',
+                'linux_host_engine',
+                'linux_web_engine',
+                'mac_host_engine',
+                'mac_unopt',
 
-            // Engine test shards that run golden file tests
-            // Monorepo
-            'linux_android_emulator',
-            'linux_host_engine',
-            'linux_web_engine',
-            'mac_host_engine',
-            'mac_unopt',
-
-            // Integration test shards that run golden file tests
-            'android_engine_vulkan_tests',
-            'android_engine_opengles_tests',
-            'flutter_driver_android_test',
-          ].any(name.contains)) {
+                // Integration test shards that run golden file tests
+                'android_engine_vulkan_tests',
+                'android_engine_opengles_tests',
+                'flutter_driver_android_test',
+              ].any(name.contains)) {
             runsGoldenFileTests = true;
           }
         }

--- a/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
+++ b/app_dart/lib/src/request_handlers/push_gold_status_to_github.dart
@@ -139,6 +139,9 @@ final class PushGoldStatusToGithub extends ApiRequestHandler {
         final name = checkRun['name'].toLowerCase() as String;
         if (slug == Config.flutterSlug) {
           if (const <String>[
+            // Unified check run
+            'dashboard checks',
+
             // Framework test shards that run golden file tests
             'framework',
             'misc',

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -175,82 +175,43 @@ void main() {
         expect(log, hasNoWarningsOrHigher);
       });
 
-      test(
-        'if there are no framework or web engine tests for this PR',
-        () async {
-          checkRuns = <dynamic>[
-            <String, String>{
-              'name': 'tool-test1',
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-            <String, String>{
-              'name': 'linux-host1',
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-          ];
-          final flutterPr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[flutterPr];
+      test('if there are no Dashboard Checks for this PR', () async {
+        checkRuns = <dynamic>[
+          <String, String>{
+            'name': 'tool-test1',
+            'status': 'completed',
+            'conclusion': 'success',
+          },
+          <String, String>{
+            'name': 'linux-host1',
+            'status': 'completed',
+            'conclusion': 'success',
+          },
+        ];
+        final flutterPr = newPullRequest(123, 'abc', 'master');
+        prsFromGitHub = <PullRequest>[flutterPr];
 
-          firestore.putDocument(
-            newGithubGoldStatus(slug, flutterPr, '', '', ''),
-          );
+        firestore.putDocument(newGithubGoldStatus(slug, flutterPr, '', '', ''));
 
-          final body = await tester.get(handler);
-          expect(body, same(Response.emptyOk));
-          expect(log, hasNoWarningsOrHigher);
+        final body = await tester.get(handler);
+        expect(body, same(Response.emptyOk));
+        expect(log, hasNoWarningsOrHigher);
 
-          // Should not apply labels or make comments
-          verifyNever(
-            issuesService.addLabelsToIssue(slug, flutterPr.number!, <String>[
-              kGoldenFileLabel,
-            ]),
-          );
+        // Should not apply labels or make comments
+        verifyNever(
+          issuesService.addLabelsToIssue(slug, flutterPr.number!, <String>[
+            kGoldenFileLabel,
+          ]),
+        );
 
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              flutterPr.number!,
-              argThat(contains(config.flutterGoldCommentID(flutterPr))),
-            ),
-          );
-        },
-      );
-
-      test(
-        'if there are no framework tests for this PR, exclude web builds',
-        () async {
-          checkRuns = <dynamic>[
-            <String, String>{
-              'name': 'web-test1',
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-          ];
-          final pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-          final body = await tester.get(handler);
-          expect(body, same(Response.emptyOk));
-          expect(log, hasNoWarningsOrHigher);
-
-          // Should not apply labels or make comments
-          verifyNever(
-            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-              kGoldenFileLabel,
-            ]),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
-        },
-      );
+        verifyNever(
+          issuesService.createComment(
+            slug,
+            flutterPr.number!,
+            argThat(contains(config.flutterGoldCommentID(flutterPr))),
+          ),
+        );
+      });
 
       test('same commit, checks running, last status running', () async {
         // Same commit
@@ -270,12 +231,7 @@ void main() {
         // Checks still running
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
-            'status': 'in_progress',
-            'conclusion': 'neutral',
-          },
-          <String, String>{
-            'name': 'web engine',
+            'name': Config.kDashboardCheckName,
             'status': 'in_progress',
             'conclusion': 'neutral',
           },
@@ -325,12 +281,7 @@ void main() {
         // Checks complete
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
-            'status': 'completed',
-            'conclusion': 'success',
-          },
-          <String, String>{
-            'name': 'web engine',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -382,12 +333,7 @@ void main() {
           // Neutral checks complete
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
-              'status': 'completed',
-              'conclusion': 'neutral',
-            },
-            <String, String>{
-              'name': 'web engine',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'neutral',
             },
@@ -440,12 +386,7 @@ void main() {
           // Checks complete
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-            <String, String>{
-              'name': 'web engine',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -513,7 +454,7 @@ void main() {
           // All checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -556,7 +497,7 @@ void main() {
         // Checks completed
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'Linux',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -599,7 +540,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -654,7 +595,7 @@ void main() {
         // Checks completed
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -687,53 +628,56 @@ void main() {
         verifyNever(issuesService.createComment(slug, pr.number!, any));
       });
 
-      test('will not fire off stale warning for non-framework PRs', () async {
-        // New commit, draft PR
-        final pr = newPullRequest(
-          123,
-          'abc',
-          'master',
-          updated: DateTime.now().subtract(const Duration(days: 30)),
-        );
-        prsFromGitHub = <PullRequest>[pr];
+      test(
+        'will not fire off stale warning for PRs without Dashboard Checks',
+        () async {
+          // New commit, draft PR
+          final pr = newPullRequest(
+            123,
+            'abc',
+            'master',
+            updated: DateTime.now().subtract(const Duration(days: 30)),
+          );
+          prsFromGitHub = <PullRequest>[pr];
 
-        firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
+          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
 
-        // Checks completed
-        checkRuns = <dynamic>[
-          <String, String>{
-            'name': 'tool-test-1',
-            'status': 'completed',
-            'conclusion': 'success',
-          },
-        ];
+          // Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{
+              'name': 'tool-test-1',
+              'status': 'completed',
+              'conclusion': 'success',
+            },
+          ];
 
-        // Already commented to update.
-        when(issuesService.listCommentsByIssue(slug, pr.number!)).thenAnswer(
-          (_) => Stream<IssueComment>.value(
-            IssueComment()..body = 'some other comment',
-          ),
-        );
+          // Already commented to update.
+          when(issuesService.listCommentsByIssue(slug, pr.number!)).thenAnswer(
+            (_) => Stream<IssueComment>.value(
+              IssueComment()..body = 'some other comment',
+            ),
+          );
 
-        final body = await tester.get(handler);
-        expect(body, same(Response.emptyOk));
-        expect(
-          firestore,
-          existsInStorage(fs.GithubGoldStatus.metadata, [
-            isGithubGoldStatus.hasUpdates(0),
-          ]),
-        );
-        expect(log, hasNoWarningsOrHigher);
+          final body = await tester.get(handler);
+          expect(body, same(Response.emptyOk));
+          expect(
+            firestore,
+            existsInStorage(fs.GithubGoldStatus.metadata, [
+              isGithubGoldStatus.hasUpdates(0),
+            ]),
+          );
+          expect(log, hasNoWarningsOrHigher);
 
-        // Should not apply labels or make comments
-        verifyNever(
-          issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-            kGoldenFileLabel,
-          ]),
-        );
+          // Should not apply labels or make comments
+          verifyNever(
+            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
+              kGoldenFileLabel,
+            ]),
+          );
 
-        verifyNever(issuesService.createComment(slug, pr.number!, any));
-      });
+          verifyNever(issuesService.createComment(slug, pr.number!, any));
+        },
+      );
     });
 
     group('updates GitHub and/or Firestore', () {
@@ -747,12 +691,7 @@ void main() {
         // Checks running
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
-            'status': 'in_progress',
-            'conclusion': 'neutral',
-          },
-          <String, String>{
-            'name': 'Linux linux_web_engine',
+            'name': Config.kDashboardCheckName,
             'status': 'in_progress',
             'conclusion': 'neutral',
           },
@@ -785,330 +724,6 @@ void main() {
         );
       });
 
-      test('includes misc test shards', () async {
-        // New commit
-        final pr = newPullRequest(123, 'abc', 'master');
-        prsFromGitHub = <PullRequest>[pr];
-
-        firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-
-        // Checks completed
-        checkRuns = <dynamic>[
-          <String, String>{
-            'name': 'misc',
-            'status': 'completed',
-            'conclusion': 'success',
-          },
-        ];
-
-        // Change detected by Gold
-        mockHttpClient = MockClient((http.Request request) async {
-          if (request.url.toString() ==
-              'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-            return http.Response(tryjobEmpty(), HttpStatus.ok);
-          }
-          throw const HttpException('Unexpected http request');
-        });
-        handler = PushGoldStatusToGithub(
-          config: config,
-          authenticationProvider: auth,
-          goldClient: mockHttpClient,
-          ingestionDelay: Duration.zero,
-          firestore: firestore,
-        );
-
-        final body = await tester.get(handler);
-        expect(body, same(Response.emptyOk));
-        expect(log, hasNoWarningsOrHigher);
-
-        expect(
-          firestore,
-          existsInStorage(fs.GithubGoldStatus.metadata, [
-            isGithubGoldStatus.hasUpdates(1),
-          ]),
-        );
-
-        // Should not label or comment
-        verifyNever(
-          issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-            kGoldenFileLabel,
-          ]),
-        );
-
-        verifyNever(
-          issuesService.createComment(
-            slug,
-            pr.number!,
-            argThat(contains(config.flutterGoldCommentID(pr))),
-          ),
-        );
-      });
-
-      Future<void> includesEngineShard(String shard) async {
-        // New commit
-        final pr = newPullRequest(123, 'abc', 'master');
-        prsFromGitHub = <PullRequest>[pr];
-
-        firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-
-        // Checks completed
-        checkRuns = <dynamic>[
-          <String, String>{
-            'name': shard,
-            'status': 'completed',
-            'conclusion': 'success',
-          },
-        ];
-
-        // Change detected by Gold
-        mockHttpClient = MockClient((http.Request request) async {
-          if (request.url.toString() ==
-              'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-            return http.Response(tryjobEmpty(), HttpStatus.ok);
-          }
-          throw const HttpException('Unexpected http request');
-        });
-        handler = PushGoldStatusToGithub(
-          config: config,
-          authenticationProvider: auth,
-          goldClient: mockHttpClient,
-          ingestionDelay: Duration.zero,
-          firestore: firestore,
-        );
-
-        final body = await tester.get(handler);
-        expect(body, same(Response.emptyOk));
-        expect(log, hasNoWarningsOrHigher);
-
-        expect(
-          firestore,
-          existsInStorage(fs.GithubGoldStatus.metadata, [
-            isGithubGoldStatus.hasUpdates(1),
-          ]),
-        );
-
-        // Should not label or comment
-        verifyNever(
-          issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-            kGoldenFileLabel,
-          ]),
-        );
-
-        verifyNever(
-          issuesService.createComment(
-            slug,
-            pr.number!,
-            argThat(contains(config.flutterGoldCommentID(pr))),
-          ),
-        );
-      }
-
-      test('includes linux_android_emulator test shard - monorepo', () async {
-        await includesEngineShard('linux_android_emulator');
-      });
-
-      test('includes linux_host_engine test shard - monorepo', () async {
-        await includesEngineShard('linux_host_engine');
-      });
-
-      test('includes linux_web_engine test shard - monorepo', () async {
-        await includesEngineShard('linux_web_engine');
-      });
-
-      test('includes mac_host_engine test shard - monorepo', () async {
-        await includesEngineShard('mac_host_engine');
-      });
-
-      test('includes mac_unopt test shard - monorepo', () async {
-        await includesEngineShard('mac_unopt');
-      });
-
-      test('includes dashboard checks check run', () async {
-        await includesEngineShard(Config.kDashboardCheckName);
-      });
-
-      test(
-        'applies gold status and label when unified Dashboard Checks detects untriaged goldens',
-        () async {
-          // New commit
-          final pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-
-          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-
-          // Unified Dashboard Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{
-              'name': Config.kDashboardCheckName,
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-            <String, String>{
-              'name': Config.kCiYamlCheckName,
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-          ];
-
-          // Change detected by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobDigests(pr), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-            firestore: firestore,
-          );
-
-          // Have not already commented for this commit.
-          when(issuesService.listCommentsByIssue(slug, pr.number!)).thenAnswer(
-            (_) => Stream<IssueComment>.value(
-              IssueComment()..body = 'some other comment',
-            ),
-          );
-
-          final body = await tester.get(handler);
-          expect(body, same(Response.emptyOk));
-          expect(log, hasNoWarningsOrHigher);
-
-          expect(
-            firestore,
-            existsInStorage(fs.GithubGoldStatus.metadata, [
-              isGithubGoldStatus.hasUpdates(1),
-            ]),
-          );
-
-          // Should label and comment
-          verify(
-            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-              kGoldenFileLabel,
-            ]),
-          ).called(1);
-
-          verify(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          ).called(1);
-        },
-      );
-
-      test(
-        'waits in pending state when unified Dashboard Checks is still in progress',
-        () async {
-          // New commit
-          final pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-
-          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-
-          // Unified Dashboard Checks in progress
-          checkRuns = <dynamic>[
-            <String, String>{
-              'name': Config.kDashboardCheckName,
-              'status': 'in_progress',
-              'conclusion': 'neutral',
-            },
-          ];
-
-          final body = await tester.get(handler);
-          expect(body, same(Response.emptyOk));
-          expect(log, hasNoWarningsOrHigher);
-
-          expect(
-            firestore,
-            existsInStorage(fs.GithubGoldStatus.metadata, [
-              isGithubGoldStatus.hasUpdates(1),
-            ]),
-          );
-
-          // Should not apply labels or make comments
-          verifyNever(
-            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-              kGoldenFileLabel,
-            ]),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
-        },
-      );
-
-      test(
-        'marks status completed when unified Dashboard Checks finishes and goldens are clean/approved',
-        () async {
-          // New commit
-          final pr = newPullRequest(123, 'abc', 'master');
-          prsFromGitHub = <PullRequest>[pr];
-
-          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
-
-          // Unified Dashboard Checks completed
-          checkRuns = <dynamic>[
-            <String, String>{
-              'name': Config.kDashboardCheckName,
-              'status': 'completed',
-              'conclusion': 'success',
-            },
-          ];
-
-          // Clean status reported by Gold
-          mockHttpClient = MockClient((http.Request request) async {
-            if (request.url.toString() ==
-                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
-              return http.Response(tryjobEmpty(), HttpStatus.ok);
-            }
-            throw const HttpException('Unexpected http request');
-          });
-          handler = PushGoldStatusToGithub(
-            config: config,
-            authenticationProvider: auth,
-            goldClient: mockHttpClient,
-            ingestionDelay: Duration.zero,
-            firestore: firestore,
-          );
-
-          final body = await tester.get(handler);
-          expect(body, same(Response.emptyOk));
-          expect(log, hasNoWarningsOrHigher);
-
-          expect(
-            firestore,
-            existsInStorage(fs.GithubGoldStatus.metadata, [
-              isGithubGoldStatus.hasUpdates(1),
-            ]),
-          );
-
-          // Should not label or comment
-          verifyNever(
-            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
-              kGoldenFileLabel,
-            ]),
-          );
-
-          verifyNever(
-            issuesService.createComment(
-              slug,
-              pr.number!,
-              argThat(contains(config.flutterGoldCommentID(pr))),
-            ),
-          );
-        },
-      );
-
       test('new commit, checks complete, no changes detected', () async {
         // New commit
         final pr = newPullRequest(123, 'abc', 'master');
@@ -1119,7 +734,7 @@ void main() {
         // Checks completed
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -1180,7 +795,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1249,7 +864,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1329,7 +944,7 @@ void main() {
           // Checks complete
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1404,7 +1019,7 @@ void main() {
         // Checks complete
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -1494,7 +1109,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1570,7 +1185,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1628,7 +1243,7 @@ void main() {
           // Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1678,7 +1293,7 @@ void main() {
           // Checks failed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'framework',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'failure',
             },
@@ -1737,7 +1352,7 @@ void main() {
         // Checks completed
         checkRuns = <dynamic>[
           <String, String>{
-            'name': 'framework',
+            'name': Config.kDashboardCheckName,
             'status': 'completed',
             'conclusion': 'success',
           },
@@ -1791,7 +1406,7 @@ void main() {
     );
 
     test(
-      'accounts for null status description when parsing for Luci builds',
+      'accounts for null status description when parsing check runs',
       () async {
         // Same commit
         final pr = newPullRequest(123, 'abc', 'master');
@@ -1807,10 +1422,10 @@ void main() {
           ),
         );
 
-        // null status for luci build
+        // null status for check run
         checkRuns = <dynamic>[
           <String, String?>{
-            'name': 'framework',
+            'name': Config.kDashboardCheckName,
             'status': null,
             'conclusion': null,
           },
@@ -1853,12 +1468,7 @@ void main() {
       // Checks completed
       checkRuns = <dynamic>[
         <String, String>{
-          'name': 'framework',
-          'status': 'completed',
-          'conclusion': 'success',
-        },
-        <String, String>{
-          'name': 'Linux linux_web_engine',
+          'name': Config.kDashboardCheckName,
           'status': 'completed',
           'conclusion': 'success',
         },

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -922,6 +922,192 @@ void main() {
         await includesEngineShard('mac_unopt');
       });
 
+      test('includes dashboard checks check run', () async {
+        await includesEngineShard('Dashboard Checks');
+      });
+
+      test(
+        'applies gold status and label when unified Dashboard Checks detects untriaged goldens',
+        () async {
+          // New commit
+          final pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+
+          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
+
+          // Unified Dashboard Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{
+              'name': 'Dashboard Checks',
+              'status': 'completed',
+              'conclusion': 'success',
+            },
+            <String, String>{
+              'name': 'ci.yaml validation',
+              'status': 'completed',
+              'conclusion': 'success',
+            },
+          ];
+
+          // Change detected by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobDigests(pr), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+            firestore: firestore,
+          );
+
+          // Have not already commented for this commit.
+          when(issuesService.listCommentsByIssue(slug, pr.number!)).thenAnswer(
+            (_) => Stream<IssueComment>.value(
+              IssueComment()..body = 'some other comment',
+            ),
+          );
+
+          final body = await tester.get(handler);
+          expect(body, same(Response.emptyOk));
+          expect(log, hasNoWarningsOrHigher);
+
+          expect(
+            firestore,
+            existsInStorage(fs.GithubGoldStatus.metadata, [
+              isGithubGoldStatus.hasUpdates(1),
+            ]),
+          );
+
+          // Should label and comment
+          verify(
+            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
+              kGoldenFileLabel,
+            ]),
+          ).called(1);
+
+          verify(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'waits in pending state when unified Dashboard Checks is still in progress',
+        () async {
+          // New commit
+          final pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+
+          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
+
+          // Unified Dashboard Checks in progress
+          checkRuns = <dynamic>[
+            <String, String>{
+              'name': 'Dashboard Checks',
+              'status': 'in_progress',
+              'conclusion': 'neutral',
+            },
+          ];
+
+          final body = await tester.get(handler);
+          expect(body, same(Response.emptyOk));
+          expect(log, hasNoWarningsOrHigher);
+
+          expect(
+            firestore,
+            existsInStorage(fs.GithubGoldStatus.metadata, [
+              isGithubGoldStatus.hasUpdates(1),
+            ]),
+          );
+
+          // Should not apply labels or make comments
+          verifyNever(
+            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
+              kGoldenFileLabel,
+            ]),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        },
+      );
+
+      test(
+        'marks status completed when unified Dashboard Checks finishes and goldens are clean/approved',
+        () async {
+          // New commit
+          final pr = newPullRequest(123, 'abc', 'master');
+          prsFromGitHub = <PullRequest>[pr];
+
+          firestore.putDocument(newGithubGoldStatus(slug, pr, '', '', ''));
+
+          // Unified Dashboard Checks completed
+          checkRuns = <dynamic>[
+            <String, String>{
+              'name': 'Dashboard Checks',
+              'status': 'completed',
+              'conclusion': 'success',
+            },
+          ];
+
+          // Clean status reported by Gold
+          mockHttpClient = MockClient((http.Request request) async {
+            if (request.url.toString() ==
+                'https://flutter-gold.skia.org/json/v1/changelist_summary/github/${pr.number}') {
+              return http.Response(tryjobEmpty(), HttpStatus.ok);
+            }
+            throw const HttpException('Unexpected http request');
+          });
+          handler = PushGoldStatusToGithub(
+            config: config,
+            authenticationProvider: auth,
+            goldClient: mockHttpClient,
+            ingestionDelay: Duration.zero,
+            firestore: firestore,
+          );
+
+          final body = await tester.get(handler);
+          expect(body, same(Response.emptyOk));
+          expect(log, hasNoWarningsOrHigher);
+
+          expect(
+            firestore,
+            existsInStorage(fs.GithubGoldStatus.metadata, [
+              isGithubGoldStatus.hasUpdates(1),
+            ]),
+          );
+
+          // Should not label or comment
+          verifyNever(
+            issuesService.addLabelsToIssue(slug, pr.number!, <String>[
+              kGoldenFileLabel,
+            ]),
+          );
+
+          verifyNever(
+            issuesService.createComment(
+              slug,
+              pr.number!,
+              argThat(contains(config.flutterGoldCommentID(pr))),
+            ),
+          );
+        },
+      );
+
       test('new commit, checks complete, no changes detected', () async {
         // New commit
         final pr = newPullRequest(123, 'abc', 'master');

--- a/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
+++ b/app_dart/test/request_handlers/push_gold_status_to_github_test.dart
@@ -15,6 +15,7 @@ import 'package:cocoon_service/src/model/firestore/github_gold_status.dart'
 import 'package:cocoon_service/src/model/firestore/github_gold_status.dart';
 import 'package:cocoon_service/src/request_handlers/push_gold_status_to_github.dart';
 import 'package:cocoon_service/src/request_handling/response.dart';
+import 'package:cocoon_service/src/service/config.dart';
 import 'package:github/github.dart';
 import 'package:graphql/client.dart' hide Response;
 import 'package:http/http.dart' as http;
@@ -923,7 +924,7 @@ void main() {
       });
 
       test('includes dashboard checks check run', () async {
-        await includesEngineShard('Dashboard Checks');
+        await includesEngineShard(Config.kDashboardCheckName);
       });
 
       test(
@@ -938,12 +939,12 @@ void main() {
           // Unified Dashboard Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'Dashboard Checks',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
             <String, String>{
-              'name': 'ci.yaml validation',
+              'name': Config.kCiYamlCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },
@@ -1012,7 +1013,7 @@ void main() {
           // Unified Dashboard Checks in progress
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'Dashboard Checks',
+              'name': Config.kDashboardCheckName,
               'status': 'in_progress',
               'conclusion': 'neutral',
             },
@@ -1058,7 +1059,7 @@ void main() {
           // Unified Dashboard Checks completed
           checkRuns = <dynamic>[
             <String, String>{
-              'name': 'Dashboard Checks',
+              'name': Config.kDashboardCheckName,
               'status': 'completed',
               'conclusion': 'success',
             },


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/191483

As detailed in the issue, the rollout of unified check runs replaced individual shard check runs with `Dashboard Checks`. Because `PushGoldStatusToGithub` matched against a hardcoded list of legacy shard names, golden status updates and triage labels stopped triggering on PRs. This PR adds `'dashboard checks'` to the recognized check run list.

Under the unified flow, individual shard check runs are no longer published to GitHub. While we could theoretically inspect individual shards by querying Firestore `PresubmitGuard` records, doing so is unnecessary. `Dashboard Checks` only completes once all scheduled presubmit builds have finished, and tests upload golden image digests directly to Skia Gold as they run. When `Dashboard Checks` completes, Skia Gold already knows whether golden tests ran and whether any unexpected images were produced. For PRs that do not touch goldens (or do not run golden tests at all), Skia Gold returns zero untriaged images, so Cocoon cleanly marks `flutter-gold` as `SUCCESS` without posting comments or applying labels. Skipping Firestore queries keeps `PushGoldStatusToGithub` simple, fast, and stateless against GitHub and Gold.

Added unit tests in `push_gold_status_to_github_test.dart` for in-progress, untriaged, and clean `Dashboard Checks` states.

cc @ievdokdm @jtmcdole

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
