### PR TITLE
Decouple bringup tasks from staging bucket and run in prod

### DIFF
--- a/app_dart/lib/src/model/ci_yaml/target.dart
+++ b/app_dart/lib/src/model/ci_yaml/target.dart
@@ -283,11 +283,6 @@ final class Target {
     return _value.name.split(' ').first.toLowerCase();
   }
 
-  /// Get the associated LUCI bucket to run this [Target] in.
-  String getBucket() {
-    return _value.bringup ? 'staging' : 'prod';
-  }
-
   /// Returns value of ignore_flakiness property.
   ///
   /// Returns the value of ignore_flakiness property if

--- a/app_dart/lib/src/model/firestore/suppressed_test.dart
+++ b/app_dart/lib/src/model/firestore/suppressed_test.dart
@@ -10,8 +10,8 @@ import 'base.dart';
 /// List of manual overrides for failing tests to flip the tree green.
 ///
 /// This should be used sparingly and only when a test is flaky or clearly
-/// breaking a roll. This is faster than moving the test to staging via
-/// the bringup:true method.
+/// breaking a roll. This is faster than marking the test as bringup: true in
+/// .ci.yaml.
 final class SuppressedTest extends AppDocument<SuppressedTest> {
   static const kCollectionId = 'suppressed_tests';
 

--- a/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
+++ b/app_dart/lib/src/request_handlers/flaky_handler_utils.dart
@@ -77,9 +77,7 @@ class IssueBuilder {
   final double threshold;
   final bool bringup;
 
-  Bucket get buildBucket {
-    return bringup ? Bucket.staging : Bucket.prod;
-  }
+  Bucket get buildBucket => Bucket.prod;
 
   String get issueTitle {
     return '${statistic.name} is ${_formatRate(statistic.flakyRate)}% flaky';

--- a/app_dart/lib/src/service/luci_build_service.dart
+++ b/app_dart/lib/src/service/luci_build_service.dart
@@ -1038,7 +1038,7 @@ class LuciBuildService {
     return bbv2.ScheduleBuildRequest(
       builder: bbv2.BuilderID(
         project: 'flutter',
-        bucket: target.getBucket(),
+        bucket: 'prod',
         builder: target.name,
       ),
       dimensions: requestedDimensions,
@@ -1103,7 +1103,7 @@ class LuciBuildService {
     return bbv2.ScheduleBuildRequest(
       builder: bbv2.BuilderID(
         project: 'flutter',
-        bucket: target.getBucket(),
+        bucket: 'prod',
         builder: target.name,
       ),
       dimensions: requestedDimensions,

--- a/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
+++ b/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
@@ -7,6 +7,7 @@ import 'package:cocoon_server_test/mocks.dart';
 import 'package:cocoon_server_test/test_logging.dart';
 import 'package:cocoon_service/protos.dart' as pb;
 import 'package:cocoon_service/src/request_handlers/flaky_handler_utils.dart';
+import 'package:cocoon_service/src/service/big_query.dart';
 import 'package:cocoon_service/src/service/config.dart';
 import 'package:cocoon_service/src/service/github_service.dart';
 import 'package:github/github.dart' hide Team;
@@ -193,6 +194,36 @@ abc_test.sh @ghi @flutter/framework
 
     test('returns null when not matched', () async {
       expect(getTeamLabelFromTeam(Team.unknown), null);
+    });
+  });
+
+  group('IssueBuilder', () {
+    test('buildBucket is prod regardless of bringup', () {
+      final statistic = BuilderStatistic(
+        name: 'Linux abc',
+        flakyRate: 0.5,
+        flakyNumber: 5,
+        totalNumber: 10,
+      );
+      final ownership = TestOwnership(
+        'owner',
+        Team.framework,
+      );
+      final issueBuilderBringupFalse = IssueBuilder(
+        statistic: statistic,
+        ownership: ownership,
+        threshold: 0.1,
+        bringup: false,
+      );
+      final issueBuilderBringupTrue = IssueBuilder(
+        statistic: statistic,
+        ownership: ownership,
+        threshold: 0.1,
+        bringup: true,
+      );
+
+      expect(issueBuilderBringupFalse.buildBucket, Bucket.prod);
+      expect(issueBuilderBringupTrue.buildBucket, Bucket.prod);
     });
   });
 }

--- a/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
+++ b/app_dart/test/request_handlers/flaky_handler_utiles_test.dart
@@ -205,10 +205,7 @@ abc_test.sh @ghi @flutter/framework
         flakyNumber: 5,
         totalNumber: 10,
       );
-      final ownership = TestOwnership(
-        'owner',
-        Team.framework,
-      );
+      final ownership = TestOwnership('owner', Team.framework);
       final issueBuilderBringupFalse = IssueBuilder(
         statistic: statistic,
         ownership: ownership,

--- a/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
+++ b/app_dart/test/service/luci_build_service/schedule_prod_builds_test.dart
@@ -199,7 +199,7 @@ void main() {
     expect(
       scheduleBuild.builder,
       isA<bbv2.BuilderID>()
-          .having((b) => b.bucket, 'bucket', 'staging')
+          .having((b) => b.bucket, 'bucket', 'prod')
           .having((b) => b.builder, 'builder', 'Linux 1'),
     );
 

--- a/cipd_packages/README.md
+++ b/cipd_packages/README.md
@@ -34,11 +34,11 @@ This is to enable the auto build and upload. Please follow the following example
     - .ci.yaml
 ```
 
-Start with `bringup: true`, same as any other regular new target. Once validated in CI, remove it to enable running
-in the `prod` environment so that artifacts are to be uploaded to CIPD.
+Start with `bringup: true`, same as any other regular new target. Once validated in CI, remove `bringup: true`
+so that artifacts are uploaded to CIPD.
 
-Note: with `bringup: true`, the target will be executed in a staging environment and it validates only the logic
-and will not upload to CIPD.
+Note: with `bringup: true`, the target validates only the logic and will not upload artifacts to CIPD or block
+the tree.
 
 ## Adding a reference to the CIPD package
 

--- a/dashboard/lib/logic/qualified_task.dart
+++ b/dashboard/lib/logic/qualified_task.dart
@@ -22,8 +22,6 @@ final class QualifiedTask {
     : task = task.builderName,
       pool = isTaskFromDartInternalBuilder(builderName: task.builderName)
           ? 'flutter'
-          : task.isBringup
-          ? 'luci.flutter.staging'
           : 'luci.flutter.prod',
       isBringup = task.isBringup;
 

--- a/dashboard/lib/widgets/luci_task_attempt_summary.dart
+++ b/dashboard/lib/widgets/luci_task_attempt_summary.dart
@@ -28,7 +28,6 @@ class LuciTaskAttemptSummary extends StatelessWidget {
             final url = generatePostSubmitBuildLogUrl(
               buildName: task.builderName,
               buildNumber: buildNumber,
-              isBringup: task.isBringup,
             );
             await launchUrl(Uri.parse(url));
           },

--- a/dashboard/test/logic/qualified_task_test.dart
+++ b/dashboard/test/logic/qualified_task_test.dart
@@ -24,6 +24,21 @@ void main() {
     );
   });
 
+  test('QualifiedTask.sourceConfigurationUrl for luci with bringup', () {
+    final luciBringupTask = generateTaskForTest(
+      status: TaskStatus.succeeded,
+      builderName: 'abc',
+      bringup: true,
+    );
+
+    expect(
+      QualifiedTask.fromTask(luciBringupTask).sourceConfigurationUrl,
+      Uri.parse(
+        'https://ci.chromium.org/p/flutter/builders/luci.flutter.prod/abc',
+      ),
+    );
+  });
+
   test('QualifiedTask.sourceConfigurationUrl for dart-internal', () {
     final dartInternalTask = generateTaskForTest(
       status: TaskStatus.succeeded,

--- a/packages/cocoon_common/lib/build_log_url.dart
+++ b/packages/cocoon_common/lib/build_log_url.dart
@@ -13,20 +13,16 @@ const String dartInternalLogBase =
 
 /// Generates a LUCI UI URL for a postsubmit build log.
 ///
-/// The [isBringup] flag configures the URL to target the staging builder pool
-/// (if true) rather than the default production pool. [buildName] and
-/// [buildNumber] are required to identify the specific build.
+/// Targets the production builder pool. [buildName] and [buildNumber] are
+/// required to identify the specific build.
 String generatePostSubmitBuildLogUrl({
   required String buildName,
   required int buildNumber,
-  bool isBringup = false,
 }) {
   return _generateBuildLogUrl(
     buildName: buildName,
     buildNumber: buildNumber,
-    buildersGroup: isBringup
-        ? BuildersGroup.flutterStaging
-        : BuildersGroup.flutter,
+    buildersGroup: BuildersGroup.flutter,
   );
 }
 
@@ -66,13 +62,10 @@ String _generateBuildLogUrl({
 /// Represents the group or pool of builders running the task.
 ///
 /// Corresponds to the segment in the LUCI URL path to target
-/// specific builder groups (like 'prod', 'staging', or 'try').
+/// specific builder groups (like 'prod' or 'try').
 enum BuildersGroup {
   /// The production builders pool.
   flutter('prod'),
-
-  /// The staging builders pool for bringup tasks.
-  flutterStaging('staging'),
 
   /// The try builders pool for presubmit tasks.
   flutterTryBuilders('try');

--- a/packages/cocoon_common/test/build_log_url_test.dart
+++ b/packages/cocoon_common/test/build_log_url_test.dart
@@ -14,32 +14,11 @@ void main() {
       );
     });
 
-    test('generates luci staging url', () {
-      expect(
-        generatePostSubmitBuildLogUrl(
-          buildName: 'Linux',
-          buildNumber: 123,
-          isBringup: true,
-        ),
-        '$luciProdLogBase/staging/Linux/123',
-      );
-    });
-
     test('generates dart-internal url', () {
       expect(
         generatePostSubmitBuildLogUrl(
           buildName: 'Linux flutter_release_builder',
           buildNumber: 123,
-        ),
-        '$dartInternalLogBase/flutter/Linux%20flutter_release_builder/123',
-      );
-    });
-    test('generates dart-internal url with isBringup', () {
-      expect(
-        generatePostSubmitBuildLogUrl(
-          buildName: 'Linux flutter_release_builder',
-          buildNumber: 123,
-          isBringup: true,
         ),
         '$dartInternalLogBase/flutter/Linux%20flutter_release_builder/123',
       );

--- a/packages/cocoon_integration_test/lib/src/model/ci_yaml_matcher.dart
+++ b/packages/cocoon_integration_test/lib/src/model/ci_yaml_matcher.dart
@@ -75,12 +75,6 @@ final class TargetMatcher extends Matcher {
     );
   }
 
-  TargetMatcher hasBucket(Object? valueOrMatcher) {
-    return TargetMatcher._(
-      _delegate.having((e) => e.getBucket(), 'getBucket()', valueOrMatcher),
-    );
-  }
-
   TargetMatcher hasIgnoreFlakiness(Object? valueOrMatcher) {
     return TargetMatcher._(
       _delegate.having(


### PR DESCRIPTION
Previously, tasks in .ci.yaml marked with bringup: true were scheduled to run in LUCI's staging bucket against staging builders and the staging pool of bots.

Because bringup tasks do not run in presubmit, the only places where they are scheduled are postsubmit and merge queue builds. Running them in the staging bucket is unnecessary; they should run against the standard prod bots and builders like any other task while maintaining their non-blocking behavior (no postsubmit check runs, no gating on tree status).

Staging builders and the staging pool are reserved for manual testing (e.g., via led) of experimental bot configurations and should not be automatically used for normal CI tasks.

This addresses https://github.com/flutter/flutter/issues/192311